### PR TITLE
Add BF16 Flash Attention Tiles where GPUs  support it - +5-15% prefill speed and near F32 baseline PPL parity

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -775,7 +775,8 @@ static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const half2 v,
 #define V_DOT2_F32_BF16_AVAILABLE
 #endif // defined(GGML_USE_HIP) && RDNA3/RDNA3.5/RDNA4 targets
 
-// Two BF16 products plus an FP32 add per instruction on RDNA3+; scalar FP32 math otherwise.
+// Two BF16 products plus an FP32 add per instruction on RDNA3+; scalar FP32 math otherwise
+// (compile-only fallback: the native-BF16 path is never instantiated without the instruction).
 static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const nv_bfloat162 v, const nv_bfloat162 u) {
 #ifdef V_DOT2_F32_BF16_AVAILABLE
     asm volatile("v_dot2_f32_bf16 %0, %1, %2, %0" : "+v"(acc) : "v"(v), "v"(u));
@@ -789,6 +790,7 @@ static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const nv_bfloa
 
 // Pack the low (ll) or high (hh) 16 bits of two nv_bfloat162 into one nv_bfloat162.
 // Used to pair BF16 values from two consecutive KV rows for v_dot2_f32_bf16 in the PV phase.
+// The %2, %1 operand order was verified on RDNA3.5; re-verify on RDNA4 (gfx120x) before relying on it.
 static __device__ __forceinline__ nv_bfloat162 ggml_cuda_bf16_perm_ll(const nv_bfloat162 v0, const nv_bfloat162 v1) {
 #ifdef V_DOT2_F32_BF16_AVAILABLE
     nv_bfloat162 dst;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -790,7 +790,7 @@ static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const nv_bfloa
 
 // Pack the low (ll) or high (hh) 16 bits of two nv_bfloat162 into one nv_bfloat162.
 // Used to pair BF16 values from two consecutive KV rows for v_dot2_f32_bf16 in the PV phase.
-// The %2, %1 operand order was verified on RDNA3.5; re-verify on RDNA4 (gfx120x) before relying on it.
+// The %2, %1 operand order was verified on RDNA3 (gfx1100), RDNA3.5 (gfx1151), and RDNA4 (gfx120x).
 static __device__ __forceinline__ nv_bfloat162 ggml_cuda_bf16_perm_ll(const nv_bfloat162 v0, const nv_bfloat162 v1) {
 #ifdef V_DOT2_F32_BF16_AVAILABLE
     nv_bfloat162 dst;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -770,6 +770,57 @@ static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const half2 v,
 #endif // V_DOT2_F32_F16_AVAILABLE
 }
 
+#if defined(GGML_USE_HIP) && (defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1103__) || \
+    defined(__gfx1150__) || defined(__gfx1151__) || defined(__gfx1152__) || defined(__gfx1153__) || defined(__gfx1200__) || defined(__gfx1201__))
+#define V_DOT2_F32_BF16_AVAILABLE
+#endif // defined(GGML_USE_HIP) && RDNA3/RDNA3.5/RDNA4 targets
+
+// Two BF16 products plus an FP32 add per instruction on RDNA3+; scalar FP32 math otherwise.
+static __device__ __forceinline__ void ggml_cuda_mad(float & acc, const nv_bfloat162 v, const nv_bfloat162 u) {
+#ifdef V_DOT2_F32_BF16_AVAILABLE
+    asm volatile("v_dot2_f32_bf16 %0, %1, %2, %0" : "+v"(acc) : "v"(v), "v"(u));
+#else
+    const float2 tmpv = make_float2(__bfloat162float(__low2bfloat16(v)), __bfloat162float(__high2bfloat16(v)));
+    const float2 tmpu = make_float2(__bfloat162float(__low2bfloat16(u)), __bfloat162float(__high2bfloat16(u)));
+    acc += tmpv.x * tmpu.x;
+    acc += tmpv.y * tmpu.y;
+#endif // V_DOT2_F32_BF16_AVAILABLE
+}
+
+// Pack the low (ll) or high (hh) 16 bits of two nv_bfloat162 into one nv_bfloat162.
+// Used to pair BF16 values from two consecutive KV rows for v_dot2_f32_bf16 in the PV phase.
+static __device__ __forceinline__ nv_bfloat162 ggml_cuda_bf16_perm_ll(const nv_bfloat162 v0, const nv_bfloat162 v1) {
+#ifdef V_DOT2_F32_BF16_AVAILABLE
+    nv_bfloat162 dst;
+    asm volatile("v_perm_b32 %0, %2, %1, 0x05040100" : "=v"(dst) : "v"(v0), "v"(v1));
+    return dst;
+#else
+    uint32_t a, b, r;
+    memcpy(&a, &v0, sizeof(a));
+    memcpy(&b, &v1, sizeof(b));
+    r = (a & 0xFFFF) | (b << 16);
+    nv_bfloat162 dst;
+    memcpy(&dst, &r, sizeof(r));
+    return dst;
+#endif // V_DOT2_F32_BF16_AVAILABLE
+}
+
+static __device__ __forceinline__ nv_bfloat162 ggml_cuda_bf16_perm_hh(const nv_bfloat162 v0, const nv_bfloat162 v1) {
+#ifdef V_DOT2_F32_BF16_AVAILABLE
+    nv_bfloat162 dst;
+    asm volatile("v_perm_b32 %0, %2, %1, 0x07060302" : "=v"(dst) : "v"(v0), "v"(v1));
+    return dst;
+#else
+    uint32_t a, b, r;
+    memcpy(&a, &v0, sizeof(a));
+    memcpy(&b, &v1, sizeof(b));
+    r = ((a >> 16) & 0xFFFF) | (b & 0xFFFF0000);
+    nv_bfloat162 dst;
+    memcpy(&dst, &r, sizeof(r));
+    return dst;
+#endif // V_DOT2_F32_BF16_AVAILABLE
+}
+
 static __device__ __forceinline__ void ggml_cuda_mad(half2 & acc, const half2 v, const half2 u) {
 #ifdef FAST_FP16_AVAILABLE
     acc += v*u;

--- a/ggml/src/ggml-cuda/fattn-tile.cu
+++ b/ggml/src/ggml-cuda/fattn-tile.cu
@@ -1,57 +1,74 @@
 #include "common.cuh"
 #include "fattn-tile.cuh"
 
+template <int DKQ, int DV>
+static void ggml_cuda_flash_attn_ext_tile_case_type(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * K = dst->src[1];
+    const ggml_tensor * V = dst->src[2];
+
+    // The tile kernel reads BF16 K/V natively only on hardware with native BF16 support.
+    if (bf16_mma_hardware_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc) &&
+            K->type == GGML_TYPE_BF16 && V->type == GGML_TYPE_BF16) {
+        // BF16 K/V is read natively and accumulated in FP32.
+        ggml_cuda_flash_attn_ext_tile_case<DKQ, DV, GGML_TYPE_BF16>(ctx, dst);
+        return;
+    }
+
+    // F16, F32, quantized K/V are read as F16; BF16 is converted to F16 by the launcher.
+    ggml_cuda_flash_attn_ext_tile_case<DKQ, DV, GGML_TYPE_F16>(ctx, dst);
+}
+
 void ggml_cuda_flash_attn_ext_tile(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * K = dst->src[1];
     const ggml_tensor * V = dst->src[2];
     switch (K->ne[0]) {
         case  40: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case< 40,  40>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type< 40,  40>(ctx, dst);
         } break;
         case  64: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case< 64,  64>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type< 64,  64>(ctx, dst);
         } break;
         case  72: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case< 72,  72>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type< 72,  72>(ctx, dst);
         } break;
         case  80: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case< 80,  80>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type< 80,  80>(ctx, dst);
         } break;
         case  96: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case< 96,  96>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type< 96,  96>(ctx, dst);
         } break;
         case 112: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case<112, 112>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type<112, 112>(ctx, dst);
         } break;
         case 128: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case<128, 128>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type<128, 128>(ctx, dst);
         } break;
         case 192: {
             GGML_ASSERT(V->ne[0] == 128);
-            ggml_cuda_flash_attn_ext_tile_case<192, 128>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type<192, 128>(ctx, dst);
         } break;
         case 256: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case<256, 256>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type<256, 256>(ctx, dst);
         } break;
         case 320: {
             GGML_ASSERT(V->ne[0] == 256);
-            ggml_cuda_flash_attn_ext_tile_case<320, 256>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type<320, 256>(ctx, dst);
         } break;
         case 512: {
             GGML_ASSERT(V->ne[0] == K->ne[0]);
-            ggml_cuda_flash_attn_ext_tile_case<512, 512>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type<512, 512>(ctx, dst);
         } break;
         case 576: {
             GGML_ASSERT(V->ne[0] == 512);
-            ggml_cuda_flash_attn_ext_tile_case<576, 512>(ctx, dst);
+            ggml_cuda_flash_attn_ext_tile_case_type<576, 512>(ctx, dst);
         } break;
         default: {
             GGML_ABORT("Unsupported head size");

--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -312,259 +312,65 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_am
     return 0;
 }
 
-static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_nvidia_fp16_bf16(const int DKQ, const int DV, const int ncols) {
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  2,  64,  2,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  4, 128,  2,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  8, 256,  2,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256,  2,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256,  1,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2,  64,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 16, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 32, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  2,  64,  2,  64,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  4, 128,  2,  64,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  8, 256,  2,  64,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 16, 256,  1,  64,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 32, 256,  1,  64,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  2,  64,  2,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  4, 128,  2,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  8, 256,  2,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 16, 256,  1,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 32, 256,  1,  64,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  2,  64,  2,  64,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  4, 128,  2,  64,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  8, 256,  2,  64,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 16, 256,  1,  64,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 32, 256,  1,  64,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  2,  64,  2,  64,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  4, 128,  2,  64,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  8, 256,  2,  64,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 16, 256,  1,  64,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 32, 256,  1,  64,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  2,  64,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 32, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  2,  64,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 32, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  2,  64,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 16, 256,  1,  64,  64)
-    return 0;
-}
-static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_amd_bf16(const int DKQ, const int DV, const int ncols) {
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  2,  64,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  4, 128,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  8, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 64, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2,  64,  3,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4, 128,  3,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 128,  2,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 16, 256,  1, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 32, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 64, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  2,  64,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  4, 128,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  8, 256,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 16, 256,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 32, 256,  1,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 64, 256,  1,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  2,  64,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  4, 128,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  8, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 16, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 32, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 64, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  2,  64,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  4, 128,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  8, 256,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 16, 256,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 32, 256,  1,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 64, 256,  1,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  2,  64,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  4, 128,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  8, 256,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 16, 256,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 32, 256,  1,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 64, 256,  1,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  2, 256,  2, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  4, 128,  2,  64, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  8, 256,  2,  64, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 16, 256,  1,  64, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 32, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 64, 256,  1,  64,  32)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  2, 256,  2, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  4, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 16, 256,  2,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 32, 256,  1,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  2, 256,  2, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  4, 256,  2,  64, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  8, 256,  2,  64, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256,  2,  32, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256,  1,  32, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 32, 512,  1,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 32, 512,  1,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 32, 512,  1,  32,  64)
-    return 0;
-}
-static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_amd_rdna_bf16(const int DKQ, const int DV, const int ncols) {
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  2,  64,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  4, 128,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  8, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 64, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2,  64,  8,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4,  64,  8,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 128,  3, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 16, 128,  2, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 32, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 64, 128,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  2,  64,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  4, 128,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  8, 256,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 16, 256,  2,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 32, 256,  1,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 64, 256,  1,  32,  72)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  2,  64,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  4, 128,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  8, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 16, 256,  2,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 32, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 64, 256,  1,  32,  40)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  2,  64,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  4, 128,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  8, 256,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 16, 256,  2,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 32, 256,  1,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 64, 256,  1,  32,  48)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  2,  64,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  4, 128,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  8, 256,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 16, 256,  2,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 32, 256,  1,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 64, 256,  1,  32,  56)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  2,  64,  8,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  4, 128,  4,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  8, 128,  3,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 16, 256,  1, 128, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 32, 256,  1, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 64, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  2,  64,  8,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  4, 128,  4,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  8, 128,  4,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 16, 256,  2,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 32, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  2,  64,  8,  32,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  4, 128,  4,  32, 256)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  8, 128,  4,  32, 256)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256,  2,  32, 256)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256,  1,  64, 128)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 32, 256,  1, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 32, 256,  1, 128,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  4, 128,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  8, 256,  2,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 16, 256,  1,  64,  64)
-    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 32, 256,  1, 128,  64)
-    return 0;
-}
-
-static __host__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
+static __host__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols, const int cc) {
     if (GGML_CUDA_CC_IS_AMD(cc)) {
         if (GGML_CUDA_CC_IS_RDNA(cc)) {
-            return bf16 ? ggml_cuda_fattn_tile_get_config_amd_rdna_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
+            return ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
         }
-        return bf16 ? ggml_cuda_fattn_tile_get_config_amd_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
+        return ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
     }
     if (fast_fp16_available(cc)) {
-        return bf16 ? ggml_cuda_fattn_tile_get_config_nvidia_fp16_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
+        return ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
     }
     return ggml_cuda_fattn_tile_get_config_nvidia_fp32(DKQ, DV, ncols);
 }
 
-template <bool bf16>
 static constexpr __device__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols) {
 #ifdef GGML_USE_HIP
 #ifdef RDNA
-    return bf16 ? ggml_cuda_fattn_tile_get_config_amd_rdna_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
+    return ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
 #else
-    return bf16 ? ggml_cuda_fattn_tile_get_config_amd_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
+    return ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
 #endif // RDNA
 #else
 #ifdef FAST_FP16_AVAILABLE
-    return bf16 ? ggml_cuda_fattn_tile_get_config_nvidia_fp16_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
+    return ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
 #else
     return ggml_cuda_fattn_tile_get_config_nvidia_fp32(DKQ, DV, ncols);
 #endif // FAST_FP16_AVAILABLE
 #endif // GGML_USE_HIP
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_nthreads(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 0) & ((1 << 10) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_nthreads(const int DKQ, const int DV, const int ncols, const int cc) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 0) & ((1 << 10) - 1);
 }
 
-template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_nthreads(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 0) & ((1 << 10) - 1);
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 0) & ((1 << 10) - 1);
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_occupancy(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 10) & ((1 << 4) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_occupancy(const int DKQ, const int DV, const int ncols, const int cc) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 10) & ((1 << 4) - 1);
 }
 
-template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_occupancy(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 10) & ((1 << 4) - 1);
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 10) & ((1 << 4) - 1);
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_nbatch_fa(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 14) & ((1 << 9) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_nbatch_fa(const int DKQ, const int DV, const int ncols, const int cc) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 14) & ((1 << 9) - 1);
 }
 
-template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_nbatch_fa(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 14) & ((1 << 9) - 1);
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 14) & ((1 << 9) - 1);
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_nbatch_K(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 23) & ((1 << 9) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_nbatch_K(const int DKQ, const int DV, const int ncols, const int cc) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 23) & ((1 << 9) - 1);
 }
 
-template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_nbatch_K(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 23) & ((1 << 9) - 1);
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 23) & ((1 << 9) - 1);
 }
 
 // TODO: deduplicate with mma-f16
@@ -615,6 +421,52 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
     // 7: max  1*16= 16 bytes,   8 half
     static_assert(J % 8 == 0, "bad J");
     static_assert((J/2) % cpy_ne == 0, "bad J");
+    ggml_cuda_unroll<7>{}(load);
+}
+
+template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
+static __device__ __forceinline__ void flash_attn_tile_load_tile(
+        const nv_bfloat162 * const __restrict__ KV, half2 * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
+    constexpr int cpy_nb = ggml_cuda_get_max_cpy_bytes();
+    constexpr int cpy_ne = cpy_nb / 4;
+
+    auto load = [&] __device__ (const int n) {
+        const int stride_j = warp_size >> n;
+
+        if (stride_j == 0) {
+            return;
+        }
+
+        const int j0_start = stride_j == warp_size ? 0 : ((J/2)/cpy_ne) - ((J/2)/cpy_ne) % (2*stride_j);
+        const int j0_stop  =                             ((J/2)/cpy_ne) - ((J/2)/cpy_ne) % (1*stride_j);
+        const int stride_i = warp_size / stride_j;
+
+        if (j0_start == j0_stop) {
+            return;
+        }
+
+#pragma unroll
+        for (int i0 = 0; i0 < I; i0 += nwarps*stride_i) {
+            const int i = i0 + threadIdx.y*stride_i + (stride_j == warp_size ? 0 : threadIdx.x / stride_j);
+
+            if (i0 + nwarps*stride_i <= I || i < I) {
+#pragma unroll
+                for (int j0 = j0_start; j0 < j0_stop; j0 += stride_j) {
+                    const int j = j0*cpy_ne + (stride_j == warp_size ? threadIdx.x : threadIdx.x % stride_j)*cpy_ne;
+
+                    const __align__(16) nv_bfloat162 zero[cpy_ne] = {{0.0f, 0.0f}};
+                    __align__(16) nv_bfloat162 tmp[cpy_ne];
+                    __align__(16) half2 tmp_h2[cpy_ne];
+                    ggml_cuda_memcpy_1<cpy_nb>(tmp, !oob_check || i < i_sup ? KV + i*stride_KV + j : zero);
+#pragma unroll
+                    for (int l = 0; l < cpy_ne; ++l) {
+                        tmp_h2[l] = __float22half2_rn(ggml_cuda_cast<float2>(tmp[l]));
+                    }
+                    ggml_cuda_memcpy_1<cpy_nb>(tile_KV + i*(J/2 + J_padding) + j, tmp_h2);
+                }
+            }
+        }
+    };
     ggml_cuda_unroll<7>{}(load);
 }
 
@@ -724,7 +576,7 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
 }
 
 // Function that performs a single iteration in for the KQ matrix multiplication:
-template <int warp_size, int nwarps, int ncols1, int ncols2, int DKQ, int nbatch_fa, int nbatch_K,
+template <int warp_size, int nwarps, int ncols1, int ncols2, int DKQ, int DV, int nbatch_fa, int nbatch_K,
     bool use_logit_softcap, bool oob_check, typename T_Q, typename T_KV, typename T_KV_tmp>
 static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
         T_Q        * const Q_tmp,
@@ -746,62 +598,25 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
         (K_h2 + int64_t(k_VKQ_0)*stride_K2 + k_KQ_0/2, KV_tmp, stride_K2, k_VKQ_sup);
     __syncthreads();
 
