### PR TITLE
ci: fix failed runs

### DIFF
--- a/.github/workflows/build-cmake-pkg.yml
+++ b/.github/workflows/build-cmake-pkg.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   linux:
-    runs-on: [self-hosted, Linux, CPU]
+    runs-on: [self-hosted, Linux]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -22,7 +22,7 @@ jobs:
                 -DLLAMA_BUILD_EXAMPLES=OFF \
                 -DLLAMA_BUILD_APP=OFF \
                 -DCMAKE_BUILD_TYPE=Release
-          cmake --build build --config Release
+          cmake --build build --config Release -j $(nproc)
           cmake --install build --prefix "$PREFIX" --config Release
 
           export LLAMA_CONFIG="$PREFIX"/lib/cmake/llama/llama-config.cmake
@@ -48,4 +48,4 @@ jobs:
 
           cd examples/simple-cmake-pkg
           cmake -S . -B build -DCMAKE_PREFIX_PATH="$PREFIX"/lib/cmake
-          cmake --build build
+          cmake --build build -j $(nproc)

--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -94,6 +94,7 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build \
+            -DGGML_NATIVE=OFF \
             -DLLAMA_FATAL_WARNINGS=ON \
             -DGGML_RPC=ON
           time cmake --build build --config Release -j $(nproc)

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -39,9 +39,9 @@ jobs:
     strategy:
       matrix:
         include:
+        # thread and address doesn't run properly on some self hosted machines, so run it on Github instead
         - sanitizer: ADDRESS
-          machine: [self-hosted, X64, Linux, Intel, OpenVINO]
-        # thread doesn't run properly on some self hosted machines, so run it on Github instead
+          machine: ubuntu-24.04
         - sanitizer: THREAD
           machine: ubuntu-24.04
         - sanitizer: UNDEFINED
@@ -56,9 +56,9 @@ jobs:
 
       - name: ccache
         uses: ggml-org/ccache-action@v1.2.21
-        if: ${{ matrix.sanitizer == 'THREAD' }}
+        if: ${{ matrix.sanitizer != 'UNDEFINED' }}
         with:
-          key: ctest-thread-ubuntu-24.04
+          key: ctest-${{ matrix.sanitizer }}-ubuntu-24.04
           variant: ccache
           evict-old-files: 1d
           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -54,14 +54,14 @@ jobs:
         id: checkout
         uses: actions/checkout@v6
 
-      - name: ccache
-        uses: ggml-org/ccache-action@v1.2.21
-        if: ${{ matrix.sanitizer != 'UNDEFINED' }}
-        with:
-          key: ctest-${{ matrix.sanitizer }}-ubuntu-24.04
-          variant: ccache
-          evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      # - name: ccache
+      #   uses: ggml-org/ccache-action@v1.2.21
+      #   if: ${{ matrix.sanitizer != 'UNDEFINED' }}
+      #   with:
+      #     key: ctest-${{ matrix.sanitizer }}-ubuntu-24.04
+      #     variant: ccache
+      #     evict-old-files: 1d
+      #     save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
       # with UNDEFINED sanitizer, we have to build in Debug to avoid GCC 13 false-positive warnings
       - name: Build (undefined)

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
         - sanitizer: ADDRESS
-          machine: [self-hosted, X64, Linux]
+          machine: Intel-LNL-U7-258V
         # thread doesn't run properly on some self hosted machines, so run it on Github instead
         - sanitizer: THREAD
           machine: ubuntu-24.04

--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         include:
         - sanitizer: ADDRESS
-          machine: Intel-LNL-U7-258V
+          machine: [self-hosted, X64, Linux, Intel, OpenVINO]
         # thread doesn't run properly on some self hosted machines, so run it on Github instead
         - sanitizer: THREAD
           machine: ubuntu-24.04


### PR DESCRIPTION
This fixes the broken [#26593](https://github.com/ggml-org/llama.cpp/pull/26593) thread test by moving it to a Github machine, fixes the occasionally failing cpu x86 run, and makes the cmake run runnable on all machines (tclsh comes with Ubuntu and I think all our self hosted Linux machines are Ubuntu).

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
