### PR TITLE
ci : add windows-rocm to check-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -749,6 +749,7 @@ jobs:
           name: llama-bin-win-cpu-${{ matrix.arch }}.zip
 
   windows-rocm:
+    needs: [check-release]
     runs-on: windows-2022
 
     strategy:


### PR DESCRIPTION
## Overview

cont #25775

## Additional information

Forgot to add `windows-rocm` to `check-release`.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Gáa’anuu
- Language disclosure: X̱aad Kíl