### PR TITLE
server: tools: web search

### DIFF
--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -1548,6 +1548,7 @@ static server_tool & find_tool(std::vector<std::unique_ptr<server_tool>> & tools
 //
 // web_search: search the web using DuckDuckGo via HTML interface
 //
+
 struct server_tool_web_search : server_tool {
     server_tool_web_search() {
         name = "web_search";
@@ -1560,15 +1561,14 @@ struct server_tool_web_search : server_tool {
             {"type", "function"},
             {"function", {
                 {"name", name},
-                {"description", "Search the web using search engine. Returns a list of results containing titles, URLs, and snippets."},
+                {"description", "Search the web using search engine or URL. Returns request contents."},
                 {"parameters", {
                     {"type", "object"},
                     {"properties", {
-                        {"query", {{"type", "string"}, {"description", "The search query"}}},
-                        {"engine", {{"type", "string"}, {"description", "The search engine (default: https://ddg.gg/html/?q=)"}}},
+                        {"query", {{"type", "string"}, {"description", "The search query or a full URL."}}},
+                        {"engine", {{"type", "string"}, {"description", "The search engine (default: https://ddg.gg/html/?q=, ignored when given a URL query)"}}},
                         {"timeout",         {{"type", "integer"}, {"description", string_format("Timeout in seconds (default 10, max %d)", SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_TIMEOUT)}}},
                         {"max_output_size", {{"type", "integer"}, {"description", string_format("Maximum output size in bytes (default %zu)", SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE)}}},
-                        {"max_results",     {{"type", "integer"}, {"description", "Maximum number of results to return (default: 10)"}}},
                     }},
                     {"required", json::array({"query"})},
                 }},
@@ -1581,14 +1581,21 @@ struct server_tool_web_search : server_tool {
         std::string engine= json_value(params, "engine", std::string("https://html.duckduckgo.com/html/?q="));
         int    timeout        = json_value(params, "timeout",         10);
         size_t max_output     = (size_t) json_value(params, "max_output_size", (int) SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);
-        int    max_results    = json_value(params, "max_results", 10);
 
         timeout    = std::min(timeout,    SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_TIMEOUT);
         max_output = std::min(max_output, SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);
-        auto io = make_tools_io(params);
+        
+        // Check if the query is a URL (starts with http://, https://, or //)
+        bool is_url = (query.rfind("http://", 0) == 0) ||
+                      (query.rfind("https://", 0) == 0) ||
+                      (query.rfind("//", 0) == 0);
 
         // Encode query to prevent URL breakage
         std::string encoded_query = url_encode(query);
+        if (is_url) {
+          engine       = "";
+          encoded_query= query;
+        }
 
         // Download HTML using wget2 (outputting directly to stdout)
         // We use -qO- to avoid creating temporary files and to pipe directly to the C++ string
@@ -1596,6 +1603,7 @@ struct server_tool_web_search : server_tool {
           "--header=User-Agent: Mozilla/5.0 (compatible; WebSearch/1.0)",
           "--max-redirect=5",
           engine + encoded_query};
+        auto io  = make_tools_io(params);
         auto res = io->run(args, max_output, timeout);
         
         if (res.exit_code != 0) {

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -1510,6 +1510,9 @@ struct server_tool_web_search : server_tool {
                     {"type", "object"},
                     {"properties", {
                         {"query", {{"type", "string"}, {"description", "The search query"}}},
+                        {"engine", {{"type", "string"}, {"description", "The search engine (default: https://ddg.gg/html/?q=)"}}},
+                        {"timeout",         {{"type", "integer"}, {"description", string_format("Timeout in seconds (default 10, max %d)", SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_TIMEOUT)}}},
+                        {"max_output_size", {{"type", "integer"}, {"description", string_format("Maximum output size in bytes (default %zu)", SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE)}}},
                     }},
                     {"required", json::array({"query"})},
                 }},
@@ -1519,6 +1522,12 @@ struct server_tool_web_search : server_tool {
 
     json invoke(json params, server_tool::stream *) const override {
         std::string query = params.at("query").get<std::string>();
+        std::string engine= params.at("engine").get<std::string>();
+        int    timeout        = json_value(params, "timeout",         10);
+        size_t max_output     = (size_t) json_value(params, "max_output_size", (int) SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);
+
+        timeout    = std::min(timeout,    SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_TIMEOUT);
+        max_output = std::min(max_output, SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);
         auto io = make_tools_io(params);
 
         // 1. Encode query to prevent URL breakage
@@ -1526,8 +1535,8 @@ struct server_tool_web_search : server_tool {
 
         // 2. Download HTML using wget2 (outputting directly to stdout)
         // We use -qO- to avoid creating temporary files and to pipe directly to our C++ string
-        std::vector<std::string> args = {"wget2", "-qO-", "https://ddg.gg/html/?q=" + encoded_query};
-        auto res = io->run(args, 512 * 1024, 20); // 512KB limit, 20s timeout
+        std::vector<std::string> args = {"wget2", "-qO-", engine + encoded_query};
+        auto res = io->run(args, max_output, timeout);
 
         if (res.exit_code != 0) {
             return {{"error", "download failed: " + res.output}};
@@ -1537,17 +1546,11 @@ struct server_tool_web_search : server_tool {
         }
 
         // 3. Parse the HTML using regex
-        // We look for the specific pattern used by DuckDuckGo's HTML interface.
-        // Based on the provided xq query, we look for title, url, and snippet.
         json results = json::array();
         
         // This regex looks for the common DDG HTML result block structure:
-        // 1. The title link: <a class="result__a" href="URL">TITLE</a>
-        // 2. The snippet: <div class="result__snippet">SNIPPET</div>
-        // Note: We use a non-greedy match (.*?) to handle multiple results in one string.
         std::regex result_regex(
-            R"(<a class="result__a" href="([^"]+)"[^>]*>([^<]+)</a>.*?<div class="result__snippet">([^<]+)</div>)",
-            std::regex::extended
+            "<a class=\"result__a\" href=\"([^\"]+)\"[^>]*>([^<]+)</a>.*?<div class=\"result__snippet\">([^<]+)</div>"
         );
 
         auto words_begin = std::sregex_iterator(res.output.begin(), res.output.end(), result_regex);

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -466,6 +466,23 @@ static bool path_glob_match(const std::string & pattern, const std::string & rel
     return glob_match("**/" + pattern, rel_path);
 }
 
+static std::string url_encode(const std::string& value) {
+    static const char* hex = "0123456789ABCDEF";
+    std::string escaped;
+    escaped.reserve(value.size()); // Optimization to prevent multiple reallocations
+
+    for (unsigned char c : value) {
+        if (std::isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            escaped += c;
+        } else {
+            escaped += '%';
+            escaped += hex[c >> 4];   // High nibble
+            escaped += hex[c & 0x0F]; // Low nibble
+        }
+    }
+    return escaped;
+}
+
 //
 // read_file: read a file with optional line range and line-number prefix
 //
@@ -1474,6 +1491,87 @@ static server_tool & find_tool(std::vector<std::unique_ptr<server_tool>> & tools
 }
 
 //
+// web_search: search the web using DuckDuckGo via HTML interface
+//
+struct server_tool_web_search : server_tool {
+    server_tool_web_search() {
+        name = "web_search";
+        display_name = "Web Search";
+        permission_write = false;
+    }
+
+    json get_definition() const override {
+        return {
+            {"type", "function"},
+            {"function", {
+                {"name", name},
+                {"description", "Search the web using DuckDuckGo. Returns a list of results containing titles, URLs, and snippets."},
+                {"parameters", {
+                    {"type", "object"},
+                    {"properties", {
+                        {"query", {{"type", "string"}, {"description", "The search query"}}},
+                    }},
+                    {"required", json::array({"query"})},
+                }},
+            }},
+        };
+    }
+
+    json invoke(json params, server_tool::stream *) const override {
+        std::string query = params.at("query").get<std::string>();
+        auto io = make_tools_io(params);
+
+        // 1. Encode query to prevent URL breakage
+        std::string encoded_query = url_encode(query);
+
+        // 2. Download HTML using wget2 (outputting directly to stdout)
+        // We use -qO- to avoid creating temporary files and to pipe directly to our C++ string
+        std::vector<std::string> args = {"wget2", "-qO-", "https://ddg.gg/html/?q=" + encoded_query};
+        auto res = io->run(args, 512 * 1024, 20); // 512KB limit, 20s timeout
+
+        if (res.exit_code != 0) {
+            return {{"error", "download failed: " + res.output}};
+        }
+        if (res.timed_out) {
+            return {{"error", "search request timed out"}};
+        }
+
+        // 3. Parse the HTML using regex
+        // We look for the specific pattern used by DuckDuckGo's HTML interface.
+        // Based on the provided xq query, we look for title, url, and snippet.
+        json results = json::array();
+        
+        // This regex looks for the common DDG HTML result block structure:
+        // 1. The title link: <a class="result__a" href="URL">TITLE</a>
+        // 2. The snippet: <div class="result__snippet">SNIPPET</div>
+        // Note: We use a non-greedy match (.*?) to handle multiple results in one string.
+        std::regex result_regex(
+            R"(<a class="result__a" href="([^"]+)"[^>]*>([^<]+)</a>.*?<div class="result__snippet">([^<]+)</div>)",
+            std::regex::extended
+        );
+
+        auto words_begin = std::sregex_iterator(res.output.begin(), res.output.end(), result_regex);
+        auto words_end = std::sregex_iterator();
+
+        for (std::sregex_iterator i = words_begin; i != words_end; ++i) {
+            std::smatch match = *i;
+            results.push_back({
+                {"url",     match[1].str()},
+                {"title",   match[2].str()},
+                {"snippet", match[3].str()}
+            });
+        }
+
+        if (results.empty()) {
+            // If regex failed but download succeeded, it might be a different HTML structure or no results
+            return {{"results", json::array()}, {"info", "No results found or parsing error. Raw output length: " + std::to_string(res.output.size())}};
+        }
+
+        return {{"results", results}};
+    }
+};
+
+//
 // public API
 //
 
@@ -1487,6 +1585,7 @@ static std::vector<std::unique_ptr<server_tool>> build_tools() {
     tools.push_back(std::make_unique<server_tool_edit_file>());
     tools.push_back(std::make_unique<server_tool_get_datetime>());
     tools.push_back(std::make_unique<server_tool_get_info>());
+    tools.push_back(std::make_unique<server_tool_web_search>());
     return tools;
 }
 

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -1521,8 +1521,8 @@ struct server_tool_web_search : server_tool {
     }
 
     json invoke(json params, server_tool::stream *) const override {
-        std::string query = json_value(params, "query", std::string("https://ddg.gg/html/?q="));
-        std::string engine= params.at("engine").get<std::string>();
+        std::string query = params.at("query").get<std::string>();
+        std::string engine= json_value(params, "engine", std::string("https://ddg.gg/html/?q="));
         int    timeout        = json_value(params, "timeout",         10);
         size_t max_output     = (size_t) json_value(params, "max_output_size", (int) SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);
 

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -1505,7 +1505,7 @@ struct server_tool_web_search : server_tool {
             {"type", "function"},
             {"function", {
                 {"name", name},
-                {"description", "Search the web using DuckDuckGo. Returns a list of results containing titles, URLs, and snippets."},
+                {"description", "Search the web using search engine. Returns a list of results containing titles, URLs, and snippets."},
                 {"parameters", {
                     {"type", "object"},
                     {"properties", {
@@ -1521,7 +1521,7 @@ struct server_tool_web_search : server_tool {
     }
 
     json invoke(json params, server_tool::stream *) const override {
-        std::string query = params.at("query").get<std::string>();
+        std::string query = json_value(params, "query", std::string("https://ddg.gg/html/?q="));
         std::string engine= params.at("engine").get<std::string>();
         int    timeout        = json_value(params, "timeout",         10);
         size_t max_output     = (size_t) json_value(params, "max_output_size", (int) SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -483,6 +483,24 @@ static std::string url_encode(const std::string& value) {
     return escaped;
 }
 
+static std::vector<std::string> extract_html_matches(
+    const std::string &html,
+    const std::string &pattern) {
+    std::vector<std::string> matches;
+    std::regex regex_pattern(pattern);
+    std::smatch match;
+
+    std::string::const_iterator search_start(html.cbegin());
+    while (std::regex_search(search_start, html.cend(), match, regex_pattern)) {
+        if (match.size() > 1) {
+            matches.push_back(match[1].str());
+        }
+        search_start = match[0].second;
+    }
+
+    return matches;
+}
+
 //
 // read_file: read a file with optional line range and line-number prefix
 //
@@ -1513,6 +1531,7 @@ struct server_tool_web_search : server_tool {
                         {"engine", {{"type", "string"}, {"description", "The search engine (default: https://ddg.gg/html/?q=)"}}},
                         {"timeout",         {{"type", "integer"}, {"description", string_format("Timeout in seconds (default 10, max %d)", SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_TIMEOUT)}}},
                         {"max_output_size", {{"type", "integer"}, {"description", string_format("Maximum output size in bytes (default %zu)", SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE)}}},
+                        {"max_results",     {{"type", "integer"}, {"description", "Maximum number of results to return (default: 10)"}}},
                     }},
                     {"required", json::array({"query"})},
                 }},
@@ -1522,52 +1541,59 @@ struct server_tool_web_search : server_tool {
 
     json invoke(json params, server_tool::stream *) const override {
         std::string query = params.at("query").get<std::string>();
-        std::string engine= json_value(params, "engine", std::string("https://ddg.gg/html/?q="));
+        std::string engine= json_value(params, "engine", std::string("https://html.duckduckgo.com/html/?q="));
         int    timeout        = json_value(params, "timeout",         10);
         size_t max_output     = (size_t) json_value(params, "max_output_size", (int) SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);
+        int    max_results    = json_value(params, "max_results", 10);
 
         timeout    = std::min(timeout,    SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_TIMEOUT);
         max_output = std::min(max_output, SERVER_TOOL_EXEC_SHELL_COMMAND_MAX_OUTPUT_SIZE);
         auto io = make_tools_io(params);
 
-        // 1. Encode query to prevent URL breakage
+        // Encode query to prevent URL breakage
         std::string encoded_query = url_encode(query);
 
-        // 2. Download HTML using wget2 (outputting directly to stdout)
-        // We use -qO- to avoid creating temporary files and to pipe directly to our C++ string
-        std::vector<std::string> args = {"wget2", "-qO-", engine + encoded_query};
+        // Download HTML using wget2 (outputting directly to stdout)
+        // We use -qO- to avoid creating temporary files and to pipe directly to the C++ string
+        std::vector<std::string> args = {"wget2", "-qO-", 
+          "--header=User-Agent: Mozilla/5.0 (compatible; WebSearch/1.0)",
+          "--max-redirect=5",
+          engine + encoded_query};
         auto res = io->run(args, max_output, timeout);
-
+        
         if (res.exit_code != 0) {
             return {{"error", "download failed: " + res.output}};
         }
         if (res.timed_out) {
             return {{"error", "search request timed out"}};
         }
-
-        // 3. Parse the HTML using regex
-        json results = json::array();
         
-        // This regex looks for the common DDG HTML result block structure:
-        std::regex result_regex(
-            "<a class=\"result__a\" href=\"([^\"]+)\"[^>]*>([^<]+)</a>.*?<div class=\"result__snippet\">([^<]+)</div>"
-        );
-
-        auto words_begin = std::sregex_iterator(res.output.begin(), res.output.end(), result_regex);
-        auto words_end = std::sregex_iterator();
-
-        for (std::sregex_iterator i = words_begin; i != words_end; ++i) {
-            std::smatch match = *i;
-            results.push_back({
-                {"url",     match[1].str()},
-                {"title",   match[2].str()},
-                {"snippet", match[3].str()}
-            });
+        if (res.output.empty()) {
+            return {{"error", "Failed to fetch search results." + engine + encoded_query }};
         }
+        
+        // Regex patterns for extracting titles, URLs, and snippets
+        // Updated regex patterns for DuckDuckGo's HTML
+        std::string title_pattern   = "<h2 class=\"result__title\">\\s*<a[^>]*>(.*?)</a>\\s*</h2>";
+        std::string url_pattern     = "<a class=\"result__url\"[^>]*href=\"(.*?)\"";
+        std::string snippet_pattern = "<a class=\"result__snippet\"[^>]*>(.*?)</a>";
 
-        if (results.empty()) {
-            // If regex failed but download succeeded, it might be a different HTML structure or no results
-            return {{"results", json::array()}, {"info", "No results found or parsing error. Raw output length: " + std::to_string(res.output.size())}};
+        // Extract titles, URLs, and snippets
+        std::vector<std::string> titles   = extract_html_matches(res.output, title_pattern);
+        std::vector<std::string> urls     = extract_html_matches(res.output, url_pattern);
+        std::vector<std::string> snippets = extract_html_matches(res.output, snippet_pattern);
+
+        // Ensure all vectors have the same size
+        size_t result_count = std::min({titles.size(), urls.size(), snippets.size(), (size_t)max_results});
+        
+        json results = json::array();
+
+        for (size_t i = 0; i < result_count; ++i) {
+            results.push_back({
+                {"title",   titles[i]},
+                {"url",     urls[i]},
+                {"snippet", snippets[i]},
+            });
         }
 
         return {{"results", results}};

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -501,6 +501,43 @@ static std::vector<std::string> extract_html_matches(
     return matches;
 }
 
+// Simple HTML-to-text converter that preserves basic formatting
+static std::string html2text(const std::string &html) {
+    std::string text = html;
+
+    // Replace <br>, <p>, <div>, etc. with newlines
+    text = std::regex_replace(text, std::regex("<(br|p|div|li|/li|/p|/div)[^>]*>"), "\n");
+
+    // Replace headers with newline + uppercase (e.g., <h1>Title</h1> -> "\nTITLE\n")
+    text = std::regex_replace(text, std::regex("<h1[^>]*>(.*?)</h1>"), "\n\\1\n");
+    text = std::regex_replace(text, std::regex("<h2[^>]*>(.*?)</h2>"), "\n\\1\n");
+    text = std::regex_replace(text, std::regex("<h3[^>]*>(.*?)</h3>"), "\n\\1\n");
+    text = std::regex_replace(text, std::regex("<h4[^>]*>(.*?)</h4>"), "\n\\1\n");
+
+    // Replace bold/italic tags with asterisks/underscores (Markdown-style)
+    text = std::regex_replace(text, std::regex("<(b|strong)[^>]*>(.*?)</\\1>"), "*\\2*");
+    text = std::regex_replace(text, std::regex("<(i|em)[^>]*>(.*?)</\\1>"), "_\\2_");
+    text = std::regex_replace(text, std::regex("<u[^>]*>(.*?)</u>"), "__\\1__");
+
+    // Replace links with their text (or URL if no text)
+    text = std::regex_replace(text, std::regex("<a[^>]*href=\"[^\"]*\"[^>]*>(.*?)</a>"), "\\1");
+
+    // Remove all remaining HTML tags
+    text = std::regex_replace(text, std::regex("<[^>]*>"), "");
+
+    // Collapse multiple newlines into one
+    text = std::regex_replace(text, std::regex("\n+"), "\n");
+
+    // Collapse multiple spaces into one
+    text = std::regex_replace(text, std::regex("[ \t]+"), " ");
+
+    // Trim leading/trailing whitespace
+    text = std::regex_replace(text, std::regex("^\\s+"), "");
+    text = std::regex_replace(text, std::regex("\\s+$"), "");
+
+    return text;
+}
+
 //
 // read_file: read a file with optional line range and line-number prefix
 //
@@ -1569,32 +1606,16 @@ struct server_tool_web_search : server_tool {
         }
         
         if (res.output.empty()) {
-            return {{"error", "Failed to fetch search results." + engine + encoded_query }};
+            return {{"error", "Failed to fetch search results."}};
         }
-        
-        // Regex patterns for extracting titles, URLs, and snippets
-        // Updated regex patterns for DuckDuckGo's HTML
-        std::string title_pattern   = "<h2 class=\"result__title\">\\s*<a[^>]*>(.*?)</a>\\s*</h2>";
-        std::string url_pattern     = "<a class=\"result__url\"[^>]*href=\"(.*?)\"";
-        std::string snippet_pattern = "<a class=\"result__snippet\"[^>]*>(.*?)</a>";
-
-        // Extract titles, URLs, and snippets
-        std::vector<std::string> titles   = extract_html_matches(res.output, title_pattern);
-        std::vector<std::string> urls     = extract_html_matches(res.output, url_pattern);
-        std::vector<std::string> snippets = extract_html_matches(res.output, snippet_pattern);
-
-        // Ensure all vectors have the same size
-        size_t result_count = std::min({titles.size(), urls.size(), snippets.size(), (size_t)max_results});
         
         json results = json::array();
 
-        for (size_t i = 0; i < result_count; ++i) {
-            results.push_back({
-                {"title",   titles[i]},
-                {"url",     urls[i]},
-                {"snippet", snippets[i]},
-            });
-        }
+        results.push_back({
+            {"title",   query},
+            {"url",     engine + encoded_query},
+            {"content", html2text(res.output)},
+        });
 
         return {{"results", results}};
     }

--- a/tools/server/server-tools.cpp
+++ b/tools/server/server-tools.cpp
@@ -1561,7 +1561,7 @@ struct server_tool_web_search : server_tool {
             {"type", "function"},
             {"function", {
                 {"name", name},
-                {"description", "Search the web using search engine or URL. Returns request contents."},
+                {"description", "Search the web using search engine or URL. Returns request contents. Requires wget2 to be installed."},
                 {"parameters", {
                     {"type", "object"},
                     {"properties", {
@@ -1603,6 +1603,7 @@ struct server_tool_web_search : server_tool {
           "--header=User-Agent: Mozilla/5.0 (compatible; WebSearch/1.0)",
           "--max-redirect=5",
           engine + encoded_query};
+          
         auto io  = make_tools_io(params);
         auto res = io->run(args, max_output, timeout);
         


### PR DESCRIPTION
## Overview

This is a server tool to search the web. It requires 'wget2' to be installed.

## Additional information

This contribution add a `web_search` server tool so that we get the `llama-server` option:
```
--tools TOOL1,TOOL2,...                 experimental: whether to enable built-in tools for AI agents - do not
                                        enable in untrusted environments (default: no tools)
                                        specify "all" to enable all tools
                                        available tools: read_file, file_glob_search, grep_search,
                                        exec_shell_command, write_file, edit_file, get_datetime, get_info,
                                        web_search
                                        note: for security reasons, this will limit --cors-origins to
                                        localhost by default
                                        (env: LLAMA_ARG_TOOLS)
```

The `web_search` can be used by providing a query string. The default search engine is DuckDuckGo (ddg), but this can be changed as the 'engine' parameter. 

The query can also be given as a raw URL which is then retrieved without accessing the engine.

<img width="2082" height="1476" alt="image" src="https://github.com/user-attachments/assets/c47d281f-92f9-439a-979d-d035e82cfca8" />


## Requirements

The 'wget2' must be installed on the system, e.g. via apt, brew, conda, dnf, etc. This is indicated in the tool description, so that the LLM will report to install it in case it is not yet.

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) YES
- AI usage disclosure: YES, AI used to improve code formatting.

