### PR TITLE
[Grammars] Optimization: Single lookup, remove extra copies - 1.2x-1.3x speedup

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -870,17 +870,18 @@ static void llama_grammar_advance_stack(
     std::set<llama_grammar_stack, decltype(stack_cmp)> seen(stack_cmp);
 
     while (!todo.empty()) {
-        llama_grammar_stack curr_stack = std::move(todo.back());
+        llama_grammar_stack curr_stack_candidate = std::move(todo.back());
         todo.pop_back();
 
-        if (seen.find( curr_stack) != seen.end()) {
+        auto [curr_stack_it, inserted] = seen.insert(std::move(curr_stack_candidate));
+        if (!inserted) {
             continue;
         }
-        seen.insert(curr_stack);
+        const llama_grammar_stack & curr_stack = *curr_stack_it;
 
         if (curr_stack.empty()) {
             if (std::find(new_stacks.begin(), new_stacks.end(), curr_stack) == new_stacks.end()) {
-                new_stacks.emplace_back(std::move(curr_stack));
+                new_stacks.emplace_back(curr_stack);
             }
             continue;
         }
@@ -923,7 +924,7 @@ static void llama_grammar_advance_stack(
         case LLAMA_GRETYPE_TOKEN_NOT:
             if (std::find(new_stacks.begin(), new_stacks.end(), curr_stack) == new_stacks.end()) {
                 // only add the stack if it's not a duplicate of one we already have
-                new_stacks.emplace_back(std::move(curr_stack));
+                new_stacks.emplace_back(curr_stack);
             }
             break;
         default:


### PR DESCRIPTION
## Overview
Tinkering with #4218 again. Even though we have llguidance available (which is generally much faster), I would still like to see improvements made to our in-house grammar engine.

This is a small change, but it includes two speed optimizations for grammar-parsing here:

## 1) 2 lookups => 1 lookup
Combines two consecutive lookups (initial `if (seen.find())`, then the internal lookup performed by `seen.insert()`) into a single insert-attempt/lookup so that we don't perform two lookup operations in a row -- we only need to do it once and then see if the insert succeeded.

Before:
```c++
  // find() is one presence lookup
  if (seen.find( curr_stack) != seen.end()) {
      continue;
  }
  // insert() performs a duplicate presence lookup internally (because it will not insert a duplicate value)
  seen.insert(curr_stack); // This function has a return value that is currently not being used
```

After:
```c++
  // It's safe to blindly call `insert()` because it will not insert if it already exists -- the bool check tells us if it was successful or not, which saves time.
  // seen.insert() returns a pair of values we can be using:
  //  If successful, a pointer to the object that was inserted
  //  A boolean indicating whether or not it was inserted
  auto [curr_stack_it, inserted] = seen.insert(std::move(curr_stack_candidate));
  if (!inserted) {
      continue;
  }
  const llama_grammar_stack & curr_stack = *curr_stack_it;
```
Because `insert()` already does the check (and returns a boolean indicating whether it already existed or not), we don't need to do this `find()` operation twice -- we just need to utilize the return value from `insert()` instead of duplicating its effort.

## 2) always copy, optional move => always move, optional copy
Instead of copying every intermediate stack (expensive) and then moving it (cheap) to `new_stacks` when it's a final output state, we switch the order so that we move every intermediate stack (cheap), and then only copy it (expensive) to `new_stacks` when it's a final output state. 

There are a LOT of intermediate states that get generated with these stacks, and unless they become final output states, then all of those expensive intermediate copies are wasted.

So now we transfer ownership of each unique intermediate stack into `seen`, then copy it only if it must also be returned through `new_stacks`.

Before:
```c++
  // Get a pointer to the current stack
  llama_grammar_stack curr_stack = std::move(todo.back());
  if (...) { continue; }
  // Copy it when we mark it as seen
  seen.insert(curr_stack);
  ...
  // If it's a final output state
  if (...) {
    // Just move the pointer over, because we already copied the object earlier
    new_stacks.emplace_back(std::move(curr_stack));
  }
```

After:
```c++
  // Get a pointer to the current stack
  llama_grammar_stack curr_stack_candidate = std::move(todo.back());
  // Mark the original object as seen (without copying yet)
  seen.insert(std::move(curr_stack_candidate));
  ...
  // If it's a final output state
  if (...) {
    // Copy it now, because we know we'll use it in `new_stacks`
    new_stacks.emplace_back(std::move(curr_stack));
  }
```

## In total:

**Before:** lookup -> lookup/insert + copy -> optional move to output

**New:** lookup/insert + move -> optional copy to output

|  | Lookups | Copy | Move |
| --- | ---: | ---: | ---: |
| Before | 2 | Always | Sometimes |
| After | 1 | Sometimes | Always |

## Additional information

See overall discussion of the problem here: #4218

This doesn't tackle any of the big-hitter items that we see in that thread, but it's a small improvement that provides a measurable performance benefit and is self-contained enough to be well-understood.

### Results:

Ran three different grammar cases I have locally. Results showed anywhere from 1.2x-1.3x speedup:

| Fixture | Baseline | Optimized | Speedup |
| --- | ---: | ---: | ---: |
| Overlapping synthetic | 268.3 +/- 12.0 ms | 226.5 +/- 12.0 ms | 1.18 +/- 0.08x |
| PostgreSQL SELECT suite | 99.6 +/- 9.1 ms | 77.9 +/- 7.4 ms | 1.28 +/- 0.17x |
| SQLite SELECT suite | 49.1 +/- 3.9 ms | 40.8 +/- 6.0 ms | 1.20 +/- 0.20x |

Each command used 10 warmups and 300 measured runs. Median speedups were 1.19x, 1.27x, and 1.21x respectively. An independent 30-run pass produced 1.18x, 1.30x, and 1.22x.

Full Hyperfine [commands and test files available here](https://gist.github.com/HanClinto/b853571136fd42f8e2bde4c99c831f5d).

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES 
  - Used GH Copilot w/ GPT 5.6 Sol High to iterate through some old suggestions we've kicked around for grammar speed increases for quite some time. In the midst of testing some larger changes / improvements, happened upon this small and isolated change that gave measurable results, so decided to carve it off as its own PR before continuing with the original effort. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