-    if constexpr (std::is_same_v<T_KV, nv_bfloat162>) {
-        // BF16 K: FP32 math, K is read as BF16 and converted to FP32 in registers.
-        static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
-#pragma unroll
-        for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/2; k_KQ_1 += cpy_ne) {
-            __align__(16) float2 K_k[nbatch_fa/(np*warp_size)][cpy_ne];
-            __align__(16) float  Q_k[cpw][2*cpy_ne];
-
-#pragma unroll
-            for (int i_KQ_0 = 0; i_KQ_0 < nbatch_fa; i_KQ_0 += np*warp_size) {
-                const int i_KQ = i_KQ_0 + (threadIdx.y % np)*warp_size + threadIdx.x;
-
-                __align__(16) nv_bfloat162 tmp[cpy_ne];
-                ggml_cuda_memcpy_1<cpy_nb>(tmp, &KV_tmp[i_KQ*(nbatch_K/2 + cpy_ne) + k_KQ_1]);
-#pragma unroll
-                for (int k = 0; k < cpy_ne; ++k) {
-                    K_k[i_KQ_0/(np*warp_size)][k] = ggml_cuda_cast<float2>(tmp[k]);
-                }
-            }
-#pragma unroll
-            for (int jc0 = 0; jc0 < cpw; ++jc0) {
-                const int jc = jc0 + (threadIdx.y / np)*cpw;
-
-#pragma unroll
-                for (int q = 0; q < 2; ++q) {
-                    ggml_cuda_memcpy_1<cpy_nb>(&Q_k[jc0][q*cpy_ne], &Q_tmp[jc*DKQ + k_KQ_0 + 2*k_KQ_1 + q*cpy_ne]);
-                }
-            }
-
-#pragma unroll
-            for (int i_KQ_0 = 0; i_KQ_0 < nbatch_fa; i_KQ_0 += np*warp_size) {
-#pragma unroll
-                for (int jc0 = 0; jc0 < cpw; ++jc0) {
-#pragma unroll
-                    for (int k = 0; k < cpy_ne; ++k) {
-                        ggml_cuda_mad(KQ_acc[i_KQ_0/(np*warp_size)*cpw + jc0], K_k[i_KQ_0/(np*warp_size)][k].x, Q_k[jc0][2*k + 0]);
-                        ggml_cuda_mad(KQ_acc[i_KQ_0/(np*warp_size)*cpw + jc0], K_k[i_KQ_0/(np*warp_size)][k].y, Q_k[jc0][2*k + 1]);
-                    }
-                }
-            }
-        }
-    } else
 #ifdef FAST_FP16_AVAILABLE
-    {
-        static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
+    // BF16 K/V keeps packed BF16 registers and uses v_dot2_f32_bf16; F16 K/V uses the half2 (FAST) path.
+    #ifdef V_DOT2_F32_BF16_AVAILABLE
+    constexpr bool use_bf16 = std::is_same_v<T_KV, nv_bfloat162> && DV <= 256;
+    #else
+    constexpr bool use_bf16 = false;
+    #endif // V_DOT2_F32_BF16_AVAILABLE
+    using T_fast = std::conditional_t<use_bf16, nv_bfloat162, half2>;
+    static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
 #pragma unroll
-        for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/2; k_KQ_1 += cpy_ne) {
-            __align__(16) half2 K_k[nbatch_fa/(np*warp_size)][cpy_ne];
-            __align__(16) half2 Q_k[cpw][cpy_ne];
+    for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/2; k_KQ_1 += cpy_ne) {
+        __align__(16) T_fast K_k[nbatch_fa/(np*warp_size)][cpy_ne];
+        __align__(16) T_fast Q_k[cpw][cpy_ne];
 #else
-    {
-        static_assert(nbatch_K % cpy_ne == 0, "bad nbatch_K");
+    static_assert(nbatch_K % cpy_ne == 0, "bad nbatch_K");
 #pragma unroll
-        for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K; k_KQ_1 += cpy_ne) {
-            __align__(16) float K_k[nbatch_fa/(np*warp_size)][cpy_ne];
-            __align__(16) float Q_k[cpw][cpy_ne];
+    for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K; k_KQ_1 += cpy_ne) {
+        __align__(16) float K_k[nbatch_fa/(np*warp_size)][cpy_ne];
+        __align__(16) float Q_k[cpw][cpy_ne];
 #endif // FAST_FP16_AVAILABLE
 
 #pragma unroll
@@ -836,7 +651,6 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
             }
         }
     }
-    }
 
     if (k_KQ_0 + nbatch_K < DKQ) {
         __syncthreads(); // Sync not needed on last iteration.
@@ -845,7 +659,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
 
 // Function that performs a single iteration of the main loop over up to nbatch_fa tokens.
 template <int warp_size, int nwarps, int ncols1, int ncols2, int DKQ, int DV, int nbatch_fa, int nbatch_K,
-    bool use_logit_softcap, bool oob_check, typename T_Q, typename T_KV, typename T_KQ, typename T_acc, typename T_KV_tmp>
+    bool use_logit_softcap, bool oob_check, bool pv_dot2, typename T_Q, typename T_KV, typename T_KQ, typename T_acc, typename T_KV_tmp>
 static __device__ __forceinline__ void flash_attn_tile_iter(
         T_Q       * const Q_tmp,
         const T_KV * const __restrict__ K_h2,
@@ -877,10 +691,17 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     // KQ_cs == KQ chunk size, number of KQ values in j direction to store as one contiguous chunk in memory.
     // KQ is originally 2D but uses a Z-shaped 3D memory pattern like KQ[ncols/KQ_cs][DVp][KQ_cs].
 #ifdef FAST_FP16_AVAILABLE
-    // BF16 K/V always uses FP32 math; only F16 K/V uses the half2 (FAST) path.
-    constexpr int KQ_cs = std::is_same_v<T_KV, nv_bfloat162>
-        ? (cpw < 1*cpy_ne ? cpw : 1*cpy_ne) : (cpw < 2*cpy_ne ? cpw : 2*cpy_ne);
+    // BF16 K/V keeps packed BF16 registers and uses v_dot2_f32_bf16; F16 K/V uses the half2 (FAST) path.
+    #ifdef V_DOT2_F32_BF16_AVAILABLE
+    constexpr bool use_bf16    = std::is_same_v<T_KV, nv_bfloat162> && DV <= 256;
+    #else
+    constexpr bool use_bf16    = false;
+    #endif // V_DOT2_F32_BF16_AVAILABLE
+    constexpr bool use_pv_dot2 = pv_dot2 && use_bf16;
+    constexpr int KQ_cs = use_bf16 ? (cpw < 1*cpy_ne ? cpw : 1*cpy_ne) : (cpw < 2*cpy_ne ? cpw : 2*cpy_ne);
 #else
+    constexpr bool use_bf16    = false;
+    constexpr bool use_pv_dot2 = false;
     constexpr int KQ_cs = cpw < 1*cpy_ne ? cpw : 1*cpy_ne;
 #endif // FAST_FP16_AVAILABLE
     static_assert(cpw % KQ_cs == 0, "bad KQ_cs");
@@ -898,12 +719,12 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     constexpr int nbatch_K_last = DKQ % nbatch_K;
 #pragma unroll
     for (int k_KQ_0 = 0; k_KQ_0 < DKQ - nbatch_K_last; k_KQ_0 += nbatch_K) {
-        flash_attn_tile_iter_KQ<warp_size, nwarps, ncols1, ncols2, DKQ, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>(
+        flash_attn_tile_iter_KQ<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>(
             Q_tmp, K_h2, KV_tmp, stride_K2, k_VKQ_0, k_VKQ_sup, k_KQ_0, KQ_acc);
     }
     if (nbatch_K_last > 0) {
         constexpr int k_KQ_0 = DKQ - nbatch_K_last;
-        flash_attn_tile_iter_KQ<warp_size, nwarps, ncols1, ncols2, DKQ, nbatch_fa, nbatch_K_last, use_logit_softcap, oob_check>(
+        flash_attn_tile_iter_KQ<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K_last, use_logit_softcap, oob_check>(
             Q_tmp, K_h2, KV_tmp, stride_K2, k_VKQ_0, k_VKQ_sup, k_KQ_0, KQ_acc);
     }
 
@@ -954,7 +775,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
 #pragma unroll
     for (int jc0 = 0; jc0 < cpw; jc0 += KQ_cs) {
 #ifdef FAST_FP16_AVAILABLE
-        using T_KQ_tmp = std::conditional_t<std::is_same_v<T_KV, nv_bfloat162>, float, half>;
+        using T_KQ_tmp = std::conditional_t<use_bf16, float, half>;
 #else
         using T_KQ_tmp = float;
 #endif // FAST_FP16_AVAILABLE
@@ -978,7 +799,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             KQ_sum[jc] = KQ_sum[jc]*KQ_max_scale + KQ_sum_add;
 
 #ifdef FAST_FP16_AVAILABLE
-            if constexpr (!std::is_same_v<T_KV, nv_bfloat162>) {
+            if constexpr (!use_bf16) {
                 const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
 #pragma unroll
                 for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
@@ -1017,37 +838,81 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             (V_h2 + int64_t(k_VKQ_0 + k0)*stride_V2, KV_tmp, stride_V2, k_VKQ_sup - k0);
         __syncthreads();
 
-        if constexpr (std::is_same_v<T_KV, nv_bfloat162>) {
-            // BF16 V: FP32 math, V is read as BF16 and converted to FP32 in registers.
+        if constexpr (use_bf16) {
+            if constexpr (use_pv_dot2) {
+                // Packed BF16 PV: P rounded to BF16, V rows paired across consecutive KV rows via
+                // v_perm_b32, one v_dot2_f32_bf16 per head pair with FP32 accumulation (opt-in).
+                static_assert(np == 1, "bad np for packed bf16 PV");
+                static_assert(nbatch_V % 2 == 0, "bad nbatch_V for packed bf16 PV");
 #pragma unroll
-            for (int k1 = 0; k1 < nbatch_V; k1 += np) {
-                __align__(16) float2 V_k[(DVp/2)/warp_size];
-                __align__(16) float  KQ_k[cpw];
+                for (int k1 = 0; k1 < nbatch_V; k1 += 2) {
+                    __align__(16) nv_bfloat162 V_k0[(DVp/2)/warp_size];
+                    __align__(16) nv_bfloat162 V_k1[(DVp/2)/warp_size];
+                    __align__(16) nv_bfloat162 KQ_k[cpw];
 
-                constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
+                    constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
 #pragma unroll
-                for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
-                    __align__(16) nv_bfloat162 tmp[cpy_ne_D];
-                    ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &KV_tmp[(k1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
+                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
+                        ggml_cuda_memcpy_1<cpy_ne_D*4>(&V_k0[i0/warp_size], &KV_tmp[(k1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
+                        ggml_cuda_memcpy_1<cpy_ne_D*4>(&V_k1[i0/warp_size], &KV_tmp[(k1 + 1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
+                    }
 #pragma unroll
-                    for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
-                        V_k[i0/warp_size + i1] = ggml_cuda_cast<float2>(tmp[i1]);
+                    for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
+                        const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
+
+                        __align__(16) float tmp0[KQ_cs];
+                        __align__(16) float tmp1[KQ_cs];
+                        ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(&tmp0[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
+                        ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(&tmp1[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + 1 + threadIdx.y % np)*KQ_cs);
+#pragma unroll
+                        for (int jc_VKQ_1 = 0; jc_VKQ_1 < KQ_cs; ++jc_VKQ_1) {
+                            KQ_k[jc_VKQ_0+jc_VKQ_1] = ggml_cuda_cast<nv_bfloat162>(make_float2(tmp0[jc_VKQ_1], tmp1[jc_VKQ_1]));
+                        }
+                    }
+
+#pragma unroll
+                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+                        const nv_bfloat162 v_perm0 = ggml_cuda_bf16_perm_ll(V_k0[i0/warp_size], V_k1[i0/warp_size]);
+                        const nv_bfloat162 v_perm1 = ggml_cuda_bf16_perm_hh(V_k0[i0/warp_size], V_k1[i0/warp_size]);
+#pragma unroll
+                        for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; ++jc_VKQ_0) {
+                            ggml_cuda_mad(VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].x, v_perm0, KQ_k[jc_VKQ_0]);
+                            ggml_cuda_mad(VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].y, v_perm1, KQ_k[jc_VKQ_0]);
+                        }
                     }
                 }
+            } else {
+                // BF16 V: FP32 math, V is read as BF16 and converted to FP32 in registers.
 #pragma unroll
-                for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
-                    const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
+                for (int k1 = 0; k1 < nbatch_V; k1 += np) {
+                    __align__(16) float2 V_k[(DVp/2)/warp_size];
+                    __align__(16) float  KQ_k[cpw];
 
-                    ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
-                        &KQ_k[jc_VKQ_0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
-                }
+                    constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
+#pragma unroll
+                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
+                        __align__(16) nv_bfloat162 tmp[cpy_ne_D];
+                        ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &KV_tmp[(k1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
+#pragma unroll
+                        for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
+                            V_k[i0/warp_size + i1] = ggml_cuda_cast<float2>(tmp[i1]);
+                        }
+                    }
+#pragma unroll
+                    for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
+                        const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
+
+                        ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
+                            &KQ_k[jc_VKQ_0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
+                    }
 
 #pragma unroll
-                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
 #pragma unroll
-                    for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; ++jc_VKQ_0) {
-                        VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].x += V_k[i0/warp_size].x*KQ_k[jc_VKQ_0];
-                        VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].y += V_k[i0/warp_size].y*KQ_k[jc_VKQ_0];
+                        for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; ++jc_VKQ_0) {
+                            VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].x += V_k[i0/warp_size].x*KQ_k[jc_VKQ_0];
+                            VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].y += V_k[i0/warp_size].y*KQ_k[jc_VKQ_0];
+                        }
                     }
                 }
             }
@@ -1122,9 +987,9 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     }
 }
 
-template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, ggml_type type_KV> // D == head size
-__launch_bounds__(ggml_cuda_fattn_tile_get_nthreads<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2),
-                       ggml_cuda_fattn_tile_get_occupancy<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2))
+template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, ggml_type type_KV, bool pv_dot2> // D == head size
+__launch_bounds__(ggml_cuda_fattn_tile_get_nthreads(DKQ, DV, ncols1*ncols2),
+                       ggml_cuda_fattn_tile_get_occupancy(DKQ, DV, ncols1*ncols2))
 static __global__ void flash_attn_tile(
         const char * Q_ptr,
         const char * K_ptr,
@@ -1173,13 +1038,13 @@ static __global__ void flash_attn_tile(
         return;
     }
 
-    static_assert(ggml_cuda_fattn_tile_get_config<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2) != 0, "kernel config not defined");
+    static_assert(ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols1*ncols2) != 0, "kernel config not defined");
 
     constexpr int ncols     = ncols1*ncols2;
     constexpr int warp_size = 32;
-    constexpr int nwarps    = ggml_cuda_fattn_tile_get_nthreads <type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2) / warp_size;
-    constexpr int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2);
-    constexpr int nbatch_K  = ggml_cuda_fattn_tile_get_nbatch_K <type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2);
+    constexpr int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, ncols1*ncols2) / warp_size;
+    constexpr int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, ncols1*ncols2);
+    constexpr int nbatch_K  = ggml_cuda_fattn_tile_get_nbatch_K (DKQ, DV, ncols1*ncols2);
 
     // In this kernel Q, K, V are matrices while i, j, k are matrix indices.
 
