### PR TITLE
Update build.md: new Vulkan MSYS2 instruction step and warnings

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -458,6 +458,13 @@ pacman -S git \
     mingw-w64-ucrt-x86_64-spirv-headers
 ```
 
+(Optional) Install the ccache package to speed up recompilation.
+WARNING: Certain build-time issues stem from a bad cache state.
+
+```sh
+pacman -S mingw-w64-ucrt-x86_64-ccache
+```
+
 Switch into the `llama.cpp` directory and build using CMake.
 ```sh
 cmake -B build -DGGML_VULKAN=ON


### PR DESCRIPTION
Formally includes a Vulkan MSYS2 instruction step with WARNINGS for the (optional) package ccache.

## Overview

MSYS2 Vulkan build instructions: Mentions the _optional_ package ccache to speed up recompilation.

## Additional information

1. The package is explicitly marked optional
2. The package ccache caches compilations to speed up recompilation.
3. The package ccache is already checked for during the cmake compilation.
4. Included a warning that some common compilation issues are caused by ccache persistence.
5. Neither CMake nor ccache understands to warn that a bad compilation cache can break recompilation.

This can prevent some bug reports by informing newbies that the ccache package that CMake checks for is explicitly optional, lest they download ccache on their own and immediately corrupt their compilation cache.

## Requirements

No requirements.

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO