### PR TITLE
cuda : split argmax over multiple tiles for large rows

### DIFF
--- a/ggml/src/ggml-cuda/argmax.cu
+++ b/ggml/src/ggml-cuda/argmax.cu
@@ -66,6 +66,51 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
     }
 }
 
+// one warp per chunk of a row, writing the chunk-local (val, idx)
+static __global__ void argmax_f32_chunk(const float * __restrict__ x, float * __restrict__ part_val, int32_t * __restrict__ part_idx,
+        const int64_t ncols, const int64_t nchunks) {
+    const int64_t row        = blockIdx.y;
+    const int64_t chunk_size = (ncols + nchunks - 1) / nchunks;
+    const int64_t beg        = blockIdx.x * chunk_size;
+    const int64_t end        = beg + chunk_size < ncols ? beg + chunk_size : ncols;
+
+    float maxval = -FLT_MAX;
+    int   argmax = -1;
+    const float * rowx = x + row * ncols;
+
+    for (int64_t col = beg + threadIdx.x; col < end; col += WARP_SIZE) {
+        const float val = rowx[col];
+        if (val > maxval) {
+            maxval = val;
+            argmax = (int) col;
+        }
+    }
+
+#pragma unroll
+    for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
+        const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
+        const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
+        if (val > maxval) {
+            maxval = val;
+            argmax = col;
+        }
+    }
+
+    if (threadIdx.x == 0) {
+        part_val[row*nchunks + blockIdx.x] = maxval;
+        part_idx[row*nchunks + blockIdx.x] = argmax;
+    }
+}
+
+// map each row's winning chunk back to its column index
+static __global__ void argmax_f32_gather(const int32_t * __restrict__ winner, const int32_t * __restrict__ part_idx,
+        int32_t * __restrict__ dst, const int64_t nchunks) {
+    const int64_t row = blockIdx.x;
+    const int32_t w   = winner[row];
+
+    dst[row] = w < 0 ? -1 : part_idx[row*nchunks + w];
+}
+
 void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0 = dst->src[0];
 
@@ -81,6 +126,22 @@ void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     int32_t     * dst_d  = (int32_t     *) dst->data;
 
     cudaStream_t stream = ctx.stream();
