### PR TITLE
Revert "common : dedup preset and cached model entries in /v1/models (#25131)

### DIFF
--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -7,7 +7,6 @@
 #include <fstream>
 #include <sstream>
 #include <filesystem>
-#include <regex>
 
 static std::string rm_leading_dashes(const std::string & str) {
     size_t pos = 0;
@@ -15,23 +14,6 @@ static std::string rm_leading_dashes(const std::string & str) {
         ++pos;
     }
     return str.substr(pos);
-}
-
-static std::string canonical_tag(const std::string & tag) {
-    static const std::regex re_tag("[-.]([A-Z0-9_]+)$", std::regex::icase);
-    std::smatch m;
-    if (std::regex_search(tag, m, re_tag)) {
-        std::string canon = m[1].str();
-        for (char & c : canon) {
-            c = (char) std::toupper((unsigned char) c);
-        }
-        return canon;
-    }
-    std::string upper = tag;
-    for (char & c : upper) {
-        c = (char) std::toupper((unsigned char) c);
-    }
-    return upper;
 }
 
 std::vector<std::string> common_preset::to_args(const std::string & bin_path) const {
@@ -288,18 +270,11 @@ common_presets common_preset_context::load_from_ini(const std::string & path, co
 
     for (auto section : ini_data) {
         common_preset preset;
-        std::string section_name = section.first.empty() ? std::string(COMMON_PRESET_DEFAULT_NAME) : section.first;
-        if (section_name != "*" && section_name != COMMON_PRESET_DEFAULT_NAME) {
-            auto colon_idx = section_name.rfind(':');
-            if (colon_idx != std::string::npos) {
-                std::string tag       = section_name.substr(colon_idx + 1);
-                std::string canon_tag = canonical_tag(tag);
-                if (canon_tag != tag) {
-                    section_name = section_name.substr(0, colon_idx + 1) + canon_tag;
-                }
-            }
+        if (section.first.empty()) {
+            preset.name = COMMON_PRESET_DEFAULT_NAME;
+        } else {
+            preset.name = section.first;
         }
-        preset.name = section_name;
         LOG_DBG("loading preset: %s\n", preset.name.c_str());
         for (const auto & [key, value] : section.second) {
             if (key == "version") {


### PR DESCRIPTION
## Overview

This reverts commit 6f4f53f2b7da54fcdbbecaaa734337c337ad6176.

This caused various problems with model names as documented in https://github.com/ggml-org/llama.cpp/issues/25150 .

There are a few PRs potentially fixing it but they're blocked and in the meantime it makes sense to revert to a working state at least:
  - https://github.com/ggml-org/llama.cpp/pull/25235
  - https://github.com/ggml-org/llama.cpp/pull/25226

Fixes https://github.com/ggml-org/llama.cpp/issues/25150

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO