### PR TITLE
common : auto-detect spec type from draft GGUF metadata

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -575,11 +575,13 @@ void common_models_handler_apply(common_models_handler & handler, common_params 
         }
     }
 
-    // infer spec type from draft GGUF metadata when no sidecar or explicit type was given
+    // infer spec type from draft GGUF metadata when no sidecar or explicit type was given.
+    // NOTE: reads only the first split — DSpark drafters are single-file in practice
+    // (~11GB bf16, ~6.5GB Q2K), well below any split threshold.
     if (spec_types_is_default(params) && !params.speculative.draft.mparams.path.empty()) {
         struct gguf_init_params meta_params = {
-            /*.no_alloc =*/ true,
-            /*.ctx      =*/ nullptr,
+            /* .no_alloc = */ true,
+            /* .ctx      = */ nullptr,
         };
         struct gguf_context * gguf_ctx = gguf_init_from_file(params.speculative.draft.mparams.path.c_str(), meta_params);
         if (gguf_ctx) {
@@ -589,8 +591,10 @@ void common_models_handler_apply(common_models_handler & handler, common_params 
                 if (arch == "dflash") {
                     if (gguf_find_tensor(gguf_ctx, "markov_w1.weight") >= 0) {
                         params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK };
+                        LOG_INF("common: auto-detected speculative type 'draft-dspark' from draft model (markov_w1.weight found)\n");
                     } else {
                         params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH };
+                        LOG_INF("common: auto-detected speculative type 'draft-dflash' from draft model\n");
                     }
                 }
             }

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -10,6 +10,7 @@
 #include "sampling.h"
 #include "speculative.h"
 #include "preset.h"
+#include "gguf.h"
 
 // fix problem with std::min and std::max
 #if defined(_WIN32)
@@ -571,6 +572,29 @@ void common_models_handler_apply(common_models_handler & handler, common_params 
             plan_spec.eagle3 = {};
         } else if (!plan_spec.eagle3.local_path.empty()) {
             params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3 };
+        }
+    }
+
+    // infer spec type from draft GGUF metadata when no sidecar or explicit type was given
+    if (spec_types_is_default(params) && !params.speculative.draft.mparams.path.empty()) {
+        struct gguf_init_params meta_params = {
+            /*.no_alloc =*/ true,
+            /*.ctx      =*/ nullptr,
+        };
+        struct gguf_context * gguf_ctx = gguf_init_from_file(params.speculative.draft.mparams.path.c_str(), meta_params);
+        if (gguf_ctx) {
+            int64_t arch_idx = gguf_find_key(gguf_ctx, "general.architecture");
+            if (arch_idx >= 0) {
+                std::string arch = gguf_get_val_str(gguf_ctx, arch_idx);
+                if (arch == "dflash") {
+                    if (gguf_find_tensor(gguf_ctx, "markov_w1.weight") >= 0) {
+                        params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK };
+                    } else {
+                        params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH };
+                    }
+                }
+            }
+            gguf_free(gguf_ctx);
         }
     }
 

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -575,6 +575,7 @@ void common_models_handler_apply(common_models_handler & handler, common_params 
     }
 
     // infer the speculative type from the draft GGUF metadata when none is requested
