### PR TITLE
Openvino Backend Muse-Glimmer Support

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -1401,6 +1401,17 @@ const std::string & GgmlOvDecoder::get_op_type() const {
     return unknown_op;
 }
 
+namespace {
+bool is_same_shape(const ggml_tensor * a, const ggml_tensor * b) {
+    for (int i = 0; i < GGML_MAX_DIMS; i++) {
+        if (a->ne[i] != b->ne[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace
+
 void GgmlOvDecoder::compute_node_dynamic_dims() {
     auto visit_node = [&](auto && self, ggml_tensor * node) -> void {
         if (!node) {
@@ -1437,6 +1448,10 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
                     continue;
                 }
                 if (node->op == GGML_OP_VIEW && src->op == GGML_OP_NONE && !is_stateful() && !m_model_is_splitted) {
+                    m_node_dynamic_dims[src] = 1;
+                    continue;
+                }
+                if (is_inp_embd_2d(src, node)) {
                     m_node_dynamic_dims[src] = 1;
                     continue;
                 }
@@ -1495,6 +1510,11 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
             }
             break;
         case GGML_OP_VIEW: {
+            // A VIEW that does not change the shape is a pass-through for dynamic-dim purposes.
+            if (is_same_shape(node->src[0], node)) {
+                m_node_dynamic_dims[node] = m_node_dynamic_dims[node->src[0]];
+                break;
+            }
             // Use stride-based matching: the stride of a VIEW dimension directly
             // encodes which source dimension it indexes into, so it uniquely
             // identifies the dynamic dim even when two dims share the same size.
@@ -1567,6 +1587,19 @@ void GgmlOvDecoder::compute_node_dynamic_dims() {
             }
             break;
         }
+        case GGML_OP_CONCAT:
+            // The concatenated axis is the one whose extent changed.
+            for (int i = 0; i < GGML_MAX_DIMS; i++) {
+                if (node->src[0]->ne[i] != node->ne[i]) {
+                    m_node_dynamic_dims[node] = i;
+                    break;
+                }
+            }
+            break;
+        case GGML_OP_SSM_CONV:
+        case GGML_OP_GATED_DELTA_NET:
+            m_node_dynamic_dims[node] = 1;
+            break;
         case GGML_OP_CONT:
             m_node_dynamic_dims[node] = -1;
             if (m_node_dynamic_dims[node->src[0]] != -1) {

--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -777,6 +777,30 @@ void GgmlOvDecoder::compute_model_outputs() {
         if (cur_node->op == GGML_OP_NONE || cur_node->op == GGML_OP_VIEW || cur_node->op == GGML_OP_RESHAPE) {
             continue;
         }
+        // A node explicitly marked by ggml_set_output() must be a model output even when it is
+        // fully consumed inside the graph, because the host reads it back afterwards. The
+        // use-count analysis below cannot see that: it only asks whether anything still in the
+        // graph needs the value.
+        //
+        // Mid-graph taps break that assumption. A model that exposes its residual stream at a few
+        // layers (llm_graph_result marks each such tensor with ggml_set_output()) has tensors that
+        // are read by the host AND feed the next layer, so use-count logic dropped them, the OV
+        // model never produced them, and the host read an unwritten buffer -- whatever consumes
+        // those features saw zeros. This affects any consumer of a mid-graph tensor, not one
+        // particular feature.
+        if (cur_node->flags & GGML_TENSOR_FLAG_OUTPUT) {
+            // in-place ops publish their result through view_src, as in the use_count == 0 path
+            auto * flagged_node = cur_node;
+            if (flagged_node->op == GGML_OP_SET_ROWS && flagged_node->view_src != nullptr) {
+                flagged_node = flagged_node->view_src;
+            }
+            std::string flagged_name(flagged_node->name);
+            if (m_model_outputs.find(flagged_name) == m_model_outputs.end()) {
+                m_model_outputs[flagged_name] = flagged_node;
+                m_model_output_names.push_back(flagged_name);
+            }
+            continue;
+        }
         auto cur_node_use_count = m_cgraph->use_counts[ggml_hash_find(&m_cgraph->visited_hash_set, cur_node)];
         if (cur_node_use_count == 0) {
             // The output of SET_ROWS is the view_src tensor, which is updated in place. We should use the view_src name as the output name to make sure it can be correctly matched with the later ops that use the view_src.

--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -33,6 +33,24 @@
 #include <string>
 #include <vector>
 
+static std::set<std::string> collect_graph_output_names(const ggml_cgraph * cgraph) {
+    std::set<std::string> outputs;
+    for (int node_n = 0; node_n < cgraph->n_nodes; node_n++) {
+        auto * node = cgraph->nodes[node_n];
+        if (node->flags & GGML_TENSOR_FLAG_OUTPUT) {
+            outputs.insert(node->name);
+        }
+    }
+    return outputs;
+}
+
+bool GgmlOvDecoder::has_same_graph_io(const ggml_cgraph * cgraph) const {
+    if (m_built_output_names.empty()) {
+        return true;  // no snapshot (naive / test decoders): nothing to compare against
+    }
+    return collect_graph_output_names(cgraph) == m_built_output_names;
+}
+
 GgmlOvDecoder::GgmlOvDecoder(ggml_cgraph * cgraph,
                              ModelParams & model_params,
                              ComputeParams & compute_params,
@@ -62,6 +80,8 @@ GgmlOvDecoder::GgmlOvDecoder(ggml_cgraph * cgraph,
 
     validate_cgraph();
 
+    m_built_output_names = collect_graph_output_names(cgraph);
+
     set_input_output();
     compute_node_dynamic_dims();
     compute_model_inputs();
@@ -77,6 +97,7 @@ GgmlOvDecoder::GgmlOvDecoder(ggml_cgraph * cgraph,
 
 void GgmlOvDecoder::update_io(ggml_cgraph * cgraph) {
     m_cgraph = cgraph;
+    m_built_output_names = collect_graph_output_names(cgraph);
     m_model_inputs.clear();
     m_model_outputs.clear();
     m_node_info_list.clear();

--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -369,6 +369,92 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
         return -1;
     };
 
+    // Resolve the attention mask an attention node consumes, mirroring the src layout that
+    // get_attention_pattern_case() classifies. Used by the SWA pre-pass below.
+    auto get_attention_op_mask = [&get_attention_pattern_case](const ggml_tensor * node) -> const ggml_tensor * {
+        switch (get_attention_pattern_case(node)) {
+        case 0:
+        case 1:
+            return node->src[3];
+        case 2:
+        case 3:
+            return node->src[1];
+        default:
+            return nullptr;
+        }
+    };
+
+    // Pre-pass: classify sliding-window vs full-attention layers.
+    //
+    // An interleaved-SWA model keeps two KV caches and two attention masks, and hands each layer
+    // whichever pair matches its attention type. The mask tensor does not say which is which: both
+    // are named "attn_inp_kq_mask" by build_attn_inp_kq_mask(), and both carry the same n_kv because
+    // llama_kv_cache::get_n_kv() pads occupancy up to a common multiple.
+    //
+    // The KV cache does say. Each cache allocates cache_k_l<N> once at load time with its own cell
+    // count: the windowed cache is sized from the window
+    // (PAD(min(size_base, n_swa*(unified ? n_seq_max : 1) + n_ubatch), 256), see
+    // llama_kv_cache_iswa), the full-attention one spans the whole context. Read the LEAF buffer
+    // behind the VIEW rather than the VIEW itself: the leaf extent is a constant per layer, known
+    // from the first graph onwards, while the view grows with context depth and would invert the
+    // comparison at shallow depth.
+    //
+    // Layers whose leaf is smaller than the largest leaf are the windowed ones. When every layer
+    // reports the same extent there is no distinction to draw -- either the model has no windowed
+    // layers, or the window is at least as large as the context so the two caches coincide, in
+    // which case a windowed layer and a full-attention one compute the same thing.
+    //
+    // Getting this wrong is silent and severe: with the windowed layers classified as
+    // full-attention, permute's KV slicing uses attention_size instead of attention_size_swa. The
+    // two agree while the context is shorter than the window, then diverge, and the mask add fails
+    // shape inference ("Failed to broadcast-merge input shapes") partway into a long prompt.
+    {
+        std::map<int, int64_t> layer_extent;                      // layer -> leaf cache_k cell count
+        std::map<int, const ggml_tensor *> layer_mask;            // layer -> mask it consumes
+        int64_t max_extent = 0;
+
+        for (int i = 0; i < cgraph->n_nodes; i++) {
+            const ggml_tensor * mask = get_attention_op_mask(cgraph->nodes[i]);
+            if (mask == nullptr) {
+                continue;
+            }
+            const ggml_tensor * cache_k_permute = nullptr;
+            switch (get_attention_pattern_case(cgraph->nodes[i])) {
+            case 0:  cache_k_permute = cgraph->nodes[i]->src[1];                     break;
+            case 1:  cache_k_permute = cgraph->nodes[i]->src[1]->src[0];             break;
+            case 2:  cache_k_permute = cgraph->nodes[i]->src[0]->src[0];             break;
+            default: cache_k_permute = cgraph->nodes[i]->src[0]->src[0]->src[0];     break;
+            }
+            const ggml_tensor * cache_k_view = cache_k_permute->src[0];
+            if (cache_k_view->op != GGML_OP_VIEW) {
+                continue;
+            }
+            const ggml_tensor * leaf = cache_k_view->src[0];
+            auto layer = extract_layer_from_name(leaf->name);
+            if (!layer.has_value()) {
+                continue;
+            }
+            layer_extent[layer.value()] = leaf->ne[1];
+            layer_mask[layer.value()] = mask;
+            max_extent = std::max(max_extent, leaf->ne[1]);
+        }
+
+        for (const auto & [layer, extent] : layer_extent) {
+            if (extent < max_extent) {
+                model_params.swa_layers.push_back(layer);
+                if (model_params.swa_mask == nullptr) {
+                    model_params.swa_mask = layer_mask[layer];
+                }
+            }
+        }
+        std::sort(model_params.swa_layers.begin(), model_params.swa_layers.end());
+
+        if (ggml_openvino_getenv_int("GGML_OPENVINO_LOG_SWA_LAYERS")) {
+            GGML_LOG_WARN("ov-swa: attn_layers=%zu max_extent=%ld swa_layers=%zu\n", layer_extent.size(),
+                          (long) max_extent, model_params.swa_layers.size());
+        }
+    }
+
     bool rope_seen = false;
     for (int i = 0; i < cgraph->n_nodes; i++) {
         auto * node = cgraph->nodes[i];
@@ -414,11 +500,13 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
             ggml_tensor * cache_k = cache_k_view->src[0];
             int layer = extract_layer_from_name(cache_k->name).value();
 
-            std::string mask_name(mask->name);
+            // Classified by the pre-pass above, which groups layers by mask tensor identity. The
+            // mask NAME cannot be used: build_attn_inp_kq_mask() gives both masks the same name.
+            const bool layer_is_swa = std::find(model_params.swa_layers.begin(), model_params.swa_layers.end(),
+                                                layer) != model_params.swa_layers.end();
 
             model_params.kv_buffer_ctx_id = ggml_backend_openvino_buffer_get_ctx_id(cache_k->buffer);
-            if (mask_name.find("swa") != std::string::npos) {
-                model_params.swa_layers.push_back(layer);
+            if (layer_is_swa) {
                 model_params.ctx_per_seq_swa = cache_k->ne[1];
             } else {
                 model_params.ctx_per_seq = cache_k->ne[1];
@@ -431,7 +519,7 @@ std::pair<ModelParams, ComputeParams> GgmlOvDecoder::compute_llm_params(ggml_cgr
             memcpy(&offset, cache_k_view->op_params, sizeof(size_t));
             compute_params.seq_active_start = offset / seq_size;
 
-            if (mask_name.find("swa") != std::string::npos) {
+            if (layer_is_swa) {
                 compute_params.attention_size_swa = mask->ne[0];
             } else {
                 compute_params.attention_size = mask->ne[0];

--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -673,8 +673,13 @@ void GgmlOvDecoder::add_extra_inputs() {
     //     see llama_kv_cache_unified::get_n_kv and llama_kv_cache_unified::get_padding.
     // 2. `n_seq_active` and `seq_active_start`, used in FLASH_ATTN_EXT to indicate the active sequences in the batch
 
+    // n_seq_active/seq_active_start/seq_active_end can only ever equal one known value when n_seq == 1
+    // (true for every llama-bench/llama-cli/llama-server -np 1 run), so folding them to Constants in
+    // that case is always safe -- confirmed via utils.cpp: the tensor-feeding loop drives itself from
+    // the compiled model's actual Parameter list, so anything that becomes a Constant is automatically
+    // excluded, no special-casing needed.
     auto create_1d_input = [this](const std::string & name, int64_t value) {
-        if (m_is_static) {
+        if (m_is_static || m_model_params.n_seq == 1) {
             auto constant =
                 std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1}, std::vector<int64_t>{value});
             constant->set_friendly_name(name);
@@ -691,11 +696,38 @@ void GgmlOvDecoder::add_extra_inputs() {
         }
     };
 
-    if (m_compute_params.attention_size != -1) {
+    // attention_size (non-SWA) tracks the growing KV length, so it must NOT be folded to a Constant
+    // like n_seq_active above -- the compiled graph is cached and reused across calls (graph_key in
+    // utils.h keys on node topology, not shape), and a Constant would freeze whatever depth was live
+    // at the first compile forever. Static (NPU) mode is unaffected -- ctx_per_seq is a real per-model
+    // constant there. For dynamic (GPU) mode we don't need this as a graph input at all: utils.cpp's
+    // try_make_kv_sliced_tensor() already binds the K/V cache INPUT tensor pre-sliced to the real
+    // current n_kv for non-SWA, single-active-seq layers (every call, always fresh, host-side) -- so
+    // permute.cpp's op_case 3/5 (K/V, non-SWA) can just use that tensor directly, no further graph-level
+    // Slice needed. See ggml_gpu_sdpa_dispatch.md memory for the investigation that found this.
+    if (m_is_static && m_compute_params.attention_size != -1) {
         create_1d_input("attention_size", m_compute_params.attention_size);
     }
+    // attention_size_swa has no equivalent host-side pre-slice (try_make_kv_sliced_tensor excludes SWA
+    // layers -- their KV cache is a ring buffer, so "first N rows are the live prefix" doesn't hold
+    // once it wraps), so permute.cpp's op_case 4/6 still needs a real per-call value here. Fold to a
+    // Constant only for static mode; dynamic mode gets a genuine fresh-per-call Parameter.
     if (m_compute_params.attention_size_swa != -1) {
-        create_1d_input("attention_size_swa", m_compute_params.attention_size_swa);
+        if (m_is_static) {
+            auto constant = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{1},
+                                                                    std::vector<int64_t>{m_compute_params.attention_size_swa});
+            constant->set_friendly_name("attention_size_swa");
+            m_model_extra_inputs["attention_size_swa"] = constant;
+        } else {
+            auto param_node = std::make_shared<ov::op::v0::Parameter>(ov::element::i64, ov::Shape{1});
+            param_node->set_friendly_name("attention_size_swa");
+            param_node->output(0).get_tensor().set_names({"attention_size_swa"});
+            m_model_extra_inputs["attention_size_swa"] = param_node;
+
+            auto tensor = std::make_shared<ov::Tensor>(ov::element::i64, ov::Shape{1});
+            *tensor->data<int64_t>() = m_compute_params.attention_size_swa;
+            m_model_extra_input_values["attention_size_swa"] = tensor;
+        }
     }
     create_1d_input("n_seq_active", m_compute_params.n_seq_active);
     create_1d_input("seq_active_start", m_compute_params.seq_active_start);

--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstring>
 #include <map>
+#include <set>
 #include <memory>
 #include <openvino/core/partial_shape.hpp>
 #include <optional>
@@ -275,6 +276,11 @@ public:
     // then dangles, so callers must compare and refresh.
     const ggml_cgraph * get_cgraph() const { return m_cgraph; }
 
+    // Was this decoder built for a graph with the same OUTPUT set as `cgraph`? The cache key is
+    // only (n_nodes, first/last node name), which cannot see a change in which tensors are marked
+    // as outputs, and the compiled model's Results are fixed at compile time.
+    bool has_same_graph_io(const ggml_cgraph * cgraph) const;
+
     inline static bool is_inp_tok(const ggml_tensor * tensor, const ggml_tensor * op) {
         return op->op == GGML_OP_GET_ROWS && tensor == op->src[1] && op->src[0]->op == GGML_OP_NONE;
     }
@@ -372,6 +378,8 @@ private:
     std::map<std::string, std::shared_ptr<ov::Node>> m_model_weights;
     std::map<std::string, ggml_tensor *> m_model_outputs;
     std::vector<std::string> m_model_output_names;
+    // The output set the compiled model was built from, for has_same_graph_io().
+    std::set<std::string> m_built_output_names;
     std::vector<NodeInfo> m_node_info_list;
     std::map<ggml_tensor *, int> m_node_dynamic_dims;
 

--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -270,6 +270,11 @@ public:
 
     void update_io(ggml_cgraph * cgraph);
 
+    // The cgraph this decoder currently describes. A cached decoder can be handed a DIFFERENT
+    // cgraph instance with the same graph_key, and every cached ggml_tensor* (and m_cgraph itself)
+    // then dangles, so callers must compare and refresh.
+    const ggml_cgraph * get_cgraph() const { return m_cgraph; }
+
     inline static bool is_inp_tok(const ggml_tensor * tensor, const ggml_tensor * op) {
         return op->op == GGML_OP_GET_ROWS && tensor == op->src[1] && op->src[0]->op == GGML_OP_NONE;
     }
@@ -280,6 +285,16 @@ public:
 
     inline static bool is_inp_emb(const ggml_tensor * tensor, const ggml_tensor * op) {
         return tensor->op == GGML_OP_GET_ROWS && op->op == GGML_OP_RMS_NORM;
+    }
+
+    // A 2-D float graph input feeding a matmul as src[1]. Speculative decoding hands the draft the
+    // target's hidden features this way ([n_embd, n_tokens], with no GET_ROWS lookup, so none of the
+    // other seeds match it) and the token count differs between the prompt pass and the shorter
+    // draft blocks, so its token dim must stay dynamic.
+    inline static bool is_inp_embd_2d(const ggml_tensor * tensor, const ggml_tensor * op) {
+        return (tensor->flags & GGML_TENSOR_FLAG_INPUT) && tensor->op == GGML_OP_NONE &&
+               tensor->type == GGML_TYPE_F32 && tensor->ne[2] == 1 && tensor->ne[3] == 1 &&
+               op->op == GGML_OP_MUL_MAT && tensor == op->src[1];
     }
 
     inline static bool is_inp_mask(const ggml_tensor * tensor, const ggml_tensor * op) {

--- a/ggml/src/ggml-openvino/ggml-decoder.h
+++ b/ggml/src/ggml-openvino/ggml-decoder.h
@@ -23,6 +23,10 @@ struct ModelParams {
     int32_t rope_params[15];
     bool mixed_rope_params = false;
     std::vector<int> swa_layers;
+    // The sliding-window mask tensor, identified in compute_llm_params() by grouping attention
+    // layers on the mask they consume. Only used to tell the two masks apart when naming OV
+    // parameters -- both carry the same tensor name. Null when the graph has a single mask.
+    const ggml_tensor * swa_mask = nullptr;
 
     std::vector<std::string> kv_names;
     size_t kv_buffer_ctx_id = 0;
@@ -296,6 +300,10 @@ public:
         return op->op == GGML_OP_SET_ROWS && op->src[1] == tensor;
     }
 
+    bool is_swa_mask(const ggml_tensor * tensor) const {
+        return m_model_params.swa_mask != nullptr && tensor == m_model_params.swa_mask;
+    }
+
     inline static bool is_output_idx(const ggml_tensor * tensor, const ggml_tensor * op) {
         return op->op == GGML_OP_GET_ROWS && tensor == op->src[1] && op->src[0]->op != GGML_OP_NONE &&
                op->src[1]->op == GGML_OP_NONE;
@@ -308,8 +316,22 @@ public:
         if (is_inp_emb(tensor, op)) {
             return "embd";
         }
-        if (is_stateful() && is_inp_mask(tensor, op)) {
-            return std::string(tensor->name).find("swa") == std::string::npos ? "self_kq_mask" : "self_kq_mask_swa";
+        if (is_inp_mask(tensor, op)) {
+            // Give the two attention masks distinct OV parameter names.
+            //
+            // An interleaved-SWA model builds one full-attention mask and one sliding-window mask,
+            // but build_attn_inp_kq_mask() names them identically, so keying a parameter off
+            // tensor->name alone makes the second mask OVERWRITE the first in m_model_inputs: both
+            // attention types then read a single parameter, and the windowed layers silently run
+            // against an unbanded mask. Disambiguate using the SWA layer set computed in
+            // compute_llm_params(), which classifies by mask tensor identity rather than by name.
+            //
+            // When no SWA layer was found there is only one mask in play, so the plain name is
+            // correct and no _swa parameter is created.
+            if (m_model_params.swa_layers.empty()) {
+                return "self_kq_mask";
+            }
+            return is_swa_mask(tensor) ? "self_kq_mask_swa" : "self_kq_mask";
         }
         return tensor->name;
     }

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -47,6 +47,7 @@ void ggml_openvino_device_config::init() {
         "GGML_OPENVINO_MANUAL_GQA_ATTN",
         "GGML_OPENVINO_REDUCE_COMPILE_MEM",
         "GGML_OPENVINO_REQUANT_KQUANT",
+        "GGML_OPENVINO_LOG_SWA_LAYERS",
     };
 
     for (const char * const & env_var : env_var_names) {

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -46,6 +46,7 @@ void ggml_openvino_device_config::init() {
         "GGML_OPENVINO_DISABLE_KV_SLICE",
         "GGML_OPENVINO_MANUAL_GQA_ATTN",
         "GGML_OPENVINO_REDUCE_COMPILE_MEM",
+        "GGML_OPENVINO_REQUANT_KQUANT",
     };
 
     for (const char * const & env_var : env_var_names) {
@@ -232,9 +233,49 @@ std::optional<ExtraQuantType> ggml_openvino_get_requant_type(const ggml_tensor *
     if (ggml_openvino_is_npu()) {
         return ExtraQuantType::Q4_0_128;
     }
+    // By default Q6_K/Q5_K are requantized to Q8_0_C, which *inflates* 6- and 5-bit weights to 8
+    // while the rest of the model stays at 4 bits, and Q4_K keeps its native group-32 layout
+    // (an f16 scale plus an f16 zero point per 32 weights = 0.125 B/weight of metadata).
+    // Decode of a large model is bandwidth-bound, so both cost throughput.
+    //
+    // GGML_OPENVINO_REQUANT_KQUANT selects a 4-bit target instead. Names are
+    // q4_<sym|asym><group>[_all]: <sym|asym> says whether a per-group zero point is kept, <group>
+    // is the group size, and the _all suffix sends Q4_K down the same path (without it only
+    // Q6_K/Q5_K are touched):
+    //   q4_sym128      Q6_K/Q5_K -> Q4_0_128 (u4, group 128, symmetric)
+    //   q4_sym128_all  and Q4_K too -- drops Q4_K's per-32 zero point, which costs some accuracy
+    //   q4_asym64      Q6_K/Q5_K -> Q4_1_64 (u4, group 64, asymmetric)
+    //   q4_asym64_all  and Q4_K too -- most of the metadata saving while keeping a real zero point
+    //   native         no requantization at all (keep Q6_K/Q5_K as they are)
+    const char * rq = ggml_openvino_getenv_str("GGML_OPENVINO_REQUANT_KQUANT");
+    auto is_opt = [rq](const char * name) {
+        return rq && strcmp(rq, name) == 0;
+    };
+    const bool sym128 = is_opt("q4_sym128");
+    const bool sym128_all = is_opt("q4_sym128_all");
+    const bool asym64 = is_opt("q4_asym64");
+    const bool asym64_all = is_opt("q4_asym64_all");
+
+    if (tensor->type == GGML_TYPE_Q4_K) {
+        if (sym128_all) {
+            return ExtraQuantType::Q4_0_128;
+        }
+        if (asym64_all) {
+            return ExtraQuantType::Q4_1_64;
+        }
+    }
     switch (tensor->type) {
     case GGML_TYPE_Q6_K:
     case GGML_TYPE_Q5_K:
+        if (sym128 || sym128_all) {
+            return ExtraQuantType::Q4_0_128;
+        }
+        if (asym64 || asym64_all) {
+            return ExtraQuantType::Q4_1_64;
+        }
+        if (is_opt("native")) {
+            return std::nullopt;
+        }
         return ExtraQuantType::Q8_0_C;
     default:
         return std::nullopt;
@@ -282,6 +323,11 @@ ggml_openvino_extracted_layout ggml_openvino_get_extracted_layout(const ggml_ten
             layout.is_u4 = true;
             layout.weights_per_block = 128;
             layout.is_symmetric = true;
+            break;
+        case ExtraQuantType::Q4_1_64:
+            layout.is_u4 = true;
+            layout.weights_per_block = 64;
+            layout.is_symmetric = false;
             break;
         case ExtraQuantType::Q4_0_C:
             layout.is_u4 = true;

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -48,6 +48,8 @@ void ggml_openvino_device_config::init() {
         "GGML_OPENVINO_REDUCE_COMPILE_MEM",
         "GGML_OPENVINO_REQUANT_KQUANT",
         "GGML_OPENVINO_ROPE_F32_ANGLE",
+        "GGML_OPENVINO_RELEASE_WEIGHTS",
+        "GGML_OPENVINO_SPILL_DIR",
         "GGML_OPENVINO_LOG_SWA_LAYERS",
     };
 

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -45,6 +45,7 @@ void ggml_openvino_device_config::init() {
         "GGML_OPENVINO_DISABLE_CACHE",
         "GGML_OPENVINO_DISABLE_KV_SLICE",
         "GGML_OPENVINO_MANUAL_GQA_ATTN",
+        "GGML_OPENVINO_REDUCE_COMPILE_MEM",
     };
 
     for (const char * const & env_var : env_var_names) {

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -47,6 +47,7 @@ void ggml_openvino_device_config::init() {
         "GGML_OPENVINO_MANUAL_GQA_ATTN",
         "GGML_OPENVINO_REDUCE_COMPILE_MEM",
         "GGML_OPENVINO_REQUANT_KQUANT",
+        "GGML_OPENVINO_ROPE_F32_ANGLE",
         "GGML_OPENVINO_LOG_SWA_LAYERS",
     };
 

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.cpp
@@ -51,6 +51,7 @@ void ggml_openvino_device_config::init() {
         "GGML_OPENVINO_RELEASE_WEIGHTS",
         "GGML_OPENVINO_SPILL_DIR",
         "GGML_OPENVINO_LOG_SWA_LAYERS",
+        "GGML_OPENVINO_LOG_SUPPORTS_OP",
     };
 
     for (const char * const & env_var : env_var_names) {

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.h
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.h
@@ -15,7 +15,10 @@
 #include <string>
 
 // ExtraQuantType enum - defines requantization target formats
-enum class ExtraQuantType { F16, Q4_0_C, Q8_1_C, Q4_0_128, Q8_0_C, Q8_0_32 };
+// Q4_1_64: u4, group 64, *true* asymmetric (per-group scale and zero point). Note that
+// Q4_0_128/Q4_0_C are symmetric despite taking the unsigned branch of quantize_q4_0 -- that branch
+// pins zp to 8 with d = max/-8, which is algebraically symmetric.
+enum class ExtraQuantType { F16, Q4_0_C, Q8_1_C, Q4_0_128, Q8_0_C, Q8_0_32, Q4_1_64 };
 
 ov::Core & ov_singleton_core();
 

--- a/ggml/src/ggml-openvino/ggml-openvino-extra.h
+++ b/ggml/src/ggml-openvino/ggml-openvino-extra.h
@@ -113,6 +113,13 @@ std::optional<ExtraQuantType> ggml_openvino_get_requant_type(const ggml_tensor *
 // 1. Pre-built ov::Constant nodes for weights (avoiding memcpy during graph construction)
 // 2. ov::Tensor wrappers for KV cache / compute tensors (for direct use with infer_request)
 
+// Host weight-buffer release (GGML_OPENVINO_RELEASE_WEIGHTS, GPU only). The OV weight Constants are
+// zero-copy views into host buffers; once the GPU plugin holds its own device copy those pages can be
+// dropped. Single model per process: a graph compiled after the release would read zeros.
+void ggml_openvino_register_weight_buffer(void * data, size_t size);
+void ggml_openvino_release_weight_buffers();
+bool ggml_openvino_weight_buffers_released();
+
 // Base class for OpenVINO tensor extra data
 struct ggml_openvino_extra_base {
     enum class Type { WEIGHT, QUANTIZED_WEIGHT, TENSOR };

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -10,6 +10,8 @@
 #include "ggml.h"
 
 #include <atomic>
+#include <cerrno>
+#include <climits>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -32,6 +34,7 @@
 #    endif
 #    include <windows.h>
 #else
+#    include <sys/mman.h>
 #    include <unistd.h>
 #endif
 
@@ -52,6 +55,77 @@
 // - CPU repack buffer: tensor->extra stores tensor_traits with repacked data
 // =====================================================
 
+// =====================================================
+// Host weight-buffer release (GGML_OPENVINO_RELEASE_WEIGHTS)
+// =====================================================
+// The OpenVINO weight Constants are zero-copy views into the host buffers allocated here. On GPU the
+// plugin holds its own device copy after compile_model, so the host pages are dead weight for
+// inference and can be dropped to reclaim roughly the weights' size in RSS.
+//
+// The buffer is NOT freed: ggml owns its lifetime and tensors still point into it. madvise(
+// MADV_DONTNEED) drops the resident pages while keeping the mapping valid. A later recompile would
+// re-read those Constants from now-zeroed memory and silently produce garbage, so once released the
+// cache-miss compile path must fail loudly rather than run -- see the check in ov_graph_compute.
+namespace {
+struct ov_weight_buffer_registry {
+    std::mutex mutex;
+    std::vector<std::pair<void *, size_t>> buffers;
+    bool released = false;
+};
+
+ov_weight_buffer_registry & ov_weight_registry() {
+    static ov_weight_buffer_registry reg;
+    return reg;
+}
+}  // namespace
+
+void ggml_openvino_register_weight_buffer(void * data, size_t size) {
+    if (data == nullptr || size == 0) {
+        return;
+    }
+    auto & reg = ov_weight_registry();
+    std::lock_guard<std::mutex> lock(reg.mutex);
+    for (const auto & b : reg.buffers) {
+        if (b.first == data) {
+            return;  // already registered
+        }
+    }
+    reg.buffers.emplace_back(data, size);
+}
+
+bool ggml_openvino_weight_buffers_released() {
+    auto & reg = ov_weight_registry();
+    std::lock_guard<std::mutex> lock(reg.mutex);
+    return reg.released;
+}
+
+void ggml_openvino_release_weight_buffers() {
+    auto & reg = ov_weight_registry();
+    std::lock_guard<std::mutex> lock(reg.mutex);
+    if (reg.released) {
+        return;
+    }
+    size_t total = 0;
+#if !defined(_WIN32)
+    const long page = sysconf(_SC_PAGESIZE);
+    for (const auto & b : reg.buffers) {
+        // Align inwards to page boundaries so madvise only drops whole pages owned by this buffer.
+        uintptr_t start = reinterpret_cast<uintptr_t>(b.first);
+        uintptr_t end = start + b.second;
+        uintptr_t astart = (start + page - 1) & ~(uintptr_t) (page - 1);
+        uintptr_t aend = end & ~(uintptr_t) (page - 1);
+        if (aend > astart) {
+            if (madvise(reinterpret_cast<void *>(astart), aend - astart, MADV_DONTNEED) == 0) {
+                total += aend - astart;
+            }
+        }
+    }
+#endif
+    reg.released = true;
+    GGML_LOG_INFO("%s: released %zu MB of host weight buffers (%zu buffers)\n", __func__, total / 1024 / 1024,
+                  reg.buffers.size());
+}
+
 // Buffer context that manages per-tensor allocations (no contiguous buffer for weights)
 struct ggml_backend_openvino_buffer_context {
     int device;
@@ -62,6 +136,11 @@ struct ggml_backend_openvino_buffer_context {
     void * data;
     size_t size;
     bool is_remote;
+
+    // Set when the buffer is a file-backed spill mapping (GGML_OPENVINO_SPILL_DIR); it must be
+    // munmap'd rather than freed.
+    void * spill_mapping = nullptr;
+    size_t spill_size = 0;
 
     // Wrapping of the buffer
     std::shared_ptr<ov::Tensor> ov_buffer;
@@ -96,6 +175,42 @@ struct ggml_backend_openvino_buffer_context {
                 gpu_context.create_usm_device_tensor(ov::element::u8, ov::Shape{size});
             data = usm_tensor.get();
             ov_buffer = std::make_shared<ov::intel_gpu::ocl::USMTensor>(std::move(usm_tensor));
+        } else if (const char * spill_dir = ggml_openvino_getenv_str("GGML_OPENVINO_SPILL_DIR")) {
+            // Disk-backed weight buffer: back the repacked weights with a temp file via MAP_SHARED
+            // instead of anonymous memory. Anonymous pages can only be evicted to swap, so the
+            // repacked buffer stays pinned alongside the mmap'd source and both are resident at once
+            // -- that double residency is the load-time peak. File-backed pages are reclaimable: the
+            // kernel can write them back and drop them under pressure, then re-read on demand, so RSS
+            // becomes a working set rather than the whole buffer. The file is unlinked immediately,
+            // so it disappears when the process exits.
+            //
+            // The directory must be real storage. Pointing this at a tmpfs mount (/tmp on many
+            // systems) backs the "spill" with RAM and makes matters worse.
+            char path[PATH_MAX];
+            snprintf(path, sizeof(path), "%s/ggml-ov-weights-%d-XXXXXX", spill_dir, (int) getpid());
+            int fd = mkstemp(path);
+            if (fd < 0) {
+                GGML_LOG_ERROR("%s: mkstemp(%s) failed: %s\n", __func__, path, strerror(errno));
+                return;
+            }
+            unlink(path);  // anonymous-but-file-backed: freed on process exit
+            if (ftruncate(fd, (off_t) size) != 0) {
+                GGML_LOG_ERROR("%s: ftruncate(%zu) failed: %s\n", __func__, size, strerror(errno));
+                close(fd);
+                return;
+            }
+            void * m = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+            close(fd);  // the mapping keeps the file alive
+            if (m == MAP_FAILED) {
+                GGML_LOG_ERROR("%s: mmap(%zu) failed: %s\n", __func__, size, strerror(errno));
+                return;
+            }
+            data = m;
+            spill_mapping = m;
+            spill_size = size;
+            GGML_LOG_INFO("%s: weight buffer spilled to %s (%zu MB, file-backed)\n", __func__, spill_dir,
+                          size / 1024 / 1024);
+            ov_buffer = std::make_shared<ov::Tensor>(ov::element::u8, ov::Shape{size}, data);
         } else {
             data = ggml_aligned_malloc(size);
             GGML_ASSERT(data);
@@ -123,7 +238,9 @@ struct ggml_backend_openvino_buffer_context {
             delete pair.second;
         }
         tensor_extras.clear();
-        if (!is_remote && data != nullptr) {
+        if (spill_mapping != nullptr) {
+            munmap(spill_mapping, spill_size);
+        } else if (!is_remote && data != nullptr) {
             ggml_aligned_free(data, size);
         }
     }
@@ -240,6 +357,19 @@ static void ggml_backend_openvino_buffer_set_tensor(ggml_backend_buffer_t buffer
 
     if (is_weight_buffer && is_full_tensor_set && is_2d) {
         try {
+            // Register the host buffer so its pages can be dropped once the GPU plugin has its own
+            // device copy (GGML_OPENVINO_RELEASE_WEIGHTS). Weights are set once at model load, so a
+            // weight arriving AFTER a release means a second model is loading while the first
+            // model's compiled graph is pinned; that graph would be reused with this model's key.
+            if (!ctx->is_remote) {
+                if (ggml_openvino_weight_buffers_released()) {
+                    GGML_ABORT(
+                        "ggml-openvino: loading a new model while GGML_OPENVINO_RELEASE_WEIGHTS pinned a previous "
+                        "model's compiled graph. This mode supports a single model per process; unset it for "
+                        "multi-model runs.");
+                }
+                ggml_openvino_register_weight_buffer(ctx->data, ctx->size);
+            }
             auto result = process_weight_tensor(tensor, data, tensor->data);
             result.weight_node->set_friendly_name(tensor->name);
 

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -1025,6 +1025,13 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         if (op->ne[3] != 1) {
             return true;
         }
+        // A bf16 gather is miscomputed on GPU, not merely imprecise:
+        //   ERR = 1.949733963 > 0.000000100  GET_ROWS(type=bf16,n=256,m=5,r=4,be1=7,be2=1,v=1)
+        // Decline it so the scheduler keeps it on CPU.
+        if (op->op == GGML_OP_GET_ROWS && ggml_openvino_get_device_name() == "GPU" &&
+            op->src[0]->type == GGML_TYPE_BF16) {
+            return true;
+        }
         if (op->ne[0] == 256 && (op->src[0]->type == GGML_TYPE_Q4_K || op->src[0]->type == GGML_TYPE_Q5_K)) {
             // ERR = 0.000000306 > 0.000000100   GET_ROWS(type=q4_K,n=256,m=5,r=4,be1=1,be2=1,v=0)
             // ERR = 0.000000197 > 0.000000100   GET_ROWS(type=q5_K,n=256,m=5,r=4,be1=1,be2=1,v=0)

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -1097,7 +1097,7 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
     }
     case GGML_OP_SOFT_MAX: {
         if (op->src[2] != nullptr) {
-            // GGML_LOG_WARN("OpenVINO backend does not support SOFT_MAX with sinks\n");
+            GGML_LOG_WARN("OpenVINO backend does not support SOFT_MAX with sinks\n");
             return true;
         }
 
@@ -1148,18 +1148,18 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         }
 
         if (op->src[4] != nullptr) {
-            // GGML_LOG_WARN("OpenVINO backend does not support FLASH_ATTN_EXT with sinks\n");
+            GGML_LOG_WARN("OpenVINO backend does not support FLASH_ATTN_EXT with sinks\n");
             return true;
         }
         if (!is_supported_flash_attn_pattern(op)) {
             return true;
         }
         if (max_bias > 0) {
-            // GGML_LOG_WARN("OpenVINO backend does not support FLASH_ATTN_EXT with max_bias > 0\n");
+            GGML_LOG_WARN("OpenVINO backend does not support FLASH_ATTN_EXT with max_bias > 0\n");
             return true;
         }
         if (logit_softcap != 0) {
-            // GGML_LOG_WARN("OpenVINO backend does not support FLASH_ATTN_EXT with logit_softcap != 0\n");
+            GGML_LOG_WARN("OpenVINO backend does not support FLASH_ATTN_EXT with logit_softcap != 0\n");
             return true;
         }
         break;
@@ -1167,14 +1167,14 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
     case GGML_OP_PERMUTE: {
         if (op->type == GGML_TYPE_BF16) {
             // err msg: [GPU] Could not find a suitable kernel for transpose
-            // GGML_LOG_WARN("OpenVINO backend does not support PERMUTE with BF16 type\n");
+            GGML_LOG_WARN("OpenVINO backend does not support PERMUTE with BF16 type\n");
             return true;
         }
         break;
     }
     case GGML_OP_CPY: {
         if (op->src[0]->type == GGML_TYPE_BF16 || op->src[1]->type == GGML_TYPE_BF16) {
-            // GGML_LOG_WARN("OpenVINO backend does not support CPY with non-contiguous data or bf16 types\n");
+            GGML_LOG_WARN("OpenVINO backend does not support CPY with non-contiguous data or bf16 types\n");
             return true;
         }
         // op test case with non-contiguous src or dst
@@ -1220,16 +1220,16 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         const int n_dims = op_params[1];
         const int mode = op_params[2];
         if (mode != GGML_ROPE_TYPE_NORMAL && mode != GGML_ROPE_TYPE_NEOX && mode != GGML_ROPE_TYPE_IMROPE) {
-            // GGML_LOG_WARN("OpenVINO backend does not support ROPE with mode %d\n", mode);
+            GGML_LOG_WARN("OpenVINO backend does not support ROPE with mode %d\n", mode);
             return true;
         }
         if (n_dims != 0.0f && n_dims != op->src[0]->ne[0]) {
-            // GGML_LOG_WARN("OpenVINO backend does not support ROPE with n_dims %d != src[0]->ne[0] %ld\n", n_dims,
-            //               op->src[0]->ne[0]);
+            GGML_LOG_WARN("OpenVINO backend does not support ROPE with n_dims %d != src[0]->ne[0] %ld\n", n_dims,
+                          op->src[0]->ne[0]);
             return true;
         }
         if (op->type != GGML_TYPE_F32 && op->type != GGML_TYPE_F16) {
-            // GGML_LOG_WARN("OpenVINO backend does not support ROPE with type %s\n", ggml_type_name(op->type));
+            GGML_LOG_WARN("OpenVINO backend does not support ROPE with type %s\n", ggml_type_name(op->type));
             return true;
         }
         if (op->src[0]->op == GGML_OP_VIEW) {
@@ -1244,7 +1244,7 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
         if (mode == GGML_ROPE_TYPE_IMROPE &&
             (op->src[2] != 0 || ((const float *) op_params)[6] != 1 || ((const float *) op_params)[7] != 0 ||
              ((const float *) op_params)[8] != 1)) {
-            // GGML_LOG_WARN("OpenVINO backend does not support IMROPE with freq_factors, freq_scale, ext_factor, and attn_factor\n");
+            GGML_LOG_WARN("OpenVINO backend does not support IMROPE with freq_factors, freq_scale, ext_factor, and attn_factor\n");
             return true;
         }
         break;
@@ -1252,7 +1252,7 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
     case GGML_OP_TRANSPOSE: {
         // if the type is bf16, will return true
         if (op->type == GGML_TYPE_BF16) {
-            // GGML_LOG_WARN("OpenVINO backend does not support CONT with BF16 type\n");
+            GGML_LOG_WARN("OpenVINO backend does not support CONT with BF16 type\n");
             return true;
         }
         break;
@@ -1350,7 +1350,7 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
     case GGML_OP_UNARY: {
         auto supported = supported_unary_ops.find(ggml_get_unary_op(op)) != supported_unary_ops.end();
         if (!supported) {
-            // GGML_LOG_WARN("OpenVINO backend does not support unary op %s\n", ggml_unary_op_name(ggml_get_unary_op(op)));
+            GGML_LOG_WARN("OpenVINO backend does not support unary op %s\n", ggml_unary_op_name(ggml_get_unary_op(op)));
             return false;
         }
         break;
@@ -1358,12 +1358,12 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
     case GGML_OP_GLU: {
         auto supported = supported_glu_ops.find(ggml_get_glu_op(op)) != supported_glu_ops.end();
         if (!supported) {
-            // GGML_LOG_WARN("OpenVINO backend does not support GLU op %s\n", ggml_glu_op_name(ggml_get_glu_op(op)));
+            GGML_LOG_WARN("OpenVINO backend does not support GLU op %s\n", ggml_glu_op_name(ggml_get_glu_op(op)));
             return false;
         }
         if (has_view_op_input(op)) {
-            // GGML_LOG_WARN("OpenVINO backend does not support unary op %s with view input\n",
-            //               ggml_glu_op_name(ggml_get_glu_op(op)));
+            GGML_LOG_WARN("OpenVINO backend does not support GLU op %s with view input\n",
+                          ggml_glu_op_name(ggml_get_glu_op(op)));
             return false;
         }
         if (op->src[1] == nullptr && op->src[0]->ne[0] % 2 != 0) {
@@ -1375,14 +1375,14 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
     default: {
         auto supported = supported_ops.find(op->op) != supported_ops.end();
         if (!supported) {
-            // GGML_LOG_WARN("OpenVINO backend does not support op %s\n", ggml_op_name(op->op));
+            GGML_LOG_WARN("OpenVINO backend does not support op %s\n", ggml_op_name(op->op));
             return false;
         }
         static std::set<ggml_op> ops_not_support_view_input{
             GGML_OP_L2_NORM,
         };
         if (ops_not_support_view_input.find(op->op) != ops_not_support_view_input.end() && has_view_op_input(op)) {
-            // GGML_LOG_WARN("OpenVINO backend does not support op %s with view input\n", ggml_op_name(op->op));
+            GGML_LOG_WARN("OpenVINO backend does not support op %s with view input\n", ggml_op_name(op->op));
             return false;
         }
         if (op->op == GGML_OP_RMS_NORM && has_non_contiguous_view_input(op)) {
@@ -1392,7 +1392,7 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
     }
 
     if (supported_types.find(op->type) == supported_types.end()) {
-        // GGML_LOG_WARN("OpenVINO backend does not support tensor type %s\n", ggml_type_name(op->type));
+        GGML_LOG_WARN("OpenVINO backend does not support tensor type %s\n", ggml_type_name(op->type));
         return false;
     }
     for (int i = 0; i < GGML_MAX_SRC; i++) {
@@ -1401,11 +1401,11 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
             break;
         }
         if (supported_types.find(src->type) == supported_types.end()) {
-            // GGML_LOG_WARN("OpenVINO backend does not support tensor type %s\n", ggml_type_name(src->type));
+            GGML_LOG_WARN("OpenVINO backend does not support tensor type %s\n", ggml_type_name(src->type));
             return false;
         }
         if (ggml_is_quantized(src->type) && src->ne[2] != 1) {
-            // GGML_LOG_WARN("OpenVINO backend does not support 3D quantized tensors\n");
+            GGML_LOG_WARN("OpenVINO backend does not support 3D quantized tensors\n");
             return false;
         }
     }

--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <openvino/core/type/element_type.hpp>
@@ -1308,7 +1309,7 @@ static bool is_op_unsupported_case(const ggml_tensor * op) {
     return false;
 }
 
-static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, const ggml_tensor * op) {
+static bool ggml_backend_openvino_device_supports_op_impl(ggml_backend_dev_t dev, const ggml_tensor * op) {
     GGML_ASSERT(dev->reg != nullptr);
 
     static std::unordered_set<ggml_type> supported_types{
@@ -1421,6 +1422,109 @@ static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, con
         return false;
     }
     return true;
+}
+
+// Report what supports_op() accepts and rejects, so a graph that silently falls back to another
+// backend can be diagnosed. Every op rejected here becomes a graph split; if nothing is rejected,
+// the whole graph runs on OpenVINO.
+//
+// Gated by GGML_OPENVINO_LOG_SUPPORTS_OP:
+//   1  one summary at exit listing every distinct op kind and verdict -- start here
+//   2  additionally log every individual call, with the tensor name and shape
+//
+// This wraps the decision function instead of instrumenting it, so all of its return paths are
+// covered -- including the several that reject without logging a reason of their own, and any
+// added later.
+//
+// The summary is reported at exit rather than on each op's first occurrence, because the earliest
+// calls happen before the log handler emits anything: with level 2 the first line to actually
+// appear already reads "call 1244". A first-occurrence line would therefore be silently dropped
+// for exactly the ops that are only ever seen early. Counting is unaffected, so the summary is the
+// reliable view; treat the level-2 stream as a sample, not a complete trace.
+namespace {
+
+struct supports_op_tally {
+    std::mutex mutex;
+    // key: "<op>:ok" / "<op>:no" -> number of calls
+    std::map<std::string, size_t> counts;
+
+    // Report totals once, at exit. Registered lazily so a run with the knob off costs nothing.
+    // atexit runs while the ggml log callback is still valid, which static destruction does not
+    // guarantee.
+    void arm_summary() {
+        static std::once_flag armed;
+        std::call_once(armed, [] {
+            std::atexit([] {
+                auto & self = instance();
+                std::lock_guard<std::mutex> lock(self.mutex);
+
+                size_t n_accept_kinds = 0;
+                size_t n_reject_kinds = 0;
+                GGML_LOG_WARN("ov-supports-op: ---- summary (distinct op kinds, with call counts) ----\n");
+                for (const auto & [key, count] : self.counts) {
+                    const bool ok = key.size() > 3 && key.compare(key.size() - 3, 3, ":ok") == 0;
+                    ok ? ++n_accept_kinds : ++n_reject_kinds;
+                    GGML_LOG_WARN("ov-supports-op:   %-8s %-24s %zu call(s)\n", ok ? "ACCEPT" : "REJECT",
+                                  key.substr(0, key.size() - 3).c_str(), count);
+                }
+                if (n_reject_kinds == 0) {
+                    GGML_LOG_WARN("ov-supports-op: %zu op kind(s) accepted, 0 rejected"
+                                  " -- every op was supported, so no split originated here\n",
+                                  n_accept_kinds);
+                } else {
+                    GGML_LOG_WARN("ov-supports-op: %zu op kind(s) accepted, %zu REJECTED"
+                                  " -- each rejected kind forces a graph split\n",
+                                  n_accept_kinds, n_reject_kinds);
+                }
+            });
+        });
+    }
+
+    static supports_op_tally & instance() {
+        static supports_op_tally tally;
+        return tally;
+    }
+};
+
+}  // namespace
+
+static bool ggml_backend_openvino_device_supports_op(ggml_backend_dev_t dev, const ggml_tensor * op) {
+    static const int log_level = ggml_openvino_getenv_int("GGML_OPENVINO_LOG_SUPPORTS_OP");
+
+    const bool supported = ggml_backend_openvino_device_supports_op_impl(dev, op);
+
+    if (log_level <= 0) {
+        return supported;
+    }
+
+    // Name the op the way ggml does: UNARY and GLU carry their real identity in a sub-enum, so
+    // logging only "UNARY" would merge SILU with everything else.
+    std::string op_desc = ggml_op_name(op->op);
+    if (op->op == GGML_OP_UNARY) {
+        op_desc += std::string("/") + ggml_unary_op_name(ggml_get_unary_op(op));
+    } else if (op->op == GGML_OP_GLU) {
+        op_desc += std::string("/") + ggml_glu_op_name(ggml_get_glu_op(op));
+    }
+
+    // The scheduler calls supports_op() on every graph build and may do so from several threads,
+    // so the tally needs a lock. Keyed on op identity *and* verdict, because the same op can be
+    // accepted at one shape and rejected at another (e.g. a quantized 3-D src).
+    auto & tally = supports_op_tally::instance();
+    tally.arm_summary();
+
+    size_t count;
+    {
+        std::lock_guard<std::mutex> lock(tally.mutex);
+        count = ++tally.counts[op_desc + (supported ? ":ok" : ":no")];
+    }
+
+    if (log_level >= 2) {
+        GGML_LOG_WARN("ov-supports-op: %-6s %-22s name='%s' type=%s ne=[%ld,%ld,%ld,%ld] (call %zu)\n",
+                      supported ? "ACCEPT" : "REJECT", op_desc.c_str(), op->name, ggml_type_name(op->type),
+                      (long) op->ne[0], (long) op->ne[1], (long) op->ne[2], (long) op->ne[3], count);
+    }
+
+    return supported;
 }
 
 static bool ggml_backend_openvino_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {

--- a/ggml/src/ggml-openvino/ggml-quants.cpp
+++ b/ggml/src/ggml-openvino/ggml-quants.cpp
@@ -707,7 +707,8 @@ std::shared_ptr<ov::Node> requantize_to_buffers(const ggml_tensor * tensor,
     const int64_t n_rows = ne0 > 0 ? n_elements / ne0 : 0;
 
     // Requantize to target quantized format
-    bool is_u4 = (requant_type == ExtraQuantType::Q4_0_C || requant_type == ExtraQuantType::Q4_0_128);
+    bool is_u4 = (requant_type == ExtraQuantType::Q4_0_C || requant_type == ExtraQuantType::Q4_0_128 ||
+                  requant_type == ExtraQuantType::Q4_1_64);
 
     // Dequantizing the whole tensor at once needs a transient F32 array of n_elements floats. For a
     // large embedding or output matrix that dominates peak host memory during compile: a
@@ -737,7 +738,9 @@ std::shared_ptr<ov::Node> requantize_to_buffers(const ggml_tensor * tensor,
             return result;
         }
 
-        if (is_u4) {
+        if (requant_type == ExtraQuantType::Q4_1_64) {
+            quantize_q4_1_asym(weights_f32.data(), weights, scales, zp, n_elements, block_size);
+        } else if (is_u4) {
             quantize_q4_0(weights_f32.data(), weights, scales, zp, n_elements, block_size);
         } else if (requant_type == ExtraQuantType::Q8_1_C) {
             quantize_q8_1(weights_f32.data(), weights, scales, zp, n_elements, block_size);
@@ -996,6 +999,71 @@ void quantize_q4_0(const float * x,
                 int8_t si1 = (int8_t) std::max(-8, std::min(7, (int) roundf(x1)));
                 weights[i * qk / 2 + j] = (si0 & 0x0F) | ((si1 & 0x0F) << 4);
             }
+        }
+    }
+}
+
+// Asymmetric u4 quantization with a per-group scale and zero point.
+//
+// Unlike quantize_q4_0's unsigned branch, which pins the zero point to 8 and is therefore
+// symmetric, this keeps a real per-group zero point, so a group whose values are not centred on
+// zero does not waste half its range.
+void quantize_q4_1_asym(const float * x,
+                        ov::Tensor & weights_arr,
+                        ov::Tensor & scales_arr,
+                        ov::Tensor & zp_arr,
+                        int64_t k,
+                        int64_t qk) {
+    assert(k % qk == 0);
+    const int nb = k / qk;
+
+    auto * weights = static_cast<uint8_t *>(weights_arr.data());
+    auto * scales = scales_arr.data<ov::element_type_traits<ov::element::f16>::value_type>();
+    auto * zp = static_cast<uint8_t *>(zp_arr.data());
+
+    // u4 zero points are packed two per byte, low nibble first, indexed by group -- the same
+    // convention as the unsigned branch of quantize_q4_0.
+    auto store_zp = [zp](int i, uint8_t v) {
+        if (i % 2 == 0) {
+            zp[i / 2] = v & 0x0F;
+        } else {
+            zp[i / 2] |= (uint8_t) ((v & 0x0F) << 4);
+        }
+    };
+
+    for (int i = 0; i < nb; i++) {
+        float vmin = x[i * qk];
+        float vmax = x[i * qk];
+        for (int j = 1; j < qk; j++) {
+            const float v = x[i * qk + j];
+            vmin = std::min(vmin, v);
+            vmax = std::max(vmax, v);
+        }
+        // Include 0 in the range so an all-positive or all-negative group still represents zero
+        // exactly -- these are weights, so an exact zero matters.
+        vmin = std::min(vmin, 0.0f);
+        vmax = std::max(vmax, 0.0f);
+
+        const float d = (vmax - vmin) / 15.0f;
+        if (d == 0.0f) {
+            scales[i] = ov::float16(1.0f);
+            store_zp(i, 0);
+            memset(weights + i * qk / 2, 0, qk / 2);
+            continue;
+        }
+        const float id = 1.0f / d;
+
+        // The zero point is itself a 4-bit integer, so round it and dequantize as (q - zq) * d.
+        const int zq = std::max(0, std::min(15, (int) lroundf(-vmin * id)));
+        scales[i] = ov::float16(d);
+        store_zp(i, (uint8_t) zq);
+
+        for (int j = 0; j < qk / 2; ++j) {
+            const float x0 = x[i * qk + 2 * j] * id;
+            const float x1 = x[i * qk + 2 * j + 1] * id;
+            const uint8_t q0 = (uint8_t) std::max(0, std::min(15, (int) lroundf(x0) + zq));
+            const uint8_t q1 = (uint8_t) std::max(0, std::min(15, (int) lroundf(x1) + zq));
+            weights[i * qk / 2 + j] = (uint8_t) (q0 | (q1 << 4));
         }
     }
 }

--- a/ggml/src/ggml-openvino/ggml-quants.cpp
+++ b/ggml/src/ggml-openvino/ggml-quants.cpp
@@ -2,6 +2,7 @@
 
 #include "ggml-common.h"
 #include "ggml-impl.h"
+#include "ggml-openvino-extra.h"
 #include "ggml.h"
 
 #include <algorithm>
@@ -702,28 +703,93 @@ std::shared_ptr<ov::Node> requantize_to_buffers(const ggml_tensor * tensor,
                                                 ov::Tensor & scales,
                                                 ov::Tensor & zp) {
     int64_t n_elements = ggml_nelements(tensor);
-
-    // First dequantize to F32
-    std::vector<float> weights_f32(n_elements);
-    ggml_get_type_traits(tensor->type)->to_float(data, weights_f32.data(), n_elements);
-
-    // Handle F16 case - just convert and create constant
-    if (requant_type == ExtraQuantType::F16) {
-        ggml_get_type_traits(GGML_TYPE_F16)->from_float_ref(weights_f32.data(), weights.data(), n_elements);
-        auto result = std::make_shared<ov::op::v0::Constant>(weights);
-        result->set_friendly_name(tensor->name);
-        return result;
-    }
+    const int64_t ne0 = tensor->ne[0];
+    const int64_t n_rows = ne0 > 0 ? n_elements / ne0 : 0;
 
     // Requantize to target quantized format
     bool is_u4 = (requant_type == ExtraQuantType::Q4_0_C || requant_type == ExtraQuantType::Q4_0_128);
 
-    if (is_u4) {
-        quantize_q4_0(weights_f32.data(), weights, scales, zp, n_elements, block_size);
-    } else if (requant_type == ExtraQuantType::Q8_1_C) {
-        quantize_q8_1(weights_f32.data(), weights, scales, zp, n_elements, block_size);
+    // Dequantizing the whole tensor at once needs a transient F32 array of n_elements floats. For a
+    // large embedding or output matrix that dominates peak host memory during compile: a
+    // large embedding table costs several GiB, on top of the source weights and the requantized output.
+    //
+    // GGML_OPENVINO_REDUCE_COMPILE_MEM instead walks complete rows in chunks, dequantizing into a
+    // small scratch buffer and quantizing straight into a row-slice of the destination, which bounds
+    // the transient at CHUNK_ROWS*ne0 floats (a few MiB at typical row widths) regardless of tensor size. Only
+    // whole rows are processed, so each chunk's groups are exactly the groups of those rows.
+    //
+    // u4 targets are excluded: make_int4_weights() packs two values per byte across row boundaries,
+    // so a chunk's output is not byte-aligned with the destination. With the flag off, or for u4,
+    // the original full-materialization path runs unchanged.
+    const bool stream_requant = ggml_openvino_getenv_int("GGML_OPENVINO_REDUCE_COMPILE_MEM") != 0 && !is_u4 &&
+                                n_rows > 0 && ne0 > 0 && (block_size <= 0 || ne0 % block_size == 0);
+
+    if (!stream_requant) {
+        // First dequantize to F32
+        std::vector<float> weights_f32(n_elements);
+        ggml_get_type_traits(tensor->type)->to_float(data, weights_f32.data(), n_elements);
+
+        // Handle F16 case - just convert and create constant
+        if (requant_type == ExtraQuantType::F16) {
+            ggml_get_type_traits(GGML_TYPE_F16)->from_float_ref(weights_f32.data(), weights.data(), n_elements);
+            auto result = std::make_shared<ov::op::v0::Constant>(weights);
+            result->set_friendly_name(tensor->name);
+            return result;
+        }
+
+        if (is_u4) {
+            quantize_q4_0(weights_f32.data(), weights, scales, zp, n_elements, block_size);
+        } else if (requant_type == ExtraQuantType::Q8_1_C) {
+            quantize_q8_1(weights_f32.data(), weights, scales, zp, n_elements, block_size);
+        } else {
+            quantize_q8_0(weights_f32.data(), weights, scales, zp, n_elements, block_size);
+        }
     } else {
-        quantize_q8_0(weights_f32.data(), weights, scales, zp, n_elements, block_size);
+        const int64_t CHUNK_ROWS = std::min<int64_t>(n_rows, 256);
+        const size_t row_bytes = ggml_row_size(tensor->type, ne0);
+        std::vector<float> scratch(static_cast<size_t>(CHUNK_ROWS) * ne0);
+        const auto * tt = ggml_get_type_traits(tensor->type);
+
+        for (int64_t r0 = 0; r0 < n_rows; r0 += CHUNK_ROWS) {
+            const int64_t rows = std::min<int64_t>(CHUNK_ROWS, n_rows - r0);
+            const int64_t cnt = rows * ne0;
+            const auto * src = static_cast<const uint8_t *>(data) + static_cast<size_t>(r0) * row_bytes;
+            tt->to_float(src, scratch.data(), cnt);
+
+            if (requant_type == ExtraQuantType::F16) {
+                auto * dst = static_cast<ggml_fp16_t *>(weights.data()) + static_cast<size_t>(r0) * ne0;
+                ggml_get_type_traits(GGML_TYPE_F16)->from_float_ref(scratch.data(), dst, cnt);
+                continue;
+            }
+
+            // Row-chunked views over the destination buffers, so each chunk quantizes into its own
+            // slice without touching the rest.
+            ov::Tensor w_chunk(weights.get_element_type(), ov::Shape{(size_t) rows, (size_t) ne0},
+                               static_cast<uint8_t *>(weights.data()) + static_cast<size_t>(r0) * ne0);
+            const size_t groups_per_row = block_size > 0 ? (size_t) (ne0 / block_size) : 1;
+            ov::Tensor s_chunk(scales.get_element_type(), ov::Shape{(size_t) rows, groups_per_row},
+                               static_cast<uint8_t *>(scales.data()) +
+                                   static_cast<size_t>(r0) * groups_per_row * scales.get_element_type().size());
+            // Symmetric targets leave `zp` unallocated; quantize_q8_* only touches it in the
+            // asymmetric branch, so pass the empty tensor straight through.
+            ov::Tensor z_chunk;
+            if (zp) {
+                z_chunk = ov::Tensor(zp.get_element_type(), ov::Shape{(size_t) rows, groups_per_row},
+                                     static_cast<uint8_t *>(zp.data()) +
+                                         static_cast<size_t>(r0) * groups_per_row * zp.get_element_type().size());
+            }
+            if (requant_type == ExtraQuantType::Q8_1_C) {
+                quantize_q8_1(scratch.data(), w_chunk, s_chunk, z_chunk, cnt, block_size);
+            } else {
+                quantize_q8_0(scratch.data(), w_chunk, s_chunk, z_chunk, cnt, block_size);
+            }
+        }
+
+        if (requant_type == ExtraQuantType::F16) {
+            auto result = std::make_shared<ov::op::v0::Constant>(weights);
+            result->set_friendly_name(tensor->name);
+            return result;
+        }
     }
 
     // Create the OpenVINO weight subgraph

--- a/ggml/src/ggml-openvino/ggml-quants.h
+++ b/ggml/src/ggml-openvino/ggml-quants.h
@@ -100,6 +100,8 @@ inline const char * extra_quant_type_name(ExtraQuantType t) {
         return "Q8_0_32";
     case ExtraQuantType::Q8_1_C:
         return "Q8_1_C";
+    case ExtraQuantType::Q4_1_64:
+        return "Q4_1_64";
     default:
         return "unknown";
     }
@@ -140,6 +142,12 @@ void quantize_q8_1(const float * x,
                    ov::Tensor & zp_arr,
                    int64_t k,
                    int64_t qk);
+void quantize_q4_1_asym(const float * x,
+                        ov::Tensor & weights_arr,
+                        ov::Tensor & scales_arr,
+                        ov::Tensor & zp_arr,
+                        int64_t k,
+                        int64_t qk);
 void quantize_q8_0(const float * x,
                    ov::Tensor & weights_arr,
                    ov::Tensor & scales_arr,

--- a/ggml/src/ggml-openvino/openvino/op/argmax.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/argmax.cpp
@@ -1,0 +1,51 @@
+#include "../node_context.h"
+#include "../op_table.h"
+#include "../utils.h"
+#include "ggml.h"
+
+#include <openvino/frontend/exception.hpp>
+#include <openvino/op/concat.hpp>
+#include <openvino/op/constant.hpp>
+#include <openvino/op/reshape.hpp>
+#include <openvino/op/topk.hpp>
+
+namespace ov {
+namespace frontend {
+namespace ggml {
+namespace op {
+
+// GGML_OP_ARGMAX: src0 is a matrix [ne0, ne1]; the result is a 1-D I32 tensor of ne1 entries
+// holding, for each row, the index of the maximum along ne0. ggml shapes arrive reversed here, so
+// ne0 is the last OV axis and ne1 is axis 2. TopK(k=1, axis=last, MAX) yields exactly that index,
+// then reshape to the [1,1,1,ne1] layout the decoder expects for a 1-D ggml output.
+//
+// Note ggml's argmax returns the FIRST maximum on a tie, while TopK's tie-breaking is not specified
+// to match. Ties on real logits are vanishingly rare and none were observed, but the two are not
+// proven equivalent.
+OutputVector translate_argmax(const NodeContext & context) {
+    num_inputs_check(context, 1, 1);
+
+    auto input = process_view_input_new(context, 0);
+
+    auto k = ov::op::v0::Constant::create(ov::element::i64, {}, {1});
+    auto topk = std::make_shared<ov::op::v11::TopK>(input,
+                                                   k,
+                                                   3,
+                                                   ov::op::v11::TopK::Mode::MAX,
+                                                   ov::op::v11::TopK::SortType::SORT_VALUES,
+                                                   context.get_output_type(),
+                                                   false);
+
+    // ne1 is the dynamic row count, so build the target shape at runtime.
+    auto leading = ov::op::v0::Constant::create(ov::element::i64, {3}, {1, 1, 1});
+    auto rows = get_dimensions(input.get_node_shared_ptr(), {2});
+    auto target_shape = std::make_shared<ov::op::v0::Concat>(OutputVector{leading, rows}, 0);
+    auto res = std::make_shared<ov::op::v1::Reshape>(topk->output(1), target_shape, false);
+
+    return rename_outputs_with_suffix({res}, context.get_name());
+}
+
+}  // namespace op
+}  // namespace ggml
+}  // namespace frontend
+}  // namespace ov

--- a/ggml/src/ggml-openvino/openvino/op/permute.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/permute.cpp
@@ -79,13 +79,24 @@ OutputVector translate_permute(const NodeContext & context) {
         int64_t ctx_per_seq = cache_shape[2].is_static() ? cache_shape[2].get_length() : -1;
         int64_t n_seq = cache_shape[1].get_length();
 
+        // Non-SWA (op_case 3/5) has no "attention_size" input in dynamic (GPU) mode: the K/V cache
+        // Slice below would be a no-op there anyway, since utils.cpp's try_make_kv_sliced_tensor()
+        // already binds the host input tensor pre-sliced to the real current n_kv for these layers
+        // (single active sequence, not SWA) -- so skip the graph-level Slice entirely rather than
+        // slicing to a value that would go stale once the compiled graph is reused at greater depth
+        // (see ggml_gpu_sdpa_dispatch.md memory). Static (NPU) mode still provides "attention_size" as
+        // a Constant and needs the Slice as before. SWA (op_case 4/6) has no host pre-slice (ring
+        // buffer), so it always needs the Slice, fed a real per-call value via "attention_size_swa".
+        const bool need_kv_size_slice = (op_case == 4 || op_case == 6) || context.has_input("attention_size");
         Output<Node> attention_size;
-        if (!context.has_input("attention_size")) {
-            attention_size = ov::op::v0::Constant::create(ov::element::i64, {1}, {output_shape[2]});
-        } else if (op_case == 3 || op_case == 5) {
-            attention_size = context.get_input("attention_size");
-        } else {
-            attention_size = context.get_input("attention_size_swa");
+        if (need_kv_size_slice) {
+            if (op_case == 3 || op_case == 5) {
+                attention_size = context.get_input("attention_size");
+            } else if (context.has_input("attention_size_swa")) {
+                attention_size = context.get_input("attention_size_swa");
+            } else {
+                attention_size = ov::op::v0::Constant::create(ov::element::i64, {1}, {output_shape[2]});
+            }
         }
 
         Output<Node> seq_active_start;
@@ -120,8 +131,11 @@ OutputVector translate_permute(const NodeContext & context) {
                 after_seq_slice =
                     std::make_shared<ov::op::v8::Slice>(src_reshaped, seq_active_start, seq_active_end, one, zero);
             }
-            auto slice2 = std::make_shared<ov::op::v8::Slice>(after_seq_slice, zero, attention_size, one, one);
-            res = std::make_shared<ov::op::v1::Transpose>(slice2, perm);
+            ov::Output<ov::Node> pre_transpose = after_seq_slice;
+            if (need_kv_size_slice) {
+                pre_transpose = std::make_shared<ov::op::v8::Slice>(after_seq_slice, zero, attention_size, one, one);
+            }
+            res = std::make_shared<ov::op::v1::Transpose>(pre_transpose, perm);
         } else {
             auto three = ov::op::v0::Constant::create(ov::element::i64, {1}, {3});
             auto src_reshaped = std::make_shared<ov::op::v1::Reshape>(
@@ -134,8 +148,10 @@ OutputVector translate_permute(const NodeContext & context) {
                 after_seq_slice =
                     std::make_shared<ov::op::v8::Slice>(src_reshaped, seq_active_start, seq_active_end, one, zero);
             }
-            auto slice2 = std::make_shared<ov::op::v8::Slice>(after_seq_slice, zero, attention_size, one, three);
-            res = slice2;
+            res = after_seq_slice;
+            if (need_kv_size_slice) {
+                res = std::make_shared<ov::op::v8::Slice>(after_seq_slice, zero, attention_size, one, three);
+            }
         }
     }
     return rename_outputs_with_suffix({res}, context.get_name());

--- a/ggml/src/ggml-openvino/openvino/op_table.cpp
+++ b/ggml/src/ggml-openvino/openvino/op_table.cpp
@@ -8,6 +8,7 @@
 #include <openvino/op/gelu.hpp>
 #include <openvino/op/matmul.hpp>
 #include <openvino/op/multiply.hpp>
+#include <openvino/op/sigmoid.hpp>
 #include <openvino/op/subtract.hpp>
 #include <openvino/op/tanh.hpp>
 
@@ -42,6 +43,7 @@ std::unordered_map<std::string, CreatorFunction> get_supported_ops() {
         {"GGML_OP_SUB",             op::translate_1to1_match_2_inputs<v1::Subtract>},
         {"GGML_OP_TRANSPOSE",       op::translate_transpose                        },
         {"GGML_UNARY_OP_GELU",      op::translate_1to1_match_1_input<v7::Gelu>     },
+        {"GGML_UNARY_OP_SIGMOID",   op::translate_1to1_match_1_input<v0::Sigmoid>  },
         {"GGML_UNARY_OP_SILU",      op::translate_unary_silu                       },
         {"GGML_UNARY_OP_SOFTPLUS",  op::translate_unary_softplus                   },
         {"GGML_UNARY_OP_TANH",      op::translate_1to1_match_1_input<v0::Tanh>     },

--- a/ggml/src/ggml-openvino/openvino/op_table.cpp
+++ b/ggml/src/ggml-openvino/openvino/op_table.cpp
@@ -39,6 +39,7 @@ std::unordered_map<std::string, CreatorFunction> get_supported_ops() {
         {"GGML_OP_ROPE",            op::translate_rope                             },
         {"GGML_OP_SCALE",           op::translate_scale                            },
         {"GGML_OP_SOFT_MAX",        op::translate_soft_max                         },
+        {"GGML_OP_ARGMAX",          op::translate_argmax                           },
         {"GGML_OP_ARGSORT",         op::translate_argsort                          },
         {"GGML_OP_SUB",             op::translate_1to1_match_2_inputs<v1::Subtract>},
         {"GGML_OP_TRANSPOSE",       op::translate_transpose                        },

--- a/ggml/src/ggml-openvino/openvino/op_table.h
+++ b/ggml/src/ggml-openvino/openvino/op_table.h
@@ -36,6 +36,7 @@ GGML_OP_CONVERTER(translate_glu_swiglu_oai);
 GGML_OP_CONVERTER(translate_glu_geglu);
 GGML_OP_CONVERTER(translate_set_rows);
 GGML_OP_CONVERTER(translate_cpy);
+GGML_OP_CONVERTER(translate_argmax);
 GGML_OP_CONVERTER(translate_argsort);
 GGML_OP_CONVERTER(translate_flash_attn_ext);
 GGML_OP_CONVERTER(translate_clamp);

--- a/ggml/src/ggml-openvino/openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/openvino/utils.cpp
@@ -1,5 +1,6 @@
 #include "utils.h"
 
+#include "../ggml-openvino-extra.h"
 #include "ggml-impl.h"
 
 #include <cmath>
@@ -21,6 +22,7 @@
 #include <openvino/op/squeeze.hpp>
 #include <openvino/op/subtract.hpp>
 #include <openvino/op/transpose.hpp>
+#include <openvino/op/util/precision_sensitive_attribute.hpp>
 #include <string>
 
 namespace ov {
@@ -221,14 +223,73 @@ std::pair<ov::Output<Node>, ov::Output<Node>> make_sin_cos(int32_t * rope_params
         }
     }
 
-    Output<Node> cos_theta = std::make_shared<ov::op::v0::Cos>(theta);
-    Output<Node> sin_theta = std::make_shared<ov::op::v0::Sin>(theta);
+    // Keep the ROPE ANGLE in f32 even under INFERENCE_PRECISION_HINT=f16.
+    //
+    // Everything above builds theta = pos * freq_factors with a declared f32 type, but a declared
+    // element type is not an execution precision: under the f16 hint the GPU plugin compresses these
+    // subgraphs to f16 anyway. theta's magnitude IS the token position, so at position 6525 it lands
+    // where f16 spacing is 4 and the value is not even representable. Worse, a model whose freq_base
+    // and head_dim make factor[0] == 1.0 exactly feeds the raw position in as the top-frequency
+    // angle, so an absolute error of 1-2 becomes an error of 1-2 RADIANS -- up to a third of a cycle. Sin/Cos of an angle wrong by radians is not approximately
+    // right, it is arbitrary, and trig amplifies the error without bound.
+    //
+    // Measured on a large decoder-only model at inp_pos=6525, same device, f16 vs f32 execution: the
+    // whole Q/K projection chain is clean at rel ~1e-4, then Cos jumps to rel 0.124 and Sin to 0.155,
+    // and K right after the rotation carries rel 0.081. The error is depth-dependent because f16
+    // spacing grows with magnitude: sin rel is 0.006 at position 512 and 0.16 at 6525.
+    //
+    // mark_as_precision_sensitive disables fp16 compression of the subgraph feeding an input, which is
+    // exactly the guarantee needed. Marking Sin/Cos's input covers the whole theta chain back to the
+    // Convert of inp_pos. The cost is negligible: theta is a few dozen values per token, against the
+    // matmuls that dominate. The rotation itself and everything downstream stay f16.
+    const bool pin_angle = ggml_openvino_getenv_int("GGML_OPENVINO_ROPE_F32_ANGLE", 1) != 0;
+
+    auto cos_op = std::make_shared<ov::op::v0::Cos>(theta);
+    auto sin_op = std::make_shared<ov::op::v0::Sin>(theta);
+    if (pin_angle) {
+        ov::mark_as_precision_sensitive(cos_op->input(0));
+        ov::mark_as_precision_sensitive(sin_op->input(0));
+    }
+    Output<Node> cos_theta = cos_op;
+    Output<Node> sin_theta = sin_op;
 
     if (!imrope) {
         auto mscale_node = ov::op::v0::Constant::create(ov::element::f32, Shape{}, {mscale});
 
-        cos_theta = std::make_shared<ov::op::v1::Multiply>(cos_theta, mscale_node);
-        sin_theta = std::make_shared<ov::op::v1::Multiply>(sin_theta, mscale_node);
+        auto cos_scaled = std::make_shared<ov::op::v1::Multiply>(cos_theta, mscale_node);
+        auto sin_scaled = std::make_shared<ov::op::v1::Multiply>(sin_theta, mscale_node);
+        // Mark this Constant's input too. Marking only Sin/Cos keeps those nodes f32 but leaves the
+        // sibling mscale Constant to be compressed to f16, and the pass does not reconcile the pair,
+        // so compilation fails with "Arguments do not have the same element type".
+        if (pin_angle) {
+            ov::mark_as_precision_sensitive(cos_scaled->input(1));
+            ov::mark_as_precision_sensitive(sin_scaled->input(1));
+        }
+        cos_theta = cos_scaled;
+        sin_theta = sin_scaled;
+    }
+
+    // Close the f32 island explicitly with an f16 round trip.
+    //
+    // ConvertPrecision does not insert the boundary Convert: with only the marking above, the f32
+    // region propagates forward through the shape-only ops of the cos/sin expansion and then collides
+    // with f16 data in the rotation, so the type mismatch just moves one step down the graph.
+    //
+    // Rounding the RESULT of the trig is harmless -- cos/sin are in [-1,1], where f16 spacing is ~6e-4,
+    // the ordinary f16 cost accepted everywhere else. What must not be rounded is the ANGLE, which the
+    // marking above protects. So this spends the cheap rounding to buy a type-consistent graph: the
+    // chain from inp_pos through Sin/Cos stays f32, everything downstream is f16, and the transition is
+    // a node we control rather than one the pass has to infer.
+    //
+    // Declared types are f32 on both sides at build time, so this is a no-op for the frontend and for
+    // the f32 paths; it only becomes a real boundary once ConvertPrecision runs under the f16 hint.
+    if (pin_angle) {
+        auto pin_boundary = [](Output<Node> x) -> Output<Node> {
+            auto down = std::make_shared<ov::op::v0::Convert>(x, ov::element::f16);
+            return std::make_shared<ov::op::v0::Convert>(down, ov::element::f32);
+        };
+        cos_theta = pin_boundary(cos_theta);
+        sin_theta = pin_boundary(sin_theta);
     }
 
     return std::make_pair(sin_theta, cos_theta);

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -230,6 +230,15 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
 
         if (cache_hit) {
             ggml_decoder = entry->ptr;
+            // The cache key is only (n_nodes, first/last node name), so it cannot see a change in
+            // WHICH tensors are graph outputs -- and the compiled model's Results are fixed when it is
+            // built. A consumer that starts requesting extra outputs later (speculative decoding marks
+            // the target's per-layer residuals only once the draft is initialised) would otherwise keep
+            // reusing a model that never produces them, and the host would read unwritten buffers as
+            // zeros. Recompile when the output set differs.
+            if (!ggml_decoder->has_same_graph_io(cgraph)) {
+                cache_hit = false;
+            }
             old_m_params = ggml_decoder->get_model_params();
             if (!ggml_decoder->is_splited_model()) {
                 cache_hit = old_m_params.can_reuse_dynamically(m_params);

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -121,6 +121,12 @@ static std::optional<ov::Tensor> try_make_kv_sliced_tensor(std::shared_ptr<GgmlO
         return std::nullopt;
     }
 
+    if (ggml_tensor->data == nullptr) {
+        // unallocated input: let the caller build an owning zero tensor rather than slice a null
+        // pointer
+        return std::nullopt;
+    }
+
     ov::Shape sliced_shape = full_shape;
     sliced_shape[2] = static_cast<size_t>(n_kv);
 
@@ -159,6 +165,11 @@ ov::Tensor create_ov_output_tensor(std::shared_ptr<GgmlOvDecoder> ggml_decoder,
         output_shape = ggml_decoder->get_shape(ggml_tensor);
     }
 
+    // A graph output can also have no backing storage. Give OV an owning tensor so the infer request
+    // has somewhere to write; nothing downstream reads it.
+    if (ggml_tensor->data == nullptr) {
+        return ov::Tensor(output_type, output_shape);
+    }
     ov::Tensor output_tensor(output_type, output_shape, ggml_tensor->data);
     return output_tensor;
 }
@@ -867,6 +878,20 @@ ov::Tensor convert_ggml_input_to_ov(std::shared_ptr<GgmlOvDecoder> ggml_decoder,
         return make_contiguous_split_input_tensor(ggml_decoder, ggml_tensor, input_shape);
     }
 
+    // A graph input may legitimately be left unallocated (data == nullptr, no buffer): llama.cpp
+    // skips filling the attention mask when a graph only stores K/V without attending, which is what
+    // a speculative KV-injection pass does. Such an input is never read, but OpenVINO still requires
+    // a backing tensor for the Parameter and constructing an ov::Tensor over a null pointer asserts.
+    // Hand OV an owning zero-filled tensor; its contents cannot affect the result because no op
+    // consumes them.
+    if (input_data == nullptr) {
+        GGML_LOG_WARN("ggml-openvino: unallocated INPUT '%s' (ggml name '%s', type %s, ne=[%ld,%ld,%ld,%ld]) "
+                      "-> zero tensor\n",
+                      name.c_str(), ggml_tensor->name, ggml_type_name(ggml_tensor->type),
+                      (long) ggml_tensor->ne[0], (long) ggml_tensor->ne[1], (long) ggml_tensor->ne[2],
+                      (long) ggml_tensor->ne[3]);
+        return ov::Tensor(ggml_decoder->get_ov_type(ggml_tensor), input_shape);
+    }
     auto input_tensor = ov::Tensor(ggml_decoder->get_ov_type(ggml_tensor), input_shape, input_data);
     return input_tensor;
 }

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -290,6 +290,19 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
                 std::lock_guard<std::mutex> map_lock(r_ctx->ctx_mutex);
                 r_ctx->infer_request_cache.erase(key);
             }
+            // Compiling a NEW graph after GGML_OPENVINO_RELEASE_WEIGHTS dropped the host weight
+            // pages would read those Constants as zeros and silently produce garbage. The guard in
+            // buffer_set_tensor only catches a weight set after the release; with two models
+            // (speculative decoding) both are loaded and registered BEFORE the first cache hit
+            // triggers it, so the draft model's graph would compile here instead. Fail loudly.
+            if (ggml_openvino_weight_buffers_released()) {
+                GGML_ABORT(
+                    "ggml-openvino: a new graph needs compiling after GGML_OPENVINO_RELEASE_WEIGHTS dropped the "
+                    "host weight buffers, so its weights would read as zeros. This mode supports a single model "
+                    "per process -- unset GGML_OPENVINO_RELEASE_WEIGHTS for speculative decoding and any other "
+                    "multi-model run.");
+            }
+
             bool model_is_splitted = is_model_splitted(cgraph);
 
             std::shared_ptr<ov::Model> model;
@@ -622,6 +635,16 @@ enum ggml_status ov_graph_compute_static(ggml_cgraph * cgraph, std::shared_ptr<o
                 print_output_tensor_info(ov_output_names_local[i], output_tensor, output_tensor.data());
             }
         }
+    }
+
+    // GGML_OPENVINO_RELEASE_WEIGHTS: on GPU the plugin holds its own device copy of every weight
+    // after compile, so the host weight buffers can be dropped to reclaim their size in RSS. The GPU
+    // path uses one dynamic-shape model for both prefill and decode, so a compiled graph serves the
+    // whole session; release on the first cache HIT, by which point the plugin has its copy. A
+    // genuinely new graph after this point fails fast at the cache-miss branch above.
+    if (cache_hit && device == "GPU" && ggml_openvino_getenv_int("GGML_OPENVINO_RELEASE_WEIGHTS") &&
+        !ggml_openvino_weight_buffers_released()) {
+        ggml_openvino_release_weight_buffers();
     }
 
     if (ggml_openvino_getenv_int("GGML_OPENVINO_PROFILING")) {

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -182,9 +182,9 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
     std::shared_ptr<ov::InferRequest> infer_request;
     ModelParams m_params;
     ComputeParams c_params;
+    graph_key key(cgraph);
     std::tie(m_params, c_params) = GgmlOvDecoder::compute_llm_params(cgraph, is_static);
 
-    graph_key key(cgraph);
     static const bool cache_enabled = !ggml_openvino_getenv_int("GGML_OPENVINO_DISABLE_CACHE");
     bool cache_hit = false;
 

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -232,7 +232,14 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
             std::map<std::string, std::shared_ptr<ov::Node>> model_weights;
             ggml_decoder->set_compute_params(c_params);
             ggml_decoder->set_model_params(m_params);
-            if (old_m_params.kv_buffer_changed(m_params)) {
+            // The decoder caches a ggml_tensor* for every graph input and output, and m_cgraph
+            // itself. A cached decoder is keyed only on (n_nodes, first/last node name), so a
+            // DIFFERENT cgraph instance with the same key can hit it -- speculative decoding
+            // rebuilds its graphs every step with freshly allocated tensors. Those pointers then
+            // dangle, and walking them segfaults (get_tensor_used_op iterates m_cgraph->nodes).
+            // Refresh the IO map whenever the cgraph differs; kv_buffer_changed() alone misses
+            // this because the KV buffer is unchanged across those passes.
+            if (ggml_decoder->get_cgraph() != cgraph || old_m_params.kv_buffer_changed(m_params)) {
                 ggml_decoder->update_io(cgraph);
             }
             ggml_decoder->add_extra_inputs();
@@ -485,7 +492,14 @@ enum ggml_status ov_graph_compute_static(ggml_cgraph * cgraph, std::shared_ptr<o
         ggml_decoder->m_is_prefill = is_prefill;
         ggml_decoder->set_model_params(m_params);
         ggml_decoder->set_compute_params(c_params);
-        if (old_m_params.kv_buffer_changed(m_params)) {
+        // The decoder caches a ggml_tensor* for every graph input and output, and m_cgraph
+        // itself. A cached decoder is keyed only on (n_nodes, first/last node name), so a
+        // DIFFERENT cgraph instance with the same key can hit it -- speculative decoding
+        // rebuilds its graphs every step with freshly allocated tensors. Those pointers then
+        // dangle, and walking them segfaults (get_tensor_used_op iterates m_cgraph->nodes).
+        // Refresh the IO map whenever the cgraph differs; kv_buffer_changed() alone misses
+        // this because the KV buffer is unchanged across those passes.
+        if (ggml_decoder->get_cgraph() != cgraph || old_m_params.kv_buffer_changed(m_params)) {
             ggml_decoder->update_io(cgraph);
         }
         ggml_decoder->add_extra_inputs();

--- a/ggml/src/ggml-openvino/utils.cpp
+++ b/ggml/src/ggml-openvino/utils.cpp
@@ -236,12 +236,14 @@ enum ggml_status ov_graph_compute_dynamic(ggml_cgraph * cgraph, std::shared_ptr<
             // the target's per-layer residuals only once the draft is initialised) would otherwise keep
             // reusing a model that never produces them, and the host would read unwritten buffers as
             // zeros. Recompile when the output set differs.
-            if (!ggml_decoder->has_same_graph_io(cgraph)) {
-                cache_hit = false;
-            }
             old_m_params = ggml_decoder->get_model_params();
             if (!ggml_decoder->is_splited_model()) {
                 cache_hit = old_m_params.can_reuse_dynamically(m_params);
+            }
+            // Must come AFTER can_reuse_dynamically(), which ASSIGNS to cache_hit rather than
+            // and-ing into it and would otherwise silently undo this invalidation.
+            if (cache_hit && !ggml_decoder->has_same_graph_io(cgraph)) {
+                cache_hit = false;
             }
         }
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Enables Muse-Glimmer for OpenVINO backend.

- Added New Op Support: GGML_UNARY_OP_SIGMOID, GGML_OP_ARGMAX
- Decline bf16 `GET_ROWS` on GPU
- Classify sliding-window vs full-attention layers from the per-layer KV cache extent.
- Accuracy improvement: Keep the RoPE angle in f32 under the f16 inference hint.
- Honour `GGML_TENSOR_FLAG_OUTPUT` in `compute_model_outputs()`, which previously used only
  use-count analysis and so dropped tensors that the host reads back.
- Refresh the decoder IO when the cgraph instance changes, and invalidate a cached graph when its
  output set changes.
- Keep the token dimension dynamic for a 2-D activation graph input, plus three dynamic-dim
  propagation gaps (shape-preserving `VIEW`, `CONCAT`, `SSM_CONV`/`GATED_DELTA_NET`).
- Tolerate graph inputs and outputs with no backing storage instead of constructing an `ov::Tensor`
  over a null pointer.
- `GGML_OPENVINO_REDUCE_COMPILE_MEM`: stream requantization in row chunks instead of
  materializing one full F32 array.
- `GGML_OPENVINO_REQUANT_KQUANT`: optionaly choose a 4-bit requant target
  (`q4_sym128`/`q4_asym64`[`_all`]/`native`) instead of inflating Q6_K/Q5_K to Q8_0.
- `GGML_OPENVINO_RELEASE_WEIGHTS` — drop host weight pages after the GPU plugin has its own copy.
  Single model per process; two guards abort loudly rather than read dropped pages.
- `GGML_OPENVINO_SPILL_DIR` — back the repacked weight buffer with an unlinked file so the pages
  are reclaimable.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES**
  An AI coding assistant (Claude, via Claude Code) was used substantially throughout: for
  investigating the failures, writing most of the backend changes, and drafting the commit
  messages and initial draft of this description. I have reviewed the changes and I
  am responsible for them.