@@ -1218,20 +1083,34 @@ static __global__ void flash_attn_tile(
     // KQ == SRAM buffer to hold KQ fragments between KQ and VKQ matrix multiplications.
     // VKQ == Accumulators in registers for the final VKQ result.
 #ifdef FAST_FP16_AVAILABLE
-    // BF16 K/V always uses FP32 math; only F16 K/V uses the half2 (FAST) path.
-    constexpr bool T_KV_uses_half2 = type_KV != GGML_TYPE_BF16;
-#else
-    constexpr bool T_KV_uses_half2 = false;
-#endif // FAST_FP16_AVAILABLE
-    constexpr int Q_tmp_count   = T_KV_uses_half2 ? ncols*DKQ/2 : ncols*DKQ;
-    constexpr int KV_tmp_stride = T_KV_uses_half2 || type_KV == GGML_TYPE_BF16 ? nbatch_K/2 + cpy_ne : nbatch_K + cpy_ne;
+    // Native BF16 tiles with FP32 math need v_dot2_f32_bf16 (RDNA3+, device pass only);
+    // BF16 K/V with DV > 256 is converted to F16 at tile load like the non-BF16 paths.
+    #ifdef V_DOT2_F32_BF16_AVAILABLE
+    constexpr bool bf16 = type_KV == GGML_TYPE_BF16 && DV <= 256;
+    #else
+    constexpr bool bf16 = false;
+    #endif // V_DOT2_F32_BF16_AVAILABLE
+    constexpr int Q_tmp_count   = ncols*DKQ/2;
+    constexpr int KV_tmp_stride = nbatch_K/2 + cpy_ne;
     constexpr int KV_tmp_count  = nbatch_fa*KV_tmp_stride + DVp-DV;
     constexpr int KQ_count      = ncols*nbatch_fa;
     constexpr int VKQ_count     = cpw * ((DVp/2)/warp_size);
-    using T_Q   = std::conditional_t<T_KV_uses_half2, half2, float>;
-    using T_KVt = std::conditional_t<type_KV == GGML_TYPE_BF16, nv_bfloat162, std::conditional_t<T_KV_uses_half2, half2, float>>;
-    using T_KQ  = std::conditional_t<T_KV_uses_half2, half, float>;
-    using T_acc = std::conditional_t<T_KV_uses_half2, half2, float2>;
+    using T_Q   = std::conditional_t<bf16, nv_bfloat162, half2>;
+    using T_KVt = T_Q;
+    using T_KQ  = std::conditional_t<bf16, float, half>;
+    using T_acc = std::conditional_t<bf16, float2, half2>;
+#else
+    constexpr bool bf16 = false;
+    constexpr int Q_tmp_count   = ncols*DKQ;
+    constexpr int KV_tmp_stride = nbatch_K + cpy_ne;
+    constexpr int KV_tmp_count  = nbatch_fa*KV_tmp_stride + DVp-DV;
+    constexpr int KQ_count      = ncols*nbatch_fa;
+    constexpr int VKQ_count     = cpw * (DVp/warp_size);
+    using T_Q   = float;
+    using T_KVt = float;
+    using T_KQ  = float;
+    using T_acc = float2;
+#endif // FAST_FP16_AVAILABLE
 
     __shared__ T_Q   Q_tmp[Q_tmp_count];
     __shared__ T_KVt KV_tmp[KV_tmp_count];
@@ -1271,7 +1150,16 @@ static __global__ void flash_attn_tile(
                 }
 
 #ifdef FAST_FP16_AVAILABLE
-                if constexpr (type_KV != GGML_TYPE_BF16) {
+                if constexpr (bf16) {
+                    __align__(16) nv_bfloat162 tmp_bf[cpy_ne_D/2];
+#pragma unroll
+                    for (int i1 = 0; i1 < cpy_ne_D; i1 += 2) {
+                        tmp_bf[i1/2] = ggml_cuda_cast<nv_bfloat162>(make_float2(tmp_f[i1 + 0], tmp_f[i1 + 1]));
+                    }
+                    ggml_cuda_memcpy_1<sizeof(tmp_bf)>(
+                        &Q_tmp[jc*(DKQ/2) + i0/2 + (threadIdx.y % np)*(warp_size*cpy_ne_D/2) + threadIdx.x*(cpy_ne_D/2)],
+                        tmp_bf);
+                } else if constexpr (!bf16) {
                     __align__(16) half2 tmp_h2[cpy_ne_D/2];
 #pragma unroll
                     for (int i1 = 0; i1 < cpy_ne_D; i1 += 2) {
@@ -1305,14 +1193,14 @@ static __global__ void flash_attn_tile(
         int k_VKQ_0 = blockIdx.y*nbatch_fa;
         while (k_VKQ_0 < k_VKQ_max - nbatch_fa) {
             constexpr bool oob_check = false;
-            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>
+            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check, pv_dot2>
                 (Q_tmp, K_h2, V_h2, maskh, ne01, logit_softcap, slope, KQ, KV_tmp,
                 stride_K2, stride_V2, stride_mask, KQ_max, KQ_sum, VKQ, k_VKQ_0, k_VKQ_max, col_Q_0);
             k_VKQ_0 += gridDim.y*nbatch_fa;
         }
         if (k_VKQ_0 < k_VKQ_max) {
             constexpr bool oob_check = true;
-            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>
+            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check, pv_dot2>
                 (Q_tmp, K_h2, V_h2, maskh, ne01, logit_softcap, slope, KQ, KV_tmp,
                 stride_K2, stride_V2, stride_mask, KQ_max, KQ_sum, VKQ, k_VKQ_0, k_VKQ_max, col_Q_0);
         }
@@ -1320,7 +1208,7 @@ static __global__ void flash_attn_tile(
         // Branch without out-of-bounds checks.
         for (int k_VKQ_0 = blockIdx.y*nbatch_fa; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*nbatch_fa) {
             constexpr bool oob_check = false;
-            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>
+            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check, pv_dot2>
                 (Q_tmp, K_h2, V_h2, maskh, ne01, logit_softcap, slope, KQ, KV_tmp,
                 stride_K2, stride_V2, stride_mask, KQ_max, KQ_sum, VKQ, k_VKQ_0, k_VKQ_max, col_Q_0);
         }
@@ -1336,7 +1224,7 @@ static __global__ void flash_attn_tile(
         static_assert(nbatch_fa*nbatch_K >= nwarps*DVp, "KV_tmp too small");
 
 #ifdef FAST_FP16_AVAILABLE
-        using T_VKQ_combine = std::conditional_t<type_KV == GGML_TYPE_BF16, float, half2>;
+        using T_VKQ_combine = std::conditional_t<bf16, float, half2>;
 #else
         using T_VKQ_combine = float;
 #endif // FAST_FP16_AVAILABLE
@@ -1345,7 +1233,7 @@ static __global__ void flash_attn_tile(
 
         if (threadIdx.y % np != 0) {
 #ifdef FAST_FP16_AVAILABLE
-            if constexpr (type_KV != GGML_TYPE_BF16) {
+            if constexpr (!bf16) {
                 constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
                 for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
@@ -1374,7 +1262,7 @@ static __global__ void flash_attn_tile(
 #pragma unroll
         for (int ip = 1; ip < np; ++ip) {
 #ifdef FAST_FP16_AVAILABLE
-            if constexpr (type_KV != GGML_TYPE_BF16) {
+            if constexpr (!bf16) {
                 constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
                 for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
@@ -1419,7 +1307,7 @@ static __global__ void flash_attn_tile(
             KQ_sum[jc0] = KQ_sum[jc0]*KQ_max_scale + val;
 
 #ifdef FAST_FP16_AVAILABLE
-            if constexpr (type_KV != GGML_TYPE_BF16) {
+            if constexpr (!bf16) {
                 const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
 #pragma unroll
                 for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
@@ -1454,7 +1342,7 @@ static __global__ void flash_attn_tile(
         const int j_dst_unrolled = ((sequence*int(ne01.z) + col_Q_0 + j)*ne02 + head0 + c)*gridDim.y + blockIdx.y;
 
 #ifdef FAST_FP16_AVAILABLE
-        if constexpr (type_KV != GGML_TYPE_BF16) {
+        if constexpr (!bf16) {
             constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
@@ -1506,7 +1394,7 @@ static __global__ void flash_attn_tile(
 #endif // FLASH_ATTN_AVAILABLE
 }
 
-template <int DKQ, int DV, int ncols2, bool use_logit_softcap, ggml_type type_KV>
+template <int DKQ, int DV, int ncols2, bool use_logit_softcap, ggml_type type_KV, bool pv_dot2>
 static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * Q = dst->src[0];
     const ggml_tensor * K = dst->src[1];
@@ -1526,9 +1414,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (DKQ <= 128) {
         if (Q->ne[1] > 32/ncols2) {
             constexpr int cols_per_block = 64;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1542,11 +1430,10 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
 #endif // GGML_USE_HIP
     {
         if (Q->ne[1] > 16/ncols2) {
-            // BF16 uses FP32 Q_tmp, which needs smaller Q tiles for large heads to fit SRAM.
-            constexpr int cols_per_block = type_KV == GGML_TYPE_BF16 && DKQ >= 256 ? 16 : 32;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
+            constexpr int cols_per_block = 32;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1557,9 +1444,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (ncols2 <= 16) {
         if (Q->ne[1] > 8/ncols2) {
             constexpr int cols_per_block = 16;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1570,9 +1457,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (ncols2 <= 8) {
         if (Q->ne[1] > 4/ncols2) {
             constexpr int cols_per_block = 8;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1583,9 +1470,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (ncols2 <= 4) {
         if (Q->ne[1] > 2/ncols2) {
             constexpr int cols_per_block = 4;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1595,9 +1482,9 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
 
     if constexpr (ncols2 <= 2) {
         constexpr int cols_per_block = 2;
-        const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
-        const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
-        fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
+        const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
+        const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
+        fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
         launch_fattn<DV, cols_per_block/ncols2, ncols2>
             (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1607,7 +1494,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     GGML_ABORT("fatal error");
 }
 
-template <int DKQ, int DV, bool use_logit_softcap, ggml_type type_KV>
+template <int DKQ, int DV, bool use_logit_softcap, ggml_type type_KV, bool pv_dot2>
 static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * KQV  = dst;
     const ggml_tensor * Q    = dst->src[0];
@@ -1632,13 +1519,13 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
         // On NVIDIA however, the tile kernel is only used for GPUs that can't use the mma kernel (Pascal and older).
         // Therefore, use a GQA ratio of 16 with 16 columns / block to stay below 48 kiB of SRAM / block.
 #ifdef GGML_USE_HIP
-        if (use_gqa_opt && (type_KV == GGML_TYPE_BF16 ? gqa_ratio % 16 == 0 : gqa_ratio % 32 == 0)) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, type_KV == GGML_TYPE_BF16 ? 16 : 32, use_logit_softcap, type_KV>(ctx, dst);
+        if (use_gqa_opt && gqa_ratio % 32 == 0) {
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 32, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
 #else
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
 #endif // GGML_USE_HIP
@@ -1647,11 +1534,11 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
 
     if constexpr (DKQ == 576) {
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
         if (use_gqa_opt && gqa_ratio % 4 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
     }
@@ -1659,11 +1546,11 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
     if constexpr (DKQ == 192) {
         // MiMo-V2.5 / V2.5-Pro / V2-Flash: gqa_ratio is 8 (SWA) or 16 (full attn)
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
         if (use_gqa_opt && gqa_ratio % 8 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
         GGML_ABORT("flash-attn tile (192/128): expected GQA ratio multiple of 8");
@@ -1671,22 +1558,22 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
 
     if constexpr (DKQ <= 512 && DKQ != 320 && DKQ != 192) {
         if (use_gqa_opt && gqa_ratio % 8 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
 
         if (use_gqa_opt && gqa_ratio % 4 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
 
         if (use_gqa_opt && gqa_ratio % 2 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 2, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 2, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
 
         if constexpr (DV <= 256) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap, type_KV>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
             return;
         }
     }
@@ -1698,12 +1585,32 @@ void ggml_cuda_flash_attn_ext_tile_case(ggml_backend_cuda_context & ctx, ggml_te
     float logit_softcap;
     memcpy(&logit_softcap, (const float *) dst->op_params + 2, sizeof(float));
 
-    if (logit_softcap == 0.0f) {
-        constexpr bool use_logit_softcap = false;
-        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV>(ctx, dst);
+    if constexpr (type_KV == GGML_TYPE_BF16) {
+        // Packed BF16 PV (P rounded to BF16, v_dot2_f32_bf16) is opt-in; FP32 PV is the default.
+        static const bool pv_dot2 = getenv("GGML_HIP_BF16_PV_DOT2") != nullptr;
+        if (logit_softcap == 0.0f) {
+            constexpr bool use_logit_softcap = false;
+            if (pv_dot2) {
+                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, true>(ctx, dst);
+            } else {
+                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
+            }
+        } else {
+            constexpr bool use_logit_softcap = true;
+            if (pv_dot2) {
+                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, true>(ctx, dst);
+            } else {
+                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
+            }
+        }
     } else {
-        constexpr bool use_logit_softcap = true;
-        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV>(ctx, dst);
+        if (logit_softcap == 0.0f) {
+            constexpr bool use_logit_softcap = false;
+            launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
+        } else {
+            constexpr bool use_logit_softcap = true;
+            launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
+        }
     }
 }
 

--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -659,7 +659,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
 
 // Function that performs a single iteration of the main loop over up to nbatch_fa tokens.
 template <int warp_size, int nwarps, int ncols1, int ncols2, int DKQ, int DV, int nbatch_fa, int nbatch_K,
-    bool use_logit_softcap, bool oob_check, bool pv_dot2, typename T_Q, typename T_KV, typename T_KQ, typename T_acc, typename T_KV_tmp>
+    bool use_logit_softcap, bool oob_check, typename T_Q, typename T_KV, typename T_KQ, typename T_acc, typename T_KV_tmp>
 static __device__ __forceinline__ void flash_attn_tile_iter(
         T_Q       * const Q_tmp,
         const T_KV * const __restrict__ K_h2,
@@ -697,11 +697,9 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     #else
     constexpr bool use_bf16    = false;
     #endif // V_DOT2_F32_BF16_AVAILABLE
-    constexpr bool use_pv_dot2 = pv_dot2 && use_bf16;
     constexpr int KQ_cs = use_bf16 ? (cpw < 1*cpy_ne ? cpw : 1*cpy_ne) : (cpw < 2*cpy_ne ? cpw : 2*cpy_ne);
 #else
     constexpr bool use_bf16    = false;
-    constexpr bool use_pv_dot2 = false;
     constexpr int KQ_cs = cpw < 1*cpy_ne ? cpw : 1*cpy_ne;
 #endif // FAST_FP16_AVAILABLE
     static_assert(cpw % KQ_cs == 0, "bad KQ_cs");
@@ -839,11 +837,10 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
         __syncthreads();
 
         if constexpr (use_bf16) {
-            if constexpr (use_pv_dot2) {
-                // Packed BF16 PV: P rounded to BF16, V rows paired across consecutive KV rows via
-                // v_perm_b32, one v_dot2_f32_bf16 per head pair with FP32 accumulation (opt-in).
-                static_assert(np == 1, "bad np for packed bf16 PV");
-                static_assert(nbatch_V % 2 == 0, "bad nbatch_V for packed bf16 PV");
+            // Packed BF16 PV: P rounded to BF16, V rows paired across consecutive KV rows via
+            // v_perm_b32, one v_dot2_f32_bf16 per head pair with FP32 accumulation.
+            static_assert(np == 1, "bad np for packed bf16 PV");
+            static_assert(nbatch_V % 2 == 0, "bad nbatch_V for packed bf16 PV");
 #pragma unroll
                 for (int k1 = 0; k1 < nbatch_V; k1 += 2) {
                     __align__(16) nv_bfloat162 V_k0[(DVp/2)/warp_size];
@@ -881,41 +878,6 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
                         }
                     }
                 }
-            } else {
-                // BF16 V: FP32 math, V is read as BF16 and converted to FP32 in registers.
-#pragma unroll
-                for (int k1 = 0; k1 < nbatch_V; k1 += np) {
-                    __align__(16) float2 V_k[(DVp/2)/warp_size];
-                    __align__(16) float  KQ_k[cpw];
-
-                    constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
-#pragma unroll
-                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
-                        __align__(16) nv_bfloat162 tmp[cpy_ne_D];
-                        ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &KV_tmp[(k1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
-#pragma unroll
-                        for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
-                            V_k[i0/warp_size + i1] = ggml_cuda_cast<float2>(tmp[i1]);
-                        }
-                    }
-#pragma unroll
-                    for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
-                        const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
-
-                        ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
-                            &KQ_k[jc_VKQ_0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
-                    }
-
-#pragma unroll
-                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-#pragma unroll
-                        for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; ++jc_VKQ_0) {
-                            VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].x += V_k[i0/warp_size].x*KQ_k[jc_VKQ_0];
-                            VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].y += V_k[i0/warp_size].y*KQ_k[jc_VKQ_0];
-                        }
-                    }
-                }
-            }
         } else
 #ifdef FAST_FP16_AVAILABLE
         {
@@ -987,7 +949,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     }
 }
 
-template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, ggml_type type_KV, bool pv_dot2> // D == head size
+template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, ggml_type type_KV> // D == head size
 __launch_bounds__(ggml_cuda_fattn_tile_get_nthreads(DKQ, DV, ncols1*ncols2),
                        ggml_cuda_fattn_tile_get_occupancy(DKQ, DV, ncols1*ncols2))
 static __global__ void flash_attn_tile(
@@ -1193,14 +1155,14 @@ static __global__ void flash_attn_tile(
         int k_VKQ_0 = blockIdx.y*nbatch_fa;
         while (k_VKQ_0 < k_VKQ_max - nbatch_fa) {
             constexpr bool oob_check = false;
-            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check, pv_dot2>
+            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>
                 (Q_tmp, K_h2, V_h2, maskh, ne01, logit_softcap, slope, KQ, KV_tmp,
                 stride_K2, stride_V2, stride_mask, KQ_max, KQ_sum, VKQ, k_VKQ_0, k_VKQ_max, col_Q_0);
             k_VKQ_0 += gridDim.y*nbatch_fa;
         }
         if (k_VKQ_0 < k_VKQ_max) {
             constexpr bool oob_check = true;
-            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check, pv_dot2>
+            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>
                 (Q_tmp, K_h2, V_h2, maskh, ne01, logit_softcap, slope, KQ, KV_tmp,
                 stride_K2, stride_V2, stride_mask, KQ_max, KQ_sum, VKQ, k_VKQ_0, k_VKQ_max, col_Q_0);
         }
@@ -1208,7 +1170,7 @@ static __global__ void flash_attn_tile(
         // Branch without out-of-bounds checks.
         for (int k_VKQ_0 = blockIdx.y*nbatch_fa; k_VKQ_0 < k_VKQ_max; k_VKQ_0 += gridDim.y*nbatch_fa) {
             constexpr bool oob_check = false;
-            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check, pv_dot2>
+            flash_attn_tile_iter<warp_size, nwarps, ncols1, ncols2, DKQ, DV, nbatch_fa, nbatch_K, use_logit_softcap, oob_check>
                 (Q_tmp, K_h2, V_h2, maskh, ne01, logit_softcap, slope, KQ, KV_tmp,
                 stride_K2, stride_V2, stride_mask, KQ_max, KQ_sum, VKQ, k_VKQ_0, k_VKQ_max, col_Q_0);
         }
@@ -1394,7 +1356,7 @@ static __global__ void flash_attn_tile(
 #endif // FLASH_ATTN_AVAILABLE
 }
 
-template <int DKQ, int DV, int ncols2, bool use_logit_softcap, ggml_type type_KV, bool pv_dot2>
+template <int DKQ, int DV, int ncols2, bool use_logit_softcap, ggml_type type_KV>
 static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * Q = dst->src[0];
     const ggml_tensor * K = dst->src[1];
@@ -1416,7 +1378,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 64;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1433,7 +1395,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 32;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1446,7 +1408,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 16;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1459,7 +1421,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 8;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1472,7 +1434,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
             constexpr int cols_per_block = 4;
             const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
             const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
                 (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1484,7 +1446,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
         constexpr int cols_per_block = 2;
         const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
         const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-        fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV, pv_dot2>;
+        fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
         launch_fattn<DV, cols_per_block/ncols2, ncols2>
             (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
                 need_f16_K, need_f16_V, false, warp_size);
@@ -1494,7 +1456,7 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     GGML_ABORT("fatal error");
 }
 
-template <int DKQ, int DV, bool use_logit_softcap, ggml_type type_KV, bool pv_dot2>
+template <int DKQ, int DV, bool use_logit_softcap, ggml_type type_KV>
 static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * KQV  = dst;
     const ggml_tensor * Q    = dst->src[0];
@@ -1520,12 +1482,12 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
         // Therefore, use a GQA ratio of 16 with 16 columns / block to stay below 48 kiB of SRAM / block.
 #ifdef GGML_USE_HIP
         if (use_gqa_opt && gqa_ratio % 32 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 32, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 32, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 #else
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 #endif // GGML_USE_HIP
@@ -1534,11 +1496,11 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
 
     if constexpr (DKQ == 576) {
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
         if (use_gqa_opt && gqa_ratio % 4 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
     }
@@ -1546,11 +1508,11 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
     if constexpr (DKQ == 192) {
         // MiMo-V2.5 / V2.5-Pro / V2-Flash: gqa_ratio is 8 (SWA) or 16 (full attn)
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
         if (use_gqa_opt && gqa_ratio % 8 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
         GGML_ABORT("flash-attn tile (192/128): expected GQA ratio multiple of 8");
@@ -1558,22 +1520,22 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
 
     if constexpr (DKQ <= 512 && DKQ != 320 && DKQ != 192) {
         if (use_gqa_opt && gqa_ratio % 8 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 
         if (use_gqa_opt && gqa_ratio % 4 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 
         if (use_gqa_opt && gqa_ratio % 2 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 2, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 2, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 
         if constexpr (DV <= 256) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap, type_KV, pv_dot2>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
     }
@@ -1585,32 +1547,12 @@ void ggml_cuda_flash_attn_ext_tile_case(ggml_backend_cuda_context & ctx, ggml_te
     float logit_softcap;
     memcpy(&logit_softcap, (const float *) dst->op_params + 2, sizeof(float));
 
-    if constexpr (type_KV == GGML_TYPE_BF16) {
-        // Packed BF16 PV (P rounded to BF16, v_dot2_f32_bf16) is opt-in; FP32 PV is the default.
-        static const bool pv_dot2 = getenv("GGML_HIP_BF16_PV_DOT2") != nullptr;
-        if (logit_softcap == 0.0f) {
-            constexpr bool use_logit_softcap = false;
-            if (pv_dot2) {
-                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, true>(ctx, dst);
-            } else {
-                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
-            }
-        } else {
-            constexpr bool use_logit_softcap = true;
-            if (pv_dot2) {
-                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, true>(ctx, dst);
-            } else {
-                launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
-            }
-        }
+    if (logit_softcap == 0.0f) {
+        constexpr bool use_logit_softcap = false;
+        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV>(ctx, dst);
     } else {
-        if (logit_softcap == 0.0f) {
-            constexpr bool use_logit_softcap = false;
-            launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
-        } else {
-            constexpr bool use_logit_softcap = true;
-            launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV, false>(ctx, dst);
-        }
+        constexpr bool use_logit_softcap = true;
+        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV>(ctx, dst);
     }
 }
 

--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -600,11 +600,11 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
 
 #ifdef FAST_FP16_AVAILABLE
     // BF16 K/V keeps packed BF16 registers and uses v_dot2_f32_bf16; F16 K/V uses the half2 (FAST) path.
-    #ifdef V_DOT2_F32_BF16_AVAILABLE
+#ifdef V_DOT2_F32_BF16_AVAILABLE
     constexpr bool use_bf16 = std::is_same_v<T_KV, nv_bfloat162> && DV <= 256;
-    #else
+#else
     constexpr bool use_bf16 = false;
-    #endif // V_DOT2_F32_BF16_AVAILABLE
+#endif // V_DOT2_F32_BF16_AVAILABLE
     using T_fast = std::conditional_t<use_bf16, nv_bfloat162, half2>;
     static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
 #pragma unroll
@@ -692,14 +692,14 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     // KQ is originally 2D but uses a Z-shaped 3D memory pattern like KQ[ncols/KQ_cs][DVp][KQ_cs].
 #ifdef FAST_FP16_AVAILABLE
     // BF16 K/V keeps packed BF16 registers and uses v_dot2_f32_bf16; F16 K/V uses the half2 (FAST) path.
-    #ifdef V_DOT2_F32_BF16_AVAILABLE
-    constexpr bool use_bf16    = std::is_same_v<T_KV, nv_bfloat162> && DV <= 256;
-    #else
-    constexpr bool use_bf16    = false;
-    #endif // V_DOT2_F32_BF16_AVAILABLE
+#ifdef V_DOT2_F32_BF16_AVAILABLE
+    constexpr bool use_bf16 = std::is_same_v<T_KV, nv_bfloat162> && DV <= 256;
+#else
+    constexpr bool use_bf16 = false;
+#endif // V_DOT2_F32_BF16_AVAILABLE
     constexpr int KQ_cs = use_bf16 ? (cpw < 1*cpy_ne ? cpw : 1*cpy_ne) : (cpw < 2*cpy_ne ? cpw : 2*cpy_ne);
 #else
-    constexpr bool use_bf16    = false;
+    constexpr bool use_bf16 = false;
     constexpr int KQ_cs = cpw < 1*cpy_ne ? cpw : 1*cpy_ne;
 #endif // FAST_FP16_AVAILABLE
     static_assert(cpw % KQ_cs == 0, "bad KQ_cs");
@@ -842,42 +842,47 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             static_assert(np == 1, "bad np for packed bf16 PV");
             static_assert(nbatch_V % 2 == 0, "bad nbatch_V for packed bf16 PV");
 #pragma unroll
-                for (int k1 = 0; k1 < nbatch_V; k1 += 2) {
-                    __align__(16) nv_bfloat162 V_k0[(DVp/2)/warp_size];
-                    __align__(16) nv_bfloat162 V_k1[(DVp/2)/warp_size];
-                    __align__(16) nv_bfloat162 KQ_k[cpw];
+            for (int k1 = 0; k1 < nbatch_V; k1 += 2) {
+                __align__(16) nv_bfloat162 V_k0[(DVp/2)/warp_size];
+                __align__(16) nv_bfloat162 V_k1[(DVp/2)/warp_size];
+                __align__(16) nv_bfloat162 KQ_k[cpw];
 
-                    constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
+                constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
 #pragma unroll
-                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
-                        ggml_cuda_memcpy_1<cpy_ne_D*4>(&V_k0[i0/warp_size], &KV_tmp[(k1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
-                        ggml_cuda_memcpy_1<cpy_ne_D*4>(&V_k1[i0/warp_size], &KV_tmp[(k1 + 1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
-                    }
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(
+                        &V_k0[i0/warp_size], &KV_tmp[(k1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(
+                        &V_k1[i0/warp_size], &KV_tmp[(k1 + 1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
+                }
 #pragma unroll
-                    for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
-                        const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
+                for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
+                    const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
 
-                        __align__(16) float tmp0[KQ_cs];
-                        __align__(16) float tmp1[KQ_cs];
-                        ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(&tmp0[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
-                        ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(&tmp1[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + 1 + threadIdx.y % np)*KQ_cs);
+                    __align__(16) float tmp0[KQ_cs];
+                    __align__(16) float tmp1[KQ_cs];
+                    ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
+                        &tmp0[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
+                    ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
+                        &tmp1[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + 1 + threadIdx.y % np)*KQ_cs);
 #pragma unroll
-                        for (int jc_VKQ_1 = 0; jc_VKQ_1 < KQ_cs; ++jc_VKQ_1) {
-                            KQ_k[jc_VKQ_0+jc_VKQ_1] = ggml_cuda_cast<nv_bfloat162>(make_float2(tmp0[jc_VKQ_1], tmp1[jc_VKQ_1]));
-                        }
-                    }
-
-#pragma unroll
-                    for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                        const nv_bfloat162 v_perm0 = ggml_cuda_bf16_perm_ll(V_k0[i0/warp_size], V_k1[i0/warp_size]);
-                        const nv_bfloat162 v_perm1 = ggml_cuda_bf16_perm_hh(V_k0[i0/warp_size], V_k1[i0/warp_size]);
-#pragma unroll
-                        for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; ++jc_VKQ_0) {
-                            ggml_cuda_mad(VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].x, v_perm0, KQ_k[jc_VKQ_0]);
-                            ggml_cuda_mad(VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].y, v_perm1, KQ_k[jc_VKQ_0]);
-                        }
+                    for (int jc_VKQ_1 = 0; jc_VKQ_1 < KQ_cs; ++jc_VKQ_1) {
+                        KQ_k[jc_VKQ_0+jc_VKQ_1] =
+                            ggml_cuda_cast<nv_bfloat162>(make_float2(tmp0[jc_VKQ_1], tmp1[jc_VKQ_1]));
                     }
                 }
+
+#pragma unroll
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+                    const nv_bfloat162 v_perm0 = ggml_cuda_bf16_perm_ll(V_k0[i0/warp_size], V_k1[i0/warp_size]);
+                    const nv_bfloat162 v_perm1 = ggml_cuda_bf16_perm_hh(V_k0[i0/warp_size], V_k1[i0/warp_size]);
+#pragma unroll
+                    for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; ++jc_VKQ_0) {
+                        ggml_cuda_mad(VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].x, v_perm0, KQ_k[jc_VKQ_0]);
+                        ggml_cuda_mad(VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].y, v_perm1, KQ_k[jc_VKQ_0]);
+                    }
+                }
+            }
         } else
 #ifdef FAST_FP16_AVAILABLE
         {
@@ -1047,11 +1052,11 @@ static __global__ void flash_attn_tile(
 #ifdef FAST_FP16_AVAILABLE
     // Native BF16 tiles with FP32 math need v_dot2_f32_bf16 (RDNA3+, device pass only);
     // BF16 K/V with DV > 256 is converted to F16 at tile load like the non-BF16 paths.
-    #ifdef V_DOT2_F32_BF16_AVAILABLE
+#ifdef V_DOT2_F32_BF16_AVAILABLE
     constexpr bool bf16 = type_KV == GGML_TYPE_BF16 && DV <= 256;
-    #else
+#else
     constexpr bool bf16 = false;
-    #endif // V_DOT2_F32_BF16_AVAILABLE
+#endif // V_DOT2_F32_BF16_AVAILABLE
     constexpr int Q_tmp_count   = ncols*DKQ/2;
     constexpr int KV_tmp_stride = nbatch_K/2 + cpy_ne;
     constexpr int KV_tmp_count  = nbatch_fa*KV_tmp_stride + DVp-DV;

--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -522,6 +522,61 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
 
 template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
 static __device__ __forceinline__ void flash_attn_tile_load_tile(
+        const nv_bfloat162 * const __restrict__ KV, float * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
+    constexpr int cpy_nb = ggml_cuda_get_max_cpy_bytes();
+    constexpr int cpy_ne = cpy_nb / 4;
+
+    auto load = [&] __device__ (const int n) {
+        const int stride_j = warp_size >> n;
+
+        if (stride_j == 0) {
+            return;
+        }
+
+        const int j0_start = stride_j == warp_size ? 0 : (J/cpy_ne) - (J/cpy_ne) % (2*stride_j);
+        const int j0_stop  =                             (J/cpy_ne) - (J/cpy_ne) % (1*stride_j);
+        const int stride_i = warp_size / stride_j;
+
+        if (j0_start == j0_stop) {
+            return;
+        }
+
+#pragma unroll
+        for (int i0 = 0; i0 < I; i0 += nwarps*stride_i) {
+            const int i = i0 + threadIdx.y*stride_i + (stride_j == warp_size ? 0 : threadIdx.x / stride_j);
+
+            if (i0 + nwarps*stride_i <= I || i < I) {
+#pragma unroll
+                for (int j0 = j0_start; j0 < j0_stop; j0 += stride_j) {
+                    const int j = j0*(cpy_ne/2) + (stride_j == warp_size ? threadIdx.x : threadIdx.x % stride_j)*(cpy_ne/2);
+
+                    const nv_bfloat162 zero[cpy_ne/2] = {{0.0f, 0.0f}};
+                    __align__(16) nv_bfloat162 tmp_bf[cpy_ne/2];
+                    ggml_cuda_memcpy_1<sizeof(tmp_bf)>(
+                        tmp_bf, !oob_check || i < i_sup ? KV + i*stride_KV + j : zero);
+
+                    __align__(16) float2 tmp_f2[cpy_ne/2];
+#pragma unroll
+                    for (int l = 0; l < cpy_ne/2; ++l) {
+                        tmp_f2[l] = ggml_cuda_cast<float2>(tmp_bf[l]);
+                    }
+                    ggml_cuda_memcpy_1<sizeof(tmp_f2)>(tile_KV + i*(J + J_padding) + 2*j, tmp_f2);
+                }
+            }
+        }
+    };
+    // 1: max 32*16=512 bytes, 128 float
+    // 2: max 16*16=256 bytes,  64 float
+    // 3: max  8*16=128 bytes,  32 float
+    // 4: max  4*16= 64 bytes,  16 float
+    // 5: max  2*16= 32 bytes,   8 float
+    static_assert(J % 8 == 0, "bad J");
+    static_assert(J % cpy_ne == 0, "bad J");
+    ggml_cuda_unroll<5>{}(load);
+}
+
+template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
+static __device__ __forceinline__ void flash_attn_tile_load_tile(
         const half2 * const __restrict__ KV, float * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
     constexpr int cpy_nb = ggml_cuda_get_max_cpy_bytes();
     constexpr int cpy_ne = cpy_nb / 4;
@@ -575,6 +630,17 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
     ggml_cuda_unroll<5>{}(load);
 }
 
+// Native BF16 tiles with FP32 math need the packed BF16 dot (RDNA3+, device pass only).
+// Without it, the kernel uses the F16-math path with BF16->F16 tile conversion.
+template <typename T_KV>
+static constexpr __host__ __device__ bool ggml_cuda_fattn_tile_use_bf16() {
+#ifdef V_DOT2_F32_BF16_AVAILABLE
+    return std::is_same_v<T_KV, nv_bfloat162>;
+#else
+    return false;
+#endif // V_DOT2_F32_BF16_AVAILABLE
+}
+
 // Function that performs a single iteration in for the KQ matrix multiplication:
 template <int warp_size, int nwarps, int ncols1, int ncols2, int DKQ, int DV, int nbatch_fa, int nbatch_K,
     bool use_logit_softcap, bool oob_check, typename T_Q, typename T_KV, typename T_KV_tmp>
@@ -600,11 +666,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
 
 #ifdef FAST_FP16_AVAILABLE
     // BF16 K/V keeps packed BF16 registers and uses v_dot2_f32_bf16; F16 K/V uses the half2 (FAST) path.
-#ifdef V_DOT2_F32_BF16_AVAILABLE
-    constexpr bool use_bf16 = std::is_same_v<T_KV, nv_bfloat162> && DV <= 256;
-#else
-    constexpr bool use_bf16 = false;
-#endif // V_DOT2_F32_BF16_AVAILABLE
+    constexpr bool use_bf16 = ggml_cuda_fattn_tile_use_bf16<T_KV>();
     using T_fast = std::conditional_t<use_bf16, nv_bfloat162, half2>;
     static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
 #pragma unroll
@@ -692,11 +754,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     // KQ is originally 2D but uses a Z-shaped 3D memory pattern like KQ[ncols/KQ_cs][DVp][KQ_cs].
 #ifdef FAST_FP16_AVAILABLE
     // BF16 K/V keeps packed BF16 registers and uses v_dot2_f32_bf16; F16 K/V uses the half2 (FAST) path.
-#ifdef V_DOT2_F32_BF16_AVAILABLE
-    constexpr bool use_bf16 = std::is_same_v<T_KV, nv_bfloat162> && DV <= 256;
-#else
-    constexpr bool use_bf16 = false;
-#endif // V_DOT2_F32_BF16_AVAILABLE
+    constexpr bool use_bf16 = ggml_cuda_fattn_tile_use_bf16<T_KV>();
     constexpr int KQ_cs = use_bf16 ? (cpw < 1*cpy_ne ? cpw : 1*cpy_ne) : (cpw < 2*cpy_ne ? cpw : 2*cpy_ne);
 #else
     constexpr bool use_bf16 = false;
@@ -818,9 +876,20 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
         for (int i0 = 0; i0 < nbatch_fa; i0 += np*warp_size) {
             const int i = i0 + (threadIdx.y % np)*warp_size + threadIdx.x;
 
-            ggml_cuda_memcpy_1<sizeof(tmp[0])>(
-                KQ + (jc0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs))*(nbatch_fa*KQ_cs) + i*KQ_cs,
-                tmp[i0/(np*warp_size)]);
+            if constexpr (use_bf16) {
+                __align__(16) nv_bfloat16 tmp_bf[KQ_cs];
+#pragma unroll
+                for (int j = 0; j < KQ_cs; ++j) {
+                    tmp_bf[j] = __float2bfloat16(tmp[i0/(np*warp_size)][j]);
+                }
+                ggml_cuda_memcpy_1<KQ_cs*sizeof(nv_bfloat16)>(
+                    KQ + (jc0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs))*(nbatch_fa*KQ_cs) + i*KQ_cs,
+                    tmp_bf);
+            } else {
+                ggml_cuda_memcpy_1<sizeof(tmp[0])>(
+                    KQ + (jc0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs))*(nbatch_fa*KQ_cs) + i*KQ_cs,
+                    tmp[i0/(np*warp_size)]);
+            }
         }
     }
 
@@ -859,16 +928,16 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
                 for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
                     const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
 
-                    __align__(16) float tmp0[KQ_cs];
-                    __align__(16) float tmp1[KQ_cs];
-                    ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
+                    __align__(16) nv_bfloat16 tmp0[KQ_cs];
+                    __align__(16) nv_bfloat16 tmp1[KQ_cs];
+                    ggml_cuda_memcpy_1<KQ_cs*sizeof(nv_bfloat16)>(
                         &tmp0[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
-                    ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
+                    ggml_cuda_memcpy_1<KQ_cs*sizeof(nv_bfloat16)>(
                         &tmp1[0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + 1 + threadIdx.y % np)*KQ_cs);
 #pragma unroll
                     for (int jc_VKQ_1 = 0; jc_VKQ_1 < KQ_cs; ++jc_VKQ_1) {
-                        KQ_k[jc_VKQ_0+jc_VKQ_1] =
-                            ggml_cuda_cast<nv_bfloat162>(make_float2(tmp0[jc_VKQ_1], tmp1[jc_VKQ_1]));
+                        KQ_k[jc_VKQ_0+jc_VKQ_1] = ggml_cuda_cast<nv_bfloat162>(
+                            make_float2(__bfloat162float(tmp0[jc_VKQ_1]), __bfloat162float(tmp1[jc_VKQ_1])));
                     }
                 }
 
@@ -954,6 +1023,10 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     }
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpass-failed"
+#endif // __clang__
 template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, ggml_type type_KV> // D == head size
 __launch_bounds__(ggml_cuda_fattn_tile_get_nthreads(DKQ, DV, ncols1*ncols2),
                        ggml_cuda_fattn_tile_get_occupancy(DKQ, DV, ncols1*ncols2))
@@ -1050,13 +1123,8 @@ static __global__ void flash_attn_tile(
     // KQ == SRAM buffer to hold KQ fragments between KQ and VKQ matrix multiplications.
     // VKQ == Accumulators in registers for the final VKQ result.
 #ifdef FAST_FP16_AVAILABLE
-    // Native BF16 tiles with FP32 math need v_dot2_f32_bf16 (RDNA3+, device pass only);
-    // BF16 K/V with DV > 256 is converted to F16 at tile load like the non-BF16 paths.
-#ifdef V_DOT2_F32_BF16_AVAILABLE
-    constexpr bool bf16 = type_KV == GGML_TYPE_BF16 && DV <= 256;
-#else
-    constexpr bool bf16 = false;
-#endif // V_DOT2_F32_BF16_AVAILABLE
+    // Native BF16 tiles with FP32 math need v_dot2_f32_bf16 (RDNA3+, device pass only).
+    constexpr bool bf16 = ggml_cuda_fattn_tile_use_bf16<T_KV>();
     constexpr int Q_tmp_count   = ncols*DKQ/2;
     constexpr int KV_tmp_stride = nbatch_K/2 + cpy_ne;
     constexpr int KV_tmp_count  = nbatch_fa*KV_tmp_stride + DVp-DV;
@@ -1064,7 +1132,7 @@ static __global__ void flash_attn_tile(
     constexpr int VKQ_count     = cpw * ((DVp/2)/warp_size);
     using T_Q   = std::conditional_t<bf16, nv_bfloat162, half2>;
     using T_KVt = T_Q;
-    using T_KQ  = std::conditional_t<bf16, float, half>;
+    using T_KQ  = std::conditional_t<bf16, nv_bfloat16, half>;
     using T_acc = std::conditional_t<bf16, float2, half2>;
 #else
     constexpr bool bf16 = false;
@@ -1360,6 +1428,9 @@ static __global__ void flash_attn_tile(
     NO_DEVICE_CODE;
 #endif // FLASH_ATTN_AVAILABLE
 }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // __clang__
 
 template <int DKQ, int DV, int ncols2, bool use_logit_softcap, ggml_type type_KV>
 static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -312,65 +312,259 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_am
     return 0;
 }
 
-static __host__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols, const int cc) {
+static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_nvidia_fp16_bf16(const int DKQ, const int DV, const int ncols) {
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  2,  64,  2,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  4, 128,  2,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  8, 256,  2,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256,  2,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256,  1,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2,  64,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 16, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 32, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  2,  64,  2,  64,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  4, 128,  2,  64,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  8, 256,  2,  64,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 16, 256,  1,  64,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 32, 256,  1,  64,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  2,  64,  2,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  4, 128,  2,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  8, 256,  2,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 16, 256,  1,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 32, 256,  1,  64,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  2,  64,  2,  64,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  4, 128,  2,  64,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  8, 256,  2,  64,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 16, 256,  1,  64,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 32, 256,  1,  64,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  2,  64,  2,  64,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  4, 128,  2,  64,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  8, 256,  2,  64,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 16, 256,  1,  64,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 32, 256,  1,  64,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  2,  64,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 32, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  2,  64,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 32, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  2,  64,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 16, 256,  1,  64,  64)
+    return 0;
+}
+static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_amd_bf16(const int DKQ, const int DV, const int ncols) {
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  2,  64,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  4, 128,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  8, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 64, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2,  64,  3,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4, 128,  3,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 128,  2,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 16, 256,  1, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 32, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 64, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  2,  64,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  4, 128,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  8, 256,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 16, 256,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 32, 256,  1,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 64, 256,  1,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  2,  64,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  4, 128,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  8, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 16, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 32, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 64, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  2,  64,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  4, 128,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  8, 256,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 16, 256,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 32, 256,  1,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 64, 256,  1,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  2,  64,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  4, 128,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  8, 256,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 16, 256,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 32, 256,  1,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 64, 256,  1,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  2, 256,  2, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  4, 128,  2,  64, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  8, 256,  2,  64, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 16, 256,  1,  64, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 32, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 64, 256,  1,  64,  32)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  2, 256,  2, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  4, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 16, 256,  2,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 32, 256,  1,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  2, 256,  2, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  4, 256,  2,  64, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  8, 256,  2,  64, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256,  2,  32, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256,  1,  32, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 32, 512,  1,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 32, 512,  1,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 32, 512,  1,  32,  64)
+    return 0;
+}
+static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_amd_rdna_bf16(const int DKQ, const int DV, const int ncols) {
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  2,  64,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  4, 128,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40,  8, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 16, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 32, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 40,  40, 64, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  2,  64,  8,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  4,  64,  8,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64,  8, 128,  3, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 16, 128,  2, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 32, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 64,  64, 64, 128,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  2,  64,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  4, 128,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72,  8, 256,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 16, 256,  2,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 32, 256,  1,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 72,  72, 64, 256,  1,  32,  72)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  2,  64,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  4, 128,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80,  8, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 16, 256,  2,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 32, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 80,  80, 64, 256,  1,  32,  40)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  2,  64,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  4, 128,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96,  8, 256,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 16, 256,  2,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 32, 256,  1,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE( 96,  96, 64, 256,  1,  32,  48)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  2,  64,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  4, 128,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112,  8, 256,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 16, 256,  2,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 32, 256,  1,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(112, 112, 64, 256,  1,  32,  56)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  2,  64,  8,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  4, 128,  4,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128,  8, 128,  3,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 16, 256,  1, 128, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 32, 256,  1, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(128, 128, 64, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  2,  64,  8,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  4, 128,  4,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128,  8, 128,  4,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 16, 256,  2,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(192, 128, 32, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  2,  64,  8,  32,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  4, 128,  4,  32, 256)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256,  8, 128,  4,  32, 256)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256,  2,  32, 256)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256,  1,  64, 128)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(320, 256, 32, 256,  1, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 32, 256,  1, 128,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  4, 128,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512,  8, 256,  2,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 16, 256,  1,  64,  64)
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(576, 512, 32, 256,  1, 128,  64)
+    return 0;
+}
+
+static __host__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
     if (GGML_CUDA_CC_IS_AMD(cc)) {
         if (GGML_CUDA_CC_IS_RDNA(cc)) {
-            return ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
+            return bf16 ? ggml_cuda_fattn_tile_get_config_amd_rdna_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
         }
-        return ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
+        return bf16 ? ggml_cuda_fattn_tile_get_config_amd_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
     }
     if (fast_fp16_available(cc)) {
-        return ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
+        return bf16 ? ggml_cuda_fattn_tile_get_config_nvidia_fp16_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
     }
     return ggml_cuda_fattn_tile_get_config_nvidia_fp32(DKQ, DV, ncols);
 }
 
+template <bool bf16>
 static constexpr __device__ uint32_t ggml_cuda_fattn_tile_get_config(const int DKQ, const int DV, const int ncols) {
 #ifdef GGML_USE_HIP
 #ifdef RDNA
-    return ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
+    return bf16 ? ggml_cuda_fattn_tile_get_config_amd_rdna_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd_rdna(DKQ, DV, ncols);
 #else
-    return ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
+    return bf16 ? ggml_cuda_fattn_tile_get_config_amd_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_amd(DKQ, DV, ncols);
 #endif // RDNA
 #else
 #ifdef FAST_FP16_AVAILABLE
-    return ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
+    return bf16 ? ggml_cuda_fattn_tile_get_config_nvidia_fp16_bf16(DKQ, DV, ncols) : ggml_cuda_fattn_tile_get_config_nvidia_fp16(DKQ, DV, ncols);
 #else
     return ggml_cuda_fattn_tile_get_config_nvidia_fp32(DKQ, DV, ncols);
 #endif // FAST_FP16_AVAILABLE
 #endif // GGML_USE_HIP
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_nthreads(const int DKQ, const int DV, const int ncols, const int cc) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 0) & ((1 << 10) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_nthreads(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 0) & ((1 << 10) - 1);
 }
 
+template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_nthreads(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 0) & ((1 << 10) - 1);
+    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 0) & ((1 << 10) - 1);
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_occupancy(const int DKQ, const int DV, const int ncols, const int cc) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 10) & ((1 << 4) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_occupancy(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 10) & ((1 << 4) - 1);
 }
 
+template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_occupancy(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 10) & ((1 << 4) - 1);
+    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 10) & ((1 << 4) - 1);
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_nbatch_fa(const int DKQ, const int DV, const int ncols, const int cc) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 14) & ((1 << 9) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_nbatch_fa(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 14) & ((1 << 9) - 1);
 }
 
+template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_nbatch_fa(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 14) & ((1 << 9) - 1);
+    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 14) & ((1 << 9) - 1);
 }
 
-static __host__ int ggml_cuda_fattn_tile_get_nbatch_K(const int DKQ, const int DV, const int ncols, const int cc) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc) >> 23) & ((1 << 9) - 1);
+static __host__ int ggml_cuda_fattn_tile_get_nbatch_K(const int DKQ, const int DV, const int ncols, const int cc, const bool bf16 = false) {
+    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols, cc, bf16) >> 23) & ((1 << 9) - 1);
 }
 
+template <bool bf16>
 static constexpr __device__ int ggml_cuda_fattn_tile_get_nbatch_K(const int DKQ, const int DV, const int ncols) {
-    return (ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols) >> 23) & ((1 << 9) - 1);
+    return (ggml_cuda_fattn_tile_get_config<bf16>(DKQ, DV, ncols) >> 23) & ((1 << 9) - 1);
 }
 
 // TODO: deduplicate with mma-f16
@@ -419,6 +613,56 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
     // 5: max  4*16= 64 bytes,  32 half
     // 6: max  2*16= 32 bytes,  16 half
     // 7: max  1*16= 16 bytes,   8 half
+    static_assert(J % 8 == 0, "bad J");
+    static_assert((J/2) % cpy_ne == 0, "bad J");
+    ggml_cuda_unroll<7>{}(load);
+}
+
+template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
+static __device__ __forceinline__ void flash_attn_tile_load_tile(
+        const nv_bfloat162 * const __restrict__ KV, nv_bfloat162 * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
+    constexpr int cpy_nb = ggml_cuda_get_max_cpy_bytes();
+    constexpr int cpy_ne = cpy_nb / 4;
+
+    auto load = [&] __device__ (const int n) {
+        const int stride_j = warp_size >> n;
+
+        if (stride_j == 0) {
+            return;
+        }
+
+        const int j0_start = stride_j == warp_size ? 0 : ((J/2)/cpy_ne) - ((J/2)/cpy_ne) % (2*stride_j);
+        const int j0_stop  =                             ((J/2)/cpy_ne) - ((J/2)/cpy_ne) % (1*stride_j);
+        const int stride_i = warp_size / stride_j;
+
+        if (j0_start == j0_stop) {
+            return;
+        }
+
+#pragma unroll
+        for (int i0 = 0; i0 < I; i0 += nwarps*stride_i) {
+            const int i = i0 + threadIdx.y*stride_i + (stride_j == warp_size ? 0 : threadIdx.x / stride_j);
+
+            if (i0 + nwarps*stride_i <= I || i < I) {
+#pragma unroll
+                for (int j0 = j0_start; j0 < j0_stop; j0 += stride_j) {
+                    const int j = j0*cpy_ne + (stride_j == warp_size ? threadIdx.x : threadIdx.x % stride_j)*cpy_ne;
+
+                    const __align__(16) nv_bfloat162 zero[cpy_ne] = {{0.0f, 0.0f}};
+                    ggml_cuda_memcpy_1<cpy_nb>(
+                        tile_KV + i*(J/2 + J_padding) + j,
+                        !oob_check || i < i_sup ? KV + i*stride_KV + j : zero);
+                }
+            }
+        }
+    };
+    // 1: max 64*16=512 bytes, 256 bf16
+    // 2: max 32*16=512 bytes, 128 bf16
+    // 3: max 16*16=256 bytes,  64 bf16
+    // 4: max  8*16=128 bytes,  32 bf16
+    // 5: max  4*16= 64 bytes,  16 bf16
+    // 6: max  2*16= 32 bytes,   8 bf16
+    // 7: max  1*16= 16 bytes,   4 bf16
     static_assert(J % 8 == 0, "bad J");
     static_assert((J/2) % cpy_ne == 0, "bad J");
     ggml_cuda_unroll<7>{}(load);
@@ -481,11 +725,11 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
 
 // Function that performs a single iteration in for the KQ matrix multiplication:
 template <int warp_size, int nwarps, int ncols1, int ncols2, int DKQ, int nbatch_fa, int nbatch_K,
-    bool use_logit_softcap, bool oob_check, typename T_vec_dot>
+    bool use_logit_softcap, bool oob_check, typename T_Q, typename T_KV, typename T_KV_tmp>
 static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
-        T_vec_dot   * const Q_tmp,
-        const half2 * const __restrict__ K_h2,
-        T_vec_dot   * const KV_tmp,
+        T_Q        * const Q_tmp,
+        const T_KV * const __restrict__ K_h2,
+        T_KV_tmp   * const KV_tmp,
         const int stride_K2,
         const int k_VKQ_0,
         const int k_VKQ_sup,
@@ -502,18 +746,62 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
         (K_h2 + int64_t(k_VKQ_0)*stride_K2 + k_KQ_0/2, KV_tmp, stride_K2, k_VKQ_sup);
     __syncthreads();
 
+    if constexpr (std::is_same_v<T_KV, nv_bfloat162>) {
+        // BF16 K: FP32 math, K is read as BF16 and converted to FP32 in registers.
+        static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
+#pragma unroll
+        for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/2; k_KQ_1 += cpy_ne) {
+            __align__(16) float2 K_k[nbatch_fa/(np*warp_size)][cpy_ne];
+            __align__(16) float  Q_k[cpw][2*cpy_ne];
+
+#pragma unroll
+            for (int i_KQ_0 = 0; i_KQ_0 < nbatch_fa; i_KQ_0 += np*warp_size) {
+                const int i_KQ = i_KQ_0 + (threadIdx.y % np)*warp_size + threadIdx.x;
+
+                __align__(16) nv_bfloat162 tmp[cpy_ne];
+                ggml_cuda_memcpy_1<cpy_nb>(tmp, &KV_tmp[i_KQ*(nbatch_K/2 + cpy_ne) + k_KQ_1]);
+#pragma unroll
+                for (int k = 0; k < cpy_ne; ++k) {
+                    K_k[i_KQ_0/(np*warp_size)][k] = ggml_cuda_cast<float2>(tmp[k]);
+                }
+            }
+#pragma unroll
+            for (int jc0 = 0; jc0 < cpw; ++jc0) {
+                const int jc = jc0 + (threadIdx.y / np)*cpw;
+
+#pragma unroll
+                for (int q = 0; q < 2; ++q) {
+                    ggml_cuda_memcpy_1<cpy_nb>(&Q_k[jc0][q*cpy_ne], &Q_tmp[jc*DKQ + k_KQ_0 + 2*k_KQ_1 + q*cpy_ne]);
+                }
+            }
+
+#pragma unroll
+            for (int i_KQ_0 = 0; i_KQ_0 < nbatch_fa; i_KQ_0 += np*warp_size) {
+#pragma unroll
+                for (int jc0 = 0; jc0 < cpw; ++jc0) {
+#pragma unroll
+                    for (int k = 0; k < cpy_ne; ++k) {
+                        ggml_cuda_mad(KQ_acc[i_KQ_0/(np*warp_size)*cpw + jc0], K_k[i_KQ_0/(np*warp_size)][k].x, Q_k[jc0][2*k + 0]);
+                        ggml_cuda_mad(KQ_acc[i_KQ_0/(np*warp_size)*cpw + jc0], K_k[i_KQ_0/(np*warp_size)][k].y, Q_k[jc0][2*k + 1]);
+                    }
+                }
+            }
+        }
+    } else
 #ifdef FAST_FP16_AVAILABLE
-    static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
+    {
+        static_assert((nbatch_K/2) % cpy_ne == 0, "bad nbatch_K");
 #pragma unroll
-    for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/2; k_KQ_1 += cpy_ne) {
-        __align__(16) half2 K_k[nbatch_fa/(np*warp_size)][cpy_ne];
-        __align__(16) half2 Q_k[cpw][cpy_ne];
+        for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K/2; k_KQ_1 += cpy_ne) {
+            __align__(16) half2 K_k[nbatch_fa/(np*warp_size)][cpy_ne];
+            __align__(16) half2 Q_k[cpw][cpy_ne];
 #else
-    static_assert(nbatch_K % cpy_ne == 0, "bad nbatch_K");
+    {
+        static_assert(nbatch_K % cpy_ne == 0, "bad nbatch_K");
 #pragma unroll
-    for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K; k_KQ_1 += cpy_ne) {
-        __align__(16) float K_k[nbatch_fa/(np*warp_size)][cpy_ne];
-        __align__(16) float Q_k[cpw][cpy_ne];
+        for (int k_KQ_1 = 0; k_KQ_1 < nbatch_K; k_KQ_1 += cpy_ne) {
+            __align__(16) float K_k[nbatch_fa/(np*warp_size)][cpy_ne];
+            __align__(16) float Q_k[cpw][cpy_ne];
 #endif // FAST_FP16_AVAILABLE
 
 #pragma unroll
@@ -548,6 +836,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
             }
         }
     }
+    }
 
     if (k_KQ_0 + nbatch_K < DKQ) {
         __syncthreads(); // Sync not needed on last iteration.
@@ -556,17 +845,17 @@ static __device__ __forceinline__ void flash_attn_tile_iter_KQ(
 
 // Function that performs a single iteration of the main loop over up to nbatch_fa tokens.
 template <int warp_size, int nwarps, int ncols1, int ncols2, int DKQ, int DV, int nbatch_fa, int nbatch_K,
-    bool use_logit_softcap, bool oob_check, typename T_vec_dot, typename T_KQ, typename T_acc>
+    bool use_logit_softcap, bool oob_check, typename T_Q, typename T_KV, typename T_KQ, typename T_acc, typename T_KV_tmp>
 static __device__ __forceinline__ void flash_attn_tile_iter(
-        T_vec_dot * const Q_tmp,
-        const half2 * const __restrict__ K_h2,
-        const half2 * const __restrict__ V_h2,
+        T_Q       * const Q_tmp,
+        const T_KV * const __restrict__ K_h2,
+        const T_KV * const __restrict__ V_h2,
         const half  * const __restrict__ mask,
         const uint3 ne01,
         const float logit_softcap,
         const float slope,
         T_KQ      * const KQ,
-        T_vec_dot * const KV_tmp,
+        T_KV_tmp  * const KV_tmp,
         const int stride_K2,
         const int stride_V2,
         const int stride_mask,
@@ -588,7 +877,9 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
     // KQ_cs == KQ chunk size, number of KQ values in j direction to store as one contiguous chunk in memory.
     // KQ is originally 2D but uses a Z-shaped 3D memory pattern like KQ[ncols/KQ_cs][DVp][KQ_cs].
 #ifdef FAST_FP16_AVAILABLE
-    constexpr int KQ_cs = cpw < 2*cpy_ne ? cpw : 2*cpy_ne;
+    // BF16 K/V always uses FP32 math; only F16 K/V uses the half2 (FAST) path.
+    constexpr int KQ_cs = std::is_same_v<T_KV, nv_bfloat162>
+        ? (cpw < 1*cpy_ne ? cpw : 1*cpy_ne) : (cpw < 2*cpy_ne ? cpw : 2*cpy_ne);
 #else
     constexpr int KQ_cs = cpw < 1*cpy_ne ? cpw : 1*cpy_ne;
 #endif // FAST_FP16_AVAILABLE
@@ -663,10 +954,11 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
 #pragma unroll
     for (int jc0 = 0; jc0 < cpw; jc0 += KQ_cs) {
 #ifdef FAST_FP16_AVAILABLE
-        __align__(16) half  tmp[nbatch_fa/(np*warp_size)][KQ_cs];
+        using T_KQ_tmp = std::conditional_t<std::is_same_v<T_KV, nv_bfloat162>, float, half>;
 #else
-        __align__(16) float tmp[nbatch_fa/(np*warp_size)][KQ_cs];
+        using T_KQ_tmp = float;
 #endif // FAST_FP16_AVAILABLE
+        __align__(16) T_KQ_tmp tmp[nbatch_fa/(np*warp_size)][KQ_cs];
 
 #pragma unroll
         for (int jc1 = 0; jc1 < KQ_cs; ++jc1) {
@@ -686,18 +978,21 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             KQ_sum[jc] = KQ_sum[jc]*KQ_max_scale + KQ_sum_add;
 
 #ifdef FAST_FP16_AVAILABLE
-            const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
+            if constexpr (!std::is_same_v<T_KV, nv_bfloat162>) {
+                const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
 #pragma unroll
-            for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                VKQ[jc*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
-            }
-#else
-#pragma unroll
-            for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
-                VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
-            }
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+                    VKQ[jc*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
+                }
+            } else
 #endif // FAST_FP16_AVAILABLE
+            {
+#pragma unroll
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+                    VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
+                    VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
+                }
+            }
         }
 
 #pragma unroll
@@ -722,7 +1017,43 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             (V_h2 + int64_t(k_VKQ_0 + k0)*stride_V2, KV_tmp, stride_V2, k_VKQ_sup - k0);
         __syncthreads();
 
+        if constexpr (std::is_same_v<T_KV, nv_bfloat162>) {
+            // BF16 V: FP32 math, V is read as BF16 and converted to FP32 in registers.
+#pragma unroll
+            for (int k1 = 0; k1 < nbatch_V; k1 += np) {
+                __align__(16) float2 V_k[(DVp/2)/warp_size];
+                __align__(16) float  KQ_k[cpw];
+
+                constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
+#pragma unroll
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
+                    __align__(16) nv_bfloat162 tmp[cpy_ne_D];
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &KV_tmp[(k1 + threadIdx.y % np)*(DV/2) + i0 + threadIdx.x*cpy_ne_D]);
+#pragma unroll
+                    for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
+                        V_k[i0/warp_size + i1] = ggml_cuda_cast<float2>(tmp[i1]);
+                    }
+                }
+#pragma unroll
+                for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; jc_VKQ_0 += KQ_cs) {
+                    const int jc_KQ = jc_VKQ_0/KQ_cs + (threadIdx.y / np)*(cpw/KQ_cs);
+
+                    ggml_cuda_memcpy_1<KQ_cs*sizeof(float)>(
+                        &KQ_k[jc_VKQ_0], KQ + jc_KQ*(nbatch_fa*KQ_cs) + (k0 + k1 + threadIdx.y % np)*KQ_cs);
+                }
+
+#pragma unroll
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+#pragma unroll
+                    for (int jc_VKQ_0 = 0; jc_VKQ_0 < cpw; ++jc_VKQ_0) {
+                        VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].x += V_k[i0/warp_size].x*KQ_k[jc_VKQ_0];
+                        VKQ[jc_VKQ_0*((DVp/2)/warp_size) + i0/warp_size].y += V_k[i0/warp_size].y*KQ_k[jc_VKQ_0];
+                    }
+                }
+            }
+        } else
 #ifdef FAST_FP16_AVAILABLE
+        {
 #pragma unroll
         for (int k1 = 0; k1 < nbatch_V; k1 += np) {
             __align__(16) half2 V_k[(DVp/2)/warp_size];
@@ -754,7 +1085,9 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
                 }
             }
         }
+        }
 #else
+        {
 #pragma unroll
         for (int k1 = 0; k1 < nbatch_V; k1 += np) {
             __align__(16) float2 V_k[(DVp/2)/warp_size];
@@ -782,14 +1115,16 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
                 }
             }
         }
+        }
 #endif // FAST_FP16_AVAILABLE
 
         __syncthreads();
     }
 }
 
-template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap> // D == head size
-__launch_bounds__(ggml_cuda_fattn_tile_get_nthreads(DKQ, DV, ncols1*ncols2), ggml_cuda_fattn_tile_get_occupancy(DKQ, DV, ncols1*ncols2))
+template<int DKQ, int DV, int ncols1, int ncols2, bool use_logit_softcap, ggml_type type_KV> // D == head size
+__launch_bounds__(ggml_cuda_fattn_tile_get_nthreads<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2),
+                       ggml_cuda_fattn_tile_get_occupancy<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2))
 static __global__ void flash_attn_tile(
         const char * Q_ptr,
         const char * K_ptr,
@@ -838,13 +1173,13 @@ static __global__ void flash_attn_tile(
         return;
     }
 
-    static_assert(ggml_cuda_fattn_tile_get_config(DKQ, DV, ncols1*ncols2) != 0, "kernel config not defined");
+    static_assert(ggml_cuda_fattn_tile_get_config<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2) != 0, "kernel config not defined");
 
     constexpr int ncols     = ncols1*ncols2;
     constexpr int warp_size = 32;
-    constexpr int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, ncols1*ncols2) / warp_size;
-    constexpr int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, ncols1*ncols2);
-    constexpr int nbatch_K  = ggml_cuda_fattn_tile_get_nbatch_K (DKQ, DV, ncols1*ncols2);
+    constexpr int nwarps    = ggml_cuda_fattn_tile_get_nthreads <type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2) / warp_size;
+    constexpr int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa<type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2);
+    constexpr int nbatch_K  = ggml_cuda_fattn_tile_get_nbatch_K <type_KV == GGML_TYPE_BF16>(DKQ, DV, ncols1*ncols2);
 
     // In this kernel Q, K, V are matrices while i, j, k are matrix indices.
 
@@ -854,8 +1189,9 @@ static __global__ void flash_attn_tile(
     const int head0 = blockIdx.z*ncols2 - sequence*ne02; // == blockIdx.z % (ne02/ncols2)
     const int gqa_ratio = ne02 / ne12; // With grouped query attention there are > 1 Q matrices per K, V matrix.
     const float * Q_f  = (const float *) (Q + nb03*sequence + nb02* head0);
-    const half2 * K_h2 = (const half2 *) (K + nb13*sequence + nb12*(head0 / gqa_ratio));
-    const half2 * V_h2 = (const half2 *) (V + nb23*sequence + nb22*(head0 / gqa_ratio)); // K and V have same shape
+    using T_KV = std::conditional_t<type_KV == GGML_TYPE_BF16, nv_bfloat162, half2>;
+    const T_KV * K_h2 = (const T_KV *) (K + nb13*sequence + nb12*(head0 / gqa_ratio));
+    const T_KV * V_h2 = (const T_KV *) (V + nb23*sequence + nb22*(head0 / gqa_ratio)); // K and V have same shape
 
     const half * maskh = mask ? (const half *) (mask + nb33*(sequence % ne33)) : nullptr;
 
@@ -882,16 +1218,25 @@ static __global__ void flash_attn_tile(
     // KQ == SRAM buffer to hold KQ fragments between KQ and VKQ matrix multiplications.
     // VKQ == Accumulators in registers for the final VKQ result.
 #ifdef FAST_FP16_AVAILABLE
-    __shared__ half2 Q_tmp[ncols * DKQ/2];
-    __shared__ half2 KV_tmp[nbatch_fa * (nbatch_K/2 + cpy_ne) + DVp-DV];
-    __shared__ half  KQ[ncols * nbatch_fa];
-    __align__(16) half2 VKQ[cpw * ((DVp/2)/warp_size)] = {{0.0f, 0.0f}};
+    // BF16 K/V always uses FP32 math; only F16 K/V uses the half2 (FAST) path.
+    constexpr bool T_KV_uses_half2 = type_KV != GGML_TYPE_BF16;
 #else
-    __shared__ float Q_tmp[ncols * DKQ];
-    __shared__ float KV_tmp[nbatch_fa * (nbatch_K + cpy_ne) + DVp-DV];
-    __shared__ float KQ[ncols * nbatch_fa];
-    __align__(16) float2 VKQ[cpw * ((DVp/2)/warp_size)] = {{0.0f, 0.0f}};
+    constexpr bool T_KV_uses_half2 = false;
 #endif // FAST_FP16_AVAILABLE
+    constexpr int Q_tmp_count   = T_KV_uses_half2 ? ncols*DKQ/2 : ncols*DKQ;
+    constexpr int KV_tmp_stride = T_KV_uses_half2 || type_KV == GGML_TYPE_BF16 ? nbatch_K/2 + cpy_ne : nbatch_K + cpy_ne;
+    constexpr int KV_tmp_count  = nbatch_fa*KV_tmp_stride + DVp-DV;
+    constexpr int KQ_count      = ncols*nbatch_fa;
+    constexpr int VKQ_count     = cpw * ((DVp/2)/warp_size);
+    using T_Q   = std::conditional_t<T_KV_uses_half2, half2, float>;
+    using T_KVt = std::conditional_t<type_KV == GGML_TYPE_BF16, nv_bfloat162, std::conditional_t<T_KV_uses_half2, half2, float>>;
+    using T_KQ  = std::conditional_t<T_KV_uses_half2, half, float>;
+    using T_acc = std::conditional_t<T_KV_uses_half2, half2, float2>;
+
+    __shared__ T_Q   Q_tmp[Q_tmp_count];
+    __shared__ T_KVt KV_tmp[KV_tmp_count];
+    __shared__ T_KQ  KQ[KQ_count];
+    __align__(16) T_acc VKQ[VKQ_count] = {{0.0f, 0.0f}};
 
     float KQ_max[cpw];
 #pragma unroll
@@ -926,24 +1271,27 @@ static __global__ void flash_attn_tile(
                 }
 
 #ifdef FAST_FP16_AVAILABLE
-                __align__(16) half2 tmp_h2[cpy_ne_D/2];
+                if constexpr (type_KV != GGML_TYPE_BF16) {
+                    __align__(16) half2 tmp_h2[cpy_ne_D/2];
 #pragma unroll
-                for (int i1 = 0; i1 < cpy_ne_D; i1 += 2) {
-                    tmp_h2[i1/2] = make_half2(tmp_f[i1 + 0], tmp_f[i1 + 1]);
+                    for (int i1 = 0; i1 < cpy_ne_D; i1 += 2) {
+                        tmp_h2[i1/2] = make_half2(tmp_f[i1 + 0], tmp_f[i1 + 1]);
 #if defined(FAST_FP16_AVAILABLE) && !defined(V_DOT2_F32_F16_AVAILABLE)
-                    // Without the v_dot2_f32_f16 instruction there is a higher risk of numerical overflow in the KQ calculation.
-                    // Therefore, scale down Q values and apply the inverse scale the FP32 KQ values afterwards again.
-                    tmp_h2[i1/2] *= make_half2(0.25f, 0.25f);
+                        // Without the v_dot2_f32_f16 instruction there is a higher risk of numerical overflow in the KQ calculation.
+                        // Therefore, scale down Q values and apply the inverse scale the FP32 KQ values afterwards again.
+                        tmp_h2[i1/2] *= make_half2(0.25f, 0.25f);
 #endif // defined(FAST_FP16_AVAILABLE) && !defined(V_DOT2_F32_F16_AVAILABLE)
-                }
-                ggml_cuda_memcpy_1<sizeof(tmp_h2)>(
-                    &Q_tmp[jc*(DKQ/2) + i0/2 + (threadIdx.y % np)*(warp_size*cpy_ne_D/2) + threadIdx.x*(cpy_ne_D/2)],
-                    tmp_h2);
-#else
-                ggml_cuda_memcpy_1<sizeof(tmp_f)>(
-                    &Q_tmp[jc* DKQ    + i0   + (threadIdx.y % np)*(warp_size*cpy_ne_D)   + threadIdx.x* cpy_ne_D],
-                    tmp_f);
+                    }
+                    ggml_cuda_memcpy_1<sizeof(tmp_h2)>(
+                        &Q_tmp[jc*(DKQ/2) + i0/2 + (threadIdx.y % np)*(warp_size*cpy_ne_D/2) + threadIdx.x*(cpy_ne_D/2)],
+                        tmp_h2);
+                } else
 #endif // FAST_FP16_AVAILABLE
+                {
+                    ggml_cuda_memcpy_1<sizeof(tmp_f)>(
+                        &Q_tmp[jc*DKQ + i0 + (threadIdx.y % np)*(warp_size*cpy_ne_D) + threadIdx.x*cpy_ne_D],
+                        tmp_f);
+                }
             }
         }
     }
@@ -988,27 +1336,31 @@ static __global__ void flash_attn_tile(
         static_assert(nbatch_fa*nbatch_K >= nwarps*DVp, "KV_tmp too small");
 
 #ifdef FAST_FP16_AVAILABLE
-        half2 * VKQ_combine    = (half2 *) KV_tmp;
+        using T_VKQ_combine = std::conditional_t<type_KV == GGML_TYPE_BF16, float, half2>;
 #else
-        float * VKQ_combine    = (float *) KV_tmp;
+        using T_VKQ_combine = float;
 #endif // FAST_FP16_AVAILABLE
+        T_VKQ_combine * VKQ_combine = (T_VKQ_combine *) KV_tmp;
         float * KQ_sum_combine = (float *) Q_tmp;
 
         if (threadIdx.y % np != 0) {
 #ifdef FAST_FP16_AVAILABLE
-            constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
+            if constexpr (type_KV != GGML_TYPE_BF16) {
+                constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
-            for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
-                ggml_cuda_memcpy_1<cpy_ne_D*4>(&VKQ_combine[threadIdx.y*(DVp/2) + i0 + threadIdx.x*cpy_ne_D], &VKQ[i0/warp_size]);
-            }
-#else
-            constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
-#pragma unroll
-            for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
-                ggml_cuda_memcpy_1<cpy_ne_D*4>(
-                    &VKQ_combine[threadIdx.y*DVp + i0 + threadIdx.x*cpy_ne_D], ((const float *) VKQ) + i0/warp_size);
-            }
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(&VKQ_combine[threadIdx.y*(DVp/2) + i0 + threadIdx.x*cpy_ne_D], &VKQ[i0/warp_size]);
+                }
+            } else
 #endif // FAST_FP16_AVAILABLE
+            {
+                constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
+#pragma unroll
+                for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(
+                        &VKQ_combine[threadIdx.y*DVp + i0 + threadIdx.x*cpy_ne_D], ((const float *) VKQ) + i0/warp_size);
+                }
+            }
 
             if (threadIdx.x == 0) {
                 KQ_sum_combine[threadIdx.y] = KQ_sum[0];
@@ -1022,28 +1374,31 @@ static __global__ void flash_attn_tile(
 #pragma unroll
         for (int ip = 1; ip < np; ++ip) {
 #ifdef FAST_FP16_AVAILABLE
-            constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
+            if constexpr (type_KV != GGML_TYPE_BF16) {
+                constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
-            for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
-                __align__(16) half2 tmp[cpy_ne_D];
-                ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &VKQ_combine[(threadIdx.y + ip)*(DVp/2) + i0 + threadIdx.x*cpy_ne_D]);
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
+                    __align__(16) half2 tmp[cpy_ne_D];
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &VKQ_combine[(threadIdx.y + ip)*(DVp/2) + i0 + threadIdx.x*cpy_ne_D]);
 #pragma unroll
-                for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
-                    VKQ[i0/warp_size + i1] += tmp[i1];
+                    for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
+                        VKQ[i0/warp_size + i1] += tmp[i1];
+                    }
                 }
-            }
-#else
-            constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
-#pragma unroll
-            for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
-                __align__(16) float tmp[cpy_ne_D];
-                ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &VKQ_combine[(threadIdx.y + ip)*DVp + i0 + threadIdx.x*cpy_ne_D]);
-#pragma unroll
-                for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
-                    ((float *)VKQ)[i0/warp_size + i1] += tmp[i1];
-                }
-            }
+            } else
 #endif // FAST_FP16_AVAILABLE
+            {
+                constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
+#pragma unroll
+                for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
+                    __align__(16) float tmp[cpy_ne_D];
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(tmp, &VKQ_combine[(threadIdx.y + ip)*DVp + i0 + threadIdx.x*cpy_ne_D]);
+#pragma unroll
+                    for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
+                        ((float *)VKQ)[i0/warp_size + i1] += tmp[i1];
+                    }
+                }
+            }
 
             KQ_sum[0] += KQ_sum_combine[threadIdx.y + ip];
         }