+
+    // one block per row leaves most SMs idle for few large rows -> reduce chunks first
+    const int64_t nchunks = ne00 < 8192 ? 0 :
+        std::min<int64_t>(ne00/128, 8*ggml_cuda_info().devices[ggml_cuda_get_device()].nsm/nrows);
+
+    if (nchunks >= 4) {
+        ggml_cuda_pool_alloc<float>   part_val(ctx.pool(), nrows*nchunks);
+        ggml_cuda_pool_alloc<int32_t> part_idx(ctx.pool(), nrows*nchunks);
+        ggml_cuda_pool_alloc<int32_t> winner  (ctx.pool(), nrows);
+
+        argmax_f32_chunk<<<dim3(nchunks, nrows, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(src0_d, part_val.get(), part_idx.get(), ne00, nchunks);
+        argmax_f32<<<dim3(nrows, 1, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(part_val.get(), winner.get(), nchunks);
+        argmax_f32_gather<<<dim3(nrows, 1, 1), dim3(1, 1, 1), 0, stream>>>(winner.get(), part_idx.get(), dst_d, nchunks);
+
+        return;
+    }
 
     const int64_t num_blocks = nrows;
     const int64_t num_threads = std::min<int64_t>(1024, (ne00 + WARP_SIZE - 1) / WARP_SIZE * WARP_SIZE);

--- a/ggml/src/ggml-cuda/argmax.cu
+++ b/ggml/src/ggml-cuda/argmax.cu
@@ -24,11 +24,11 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
     int   argmax = -1;
     const float * rowx = x + row * ncols;
 
-    for (int64_t col = threadIdx.x; col < ncols; col += blockDim.x) {
+    for (int32_t col = threadIdx.x; col < ncols; col += blockDim.x) {
         const float val = rowx[col];
         if (val > maxval) {
             maxval = val;
-            argmax = (int) col;
+            argmax = col;
         }
     }
 
@@ -62,49 +62,59 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
     }
 }
 
-// one warp per chunk of a row, writing the chunk-local (val, idx)
-static __global__ void argmax_f32_chunk(const float * __restrict__ x, float * __restrict__ part_val, int32_t * __restrict__ part_idx,
-        const int64_t ncols, const int64_t nchunks) {
-    const int64_t row        = blockIdx.x / nchunks;
-    const int64_t chunk      = blockIdx.x % nchunks;
-    const int64_t chunk_size = (ncols + nchunks - 1) / nchunks;
-    const int64_t beg        = chunk * chunk_size;
-    const int64_t end        = beg + chunk_size < ncols ? beg + chunk_size : ncols;
+// Two-stage reduction for wide rows: stage 1 tiles the row across SMs (ARGMAX_BLOCK
+// threads each, smem tree reduce); stage 2 reduces the small partial array with one warp.
+#define ARGMAX_TILE  8192
+#define ARGMAX_BLOCK  256
+
+static __global__ void argmax_f32_tile(
+        const float * __restrict__ x, float * __restrict__ part_val, int32_t * __restrict__ part_idx,
+        const int64_t ncols, const int64_t ntiles) {
+    __shared__ float smem_val[ARGMAX_BLOCK];
+    __shared__ int   smem_idx[ARGMAX_BLOCK];
+
+    const int64_t row  = blockIdx.x / ntiles;
+    const int64_t tile = blockIdx.x % ntiles;
+    const int64_t beg  = tile * ARGMAX_TILE;
+    const int64_t end  = beg + ARGMAX_TILE < ncols ? beg + ARGMAX_TILE : ncols;
 
     float maxval = -FLT_MAX;
     int   argmax = -1;
-    const float * rowx = x + row * ncols;
 
-    for (int64_t col = beg + threadIdx.x; col < end; col += WARP_SIZE) {
-        const float val = rowx[col];
-        if (val > maxval) {
-            maxval = val;
-            argmax = (int) col;
-        }
+    for (int64_t col = beg + threadIdx.x; col < end; col += ARGMAX_BLOCK) {
+        const float val = x[row * ncols + col];
+        if (val > maxval) { maxval = val; argmax = (int) col; }
     }
 
-    argmax_warp_reduce(maxval, argmax);
+    smem_val[threadIdx.x] = maxval;
+    smem_idx[threadIdx.x] = argmax;
+    __syncthreads();
+
+    for (int s = ARGMAX_BLOCK / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s && smem_val[threadIdx.x + s] > smem_val[threadIdx.x]) {
+            smem_val[threadIdx.x] = smem_val[threadIdx.x + s];
+            smem_idx[threadIdx.x] = smem_idx[threadIdx.x + s];
+        }
+        __syncthreads();
+    }
 
     if (threadIdx.x == 0) {
-        part_val[row*nchunks + chunk] = maxval;
-        part_idx[row*nchunks + chunk] = argmax;
+        part_val[row * ntiles + tile] = smem_val[0];
+        part_idx[row * ntiles + tile] = smem_idx[0];
     }
 }
 
-// one warp per row, reducing the per-chunk partials to the row's column index
-static __global__ void argmax_f32_combine(const float * __restrict__ part_val, const int32_t * __restrict__ part_idx,
-        int32_t * __restrict__ dst, const int64_t nchunks) {
+static __global__ void argmax_f32_combine(
+        const float * __restrict__ part_val, const int32_t * __restrict__ part_idx,
+        int32_t * __restrict__ dst, const int64_t ntiles) {
     const int64_t row = blockIdx.x;
 
     float maxval = -FLT_MAX;
     int   argmax = -1;
 
-    for (int i = threadIdx.x; i < nchunks; i += WARP_SIZE) {
-        const float val = part_val[row*nchunks + i];
-        if (val > maxval) {
-            maxval = val;
-            argmax = part_idx[row*nchunks + i];
-        }
+    for (int i = threadIdx.x; i < ntiles; i += WARP_SIZE) {
+        const float val = part_val[row * ntiles + i];
+        if (val > maxval) { maxval = val; argmax = part_idx[row * ntiles + i]; }
     }
 
     argmax_warp_reduce(maxval, argmax);
@@ -119,38 +129,30 @@ void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     GGML_ASSERT(src0->type == GGML_TYPE_F32);
     GGML_ASSERT( dst->type == GGML_TYPE_I32);
-
     GGML_ASSERT(ggml_is_contiguous(src0));
 
     const int64_t ne00  = src0->ne[0];
     const int64_t nrows = ggml_nrows(src0);
 
-    // the result indices are I32
     GGML_ASSERT(ne00 <= INT32_MAX);
 
     const float * src0_d = (const float *) src0->data;
     int32_t     * dst_d  = (int32_t     *) dst->data;
-
     cudaStream_t stream = ctx.stream();
 
-    // one block per row leaves most SMs idle for few large rows -> reduce chunks first
-    const int64_t nchunks = ne00 < 8192 ? 0 :
-        std::min<int64_t>(ne00/128, 8*ggml_cuda_info().devices[ggml_cuda_get_device()].nsm/nrows);
+    if (ne00 >= ARGMAX_TILE) {
+        const int64_t ntiles = (ne00 + ARGMAX_TILE - 1) / ARGMAX_TILE;
 
-    if (nchunks >= 4) {
-        ggml_cuda_pool_alloc<float>   part_val(ctx.pool(), nrows*nchunks);
-        ggml_cuda_pool_alloc<int32_t> part_idx(ctx.pool(), nrows*nchunks);
+        ggml_cuda_pool_alloc<float>   part_val(ctx.pool(), nrows * ntiles);
+        ggml_cuda_pool_alloc<int32_t> part_idx(ctx.pool(), nrows * ntiles);
 
-        argmax_f32_chunk<<<dim3(nrows*nchunks, 1, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(src0_d, part_val.get(), part_idx.get(), ne00, nchunks);
-        argmax_f32_combine<<<dim3(nrows, 1, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(part_val.get(), part_idx.get(), dst_d, nchunks);
-
+        argmax_f32_tile   <<<dim3(nrows * ntiles, 1, 1), dim3(ARGMAX_BLOCK, 1, 1), 0, stream>>>(
+                src0_d, part_val.get(), part_idx.get(), ne00, ntiles);
+        argmax_f32_combine<<<dim3(nrows,          1, 1), dim3(WARP_SIZE,    1, 1), 0, stream>>>(
+                part_val.get(), part_idx.get(), dst_d, ntiles);
         return;
     }
 
-    const int64_t num_blocks = nrows;
     const int64_t num_threads = std::min<int64_t>(1024, (ne00 + WARP_SIZE - 1) / WARP_SIZE * WARP_SIZE);
-    const dim3 blocks_dim(num_threads, 1, 1);
-    const dim3 blocks_num(num_blocks, 1, 1);
-
-    argmax_f32<<<blocks_num, blocks_dim, 0, stream>>>(src0_d, dst_d, ne00);
+    argmax_f32<<<dim3(nrows, 1, 1), dim3(num_threads, 1, 1), 0, stream>>>(src0_d, dst_d, ne00);
 }

--- a/ggml/src/ggml-cuda/argmax.cu
+++ b/ggml/src/ggml-cuda/argmax.cu
@@ -24,11 +24,11 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
     int   argmax = -1;
     const float * rowx = x + row * ncols;
 
-    for (int32_t col = threadIdx.x; col < ncols; col += blockDim.x) {
+    for (int64_t col = threadIdx.x; col < ncols; col += blockDim.x) {
         const float val = rowx[col];
         if (val > maxval) {
             maxval = val;
-            argmax = col;
+            argmax = (int) col;
         }
     }
 

--- a/ggml/src/ggml-cuda/argmax.cu
+++ b/ggml/src/ggml-cuda/argmax.cu
@@ -5,6 +5,18 @@
 #include "common.cuh"
 #include "sum.cuh"
 
+static __device__ __forceinline__ void argmax_warp_reduce(float & maxval, int & argmax) {
+#pragma unroll
+    for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
+        const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
+        const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
+        if (val > maxval) {
+            maxval = val;
+            argmax = col;
+        }
+    }
+}
+
 static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __restrict__ dst, const int64_t ncols) {
     const int64_t row = blockIdx.x;
 
@@ -20,15 +32,7 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
         }
     }
 
-#pragma unroll
-    for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
-        const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
-        const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
-        if (val > maxval) {
-            maxval = val;
-            argmax = col;
-        }
-    }
+    argmax_warp_reduce(maxval, argmax);
 
     const int n_warps = blockDim.x / WARP_SIZE;
     const int lane_id = threadIdx.x % WARP_SIZE;
@@ -49,15 +53,7 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
                 maxval = shared_maxval[lane_id];
                 argmax = shared_argmax[lane_id];
             }
-#pragma unroll
-            for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
-                const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
-                const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
-                if (val > maxval) {
-                    maxval = val;
-                    argmax = col;
-                }
-            }
+            argmax_warp_reduce(maxval, argmax);
         }
     }
 
