### PR TITLE
common : handle missing gbnf regex anchors with .* fallback

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -346,11 +346,17 @@ private:
     }
 
     std::string _visit_pattern(const std::string & pattern, const std::string & name) {
-        if (!(pattern.front() == '^' && pattern.back() == '$')) {
-            _errors.push_back("Pattern must start with '^' and end with '$'");
-            return "";
+        std::string sub_pattern = pattern;
+        if (!sub_pattern.empty() && sub_pattern.front() == '^') {
+            sub_pattern = sub_pattern.substr(1);
+        } else {
+            sub_pattern = ".*" + sub_pattern;
         }
-        std::string sub_pattern = pattern.substr(1, pattern.length() - 2);
+        if (!sub_pattern.empty() && sub_pattern.back() == '$') {
+            sub_pattern.pop_back();
+        } else {
+            sub_pattern += ".*";
+        }
         std::unordered_map<std::string, std::string> sub_rule_ids;
 
         size_t i = 0;


### PR DESCRIPTION
## Overview

This PR addresses a strict validation failure in `json-schema-to-grammar.cpp`. When a JSON schema pattern lacks `^` or `$` anchors, the current regex compiler throws a hard error. This patch surgically modifies `_visit_pattern` to gracefully fallback by prepending/appending `.*` to unanchored patterns. This ensures valid GBNF grammar generation without breaking existing anchored schema validations.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Used an AI assistant strictly to automate the Git CLI branching workflow and format a targeted, surgical regex fallback patch. I manually reviewed the logic, verified the architectural impact, and validated the local compilation prior to submission.