@@ -1064,18 +1419,21 @@ static __global__ void flash_attn_tile(
             KQ_sum[jc0] = KQ_sum[jc0]*KQ_max_scale + val;
 
 #ifdef FAST_FP16_AVAILABLE
-            const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
+            if constexpr (type_KV != GGML_TYPE_BF16) {
+                const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
 #pragma unroll
-            for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
-            }
-#else
-#pragma unroll
-            for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
-                VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
-            }
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+                    VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
+                }
+            } else
 #endif // FAST_FP16_AVAILABLE
+            {
+#pragma unroll
+                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
+                    VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
+                    VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
+                }
+            }
         }
     }
 
@@ -1096,36 +1454,39 @@ static __global__ void flash_attn_tile(
         const int j_dst_unrolled = ((sequence*int(ne01.z) + col_Q_0 + j)*ne02 + head0 + c)*gridDim.y + blockIdx.y;
 
 #ifdef FAST_FP16_AVAILABLE
-        constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
+        if constexpr (type_KV != GGML_TYPE_BF16) {
+            constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
 #pragma unroll
-        for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
-            __align__(16) float2 tmp[cpy_ne_D];
+            for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
+                __align__(16) float2 tmp[cpy_ne_D];
 #pragma unroll
-            for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
-                tmp[i1] = __half22float2(VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size + i1]);
-                tmp[i1].x *= scale;
-                tmp[i1].y *= scale;
-            }
-            if (i0 + warp_size*cpy_ne_D <= DV/2 || i0 + threadIdx.x*cpy_ne_D < DV/2) {
-                ggml_cuda_memcpy_1<sizeof(tmp)>(&dst[j_dst_unrolled*DV + 2*i0 + threadIdx.x*(2*cpy_ne_D)], tmp);
-            }
-        }
-#else
-        constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
-#pragma unroll
-        for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
-            if (i0 + warp_size*cpy_ne_D <= DV || i0 + threadIdx.x*cpy_ne_D < DV) {
-#pragma unroll
-                for (int i1 = 0; i1 < cpy_ne_D/2; ++i1) {
-                    VKQ[jc0*((DVp/2)/warp_size) + i0/(2*warp_size) + i1].x *= scale;
-                    VKQ[jc0*((DVp/2)/warp_size) + i0/(2*warp_size) + i1].y *= scale;
+                for (int i1 = 0; i1 < cpy_ne_D; ++i1) {
+                    tmp[i1] = __half22float2(VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size + i1]);
+                    tmp[i1].x *= scale;
+                    tmp[i1].y *= scale;
                 }
-                ggml_cuda_memcpy_1<cpy_ne_D*4>(
-                    &dst[j_dst_unrolled*DV + i0 + threadIdx.x*cpy_ne_D],
-                    &VKQ[jc0*((DVp/2)/warp_size) + i0/(2*warp_size)]);
+                if (i0 + warp_size*cpy_ne_D <= DV/2 || i0 + threadIdx.x*cpy_ne_D < DV/2) {
+                    ggml_cuda_memcpy_1<sizeof(tmp)>(&dst[j_dst_unrolled*DV + 2*i0 + threadIdx.x*(2*cpy_ne_D)], tmp);
+                }
+            }
+        } else
+#endif // FAST_FP16_AVAILABLE
+        {
+            constexpr int cpy_ne_D = cpy_ne < DVp/warp_size ? cpy_ne : DVp/warp_size;
+#pragma unroll
+            for (int i0 = 0; i0 < DVp; i0 += warp_size*cpy_ne_D) {
+                if (i0 + warp_size*cpy_ne_D <= DV || i0 + threadIdx.x*cpy_ne_D < DV) {
+#pragma unroll
+                    for (int i1 = 0; i1 < cpy_ne_D/2; ++i1) {
+                        VKQ[jc0*((DVp/2)/warp_size) + i0/(2*warp_size) + i1].x *= scale;
+                        VKQ[jc0*((DVp/2)/warp_size) + i0/(2*warp_size) + i1].y *= scale;
+                    }
+                    ggml_cuda_memcpy_1<cpy_ne_D*4>(
+                        &dst[j_dst_unrolled*DV + i0 + threadIdx.x*cpy_ne_D],
+                        &VKQ[jc0*((DVp/2)/warp_size) + i0/(2*warp_size)]);
+                }
             }
         }
