### PR TITLE
llama: Restore quantization of mmprojs

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -40,6 +40,8 @@
 
 static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params & params) {
     switch (arch) {
+        case LLM_ARCH_CLIP:
+            return new llama_model_clip(params);
         case LLM_ARCH_LLAMA:
             return new llama_model_llama(params);
         case LLM_ARCH_LLAMA4:

--- a/src/models/clip.cpp
+++ b/src/models/clip.cpp
@@ -1,0 +1,15 @@
+#include "models.h"
+
+// Stub to allow llama-quantize to open mmproj GGUFs
+
+void llama_model_clip::load_arch_hparams(llama_model_loader &) {
+    GGML_ABORT("CLIP is a quant-only stub; load_arch_hparams should not be called");
+}
+
+void llama_model_clip::load_arch_tensors(llama_model_loader &) {
+    GGML_ABORT("CLIP is a quant-only stub; load_arch_tensors should not be called");
+}
+
+std::unique_ptr<llm_graph_context> llama_model_clip::build_arch_graph(const llm_graph_params &) const {
+    GGML_ABORT("CLIP has no inference graph via llama_model dispatch; runtime lives in tools/mtmd/clip.cpp");
+}

--- a/src/models/clip.cpp
+++ b/src/models/clip.cpp
@@ -2,14 +2,17 @@
 
 // Stub to allow llama-quantize to open mmproj GGUFs
 
+[[noreturn]]
 void llama_model_clip::load_arch_hparams(llama_model_loader &) {
     GGML_ABORT("CLIP is a quant-only stub; load_arch_hparams should not be called");
 }
 
+[[noreturn]]
 void llama_model_clip::load_arch_tensors(llama_model_loader &) {
     GGML_ABORT("CLIP is a quant-only stub; load_arch_tensors should not be called");
 }
 
+[[noreturn]]
 std::unique_ptr<llm_graph_context> llama_model_clip::build_arch_graph(const llm_graph_params &) const {
     GGML_ABORT("CLIP has no inference graph via llama_model dispatch; runtime lives in tools/mtmd/clip.cpp");
 }

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -387,10 +387,17 @@ struct llama_model_bloom : public llama_model_base {
 
 
 // Quant-only stub for mmproj GGUFs
+// none of these are ever called, they only exist to satisfy the llama_model_base interface
 struct llama_model_clip : public llama_model_base {
     llama_model_clip(const struct llama_model_params & params) : llama_model_base(params) {}
+
+    [[noreturn]]
     void load_arch_hparams(llama_model_loader & ml) override;
+
+    [[noreturn]]
     void load_arch_tensors(llama_model_loader & ml) override;
+
+    [[noreturn]]
     std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
 };
 

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -386,6 +386,15 @@ struct llama_model_bloom : public llama_model_base {
 };
 
 
+// Quant-only stub for mmproj GGUFs
+struct llama_model_clip : public llama_model_base {
+    llama_model_clip(const struct llama_model_params & params) : llama_model_base(params) {}
+    void load_arch_hparams(llama_model_loader & ml) override;
+    void load_arch_tensors(llama_model_loader & ml) override;
+    std::unique_ptr<llm_graph_context> build_arch_graph(const llm_graph_params & params) const override;
+};
+
+
 struct llama_model_mpt : public llama_model_base {
     llama_model_mpt(const struct llama_model_params & params) : llama_model_base(params) {}
     void load_arch_hparams(llama_model_loader & ml) override;


### PR DESCRIPTION
This was inadvertently lost in the refactor undertaken in #22004.
Fix as discussed offline with @ngxson.

## Overview

Since #22004, mmproj GGUFs cannot be quantized, because the `clip` architecture cannot be loaded. We have reason to believe that larger vision towers may be released and interest for quantized mmproj files might be renewed.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES: triage the issue, assess fix directions.
