### PR TITLE
wavtokenizer-dec : bound posnet/convnext block_count against n_layer_all

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1114,8 +1114,9 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
 
         ml.get_key(LLM_KV_CONVNEXT_EMBEDDING_LENGTH, hparams.convnext.n_embd);
         ml.get_key(LLM_KV_CONVNEXT_BLOCK_COUNT,      hparams.convnext.n_layer);
-    GGML_ASSERT(hparams.posnet.n_layer   <= hparams.n_layer_all);
-    GGML_ASSERT(hparams.convnext.n_layer <= hparams.n_layer_all);
+
+        GGML_ASSERT(hparams.posnet.n_layer   <= hparams.n_layer_all);
+        GGML_ASSERT(hparams.convnext.n_layer <= hparams.n_layer_all);
     }
 
     GGML_ASSERT(hparams.n_expert <= LLAMA_MAX_EXPERTS);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1114,6 +1114,8 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
 
         ml.get_key(LLM_KV_CONVNEXT_EMBEDDING_LENGTH, hparams.convnext.n_embd);
         ml.get_key(LLM_KV_CONVNEXT_BLOCK_COUNT,      hparams.convnext.n_layer);
+    GGML_ASSERT(hparams.posnet.n_layer   <= hparams.n_layer_all);
+    GGML_ASSERT(hparams.convnext.n_layer <= hparams.n_layer_all);
     }
 
     GGML_ASSERT(hparams.n_expert <= LLAMA_MAX_EXPERTS);


### PR DESCRIPTION
## Overview

Adds GGML_ASSERT bounds for posnet.block_count and convnext.block_count
against the base n_layer_all. These keys were read without any upper
bound check in the wavtokenizer-dec load_hparams path, unlike block_count
which was bounded in PR #26051.

A crafted GGUF with block_count=1 but posnet.block_count>=2 causes
dev_layer.at() out_of_range during model load.

PoC: https://huggingface.co/oguzhanakkaya/poc-wavtokenizer-posnet-oob-gguf

## Additional information

2-line fix. Same bug class as the n_layer_all bound from #26051, missed
sibling keys in the same load_hparams block.

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: GitHub Copilot assisted with commit message