-#endif // FAST_FP16_AVAILABLE
 
         if (gridDim.y != 1 && threadIdx.x == 0) {
             dst_meta[j_dst_unrolled] = make_float2(KQ_max[jc0], KQ_sum[jc0]);
@@ -1145,9 +1506,15 @@ static __global__ void flash_attn_tile(
 #endif // FLASH_ATTN_AVAILABLE
 }
 
-template <int DKQ, int DV, int ncols2, bool use_logit_softcap>
+template <int DKQ, int DV, int ncols2, bool use_logit_softcap, ggml_type type_KV>
 static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * Q = dst->src[0];
+    const ggml_tensor * K = dst->src[1];
+    const ggml_tensor * V = dst->src[2];
+
+    // K/V types other than the kernel KV type are converted to it by the launcher.
+    const bool need_f16_K = K->type != type_KV;
+    const bool need_f16_V = V->type != type_KV;
 
     const int id        = ggml_cuda_get_device();
     const int cc        = ggml_cuda_info().devices[id].cc;
@@ -1159,11 +1526,12 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (DKQ <= 128) {
         if (Q->ne[1] > 32/ncols2) {
             constexpr int cols_per_block = 64;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
-                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
+                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
+                need_f16_K, need_f16_V, false, warp_size);
             return;
         }
     }
