### PR TITLE
vulkan: apply the AMD driver-timeout submission cap to all GCN parts

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17004,9 +17004,15 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
 
     // On weaker AMD GPUs larger submissions can hit a driver timeout, submit more often to avoid this
     if (ctx->device->vendor_id == VK_VENDOR_ID_AMD && ctx->device->shader_core_count > 0) {
-        if (ctx->device->architecture == AMD_GCN && ctx->device->shader_core_count < 32) {
+        // Apply to all GCN parts, not only small ones. Whether a submission trips the
+        // compute-ring timeout depends on how long it runs, not on the core count, and
+        // the cap is already per-CU so it scales itself. A 36-CU Polaris10 (RX 580) was
+        // excluded by the previous < 32 test and silently produced corrupt output on
+        // large CLIP encodes: the ring timed out, the kernel soft-recovered it, and the
+        // destroyed encode surfaced as garbage tokens with no error reported anywhere.
+        if (ctx->device->architecture == AMD_GCN) {
             flops_cap = 500'000'000ULL * ctx->device->shader_core_count;
-        } else if (ctx->device->architecture != AMD_GCN && ctx->device->shader_core_count < 24) {
+        } else if (ctx->device->shader_core_count < 24) {
             flops_cap = 2'000'000'000ULL * ctx->device->shader_core_count;
         }
     }
@@ -17037,7 +17043,9 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
         submitted_nodes = 0;
         batch_flops = 0;
         if (submit_count < 3) {
-            flops_per_submit *= 2;
+            // Never ramp past flops_cap: that cap exists to keep a single submission
+            // under the driver timeout, and an unbounded doubling can undo it.
+            flops_per_submit = std::min(flops_cap, flops_per_submit * 2);
         }
         submit_count++;
     };


### PR DESCRIPTION
## Overview

The AMD guard that lowers `flops_per_submit` to avoid driver timeouts only applies to GCN parts with fewer than 32 compute units:

```cpp
if (ctx->device->architecture == AMD_GCN && ctx->device->shader_core_count < 32) {
    flops_cap = 500'000'000ULL * ctx->device->shader_core_count;
}
```

A Radeon RX 580 (Polaris10) has 36 CUs, so it is excluded and keeps the 200 GFLOP default. On a large CLIP encode that produces one submission long enough to exceed the compute-ring timeout:

```
amdgpu 0000:01:00.0: ring comp_1.2.1 timeout, but soft recovered
```

The kernel soft-recovers the ring, so nothing crashes and no error is reported anywhere, but the encode is destroyed mid-flight and the model gets a corrupt image embedding. Full-page OCR silently returned runaway `?` instead of a transcription. Setting `GGML_VK_MAX_NODES_PER_SUBMIT=16` works around it, which is what pointed at submission size.

Two changes:

1. Drop the core-count test on the GCN branch. Whether a submission trips the timeout depends on how long it runs, not on how many CUs the part has — a larger GCN card just gets a proportionally larger graph. The cap is already per-CU, so it scales itself. This also covers Fiji and Vega (64 CU), excluded today for the same reason.

2. Clamp the `submit_count < 3` ramp-up to `flops_cap`. It currently doubles without bound, which can carry a submission back over the limit the cap exists to enforce.

## Additional information

Tested on Radeon RX 580, RADV POLARIS10 (Mesa), Qwen3.5-4B Q4_K_M + `mmproj-Qwen3.5-4B-F16`, a 1240x1754 page at 2177 image tokens. Each run on a freshly started server with the page as the first request and the prompt cache disabled.

| | expected strings found | dmesg ring timeouts |
|---|---|---|
| before | 0/9, `?`-ratio 1.000 | yes |
| after | **9/9** | none |

Text generation is unaffected: ~40 tok/s before and after. Sweeping `GGML_VK_MAX_NODES_PER_SUBMIT` on the unpatched build to locate the boundary: 100 and 64 fail, 32/16/8/1 pass, throughput flat at every value — consistent with submission duration being the variable that matters.

Smaller GCN parts already took this path before the change, so their behaviour is unchanged. I have only Polaris hardware, so testing on other GCN parts (Fiji, Vega) would be welcome. If generalising to all GCN is considered too broad on that evidence, raising the threshold from 32 to 40 would fix Polaris without making any claim about the larger parts.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES** — the code change, this description, and the commit message were written with AI assistance (Claude). The root-cause analysis and all measurements above were produced by running the described workload on the RX 580 hardware. Flagging this explicitly since the automated checker already detected it: the maintainers should weigh it as they see fit, and I understand the project asks contributors to write PR text themselves.
