### PR TITLE
CUDA: add POOL_1D

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -37,6 +37,7 @@
 #include "ggml-cuda/opt-step-sgd.cuh"
 #include "ggml-cuda/out-prod.cuh"
 #include "ggml-cuda/pad.cuh"
+#include "ggml-cuda/pool1d.cuh"
 #include "ggml-cuda/pool2d.cuh"
 #include "ggml-cuda/quantize.cuh"
 #include "ggml-cuda/rope.cuh"
@@ -2288,6 +2289,9 @@ static bool ggml_cuda_compute_forward(ggml_backend_cuda_context & ctx, struct gg
             break;
         case GGML_OP_COL2IM_1D:
             ggml_cuda_op_col2im_1d(ctx, dst);
+            break;
+        case GGML_OP_POOL_1D:
+            ggml_cuda_op_pool1d(ctx, dst);
             break;
         case GGML_OP_POOL_2D:
             ggml_cuda_op_pool2d(ctx, dst);
@@ -5203,6 +5207,8 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_CONV_TRANSPOSE_2D:
         case GGML_OP_POOL_2D:
             return true;
+        case GGML_OP_POOL_1D:
+            return op->src[0]->type == GGML_TYPE_F32 && ggml_is_contiguous(op->src[0]);
         case GGML_OP_ACC:
             // TODO: extend support like so:
             //return ggml_is_contiguous_rows(op->src[0]) && ggml_is_contiguous_rows(op->src[1]);

--- a/ggml/src/ggml-cuda/pool1d.cu
+++ b/ggml/src/ggml-cuda/pool1d.cu
@@ -1,0 +1,87 @@
+#include "pool1d.cuh"
+
+static __global__ void pool1d_kernel(
+        const int iw, const int ow,
+        const int k0, const int s0, const int p0,
+        const int parallel_elements,
+        const float * src, float * dst, const enum ggml_op_pool op) {
+    const int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    if (idx >= parallel_elements) {
+        return;
+    }
+
+    const int cur_row = idx / ow;
+    const int cur_ow  = idx - cur_row * ow;
+
+    const float * i_ptr = src + (int64_t) cur_row * iw;
+    float       * o_ptr = dst + (int64_t) cur_row * ow;
+
+    const int start = cur_ow * s0 - p0;
+    const int bw    = max(0,  start);
+    const int ew    = min(iw, start + k0);
+
+    float res = 0.0f;
+
+    switch (op) {
+        case GGML_OP_POOL_AVG: res = 0.0f;     break;
+        case GGML_OP_POOL_MAX: res = -FLT_MAX; break;
+        default: assert(false);
+    }
+
+    // Padded positions are outside [bw, ew) and are excluded from the average,
+    // matching the CPU implementation which divides by the in-bounds count.
+    int count = 0;
+
+    for (int j = bw; j < ew; ++j) {
+        const float cur = i_ptr[j];
+
+        switch (op) {
+            case GGML_OP_POOL_AVG: res += cur;             break;
+            case GGML_OP_POOL_MAX: res  = max(res, cur);   break;
+            default: assert(false);
+        }
+
+        ++count;
+    }
+
+    if (op == GGML_OP_POOL_AVG) {
+        res = count > 0 ? res / count : 0.0f;
+    }
+
+    o_ptr[cur_ow] = res;
+}
+
+static void pool1d_f32_cuda(
+        const int iw, const int ow,
+        const int k0, const int s0, const int p0,
+        const int parallel_elements,
+        const float * src, float * dst, const enum ggml_op_pool op,
+        cudaStream_t stream) {
+
+    const int num_blocks = (parallel_elements + CUDA_POOL1D_BLOCK_SIZE - 1) / CUDA_POOL1D_BLOCK_SIZE;
+    pool1d_kernel<<<num_blocks, CUDA_POOL1D_BLOCK_SIZE, 0, stream>>>(iw, ow, k0, s0, p0, parallel_elements, src, dst, op);
+}
+
+void ggml_cuda_op_pool1d(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const ggml_tensor * src0 = dst->src[0];
+    const float * src0_d = (const float *) src0->data;
+    float * dst_d = (float *) dst->data;
+    cudaStream_t stream = ctx.stream();
+
+    GGML_ASSERT(src0->type == GGML_TYPE_F32);
+    GGML_ASSERT( dst->type == GGML_TYPE_F32);
+    GGML_ASSERT(ggml_is_contiguous(src0));
+
+    const int32_t * opts = (const int32_t *) dst->op_params;
+    const enum ggml_op_pool op = static_cast<ggml_op_pool>(opts[0]);
+    const int k0 = opts[1];
+    const int s0 = opts[2];
+    const int p0 = opts[3];
+
+    const int64_t IW = src0->ne[0];
+    const int64_t OW = dst->ne[0];
+
+    const int64_t parallel_elements = ggml_nrows(dst) * OW;
+
+    pool1d_f32_cuda(IW, OW, k0, s0, p0, parallel_elements, src0_d, dst_d, op, stream);
+}

--- a/ggml/src/ggml-cuda/pool1d.cuh
+++ b/ggml/src/ggml-cuda/pool1d.cuh
@@ -1,0 +1,5 @@
+#include "common.cuh"
+
+#define CUDA_POOL1D_BLOCK_SIZE 256
+
+void ggml_cuda_op_pool1d(ggml_backend_cuda_context & ctx, ggml_tensor * dst);


### PR DESCRIPTION
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. The kernel and the backend wiring were written with AI assistance, and this description was drafted with it as well. I reviewed the change, built it and ran the tests on my own RTX 4090, and I am responsible for every line of it.

---

Adds a CUDA implementation of `GGML_OP_POOL_1D`. It and `CONV_3D` were the only ops with no CUDA support at all, so a 1D pooling node always fell back to the CPU. Vulkan has had it since #25431 and SYCL since #24584. #22297 attempted the same change and was closed by its author. Mentioned in #14909.

One thread per output element, same layout as `pool2d`. The window is clamped to `[bw, ew)`, so padded positions drop out without a branch inside the loop.

The averaging deliberately differs from `pool2d`: CPU `pool_1d` divides by the number of in-bounds elements, so padding does not contribute, while `pool2d` scales by `1/(kh*kw)`. This follows the CPU, since that is the reference `test-backend-ops` compares against.

`test-backend-ops -o POOL_1D`: 0/0 before (every case reported unsupported), 216/216 after. `perf -o POOL_1D` has no cases defined for this op. Tested on an RTX 4090, CUDA 13.0.

`supports_op` accepts contiguous F32 only, the same limit `pool2d` has. F16 input keeps falling back to the CPU rather than being mishandled.

I did not regenerate `docs/ops/CUDA.csv`. Running the script also flips 1024 `IM2COL_3D` `v=1` rows (correctly, since those are views and `supports_op` requires contiguous sources), 379 rows in other ops, and rewrites `FLASH_ATTN_EXT` from 8800 rows to 5141. FA kernel selection is compute-capability gated, so regenerating on Ada would re-baseline the matrix to this card. Happy to regenerate it if you want that anyway.