@@ -1174,12 +1542,14 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
 #endif // GGML_USE_HIP
     {
         if (Q->ne[1] > 16/ncols2) {
-            constexpr int cols_per_block = 32;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            // BF16 uses FP32 Q_tmp, which needs smaller Q tiles for large heads to fit SRAM.
+            constexpr int cols_per_block = type_KV == GGML_TYPE_BF16 && DKQ >= 256 ? 16 : 32;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
-                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
+                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
+                need_f16_K, need_f16_V, false, warp_size);
             return;
         }
     }
@@ -1187,11 +1557,12 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (ncols2 <= 16) {
         if (Q->ne[1] > 8/ncols2) {
             constexpr int cols_per_block = 16;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
-                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
+                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
+                need_f16_K, need_f16_V, false, warp_size);
             return;
         }
     }
@@ -1199,11 +1570,12 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (ncols2 <= 8) {
         if (Q->ne[1] > 4/ncols2) {
             constexpr int cols_per_block = 8;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
-                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
+                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
+                need_f16_K, need_f16_V, false, warp_size);
             return;
         }
     }
@@ -1211,29 +1583,31 @@ static void launch_fattn_tile_switch_ncols1(ggml_backend_cuda_context & ctx, ggm
     if constexpr (ncols2 <= 4) {
         if (Q->ne[1] > 2/ncols2) {
             constexpr int cols_per_block = 4;
-            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
-            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+            const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
+            const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
+            fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
             launch_fattn<DV, cols_per_block/ncols2, ncols2>
-                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
+                (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
+                need_f16_K, need_f16_V, false, warp_size);
             return;
         }
     }
 
     if constexpr (ncols2 <= 2) {
         constexpr int cols_per_block = 2;
-        const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc) / warp_size;
-        const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc);
-        fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap>;
+        const int nwarps    = ggml_cuda_fattn_tile_get_nthreads (DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16) / warp_size;
+        const int nbatch_fa = ggml_cuda_fattn_tile_get_nbatch_fa(DKQ, DV, cols_per_block, cc, type_KV == GGML_TYPE_BF16);
+        fattn_kernel_t fattn_kernel = flash_attn_tile<DKQ, DV, cols_per_block/ncols2, ncols2, use_logit_softcap, type_KV>;
         launch_fattn<DV, cols_per_block/ncols2, ncols2>
