### PR TITLE
common : assert tensor existence when loading control vectors

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1903,6 +1903,7 @@ static common_control_vector_data common_control_vector_load_one(const common_co
         }
 
         struct ggml_tensor * tensor = ggml_get_tensor(ctx, name.c_str());
+        GGML_ASSERT(tensor != nullptr);
         if (tensor->type != GGML_TYPE_F32) {
             COM_ERR("invalid (non-F32) direction tensor type in %s\n", load_info.fname.c_str());
             result.n_embd = -1;


### PR DESCRIPTION
While scanning the control vector loader, I noticed we dereference a tensor returned by ggml_get_tensor without a null check.

 The tensor name is taken from the GGUF metadata, so a null indicates a low‑level bug, not a recoverable file error. Added GGML_ASSERT(tensor != nullptr) to fail fast and document the invariant, matching the project’s existing pattern. No impact on valid files; all tests pass.

