### PR TITLE
ggml-cpu : fix CPU affinity mask being ignored on Android

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -2608,7 +2608,7 @@ static bool ggml_thread_apply_priority(int32_t prio) {
     return true;
 }
 
-#elif defined(__gnu_linux__)
+#elif defined(__linux__)
 // TODO: this may not work on BSD, to be verified
 
 static bool ggml_thread_apply_affinity(const bool * mask) {


### PR DESCRIPTION
  ## Overview

  Fixes #26836.

  `-C`/`--cpu-mask` and `--cpu-strict` are silently ignored on Android. The mask is accepted, the process exits 0, nothing is printed, and every thread keeps the full CPU set.

  The affinity implementation in `ggml/src/ggml-cpu/ggml-cpu.c` is guarded by `#elif defined(__gnu_linux__)`, which Clang does not define for Android target triples:

  ```console
  $ echo | aarch64-linux-android28-clang -dM -E - | grep -E '__gnu_linux__|__ANDROID__|__linux__'
  #define __ANDROID__ 1
  #define __linux__ 1
  ```

  Android falls through to the `#else // unsupported platforms` stub, which discards the mask and returns success. That block already contains an `#ifdef __ANDROID__` path calling
  `sched_setaffinity`, so Android support appears to have been intended.

  ```diff
  -#elif defined(__gnu_linux__)
  +#elif defined(__linux__)                                                                                                                                                     
  ```

  ### Before / after

  Per-thread affinity with `-t 2 -C 0xC0 --cpu-strict 1` (requests cpu6-7), read from `/proc/<pid>/task/<tid>/status`:

  ```console
  # before
  Cpus_allowed_list:      0-7
  Cpus_allowed_list:      0-7

  # after
  Cpus_allowed_list:      7
  Cpus_allowed_list:      6                                                                                                                                                     
  ```

  Throughput, `-t 2` held constant, only `-C` varied, runs interleaved. cpu6-7 are the two Cortex-A75 cores, cpu0-5 the six Cortex-A55:

  ```console
  # before
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0xC0 | 1 | tg128 | 22.58 +/- 0.13 |
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0x03 | 1 | tg128 | 22.74 +/- 0.26 |
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0xC0 | 1 | tg128 | 22.70 +/- 0.24 |
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0x03 | 1 | tg128 | 22.90 +/- 0.16 |

  # after
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0xC0 | 1 | tg128 | 22.77 +/- 0.12 |
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0x03 | 1 | tg128 | 11.79 +/- 0.02 |
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0xC0 | 1 | tg128 | 22.86 +/- 0.18 |
  | qwen2 1B Q4_0 | 403.20 MiB | 630.17 M | CPU | 2 | 0x03 | 1 | tg128 | 11.82 +/- 0.01 |
  ```

  Before, all four runs sit within 0.32 t/s of each other, inside the error bars. After, the two core groups separate by 1.93x.

  ## Additional information

  `__gnu_linux__` implies `__linux__`, so this only adds Android; nothing that reached the branch before stops reaching it.

  With no `-C` the mask is all-zero, `ggml_thread_cpumask_is_valid()` returns false, and no syscall is issued, so the default path is unchanged.

  The same guard also un-stubs thread priority. An unprivileged Android process is denied `SCHED_FIFO`, so `--prio` now prints `warn: failed to set thread priority N : Operation not
  permitted (1)` where it was previously silent. I think surfacing the failure is correct, but happy to gate it separately if you prefer.

  No regression test: the bug is Android-only and Android CI builds without executing, so a test would behave identically before and after on every platform CI actually runs. Happy
  to add one if wanted.

  Tested on aarch64, 6x Cortex-A55 (cpu0-5) + 2x Cortex-A75 (cpu6-7), NDK 30.0.15729638, arm64-v8a, android-31, Release.

  ## Requirements                                                                                                                                                               

  - [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
  - AI usage disclosure: YES. I diagnosed the bug and identified the one-line fix, and typed the change. I used an AI assistant to double-check the analysis, to run the Android
  builds and collect the measurements above, and to help draft this description and the linked issue. I have reviewed everything submitted.