### PR TITLE
server: support named tool_choice, and stop swallowing a trailing tool call into content

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -3148,7 +3148,13 @@ static common_chat_params common_chat_params_init_muse_glimmer(const common_chat
         auto analysis = p.ref("analysis");
 
         auto recipient  = p.optional(p.literal(" to=user"));
-        auto final_msg  = p.rule("final", recipient + p.literal("<|message|>") + p.content(p.until("<|eot|>")));
+        // A user-facing turn nominally ends at <|eot|>. In practice the model also ends
+        // it with <|eom|> and continues into a tool call, or simply appends the tool
+        // markup to the prose with no delimiter at all. Stopping only at <|eot|> makes
+        // this greedy: the tool call is swallowed into content and never parsed.
+        auto final_msg  = p.rule("final",
+                                 recipient + p.literal("<|message|>") +
+                                     p.content(p.until_one_of({ "<|eot|>", "<|eom|>", "<atem:function_calls>" })));
 
         if (has_tools && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE) {
             auto string_value = p.ac(
@@ -3186,12 +3192,19 @@ static common_chat_params common_chat_params_init_muse_glimmer(const common_chat
                     args = p.zero_or_more(arg_choice + p.space());
                 }
 
+                // The recipient header is emitted inconsistently: canonically the call is
+                // " to=<tool><|message|><atem:function_calls>", but the model also appends
+                // the markup straight onto a user-facing message with no header at all.
+                // Accept either so the call is parsed rather than left in content.
+                auto call_header = p.optional(p.literal(" to=") + p.until("<|message|>") + p.literal("<|message|>"));
+
                 auto tool_parser = p.tool(
-                    p.tool_open(p.literal(" to=") + p.until("<|message|>") +
-                                p.literal("<|message|><atem:function_calls>") + p.space() +
+                    p.tool_open(call_header +
+                                p.literal("<atem:function_calls>") + p.space() +
                                 p.literal("<atem:invoke name=\"") + p.tool_name(p.literal(name)) + p.literal("\">") + p.space())
                     << p.tool_args(args)
                     << p.tool_close(p.literal("</atem:invoke>") + p.space() + p.literal("</atem:function_calls>")));
+
 
                 tool_choice |= p.rule("tool-" + name, tool_parser);
             });
@@ -3204,7 +3217,12 @@ static common_chat_params common_chat_params_init_muse_glimmer(const common_chat
             if (inputs.tool_choice == COMMON_CHAT_TOOL_CHOICE_REQUIRED) {
                 return p.zero_or_more(start + analysis) + start + tool_calls;
             }
-            return p.zero_or_more(start + analysis) + start + (tool_calls | final_msg);
+            // A turn may be content, tool calls, or content followed by tool calls. The
+            // delimiters between the two halves are unreliable — sometimes <|eom|> and a
+            // fresh <|start|>assistant header, sometimes nothing at all — so treat both
+            // as optional rather than dropping the call.
+            auto trailing_calls = p.optional(p.optional(p.literal("<|eom|>")) + p.optional(start) + tool_calls);
+            return p.zero_or_more(start + analysis) + start + (tool_calls | (final_msg + trailing_calls));
         }
 
         return p.zero_or_more(start + analysis) + start + final_msg;

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -912,7 +912,54 @@ json oaicompat_chat_params_parse(
     auto tools = json_value(body, "tools", json());
     auto has_tools = tools.is_array() && !tools.empty();
     auto stream = json_value(body, "stream", false);
-    auto tool_choice = json_value(body, "tool_choice", std::string("auto"));
+
+    // `tool_choice` is either a string ("auto" / "none" / "required") or, to force one
+    // specific function, an object: {"type":"function","function":{"name":"..."}}.
+    //
+    // json_value() only understands the string form: given the object it logs a type
+    // warning and silently falls back to "auto". That downgrade is invisible to the
+    // caller and, for templates whose grammar is lazy under "auto", means nothing
+    // constrains the model to emit a tool call at all.
+    //
+    // Named choice is "call exactly this function", so narrow `tools` to that one entry
+    // and treat it as "required". The grammar then admits only that call, which is the
+    // OpenAI semantics and needs no per-template support.
+    std::string tool_choice = "auto";
+    if (body.contains("tool_choice") && !body.at("tool_choice").is_null()) {
+        const auto & tc = body.at("tool_choice");
+        if (tc.is_string()) {
+            tool_choice = tc.get<std::string>();
+        } else if (tc.is_object()) {
+            const std::string tc_type = json_value(tc, "type", std::string());
+            if (tc_type != "function") {
+                throw std::invalid_argument("Invalid tool_choice: object form must have type \"function\"");
+            }
+            if (!tc.contains("function") || !tc.at("function").is_object()) {
+                throw std::invalid_argument("Invalid tool_choice: missing \"function\" object");
+            }
+            const std::string tc_name = json_value(tc.at("function"), "name", std::string());
+            if (tc_name.empty()) {
+                throw std::invalid_argument("Invalid tool_choice: missing function name");
+            }
+            if (!has_tools) {
+                throw std::invalid_argument("tool_choice names a function but no tools were provided");
+            }
+
+            json filtered = json::array();
+            for (const auto & tool : tools) {
+                if (tool.contains("function") && json_value(tool.at("function"), "name", std::string()) == tc_name) {
+                    filtered.push_back(tool);
+                }
+            }
+            if (filtered.empty()) {
+                throw std::invalid_argument("tool_choice names function \"" + tc_name + "\" which is not in tools");
+            }
+            tools       = filtered;
+            tool_choice = "required";
+        } else {
+            throw std::invalid_argument("Invalid tool_choice: expected a string or an object");
+        }
+    }
 
     if (!opt.use_jinja) {
         if (has_tools) {


### PR DESCRIPTION
Two server-side tool-calling bugs, found while exercising the Muse Glimmer chat handler against a multi-turn agentic benchmark. The first is generic and affects every model; the second is specific to the Muse Glimmer parser.

## 1. Named `tool_choice` was silently downgraded to `"auto"`

`tool_choice` may be a string (`"auto"` / `"none"` / `"required"`) or, to force one specific function, an object:

```json
"tool_choice": {"type": "function", "function": {"name": "get_weather"}}
```

`json_value()` only understands the string form. Given the object it logs a type warning and returns the default `"auto"`, so the request is served as if no choice had been made — nothing surfaces to the caller.

That is not cosmetic for templates whose grammar is lazy under `"auto"`. The Muse Glimmer handler only arms its grammar once this trigger matches:

```
<|start|>assistant( to=(?!self<|message|>)(?!user<|message|>)[^<]*?<|message|>)
```

Asked to call a tool with empty arguments, the model writes the call *without* the `<|start|>assistant` header and never leaves the analysis channel:

```
to=skill<|message|><atem:function_calls>
<atem:invoke name="skill"></atem:invoke>
</atem:function_calls>
```

The trigger never fires, the grammar never arms, and the call stays buried in `reasoning_content` — `finish_reason: "stop"`, no `tool_calls`. Deterministic at temperature 0. `tool_choice: "required"` was unaffected because that path builds a non-lazy grammar.

**Fix:** parse the object form, narrow `tools` to the named function and map it to `"required"`. The grammar is then non-lazy and admits only that call, which is the OpenAI semantics and needs no per-template changes. Malformed `tool_choice` now returns 400 instead of silently behaving as `"auto"`.

## 2. A trailing tool call was swallowed into `message.content`

The Muse Glimmer parser read assistant content with `until("<|eot|>")`. The model routinely answers the user *and* calls a tool in one generation, and there is no `<|eot|>` before the call — so content ran to the end of the generation and absorbed the tool markup, which was then delivered to the user as chat text.

On a multi-turn agentic run this leaked raw tool markup into the visible reply on 43 turns across 19 of 113 tasks (~17% of tasks affected).

**Fix:** make content stop at `<|eom|>` / `<atem:function_calls>`, make the `to=<tool><|message|>` header optional, and allow content-then-tool-call with both delimiters optional.

## Testing

Against the Muse Glimmer 30B bf16 weights:

| case | before | after |
|---|---|---|
| named `tool_choice`, empty args | `finish_reason: stop`, no `tool_calls` | `tool_calls: skill {}` |
| named `tool_choice`, with args | ok | unchanged |
| named `tool_choice`, no-parameter tool | ok | unchanged |
| `tool_choice: "required"` (2 cases) | ok | unchanged |
| 5 malformed `tool_choice` inputs | silently treated as `"auto"` | 400 with a specific message |

Re-running the 19 tasks that leaked tool markup: 19/19 leaking → 0/19, and 43 leaked turns → 0 of 425.
