### PR TITLE
requirements: use stable torch packages on s390x

### DIFF
--- a/examples/model-conversion/requirements.txt
+++ b/examples/model-conversion/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch
-torchvision
+torchvision; platform_machine != "s390x"
 transformers
 huggingface-hub
 accelerate

--- a/requirements/requirements-convert_hf_to_gguf.txt
+++ b/requirements/requirements-convert_hf_to_gguf.txt
@@ -2,8 +2,4 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 ## Embedding Gemma requires PyTorch 2.6.0 or later, bumped to 2.11.0 for compatibility
-torch==2.11.0; platform_machine != "s390x"
-
-# torch s390x packages can only be found from nightly builds
---extra-index-url https://download.pytorch.org/whl/nightly
-torch>=0.0.0.dev0; platform_machine == "s390x"
+torch==2.11.0

--- a/requirements/requirements-convert_lora_to_gguf.txt
+++ b/requirements/requirements-convert_lora_to_gguf.txt
@@ -1,4 +1,2 @@
 -r ./requirements-convert_hf_to_gguf.txt
 --extra-index-url https://download.pytorch.org/whl/cpu
-# torch s390x packages can only be found from nightly builds
---extra-index-url https://download.pytorch.org/whl/nightly

--- a/tools/mtmd/requirements.txt
+++ b/tools/mtmd/requirements.txt
@@ -3,10 +3,9 @@
 pillow~=11.3.0
 
 ## Embedding Gemma requires PyTorch 2.6.0 or later, bumped to 2.11.0 for compatibility
-torch==2.11.0; platform_machine != "s390x" # check_requirements: ignore "=="
+torch==2.11.0
 torchvision==0.26.0; platform_machine != "s390x" # check_requirements: ignore "=="
 
-# torch s390x packages can only be found from nightly builds
+# torchvision s390x packages can only be found from nightly builds
 --extra-index-url https://download.pytorch.org/whl/nightly
-torch>=0.0.0.dev0; platform_machine == "s390x" # check_requirements: ignore "=="
 torchvision>=0.0.0.dev0; platform_machine == "s390x" # check_requirements: ignore "=="

--- a/tools/mtmd/requirements.txt
+++ b/tools/mtmd/requirements.txt
@@ -2,6 +2,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 pillow~=11.3.0
 
-## Embedding Gemma requires PyTorch 2.6.0 or later, bumped to 2.11.0 for compatibility
 torch==2.11.0 # check_requirements: ignore "=="
-torchvision==0.26.0 # check_requirements: ignore "=="
+torchvision==0.26.0; platform_machine != "s390x" # check_requirements: ignore "=="

--- a/tools/mtmd/requirements.txt
+++ b/tools/mtmd/requirements.txt
@@ -3,7 +3,7 @@
 pillow~=11.3.0
 
 ## Embedding Gemma requires PyTorch 2.6.0 or later, bumped to 2.11.0 for compatibility
-torch==2.11.0
+torch==2.11.0 # check_requirements: ignore "=="
 torchvision==0.26.0; platform_machine != "s390x" # check_requirements: ignore "=="
 
 # torchvision s390x packages can only be found from nightly builds

--- a/tools/mtmd/requirements.txt
+++ b/tools/mtmd/requirements.txt
@@ -4,8 +4,4 @@ pillow~=11.3.0
 
 ## Embedding Gemma requires PyTorch 2.6.0 or later, bumped to 2.11.0 for compatibility
 torch==2.11.0 # check_requirements: ignore "=="
-torchvision==0.26.0; platform_machine != "s390x" # check_requirements: ignore "=="
-
-# torchvision s390x packages can only be found from nightly builds
---extra-index-url https://download.pytorch.org/whl/nightly
-torchvision>=0.0.0.dev0; platform_machine == "s390x" # check_requirements: ignore "=="
+torchvision==0.26.0 # check_requirements: ignore "=="


### PR DESCRIPTION
## Overview

https://github.com/ggml-org/llama.cpp/pull/13699 made s390x use nightly torch packages because stable versions didn't support s390x.

Nowadays, s390x is supported in [stable builds](https://download.pytorch.org/whl/cpu/torch/). Hence, we can use the stable packages on s390x.

That said, torchvision is not built for s390x at all (not even as [nightlies](https://download.pytorch.org/whl/nightly/torchvision/)), so this PR drops that non-existent package for s390x (see [this discussion](https://github.com/ggml-org/llama.cpp/pull/26864#discussion_r3756603063)).

@taronaeo: I don't have access to an s390x machine. Would you be able to test that installation still works properly? Thank you very much in advance!

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