+    // note: reads only the first split - sharded drafts need an explicit --spec-type
     if (spec_types_is_default(params) && !params.speculative.draft.mparams.path.empty()) {
         const auto types_gguf = common_speculative_types_from_gguf(params.speculative.draft.mparams.path);
         if (!types_gguf.empty()) {

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -10,7 +10,6 @@
 #include "sampling.h"
 #include "speculative.h"
 #include "preset.h"
-#include "gguf.h"
 
 // fix problem with std::min and std::max
 #if defined(_WIN32)
@@ -575,30 +574,11 @@ void common_models_handler_apply(common_models_handler & handler, common_params 
         }
     }
 
-    // infer spec type from draft GGUF metadata when no sidecar or explicit type was given.
-    // NOTE: reads only the first split — DSpark drafters are single-file in practice
-    // (~11GB bf16, ~6.5GB Q2K), well below any split threshold.
+    // infer the speculative type from the draft GGUF metadata when none is requested
     if (spec_types_is_default(params) && !params.speculative.draft.mparams.path.empty()) {
-        struct gguf_init_params meta_params = {
-            /* .no_alloc = */ true,
-            /* .ctx      = */ nullptr,
-        };
-        struct gguf_context * gguf_ctx = gguf_init_from_file(params.speculative.draft.mparams.path.c_str(), meta_params);
-        if (gguf_ctx) {
-            int64_t arch_idx = gguf_find_key(gguf_ctx, "general.architecture");
-            if (arch_idx >= 0) {
-                std::string arch = gguf_get_val_str(gguf_ctx, arch_idx);
-                if (arch == "dflash") {
-                    if (gguf_find_tensor(gguf_ctx, "markov_w1.weight") >= 0) {
-                        params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK };
-                        LOG_INF("common: auto-detected speculative type 'draft-dspark' from draft model (markov_w1.weight found)\n");
-                    } else {
-                        params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH };
-                        LOG_INF("common: auto-detected speculative type 'draft-dflash' from draft model\n");
-                    }
-                }
-            }
-            gguf_free(gguf_ctx);
+        const auto types_gguf = common_speculative_types_from_gguf(params.speculative.draft.mparams.path);
+        if (!types_gguf.empty()) {
+            params.speculative.types = types_gguf;
         }
     }
 

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2,6 +2,7 @@
 
 #include "common.h"
 #include "ggml.h"
+#include "ggml-cpp.h"
 #include "llama.h"
 #include "log.h"
 #include "ngram-cache.h"
@@ -2225,6 +2226,38 @@ common_speculative_type common_speculative_type_from_name(const std::string & na
         return COMMON_SPECULATIVE_TYPE_COUNT;
     }
     return it->second;
+}
+
+std::vector<common_speculative_type> common_speculative_types_from_gguf(const std::string & path) {
+    struct gguf_init_params gguf_params = {
+        /* .no_alloc = */ true,
+        /* .ctx      = */ nullptr,
+    };
+
+    gguf_context_ptr gguf_ctx(gguf_init_from_file(path.c_str(), gguf_params));
+    if (!gguf_ctx) {
+        return {};
+    }
+
+    const int64_t arch_id = gguf_find_key(gguf_ctx.get(), "general.architecture");
+    if (arch_id < 0 || gguf_get_kv_type(gguf_ctx.get(), arch_id) != GGUF_TYPE_STRING) {
+        return {};
+    }
+
+    const std::string arch = gguf_get_val_str(gguf_ctx.get(), arch_id);
+    if (arch != "dflash") {
+        return {};
+    }
+
+    // the Markov head distinguishes draft-dspark from draft-dflash
+    const auto type = gguf_find_tensor(gguf_ctx.get(), "markov_w1.weight") >= 0
+                    ? COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK
+                    : COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH;
+
+    SPC_INF("auto-detected speculative type '%s' from the draft model metadata\n",
+            common_speculative_type_to_str(type).c_str());
+
+    return { type };
 }
 
 static uint32_t common_get_enabled_speculative_configs(const std::vector<common_speculative_type> & configs) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2254,8 +2254,7 @@ std::vector<common_speculative_type> common_speculative_types_from_gguf(const st
                     ? COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK
                     : COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH;
 
-    SPC_INF("auto-detected speculative type '%s' from the draft model metadata\n",
-            common_speculative_type_to_str(type).c_str());
+    SPC_INF("auto-detected speculative type '%s' from the draft model metadata\n", common_speculative_type_to_str(type).c_str());
 
     return { type };
 }

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -14,6 +14,9 @@ const char * common_speculative_all_types_str();
 // parse user provided types
 std::vector<enum common_speculative_type> common_speculative_types_from_names(const std::vector<std::string> & names);
 
+// infer the spec types from the GGUF metadata of a draft model; empty if unknown
+std::vector<enum common_speculative_type> common_speculative_types_from_gguf(const std::string & path);
+
 // convert string to type
 enum common_speculative_type common_speculative_type_from_name(const std::string & name);
 


### PR DESCRIPTION
## Overview

When -md loads a local draft model without --spec-type, the sidecar inference only checks HF repo sidecars and misses local files. The draft model loads into VRAM but speculative decoding never activates (types stays NONE, tok/decode-pass = 1.000).

Reads general.architecture from the draft GGUF header and maps dflash + markov_w1.weight to draft-dspark, dflash without markov to draft-dflash.

Related: #26636 #26339

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - code written with AI assistance, reviewed and understood