-            (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa, true, true, false, warp_size);
+            (ctx, dst, fattn_kernel, nwarps, nbytes_shared, nbatch_fa,
+                need_f16_K, need_f16_V, false, warp_size);
         return;
     }
 
     GGML_ABORT("fatal error");
 }
 
-template <int DKQ, int DV, bool use_logit_softcap>
+template <int DKQ, int DV, bool use_logit_softcap, ggml_type type_KV>
 static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * KQV  = dst;
     const ggml_tensor * Q    = dst->src[0];
@@ -1258,13 +1632,13 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
         // On NVIDIA however, the tile kernel is only used for GPUs that can't use the mma kernel (Pascal and older).
         // Therefore, use a GQA ratio of 16 with 16 columns / block to stay below 48 kiB of SRAM / block.
 #ifdef GGML_USE_HIP
-        if (use_gqa_opt && gqa_ratio % 32 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 32, use_logit_softcap>(ctx, dst);
+        if (use_gqa_opt && (type_KV == GGML_TYPE_BF16 ? gqa_ratio % 16 == 0 : gqa_ratio % 32 == 0)) {
+            launch_fattn_tile_switch_ncols1<DKQ, DV, type_KV == GGML_TYPE_BF16 ? 16 : 32, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 #else
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 #endif // GGML_USE_HIP
@@ -1273,11 +1647,11 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
 
     if constexpr (DKQ == 576) {
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
         if (use_gqa_opt && gqa_ratio % 4 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
     }
@@ -1285,11 +1659,11 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
     if constexpr (DKQ == 192) {
         // MiMo-V2.5 / V2.5-Pro / V2-Flash: gqa_ratio is 8 (SWA) or 16 (full attn)
         if (use_gqa_opt && gqa_ratio % 16 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 16, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
         if (use_gqa_opt && gqa_ratio % 8 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV,  8, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
         GGML_ABORT("flash-attn tile (192/128): expected GQA ratio multiple of 8");
@@ -1297,59 +1671,67 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
 
     if constexpr (DKQ <= 512 && DKQ != 320 && DKQ != 192) {
         if (use_gqa_opt && gqa_ratio % 8 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 8, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 
         if (use_gqa_opt && gqa_ratio % 4 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 4, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 
         if (use_gqa_opt && gqa_ratio % 2 == 0) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 2, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 2, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
 
         if constexpr (DV <= 256) {
-            launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap>(ctx, dst);
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap, type_KV>(ctx, dst);
             return;
         }
     }
     GGML_ABORT("fatal error");
 }
 
-template <int DKQ, int DV>
+template <int DKQ, int DV, ggml_type type_KV>
 void ggml_cuda_flash_attn_ext_tile_case(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
-    const ggml_tensor * KQV = dst;
-
     float logit_softcap;
-    memcpy(&logit_softcap, (const float *) KQV->op_params + 2, sizeof(float));
+    memcpy(&logit_softcap, (const float *) dst->op_params + 2, sizeof(float));
 
     if (logit_softcap == 0.0f) {
         constexpr bool use_logit_softcap = false;
-        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap>(ctx, dst);
+        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV>(ctx, dst);
     } else {
         constexpr bool use_logit_softcap = true;
-        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap>(ctx, dst);
+        launch_fattn_tile_switch_ncols2<DKQ, DV, use_logit_softcap, type_KV>(ctx, dst);
     }
 }
 
 void ggml_cuda_flash_attn_ext_tile(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 
-#define DECL_FATTN_TILE_CASE(DKQ, DV)                             \
-    template void ggml_cuda_flash_attn_ext_tile_case              \
-    <DKQ, DV>(ggml_backend_cuda_context & ctx, ggml_tensor * dst) \
+// Explicit instantiations, used by the autogenerated template-instances/fattn-tile-*.cu.
+#define DECL_FATTN_TILE_CASE(DKQ, DV)                                     \
+    template void ggml_cuda_flash_attn_ext_tile_case                      \
+    <DKQ, DV, GGML_TYPE_F16>(ggml_backend_cuda_context & ctx, ggml_tensor * dst); \
+    template void ggml_cuda_flash_attn_ext_tile_case                      \
+    <DKQ, DV, GGML_TYPE_BF16>(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
 
-extern DECL_FATTN_TILE_CASE( 40,  40);
-extern DECL_FATTN_TILE_CASE( 64,  64);
-extern DECL_FATTN_TILE_CASE( 72,  72);
-extern DECL_FATTN_TILE_CASE( 80,  80);
-extern DECL_FATTN_TILE_CASE( 96,  96);
-extern DECL_FATTN_TILE_CASE(112, 112);
-extern DECL_FATTN_TILE_CASE(128, 128);
-extern DECL_FATTN_TILE_CASE(192, 128);
-extern DECL_FATTN_TILE_CASE(256, 256);
-extern DECL_FATTN_TILE_CASE(320, 256);
-extern DECL_FATTN_TILE_CASE(512, 512);
-extern DECL_FATTN_TILE_CASE(576, 512);
+// Extern template declarations, prevent implicit instantiation in TUs that include the header.
+#define EXTERN_DECL_FATTN_TILE_CASES(DKQ, DV)                             \
+    extern template void ggml_cuda_flash_attn_ext_tile_case               \
+    <DKQ, DV, GGML_TYPE_F16>(ggml_backend_cuda_context & ctx, ggml_tensor * dst); \
+    extern template void ggml_cuda_flash_attn_ext_tile_case               \
+    <DKQ, DV, GGML_TYPE_BF16>(ggml_backend_cuda_context & ctx, ggml_tensor * dst)
+
+EXTERN_DECL_FATTN_TILE_CASES( 40,  40);
+EXTERN_DECL_FATTN_TILE_CASES( 64,  64);
+EXTERN_DECL_FATTN_TILE_CASES( 72,  72);
+EXTERN_DECL_FATTN_TILE_CASES( 80,  80);
+EXTERN_DECL_FATTN_TILE_CASES( 96,  96);
+EXTERN_DECL_FATTN_TILE_CASES(112, 112);
+EXTERN_DECL_FATTN_TILE_CASES(128, 128);
+EXTERN_DECL_FATTN_TILE_CASES(192, 128);
+EXTERN_DECL_FATTN_TILE_CASES(256, 256);
+EXTERN_DECL_FATTN_TILE_CASES(320, 256);
+EXTERN_DECL_FATTN_TILE_CASES(512, 512);
+EXTERN_DECL_FATTN_TILE_CASES(576, 512);

--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -424,6 +424,8 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
     ggml_cuda_unroll<7>{}(load);
 }
 
+// BF16->F16 converting tile load for the F16-math fallback (BF16 K/V on targets without
+// v_dot2_f32_bf16, and the host pass). Compile-only on native-BF16 targets.
 template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
 static __device__ __forceinline__ void flash_attn_tile_load_tile(
         const nv_bfloat162 * const __restrict__ KV, half2 * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
@@ -520,9 +522,11 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
     ggml_cuda_unroll<7>{}(load);
 }
 
-template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
+// Conversion-only tile load (2-byte KV element -> 4-byte float tile) for the non-FAST kernel path.
+// The nv_bfloat162 instantiation is compile-only (native-BF16 targets always build the FAST path).
+template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check, typename T_in>
 static __device__ __forceinline__ void flash_attn_tile_load_tile(
-        const nv_bfloat162 * const __restrict__ KV, float * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
+        const T_in * const __restrict__ KV, float * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
     constexpr int cpy_nb = ggml_cuda_get_max_cpy_bytes();
     constexpr int cpy_ne = cpy_nb / 4;
 
@@ -550,70 +554,19 @@ static __device__ __forceinline__ void flash_attn_tile_load_tile(
                 for (int j0 = j0_start; j0 < j0_stop; j0 += stride_j) {
                     const int j = j0*(cpy_ne/2) + (stride_j == warp_size ? threadIdx.x : threadIdx.x % stride_j)*(cpy_ne/2);
 
-                    const nv_bfloat162 zero[cpy_ne/2] = {{0.0f, 0.0f}};
-                    __align__(16) nv_bfloat162 tmp_bf[cpy_ne/2];
-                    ggml_cuda_memcpy_1<sizeof(tmp_bf)>(
-                        tmp_bf, !oob_check || i < i_sup ? KV + i*stride_KV + j : zero);
+                    const T_in zero[cpy_ne/2] = {{0.0f, 0.0f}};
+                    __align__(16) T_in tmp_in[cpy_ne/2];
+                    ggml_cuda_memcpy_1<sizeof(tmp_in)>(
+                        tmp_in, !oob_check || i < i_sup ? KV + i*stride_KV + j : zero);
 
                     __align__(16) float2 tmp_f2[cpy_ne/2];
 #pragma unroll
                     for (int l = 0; l < cpy_ne/2; ++l) {
-                        tmp_f2[l] = ggml_cuda_cast<float2>(tmp_bf[l]);
-                    }
-                    ggml_cuda_memcpy_1<sizeof(tmp_f2)>(tile_KV + i*(J + J_padding) + 2*j, tmp_f2);
-                }
-            }
-        }
-    };
-    // 1: max 32*16=512 bytes, 128 float
-    // 2: max 16*16=256 bytes,  64 float
-    // 3: max  8*16=128 bytes,  32 float
-    // 4: max  4*16= 64 bytes,  16 float
-    // 5: max  2*16= 32 bytes,   8 float
-    static_assert(J % 8 == 0, "bad J");
-    static_assert(J % cpy_ne == 0, "bad J");
-    ggml_cuda_unroll<5>{}(load);
-}
-
-template<int warp_size, int nwarps, int I, int J, int J_padding, bool oob_check>
-static __device__ __forceinline__ void flash_attn_tile_load_tile(
-        const half2 * const __restrict__ KV, float * const __restrict__ tile_KV, const int stride_KV, const int i_sup) {
-    constexpr int cpy_nb = ggml_cuda_get_max_cpy_bytes();
-    constexpr int cpy_ne = cpy_nb / 4;
-
-    auto load = [&] __device__ (const int n) {
-        const int stride_j = warp_size >> n;
-
-        if (stride_j == 0) {
-            return;
-        }
-
-        const int j0_start = stride_j == warp_size ? 0 : (J/cpy_ne) - (J/cpy_ne) % (2*stride_j);
-        const int j0_stop  =                             (J/cpy_ne) - (J/cpy_ne) % (1*stride_j);
-        const int stride_i = warp_size / stride_j;
-
-        if (j0_start == j0_stop) {
-            return;
-        }
-
-#pragma unroll
-        for (int i0 = 0; i0 < I; i0 += nwarps*stride_i) {
-            const int i = i0 + threadIdx.y*stride_i + (stride_j == warp_size ? 0 : threadIdx.x / stride_j);
-
-            if (i0 + nwarps*stride_i <= I || i < I) {
-#pragma unroll
-                for (int j0 = j0_start; j0 < j0_stop; j0 += stride_j) {
-                    const int j = j0*(cpy_ne/2) + (stride_j == warp_size ? threadIdx.x : threadIdx.x % stride_j)*(cpy_ne/2);
-
-                    const half2 zero[cpy_ne/2] = {{0.0f, 0.0f}};
-                    __align__(16) half2 tmp_h2[cpy_ne/2];
-                    ggml_cuda_memcpy_1<sizeof(tmp_h2)>(
-                        tmp_h2, !oob_check || i < i_sup ? KV + i*stride_KV + j : zero);
-
-                    __align__(16) float2 tmp_f2[cpy_ne/2];
-#pragma unroll
-                    for (int l = 0; l < cpy_ne/2; ++l) {
-                        tmp_f2[l] = __half22float2(tmp_h2[l]);
+                        if constexpr (std::is_same_v<T_in, half2>) {
+                            tmp_f2[l] = __half22float2(tmp_in[l]);
+                        } else {
+                            tmp_f2[l] = ggml_cuda_cast<float2>(tmp_in[l]);
+                        }
                     }
                     ggml_cuda_memcpy_1<sizeof(tmp_f2)>(tile_KV + i*(J + J_padding) + 2*j, tmp_f2);
                 }
@@ -639,6 +592,25 @@ static constexpr __host__ __device__ bool ggml_cuda_fattn_tile_use_bf16() {
 #else
     return false;
 #endif // V_DOT2_F32_BF16_AVAILABLE
+}
+
+// Rescale the VKQ accumulators by the softmax max scale: half2 multiply (F16 kernel) or
+// per-element float multiply (BF16/non-FAST kernels).
+template <typename T_acc>
+static __device__ __forceinline__ void flash_attn_tile_rescale_VKQ(T_acc * const VKQ, const float scale, const int count) {
+    if constexpr (std::is_same_v<T_acc, half2>) {
+        const half2 scale_h2 = make_half2(scale, scale);
+#pragma unroll
+        for (int i = 0; i < count; ++i) {
+            VKQ[i] *= scale_h2;
+        }
+    } else {
+#pragma unroll
+        for (int i = 0; i < count; ++i) {
+            VKQ[i].x *= scale;
+            VKQ[i].y *= scale;
+        }
+    }
 }
 
 // Function that performs a single iteration in for the KQ matrix multiplication:
@@ -755,7 +727,8 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
 #ifdef FAST_FP16_AVAILABLE
     // BF16 K/V keeps packed BF16 registers and uses v_dot2_f32_bf16; F16 K/V uses the half2 (FAST) path.
     constexpr bool use_bf16 = ggml_cuda_fattn_tile_use_bf16<T_KV>();
-    constexpr int KQ_cs = use_bf16 ? (cpw < 1*cpy_ne ? cpw : 1*cpy_ne) : (cpw < 2*cpy_ne ? cpw : 2*cpy_ne);
+    // The packed BF16 PV reads the P pair (two rows) as two 16-byte chunks, so KQ_cs matches the F16 kernel.
+    constexpr int KQ_cs = cpw < 2*cpy_ne ? cpw : 2*cpy_ne;
 #else
     constexpr bool use_bf16 = false;
     constexpr int KQ_cs = cpw < 1*cpy_ne ? cpw : 1*cpy_ne;
@@ -854,22 +827,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
             }
             KQ_sum[jc] = KQ_sum[jc]*KQ_max_scale + KQ_sum_add;
 
-#ifdef FAST_FP16_AVAILABLE
-            if constexpr (!use_bf16) {
-                const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
-#pragma unroll
-                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                    VKQ[jc*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
-                }
-            } else
-#endif // FAST_FP16_AVAILABLE
-            {
-#pragma unroll
-                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                    VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
-                    VKQ[jc*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
-                }
-            }
+            flash_attn_tile_rescale_VKQ(&VKQ[jc*((DVp/2)/warp_size)], KQ_max_scale, (DVp/2)/warp_size);
         }
 
 #pragma unroll
@@ -908,6 +866,7 @@ static __device__ __forceinline__ void flash_attn_tile_iter(
         if constexpr (use_bf16) {
             // Packed BF16 PV: P rounded to BF16, V rows paired across consecutive KV rows via
             // v_perm_b32, one v_dot2_f32_bf16 per head pair with FP32 accumulation.
+            // The two-row pairing assumes np == 1; np > 1 would process overlapping row ranges.
             static_assert(np == 1, "bad np for packed bf16 PV");
             static_assert(nbatch_V % 2 == 0, "bad nbatch_V for packed bf16 PV");
 #pragma unroll
@@ -1124,18 +1083,18 @@ static __global__ void flash_attn_tile(
     // VKQ == Accumulators in registers for the final VKQ result.
 #ifdef FAST_FP16_AVAILABLE
     // Native BF16 tiles with FP32 math need v_dot2_f32_bf16 (RDNA3+, device pass only).
-    constexpr bool bf16 = ggml_cuda_fattn_tile_use_bf16<T_KV>();
+    constexpr bool use_bf16 = ggml_cuda_fattn_tile_use_bf16<T_KV>();
     constexpr int Q_tmp_count   = ncols*DKQ/2;
     constexpr int KV_tmp_stride = nbatch_K/2 + cpy_ne;
     constexpr int KV_tmp_count  = nbatch_fa*KV_tmp_stride + DVp-DV;
     constexpr int KQ_count      = ncols*nbatch_fa;
     constexpr int VKQ_count     = cpw * ((DVp/2)/warp_size);
-    using T_Q   = std::conditional_t<bf16, nv_bfloat162, half2>;
+    using T_Q   = std::conditional_t<use_bf16, nv_bfloat162, half2>;
     using T_KVt = T_Q;
-    using T_KQ  = std::conditional_t<bf16, nv_bfloat16, half>;
-    using T_acc = std::conditional_t<bf16, float2, half2>;
+    using T_KQ  = std::conditional_t<use_bf16, nv_bfloat16, half>;
+    using T_acc = std::conditional_t<use_bf16, float2, half2>;
 #else
-    constexpr bool bf16 = false;
+    constexpr bool use_bf16 = false;
     constexpr int Q_tmp_count   = ncols*DKQ;
     constexpr int KV_tmp_stride = nbatch_K + cpy_ne;
     constexpr int KV_tmp_count  = nbatch_fa*KV_tmp_stride + DVp-DV;
@@ -1185,7 +1144,7 @@ static __global__ void flash_attn_tile(
                 }
 
 #ifdef FAST_FP16_AVAILABLE
-                if constexpr (bf16) {
+                if constexpr (use_bf16) {
                     __align__(16) nv_bfloat162 tmp_bf[cpy_ne_D/2];
 #pragma unroll
                     for (int i1 = 0; i1 < cpy_ne_D; i1 += 2) {
@@ -1194,27 +1153,28 @@ static __global__ void flash_attn_tile(
                     ggml_cuda_memcpy_1<sizeof(tmp_bf)>(
                         &Q_tmp[jc*(DKQ/2) + i0/2 + (threadIdx.y % np)*(warp_size*cpy_ne_D/2) + threadIdx.x*(cpy_ne_D/2)],
                         tmp_bf);
-                } else if constexpr (!bf16) {
+                } else {
                     __align__(16) half2 tmp_h2[cpy_ne_D/2];
 #pragma unroll
                     for (int i1 = 0; i1 < cpy_ne_D; i1 += 2) {
                         tmp_h2[i1/2] = make_half2(tmp_f[i1 + 0], tmp_f[i1 + 1]);
-#if defined(FAST_FP16_AVAILABLE) && !defined(V_DOT2_F32_F16_AVAILABLE)
+#if !defined(V_DOT2_F32_F16_AVAILABLE)
                         // Without the v_dot2_f32_f16 instruction there is a higher risk of numerical overflow in the KQ calculation.
                         // Therefore, scale down Q values and apply the inverse scale the FP32 KQ values afterwards again.
                         tmp_h2[i1/2] *= make_half2(0.25f, 0.25f);
-#endif // defined(FAST_FP16_AVAILABLE) && !defined(V_DOT2_F32_F16_AVAILABLE)
+#endif // !defined(V_DOT2_F32_F16_AVAILABLE)
                     }
                     ggml_cuda_memcpy_1<sizeof(tmp_h2)>(
                         &Q_tmp[jc*(DKQ/2) + i0/2 + (threadIdx.y % np)*(warp_size*cpy_ne_D/2) + threadIdx.x*(cpy_ne_D/2)],
                         tmp_h2);
-                } else
-#endif // FAST_FP16_AVAILABLE
+                }
+#else
                 {
                     ggml_cuda_memcpy_1<sizeof(tmp_f)>(
                         &Q_tmp[jc*DKQ + i0 + (threadIdx.y % np)*(warp_size*cpy_ne_D) + threadIdx.x*cpy_ne_D],
                         tmp_f);
                 }
+#endif // FAST_FP16_AVAILABLE
             }
         }
     }
@@ -1259,7 +1219,7 @@ static __global__ void flash_attn_tile(
         static_assert(nbatch_fa*nbatch_K >= nwarps*DVp, "KV_tmp too small");
 
 #ifdef FAST_FP16_AVAILABLE
-        using T_VKQ_combine = std::conditional_t<bf16, float, half2>;
+        using T_VKQ_combine = std::conditional_t<use_bf16, float, half2>;
 #else
         using T_VKQ_combine = float;
 #endif // FAST_FP16_AVAILABLE
@@ -1268,7 +1228,7 @@ static __global__ void flash_attn_tile(
 
         if (threadIdx.y % np != 0) {
 #ifdef FAST_FP16_AVAILABLE
-            if constexpr (!bf16) {
+            if constexpr (!use_bf16) {
                 constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
                 for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
@@ -1297,7 +1257,7 @@ static __global__ void flash_attn_tile(
 #pragma unroll
         for (int ip = 1; ip < np; ++ip) {
 #ifdef FAST_FP16_AVAILABLE
-            if constexpr (!bf16) {
+            if constexpr (!use_bf16) {
                 constexpr int cpy_ne_D = cpy_ne < (DVp/2)/warp_size ? cpy_ne : (DVp/2)/warp_size;
 #pragma unroll
                 for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {
@@ -1341,22 +1301,7 @@ static __global__ void flash_attn_tile(
             const float val = expf(sink - KQ_max[jc0]);
             KQ_sum[jc0] = KQ_sum[jc0]*KQ_max_scale + val;
 
-#ifdef FAST_FP16_AVAILABLE
-            if constexpr (!bf16) {
-                const half2 KQ_max_scale_h2 = make_half2(KQ_max_scale, KQ_max_scale);
-#pragma unroll
-                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                    VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size] *= KQ_max_scale_h2;
-                }
-            } else
-#endif // FAST_FP16_AVAILABLE
-            {
-#pragma unroll
-                for (int i0 = 0; i0 < DVp/2; i0 += warp_size) {
-                    VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].x *= KQ_max_scale;
-                    VKQ[jc0*((DVp/2)/warp_size) + i0/warp_size].y *= KQ_max_scale;
-                }
-            }
+            flash_attn_tile_rescale_VKQ(&VKQ[jc0*((DVp/2)/warp_size)], KQ_max_scale, (DVp/2)/warp_size);
         }
     }
 
@@ -1377,7 +1322,7 @@ static __global__ void flash_attn_tile(
         const int j_dst_unrolled = ((sequence*int(ne01.z) + col_Q_0 + j)*ne02 + head0 + c)*gridDim.y + blockIdx.y;
 
 #ifdef FAST_FP16_AVAILABLE
-        if constexpr (!bf16) {
+        if constexpr (!use_bf16) {
             constexpr int cpy_ne_D = cpy_ne/2 < (DVp/2)/warp_size ? cpy_ne/2 : (DVp/2)/warp_size;
 #pragma unroll
             for (int i0 = 0; i0 < DVp/2; i0 += warp_size*cpy_ne_D) {

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -548,7 +548,14 @@ size_t ggml_cuda_flash_attn_ext_get_alloc_size(int device, const ggml_tensor * d
     bool need_f16_V = false;
 
     switch (kernel) {
-        case BEST_FATTN_KERNEL_TILE:
+        case BEST_FATTN_KERNEL_TILE: {
+            // The tile kernel reads F16 and BF16 K/V natively; the launcher converts
+            // the remaining types to F16. BF16 K/V needs native BF16 support.
+            const bool use_bf16 = K->type == GGML_TYPE_BF16 && V->type == GGML_TYPE_BF16 &&
+                bf16_mma_hardware_available(ggml_cuda_info().devices[device].cc);
+            need_f16_K = use_bf16 ? false : K->type != GGML_TYPE_F16;
+            need_f16_V = use_bf16 ? false : V->type != GGML_TYPE_F16;
+        } break;
         case BEST_FATTN_KERNEL_MMA_F16:
             need_f16_K = true;
             need_f16_V = true;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9551,8 +9551,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
-    for (int hsk : { 40, 64, 72, 80, 96, 128, 192, 256, 320, 512, 576 }) {
-        for (int hsv : { 40, 64, 72, 80, 96, 128, 192, 256, 512 }) {
+    for (int hsk : { 40, 64, 72, 80, 96, 112, 128, 192, 256, 320, 512, 576 }) {
+        for (int hsv : { 40, 64, 72, 80, 96, 112, 128, 192, 256, 512 }) {
             if (hsk != 192 && hsk != 320 && hsk != 576 && hsk != hsv) continue;
             if (hsk == 192 && (hsv != 128 && hsv != 192)) continue;
             if (hsk == 576 && hsv != 512) continue; // DeepSeek MLA

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9581,7 +9581,9 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                                 for (ggml_prec prec : {GGML_PREC_F32, GGML_PREC_DEFAULT}) {
                                                     if (hsk != 128 && prec == GGML_PREC_DEFAULT) continue;
                                                     for (ggml_type type_KV : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_BF16, GGML_TYPE_Q8_0, GGML_TYPE_Q5_1, GGML_TYPE_Q5_0, GGML_TYPE_Q4_1, GGML_TYPE_Q4_0, GGML_TYPE_IQ4_NL}) {
-                                                        if (type_KV != GGML_TYPE_F16 && hsk != 64 && hsk != 72) continue;
+                                                        // The tile kernel has native-BF16 instantiations for every head size;
+                                                        // keep the other KV types on 64/72 to bound the test runtime.
+                                                        if (type_KV != GGML_TYPE_F16 && type_KV != GGML_TYPE_BF16 && hsk != 64 && hsk != 72) continue;
                                                         test_cases.emplace_back(new test_flash_attn_ext(
                                                                     hsk, hsv, nh, {nr2, nr3}, kv, nb, mask, sinks, max_bias, logit_softcap, prec, type_KV, type_KV));
                                                         // run fewer test cases permuted


### PR DESCRIPTION
## Overview

I was investigating why setting KV cache to BF16 on my Strix Halo seemed to result in slower performance with no  PPL gains.  I discovered that the source of the slowness was BF16 KV cache was silently mapping to F16 behind the scenes, despite the achitecture natively supporting BF16 operations.  Since AMD's RDNA 3/3.5/4 supports native BF16 vector operations,  I thought to try to fix the performance issues I was seeing.

Disclosure:  The follow discussion is a mix of my own words and AI assisted content.

## Key Takeways

- Gated on specifying BF16 for both K/V cache types and native GPU support
- +5-15% prefill speeds over baseline F16 K/V cache prefill performance even at long context
- Generation performance parity vs F16 baseline (was ~20% lower before these changes)
- Near equivalent to baseline F32 PPL parity (PPL was ~5% higher with F16 only at depth)

## Design

A precision pipeline for BF16 K/V (all supported head sizes):

```
KV cache (BF16, 2 bytes/element)
    -> BF16 tile in SRAM (pure memcpy, no BF16->F16 conversion)
    -> Q converted to BF16 once at fill
    -> QK^T via v_dot2_f32_bf16 on RDNA3+ architectures (exact BF16 products, FP32 accumulation)
    -> P computed in FP32, KQ buffer stored as BF16
    -> VKQ via packed BF16 PV: P rounded to BF16, V rows paired across
       consecutive KV rows with v_perm_b32, one v_dot2_f32_bf16 per head
       pair with FP32 accumulation
```

Key decisions:

- **Both-K/V-BF16 gate**: the native-BF16 path is selected only when
  `K->type == GGML_TYPE_BF16 && V->type == GGML_TYPE_BF16` on hardware with
  native BF16 support. No BF16 conversion plumbing in the launcher;
  `fattn-common.cuh` is byte-identical to upstream.
- **v_dot2_f32_bf16**: RDNA3+ has a hardware packed-BF16 dot instruction
  (2 BF16 products + 1 FP32 add per instruction). It gives the KQ phase
  the same 2x FP32 rate as the F16 kernel's v_dot2_f32_f16, so the
  native-BF16 path does not pay an ALU penalty. Guarded by the
  `V_DOT2_F32_BF16_AVAILABLE` macro (gfx110x/gfx115x/gfx120x).
- **BF16 Q_tmp**: Q is converted to BF16 once at fill. This halves the Q
  SRAM footprint vs an FP32 Q tile, so the standard 32-column launch and
  the standard config tables apply unchanged. 
- **Packed BF16 PV (the only VKQ variant)**: the VKQ phase rounds P to
  BF16, pairs V rows across consecutive KV rows with v_perm_b32, and runs
  v_dot2_f32_bf16 with FP32 accumulation. 
- Measured PPL impact vs FP32 VKQ: none. Applies to every head size.  The
  packed design was verified at DV = 512 (no register spills, test-backend-ops clean).
- **BF16 KQ buffer**: the softmax output is stored in SRAM as BF16. P is
  rounded to BF16 exactly once (at the store), which is what the packed PV
  does anyway, so numerics are identical to a float KQ buffer while the
  SRAM footprint and the KQ read/write traffic halve. Measured prefill
  gain vs the float KQ buffer: about +13% at 9k KV rows.
- **Automatic per-arch selection, no user-facing split**: every native-BF16
  code path is gated on `V_DOT2_F32_BF16_AVAILABLE`, defined only for AMD
  RDNA3/RDNA3.5/RDNA4 targets. `bf16/bf16` KV on a supported card
  automatically gets the native kernel; on any other target the same
  instantiation compiles to the original F16 tile path with BF16->F16 conversion at
  tile load. 
- **Config tables**: standard upstream tables for all paths
- **F16 kernel untouched**: the existing F16 path (half2 math, 0.25
  Q-scaling when v_dot2_f32_f16 is unavailable) is unchanged.


## nVidia GPU impllcations (for now)

This PR will need followup work to support nVidia GPUs.  Unfortunately I don't have any to test/develop with.

`v_dot2_f32_bf16` and `v_perm_b32` are AMD RDNA3+ instructions. NVIDIA has
no packed-BF16 dot in its CUDA cores. These are the anticipated consequences
for NVIDIA GPUs:

- The BF16 tile instantiation compiles with `V_DOT2_F32_BF16_AVAILABLE` undefined,
  so it runs the F16 tile path with  in-tile BF16->F16 conversion - the pre-existing F16-speed kernel
- **No native-BF16 precision benefit either**: on NVIDIA the tile kernel
  still converts to F16, so the deep-context half2 accumulation behavior
  is unchanged there. This matches upstream's existing numerics for BF16
  KV; it is not a regression.
- NVIDIA's main BF16 path for head sizes <= 128 is the MMA_F16 tensor-core
  kernel, which is untouched by this change.
- A native-BF16 path for NVIDIA would require a bf16-MMA tile kernel
  (following the existing `mma-f16.cuh` structure); it is separate
  follow-up work, not part of this change.


## Prefill Performance results

Using llama-bench with Qwen3.5-4B and pp1024 on Strix Halo

| Depth | F16 (t/s) | BF16 (t/s) | speed gain |
| ------- | --------: | ---------: | --: |
|  8192  | 1391.3    | 1579.2     | +13.5% |
| 16384  | 1228.5    | 1368.2     | +11.4% |


## Perplexity tests (RDNA3+ only)

Same measurements on a Radeon AI PRO R9700 (gfx1201, RDNA4, 3x GPU,
ROCm 7.1), Qwen3.5-4B-Q8_0, wiki.test.raw full, c=32768, mlock:

| KV cache / FA | PPL @ 32k |
| ------------- | --------: |
| F32 baseline (FA off) | 8.6368 |
| BF16 (this change) | 8.6403 (+0.04%) |
| F16 | 9.1400 (+5.8%) |


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES - Deepseek V4 Flash 0731 was used to create the changes from an implementation plan I had written, under strong supervision.  I've personally review the code, and tested correctness on RDNA3, 3.5, and 4 architectures (7900XTX, Strix Halo, R9700)
