### PR TITLE
ggml-rpc : fix out-of-bounds write in SET_ROWS graph execution

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1747,14 +1747,21 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
         }
     }
 
-    // PATCH: Validate graph nodes to prevent OOB writes (Issue #26912)
+    // PATCH: Validate graph nodes to prevent OOB writes (Issue #26912 and #26825)
     for (uint32_t i = 0; i < n_nodes; i++) {
         struct ggml_tensor * node = graph->nodes[i];
 
         if (node != nullptr && node->op == GGML_OP_SET_ROWS && node->src[0] != nullptr) {
             if (node->ne[2] != node->src[0]->ne[2] || node->ne[3] != node->src[0]->ne[3]) {
                 GGML_LOG_ERROR("[%s] malformed SET_ROWS graph detected (dimension mismatch)\n", __func__);
-                return false;  // Safely drop the connection
+                return false;
+            }
+        }
+
+        if (node != nullptr && node->op == GGML_OP_GET_ROWS && node->src[0] != nullptr && node->src[1] != nullptr) {
+            if (node->src[0]->ne[2] != node->src[1]->ne[1]) {
+                GGML_LOG_ERROR("[%s] malformed GET_ROWS graph detected (dimension mismatch)\n", __func__);
+                return false;
             }
         }
     }

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1746,6 +1746,19 @@ bool rpc_server::graph_compute(const std::vector<uint8_t> & input) {
             graph->use_counts[hash_pos] = tensor_ptrs.at(id)->use_count;
         }
     }
+
+    // PATCH: Validate graph nodes to prevent OOB writes (Issue #26912)
+    for (uint32_t i = 0; i < n_nodes; i++) {
+        struct ggml_tensor * node = graph->nodes[i];
+
+        if (node != nullptr && node->op == GGML_OP_SET_ROWS && node->src[0] != nullptr) {
+            if (node->ne[2] != node->src[0]->ne[2] || node->ne[3] != node->src[0]->ne[3]) {
+                GGML_LOG_ERROR("[%s] malformed SET_ROWS graph detected (dimension mismatch)\n", __func__);
+                return false;  // Safely drop the connection
+            }
+        }
+    }
+
     ggml_status status = ggml_backend_graph_compute(backends[device], graph);
     GGML_ASSERT(status == GGML_STATUS_SUCCESS && "Unsuccessful graph computations are not supported with RPC");
     stored_graphs[device].graph = graph;


### PR DESCRIPTION
## Overview

This PR fixes out-of-bounds (OOB) vulnerabilities in the RPC server caused by malformed `GGML_OP_SET_ROWS` and `GGML_OP_GET_ROWS` tensors. It introduces a pre-execution validation loop in `rpc_server::graph_compute` to verify specific tensor dimensions before handing the graph over to the backend:

- For `GGML_OP_SET_ROWS`, it verifies that the `ne[2]` and `ne[3]` dimensions of the `node` and `src[0]` strictly match.
- For `GGML_OP_GET_ROWS`, it verifies that the `ne[2]` dimension of `src[0]` strictly matches the `ne[1]` dimension of `src[1]`.

If a mismatch is detected, the server logs an error and safely aborts the request, preventing memory corruption and out-of-bounds memory exposure.

## Additional information

Fixes #26912 and fixes #26825.

Previously, a malformed network packet could bypass the local `ggml_set_rows` and `ggml_get_rows` assertions. This caused `ggml_backend_graph_compute` to either write past the allocated buffer bounds (`SET_ROWS`) or read past the `src0` buffer and copy unowned memory into the output tensor (`GET_ROWS`), which could then be retrieved via `GET_TENSOR`. This patch safely catches these shape mismatches at the network boundary.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Ai not used.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->