### PR TITLE
gguf-py : fix Llama 3 BPE tokenizer misdetection

### DIFF
--- a/gguf-py/gguf/vocab.py
+++ b/gguf-py/gguf/vocab.py
@@ -562,8 +562,8 @@ class LlamaHfVocab(Vocab):
             and not tokenizer_model.get('byte_fallback', True)
         )
         if is_llama3:
-            raise TypeError('Llama 3 must be converted with BpeVocab')
-
+            # Llama 3 uses BPE, not SentencePiece
+            setattr(self, "tokenizer_model", "gpt2")
         if not is_llama3 and (
             tokenizer_model['type'] != 'BPE' or not tokenizer_model.get('byte_fallback', False)
             or tokenizer_json['decoder']['type'] != 'Sequence'


### PR DESCRIPTION
## Overview

The LlamaHfVocab class inside gguf-py/gguf/vocab.py refuses to process Llama 3 / 3.1 / 3.2 models. So The convert_hf_to_gguf.py file is unable to convert the Llama 3 model.
There is another question: LlamaHfVocab statically defines tokenizer_model = "llama" for SentencePiece tokenizers. However, Llama 3 series uses BPE tokenization.Even if the conversion is successful, the resulting GGUF file marks tokenizer.ggml.model = "llama". When running inference in llama.cpp, this forces the SentencePiece tokenizer code path and leads to a std::out_of_range crash.
This PR has modified LlamaHfVocab to support Llama 3 BPE tokenizers, and sets tokenizer_model = "gpt2". This ensures the metadata written into the GGUF file matches the real BPE tokenizer type.
## Testing

- **Before fix:** `convert_hf_to_gguf.py` fails with `TypeError: Llama 3 must be converted with BpeVocab`, then falls through to incompatible GPT2 path causing `AssertionError`
  <details>
  <summary>Full error log (click to expand)</summary>
    File ".../vocab.py", line 567, in init
    raise TypeError('Llama 3 must be converted with BpeVocab')
    TypeError: Llama 3 must be converted with BpeVocab
    During handling of the above exception, another exception occurred:
    File ".../base.py", line 1349, in get_vocab_base
    assert max(tokenizer.vocab.values()) < vocab_size
    AssertionError
  </details>
- **After fix:** INFO:hf-to-gguf:Model successfully exported to models/Llama-3.2-1B-Instruct-f16.gguf
## Additional information
I believe this issue has affected all Llama 3 models.I chose the setattr method since tokenizer_model is defined as a ClassVar[str] on the BaseVocab protocol. Direct assignment on the instance would cause type checking failures.
- Related issues: #25882

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: **NO** — this PR was drafted and implemented entirely by myself without AI assistance.
