### PR TITLE
ci : set ccache as hip compiler launcher

### DIFF
--- a/.github/workflows/build-cuda-ubuntu.yml
+++ b/.github/workflows/build-cuda-ubuntu.yml
@@ -99,6 +99,7 @@ jobs:
         run: |
           cmake -B build -S . \
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
+            -DCMAKE_HIP_COMPILER_LAUNCHER=ccache \
             -DGPU_TARGETS="gfx1030" \
             -DGGML_HIP=ON
           cmake --build build --config Release -j $(nproc)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1366,6 +1366,7 @@ jobs:
         run: |
           cmake -B build -S . \
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
+            -DCMAKE_HIP_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_BACKEND_DL=ON \
             -DGGML_NATIVE=OFF \


### PR DESCRIPTION
## Overview

Attempt to fix Ubuntu ROCm ccache. Tests still running.

## Additional information

Since we're using ROCm SDK compiler the likely issue is that ccache isn't automatically used for building CUDA files, explaining the slow build yet high percentage ccache hits.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: нем понда
- Language disclosure: Komi-Permyak
