### PR TITLE
json-schema-to-grammar : accept unanchored patterns

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -346,19 +346,28 @@ private:
     }
 
     std::string _visit_pattern(const std::string & pattern, const std::string & name) {
-        // "pattern" is an unanchored partial match in JSON Schema: the regex only
-        // has to match *somewhere* in the string, so "^"/"$" are optional.
-        // Synthesise whichever anchor is missing with ".*" rather than rejecting
-        // the schema. A fully anchored pattern is stripped exactly as before.
+        // JSON Schema "pattern" is unanchored; fill missing ^/$ with .*
+        const bool has_start = !pattern.empty() && pattern.front() == '^';
+        bool has_end = false;
+        if (!pattern.empty() && pattern.back() == '$') {
+            size_t n_esc = 0;
+            for (size_t i = pattern.size() - 1; i > 0 && pattern[i - 1] == '\\'; --i) {
+                n_esc++;
+            }
+            has_end = (n_esc % 2 == 0);
+        }
+
         std::string sub_pattern = pattern;
-        if (!sub_pattern.empty() && sub_pattern.front() == '^') {
+        if (has_start) {
             sub_pattern.erase(0, 1);
-        } else {
+        }
+        if (has_end) {
+            sub_pattern.pop_back();
+        }
+        if (!has_start) {
             sub_pattern.insert(0, ".*");
         }
-        if (!sub_pattern.empty() && sub_pattern.back() == '$') {
-            sub_pattern.pop_back();
-        } else {
+        if (!has_end) {
             sub_pattern.append(".*");
         }
         std::unordered_map<std::string, std::string> sub_rule_ids;

--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -346,11 +346,21 @@ private:
     }
 
     std::string _visit_pattern(const std::string & pattern, const std::string & name) {
-        if (!(pattern.front() == '^' && pattern.back() == '$')) {
-            _errors.push_back("Pattern must start with '^' and end with '$'");
-            return "";
+        // "pattern" is an unanchored partial match in JSON Schema: the regex only
+        // has to match *somewhere* in the string, so "^"/"$" are optional.
+        // Synthesise whichever anchor is missing with ".*" rather than rejecting
+        // the schema. A fully anchored pattern is stripped exactly as before.
+        std::string sub_pattern = pattern;
+        if (!sub_pattern.empty() && sub_pattern.front() == '^') {
+            sub_pattern.erase(0, 1);
+        } else {
+            sub_pattern.insert(0, ".*");
         }
-        std::string sub_pattern = pattern.substr(1, pattern.length() - 2);
+        if (!sub_pattern.empty() && sub_pattern.back() == '$') {
+            sub_pattern.pop_back();
+        } else {
+            sub_pattern.append(".*");
+        }
         std::unordered_map<std::string, std::string> sub_rule_ids;
 
         size_t i = 0;

--- a/examples/json_schema_to_grammar.py
+++ b/examples/json_schema_to_grammar.py
@@ -407,12 +407,24 @@ class SchemaConverter:
             we define sub-rules to keep the output lean.
         '''
 
-        # "pattern" is an unanchored partial match in JSON Schema: the regex only
-        # has to match *somewhere* in the string, so '^'/'$' are optional.
-        # Synthesise whichever anchor is missing with '.*' rather than rejecting
-        # the schema. A fully anchored pattern is stripped exactly as before.
-        pattern = pattern[1:] if pattern.startswith('^') else '.*' + pattern
-        pattern = pattern[:-1] if pattern.endswith('$') else pattern + '.*'
+        # JSON Schema "pattern" is unanchored; fill missing ^/$ with .*
+        has_start = pattern.startswith('^')
+        has_end = False
+        if pattern.endswith('$'):
+            n_esc = 0
+            i = len(pattern) - 2
+            while i >= 0 and pattern[i] == '\\':
+                n_esc += 1
+                i -= 1
+            has_end = n_esc % 2 == 0
+        if has_start:
+            pattern = pattern[1:]
+        if has_end:
+            pattern = pattern[:-1]
+        if not has_start:
+            pattern = '.*' + pattern
+        if not has_end:
+            pattern = pattern + '.*'
         sub_rule_ids = {}
 
         i = 0

--- a/examples/json_schema_to_grammar.py
+++ b/examples/json_schema_to_grammar.py
@@ -407,8 +407,12 @@ class SchemaConverter:
             we define sub-rules to keep the output lean.
         '''
 
-        assert pattern.startswith('^') and pattern.endswith('$'), 'Pattern must start with "^" and end with "$"'
-        pattern = pattern[1:-1]
+        # "pattern" is an unanchored partial match in JSON Schema: the regex only
+        # has to match *somewhere* in the string, so '^'/'$' are optional.
+        # Synthesise whichever anchor is missing with '.*' rather than rejecting
+        # the schema. A fully anchored pattern is stripped exactly as before.
+        pattern = pattern[1:] if pattern.startswith('^') else '.*' + pattern
+        pattern = pattern[:-1] if pattern.endswith('$') else pattern + '.*'
         sub_rule_ids = {}
 
         i = 0

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -770,6 +770,48 @@ static void test_all(const std::string & lang, std::function<void(const TestCase
 
     test({
         SUCCESS,
+        "unanchored regexp",
+        R"""({
+            "type": "string",
+            "pattern": "abc"
+        })""",
+        R"""(
+            dot ::= [^\x0A\x0D]
+            root ::= "\"" (dot* "abc" dot*) "\""
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "regexp anchored at start only",
+        R"""({
+            "type": "string",
+            "pattern": "^abc"
+        })""",
+        R"""(
+            dot ::= [^\x0A\x0D]
+            root ::= "\"" ("abc" dot*) "\""
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "regexp anchored at end only",
+        R"""({
+            "type": "string",
+            "pattern": "abc$"
+        })""",
+        R"""(
+            dot ::= [^\x0A\x0D]
+            root ::= "\"" (dot* "abc") "\""
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
         "regexp escapes",
         R"""({
             "type": "string",

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -812,6 +812,33 @@ static void test_all(const std::string & lang, std::function<void(const TestCase
 
     test({
         SUCCESS,
+        "unanchored regexp with escaped dollar",
+        R"""({
+            "type": "string",
+            "pattern": "foo\\$"
+        })""",
+        R"""(
+            dot ::= [^\x0A\x0D]
+            root ::= "\"" (dot* "foo$" dot*) "\""
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
+        "regexp escaped dollar at end",
+        R"""({
+            "type": "string",
+            "pattern": "^foo\\$$"
+        })""",
+        R"""(
+            root ::= "\"" ("foo$") "\""
+            space ::= | " " | "\n"{1,2} [ \t]{0,20}
+        )"""
+    });
+
+    test({
+        SUCCESS,
         "regexp escapes",
         R"""({
             "type": "string",


### PR DESCRIPTION
Fixes #26930

## Problem

`_visit_pattern` requires a `pattern` to carry both `^` and `$`, and errors otherwise. JSON Schema defines `pattern` as an **unanchored partial match** — the regex only has to match somewhere in the string, and anchors are optional ([§6.3.3](https://json-schema.org/draft/2020-12/json-schema-validation#name-pattern)). So a valid schema like `{"type": "string", "pattern": "\\S"}` cannot be converted.

It bites hardest in tool calling, where the schema is not the caller's to fix: one tool with an unanchored pattern 400s the whole `/v1/chat/completions` request, killing every request that offers that tool rather than only the calls that use it.

## Change

Synthesise the missing anchors with `.*` instead of rejecting. A pattern that already carries both anchors is stripped exactly as before, so existing behaviour and emitted grammars are unchanged.

Applied to `examples/json_schema_to_grammar.py` as well, so the two implementations stay in lockstep and the parity test keeps passing.

## Tests

Three cases added — unanchored, start-anchored-only, end-anchored-only:

```
"pattern": "abc"   ->  root ::= "\"" (dot* "abc" dot*) "\""
"pattern": "^abc"  ->  root ::= "\"" ("abc" dot*) "\""
"pattern": "abc$"  ->  root ::= "\"" (dot* "abc") "\""
```

Full `test-json-schema-to-grammar` suite passes, for **both** the C++ and Python implementations (verified with Python on PATH so the parity pass actually runs, not skipped).

Also checked against the real-world schema from the linked issue: it converts cleanly with this patch and fails on master.

## Scope

Regex class shorthands (`\S`, `\d`, `\w`) are emitted as literals by the converter today — `^\S$` already yields `root ::= "\"" ("\S") "\""` on master. That pre-existing limitation is untouched here; this only makes unanchored patterns behave consistently with anchored ones instead of erroring.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **yes** — written with AI assistance (Claude). The change was compiled and the full test suite run against both implementations on real hardware rather than assumed; the human author is responsible for all submitted changes.