### PR TITLE
ggml-cuda: fix UMA memory detection for AMD iGPUs via sysfs VRAM

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4780,14 +4780,53 @@ static void ggml_backend_cuda_device_get_memory(ggml_backend_dev_t dev, size_t *
     bool is_uma = prop.integrated > 0 || uma_env;
 
     if (is_uma) {
-        // For UMA systems (like DGX Spark), use system memory info
-        long available_memory_kb = 0;
-        long free_swap_kb = 0;
+        // For UMA systems, try sysfs VRAM first (accurate for large-VRAM iGPUs
+        // like AMD Strix Halo where hipMemGetInfo returns system RAM).
+        // Fall back to /proc/meminfo if sysfs is unavailable.
+        bool vram_read = false;
+        for (int drm_idx = 128; drm_idx < 140; drm_idx++) {
+            char vram_path[256];
+            snprintf(vram_path, sizeof(vram_path),
+                     "/sys/class/drm/renderD%d/device/mem_info_vram_total", drm_idx);
+            FILE * vram_f = fopen(vram_path, "r");
+            if (!vram_f) continue;
 
-        if (ggml_backend_cuda_get_available_uma_memory(&available_memory_kb, &free_swap_kb) && available_memory_kb > 0) {
-            *free = (size_t)available_memory_kb * 1024;
-        } else {
-            GGML_LOG_ERROR("%s: /proc/meminfo reading failed, using cudaMemGetInfo\n", __func__);
+            unsigned long vram_total_bytes = 0;
+            if (fscanf(vram_f, "%lu", &vram_total_bytes) == 1 && vram_total_bytes > 0) {
+                fclose(vram_f);
+
+                snprintf(vram_path, sizeof(vram_path),
+                         "/sys/class/drm/renderD%d/device/mem_info_vram_used", drm_idx);
+                vram_f = fopen(vram_path, "r");
+                unsigned long vram_used_bytes = 0;
+                if (vram_f) {
+                    fscanf(vram_f, "%lu", &vram_used_bytes);
+                    fclose(vram_f);
+                }
+
+                if (vram_used_bytes <= vram_total_bytes) {
+                    *free = (size_t)(vram_total_bytes - vram_used_bytes);
+                    *total = (size_t)vram_total_bytes;
+                    vram_read = true;
+                    GGML_LOG_DEBUG("%s: using sysfs VRAM: total=%zu free=%zu\n",
+                                   __func__, *total, *free);
+                }
+            } else {
+                if (vram_f) fclose(vram_f);
+            }
+            break;
+        }
+
+        if (!vram_read) {
+            // Fall back to /proc/meminfo
+            long available_memory_kb = 0;
+            long free_swap_kb = 0;
+
+            if (ggml_backend_cuda_get_available_uma_memory(&available_memory_kb, &free_swap_kb) && available_memory_kb > 0) {
+                *free = (size_t)available_memory_kb * 1024;
+            } else {
+                GGML_LOG_ERROR("%s: /proc/meminfo reading failed, using cudaMemGetInfo\n", __func__);
+            }
         }
     }
 #endif // defined(__linux__)


### PR DESCRIPTION
## Summary

Fixes GPU memory detection on AMD Strix Halo (gfx1151) and other large-VRAM integrated GPUs where `hipMemGetInfo()` returns system free RAM instead of GPU VRAM free.

## Problem

On AMD Strix Halo (Ryzen AI MAX+ 395, Radeon 8060S, 96GB unified memory), `hipMemGetInfo()` from ROCm 7.2 returns ~27GB free (system RAM) instead of ~96GB free (GPU VRAM). This causes llama-server to split model weights 60/40 CPU/GPU instead of 100% GPU.

The existing UMA path (added in #17368) reads `/proc/meminfo` for system RAM, which is also wrong for large-VRAM iGPUs — it reports ~27GB instead of 96GB.

PR #20472 attempted a fix using `max(hipMemGetInfo, /proc/meminfo)` but this doesn't help when both return the same wrong value.

## Fix

When the GPU is integrated (`is_uma`), first try reading actual VRAM from the Linux DRM sysfs interface:

```
/sys/class/drm/renderD*/device/mem_info_vram_total
/sys/class/drm/renderD*/device/mem_info_vram_used
```

Falls back to `/proc/meminfo` if sysfs is unavailable. Falls back to `cudaMemGetInfo` if both fail.

## Backwards Compatibility

- Only activates for integrated GPUs (`is_uma = true`)
- Discrete GPUs are completely untouched
- Uses standard Linux DRM sysfs interface (available since kernel 4.x)
- Three-layer fallback: sysfs → /proc/meminfo → cudaMemGetInfo

## Testing

Built and tested on AMD Ryzen AI MAX+ 395 (gfx1151, 96GB VRAM, ROCm 7.2). Before fix: llama-server reports 27,073 MiB free. After fix: llama-server reports 98,121 MiB free (correct — 96GB minus 183MB used).

## Related

- Fixes #18159
- ROCm/ROCm#5444, ROCm/ROCm#6530
- Supersedes #20472
- Companion Ollama PR: ollama/ollama#17685 (OLLAMA_GPU_MEMORY env var for scheduler-side fix)