@@ -69,9 +65,10 @@ static __global__ void argmax_f32(const float * __restrict__ x, int32_t * __rest
 // one warp per chunk of a row, writing the chunk-local (val, idx)
 static __global__ void argmax_f32_chunk(const float * __restrict__ x, float * __restrict__ part_val, int32_t * __restrict__ part_idx,
         const int64_t ncols, const int64_t nchunks) {
-    const int64_t row        = blockIdx.y;
+    const int64_t row        = blockIdx.x / nchunks;
+    const int64_t chunk      = blockIdx.x % nchunks;
     const int64_t chunk_size = (ncols + nchunks - 1) / nchunks;
-    const int64_t beg        = blockIdx.x * chunk_size;
+    const int64_t beg        = chunk * chunk_size;
     const int64_t end        = beg + chunk_size < ncols ? beg + chunk_size : ncols;
 
     float maxval = -FLT_MAX;
@@ -86,29 +83,35 @@ static __global__ void argmax_f32_chunk(const float * __restrict__ x, float * __
         }
     }
 
-#pragma unroll
-    for (int offset = WARP_SIZE/2; offset > 0; offset >>= 1) {
-        const float val = __shfl_xor_sync(0xFFFFFFFF, maxval, offset, WARP_SIZE);
-        const int   col = __shfl_xor_sync(0xFFFFFFFF, argmax, offset, WARP_SIZE);
-        if (val > maxval) {
-            maxval = val;
-            argmax = col;
-        }
-    }
+    argmax_warp_reduce(maxval, argmax);
 
     if (threadIdx.x == 0) {
-        part_val[row*nchunks + blockIdx.x] = maxval;
-        part_idx[row*nchunks + blockIdx.x] = argmax;
+        part_val[row*nchunks + chunk] = maxval;
+        part_idx[row*nchunks + chunk] = argmax;
     }
 }
 
