### PR TITLE
speculative-simple : pass ctx_other to the draft context and fail gracefully

### DIFF
--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -84,7 +84,26 @@ int main(int argc, char ** argv) {
         }
 
         auto cparams = common_context_params_to_llama(params_dft);
+
+        // drafters that borrow tensors from the target model (e.g. DFlash models
+        // without their own token embeddings / output head) cannot create a
+        // context without a reference to the target context
+        cparams.ctx_other = ctx_tgt;
+
         ctx_dft.reset(llama_init_from_model(model_dft.get(), cparams));
+        if (ctx_dft == nullptr) {
+            LOG_ERR("failed to create context for draft model, '%s'\n", params_dft.model.path.c_str());
+            return 1;
+        }
+
+        {
+            char arch[64] = {0};
+            llama_model_meta_val_str(model_dft.get(), "general.architecture", arch, sizeof(arch));
+            if (strcmp(arch, "dflash") == 0) {
+                LOG_WRN("%s: this example does not stage target-model features for '%s' drafters - "
+                        "draft acceptance will be much lower than with llama-server\n", __func__, arch);
+            }
+        }
 
         params.speculative.draft.ctx_tgt = ctx_tgt;
         params.speculative.draft.ctx_dft = ctx_dft.get();


### PR DESCRIPTION
## Overview

`llama-speculative-simple` creates the draft context without `ctx_other` and never null-checks the result. For drafters that borrow tensors from the target model (DFlash models without their own token embeddings or output head, such as the deepseek-ai dspark checkpoints), `llama_init_from_model` returns null, and the unchecked `ctx_dft` reaches `llama_decode`, which crashes.

This PR makes the following changes:

- Passes the target context as `ctx_other` when creating the draft context.
- Exits with a clear error message if the draft context still cannot be created.
- Warns, for DFlash drafters, that this example does not stage target-model features, so draft acceptance will be much lower than through `llama-server`, which uses the full framework path.

## Additional information

The crash can be reproduced with:

```
llama-speculative-simple -m Qwen3-8B-bf16.gguf -md dspark_qwen3_8b_block7.gguf \
  --spec-type draft-dspark -ngl 99 -ngld 99 -fa on --temp 0 -n 128 -p "..."
```

The failure occurs at prompt evaluation. The "dflash requires ctx_other" message emitted during context creation is easy to miss, because the same message also appears benignly during memory fitting.

The feature-staging gap itself is described in the companion issue #26884. I am happy to work on full DFlash support in this example if there is interest.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Claude Code was used to help develop and test the fix and to format this description to the PR template. I reviewed every line and take full responsibility for the changes.