-// map each row's winning chunk back to its column index
-static __global__ void argmax_f32_gather(const int32_t * __restrict__ winner, const int32_t * __restrict__ part_idx,
+// one warp per row, reducing the per-chunk partials to the row's column index
+static __global__ void argmax_f32_combine(const float * __restrict__ part_val, const int32_t * __restrict__ part_idx,
         int32_t * __restrict__ dst, const int64_t nchunks) {
     const int64_t row = blockIdx.x;
-    const int32_t w   = winner[row];
 
-    dst[row] = w < 0 ? -1 : part_idx[row*nchunks + w];
+    float maxval = -FLT_MAX;
+    int   argmax = -1;
+
+    for (int i = threadIdx.x; i < nchunks; i += WARP_SIZE) {
+        const float val = part_val[row*nchunks + i];
+        if (val > maxval) {
+            maxval = val;
+            argmax = part_idx[row*nchunks + i];
+        }
+    }
+
+    argmax_warp_reduce(maxval, argmax);
+
+    if (threadIdx.x == 0) {
+        dst[row] = argmax;
+    }
 }
 
 void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
@@ -122,6 +125,9 @@ void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const int64_t ne00  = src0->ne[0];
     const int64_t nrows = ggml_nrows(src0);
 
+    // the result indices are I32
+    GGML_ASSERT(ne00 <= INT32_MAX);
+
     const float * src0_d = (const float *) src0->data;
     int32_t     * dst_d  = (int32_t     *) dst->data;
 
@@ -134,11 +140,9 @@ void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     if (nchunks >= 4) {
         ggml_cuda_pool_alloc<float>   part_val(ctx.pool(), nrows*nchunks);
         ggml_cuda_pool_alloc<int32_t> part_idx(ctx.pool(), nrows*nchunks);
-        ggml_cuda_pool_alloc<int32_t> winner  (ctx.pool(), nrows);
 
-        argmax_f32_chunk<<<dim3(nchunks, nrows, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(src0_d, part_val.get(), part_idx.get(), ne00, nchunks);
-        argmax_f32<<<dim3(nrows, 1, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(part_val.get(), winner.get(), nchunks);
-        argmax_f32_gather<<<dim3(nrows, 1, 1), dim3(1, 1, 1), 0, stream>>>(winner.get(), part_idx.get(), dst_d, nchunks);
+        argmax_f32_chunk<<<dim3(nrows*nchunks, 1, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(src0_d, part_val.get(), part_idx.get(), ne00, nchunks);
+        argmax_f32_combine<<<dim3(nrows, 1, 1), dim3(WARP_SIZE, 1, 1), 0, stream>>>(part_val.get(), part_idx.get(), dst_d, nchunks);
 
         return;
     }

--- a/ggml/src/ggml-cuda/argmax.cu
+++ b/ggml/src/ggml-cuda/argmax.cu
@@ -140,9 +140,10 @@ void ggml_cuda_argmax(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     int32_t     * dst_d  = (int32_t     *) dst->data;
     cudaStream_t stream = ctx.stream();
 
-    if (ne00 >= ARGMAX_TILE) {
-        const int64_t ntiles = (ne00 + ARGMAX_TILE - 1) / ARGMAX_TILE;
+    // With fewer than 4 tiles the second launch and the combine pass cost more than the parallelism they add.
+    const int64_t ntiles = (ne00 + ARGMAX_TILE - 1) / ARGMAX_TILE;
 
+    if (ntiles >= 4) {
         ggml_cuda_pool_alloc<float>   part_val(ctx.pool(), nrows * ntiles);
         ggml_cuda_pool_alloc<int32_t> part_idx(ctx.pool(), nrows * ntiles);
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8506,6 +8506,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {1024, 12, 1, 1}));
     test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {2000, 10, 1, 1}));
     test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {5438,  3, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {129023, 3, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {151936, 1, 1, 1}));
+    test_cases.emplace_back(new test_argmax(GGML_TYPE_F32, {151936, 8, 1, 1}));
 
     for (int ne3 : {1, 3}) { // CUDA backward pass only supports ne3 == 1
         test_cases.emplace_back(new test_repeat(GGML_TYPE_F32, {10, 5, 4, ne3}, {1, 1, 1, 1}));


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
One block per row leaves most SMs idle when reducing few large rows, e.g. greedy sampling over a vocab-sized row. Reduce chunks of each row to partials first, then argmax the partial rows.

## Test
 Measured with `test-backend-ops perf -o ARGMAX` (RTX 4090, CUDA 12.x)
| shape | master | PR |
| --- | --- | --- |
| [32, 10] | 1.06 us | 1.00 us |
| [1024, 10] | 1.50 us | 1.49 us |
| [32000, 512] | 18.97 us | 15.68 us |
| [151936, 1] | 19.36 us | 3.38 us |
| [151936, 8] | 19.56 us | 3.88 us |
| [1215488, 1] | 143.17 us | 4.43 us |
### SpeedBench (llama.cpp's own `tools/server/bench/speed-bench`)
Target model: Qwen3-8B Q8_0. Draft model: a Qwen3-8B DSpark drafter

 | category | master t/s | PR t/s | speedup | accept_rate |
| --- | --- | --- | --- | --- |
| coding | 182.70 | 183.82 | 1.01x | 0.3433 |
| humanities | 162.68 | 163.43 | 1.00x | 0.2829 |
| math | 173.50 | 174.23 | 1.00x | 0.3128 |
| qa | 173.71 | 174.85 | 1.01x | 0.3138 |
| rag | 190.97 | 192.29 | 1.01x | 0.3669 |
| reasoning | 172.05 | 172.80 | 1.00x | 0.3088 |
| stem | 173.57 | 174.23 | 1.00x | 0.3128 |
| writing | 169.29 | 169.77 | 1.00x | 0.3063 |
| multilingual | 188.90 | 189.75 | 1.00x | 0.3572 |
| summarization | 153.15 | 153.72 | 1.00x | 0.2566 |
| roleplay | 168.05 | 168.53 | 1.00x | 0.2978 |
| **overall** | 174.06 | 174.85 | 1.00x | 0.3158 |


<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
