### PR TITLE
convert_hf_to_gguf : use checkpoint MTP layer count

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -291,11 +291,10 @@ class _QwenMtpMixin:
         super().__init__(*args, **kwargs)
         self.block_count = self.hparams["num_hidden_layers"]
         if not self.no_mtp:
-            n_mtp = self.hparams.get("mtp_num_hidden_layers", 0)
-            # Qwen-3-Next doesn't include `mtp_num_hidden_layers` in config.
-            if n_mtp == 0:
-                assert self.opt_num_mtp_layers != 0
-                n_mtp = self.opt_num_mtp_layers
+            n_mtp = self.opt_num_mtp_layers
+            n_mtp_config = self.hparams.get("mtp_num_hidden_layers")
+            if n_mtp_config is not None and n_mtp_config != n_mtp:
+                logger.warning("MTP layer count from config (%d) does not match model tensors (%d); using model tensors", n_mtp_config, n_mtp)
             self.block_count += n_mtp
         self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
 

--- a/tests/test_convert_hf_to_gguf.py
+++ b/tests/test_convert_hf_to_gguf.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from conversion.base import gguf
+from conversion.qwen import _QwenMtpMixin
+
+
+class _ModelBase:
+    def __init__(self, config_count: int | None, tensor_count: int):
+        self.hparams = {"num_hidden_layers": 32}
+        if config_count is not None:
+            self.hparams["mtp_num_hidden_layers"] = config_count
+        self.opt_num_mtp_layers = tensor_count
+
+
+class _Model(_QwenMtpMixin, _ModelBase):
+    model_arch = gguf.MODEL_ARCH.QWEN35
+    no_mtp = False
+    mtp_only = False
+
+
+class TestQwenMtpLayerCount(unittest.TestCase):
+    def test_ignores_configured_mtp_layers_missing_from_checkpoint(self):
+        with self.assertLogs("hf-to-gguf", level="WARNING"):
+            model = _Model(config_count=1, tensor_count=0)
+
+        self.assertEqual(model.block_count, 32)
+
+    def test_keeps_mtp_layers_present_in_checkpoint(self):
+        model = _Model(config_count=1, tensor_count=1)
+
+        self.assertEqual(model.block_count, 33)
+
+    def test_counts_mtp_layers_when_config_value_is_missing(self):
+        model = _Model(config_count=None, tensor_count=1)
+
+        self.assertEqual(model.block_count, 33)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview

This fixes the https://github.com/ggml-org/llama.cpp/issues/26916

## What went wrong

The affected checkpoint’s config and tensors disagreed:

```text
num_hidden_layers       = 32
mtp_num_hidden_layers   = 1
MTP layers in tensors   = 0
```

The converter trusted the config and wrote GGUF metadata for 33 blocks. However, the file contained only `blk.0` through `blk.31`.

The loader trusted that metadata, requested the nonexistent `blk.32.attn_norm.weight`, and failed before the server started.

## How this fixes it

The converter now derives the MTP count from indexed checkpoint tensors:

```python
n_mtp = self.opt_num_mtp_layers
```

The config value is used only to warn about mismatches.

For this checkpoint, GGUF now reports 32 blocks and zero NextN/MTP layers, matching the tensors that actually exist. No loader change is needed.

## Reproduce the bug

1. Use a checkpoint configured with one MTP layer but containing no `mtp.layers.*` tensors.
2. Convert it with the old converter:

   ```bash
   python convert_hf_to_gguf.py <model-dir> --outfile <model>.gguf
   ```

3. Start the server:

   ```bash
   ./build/bin/llama-server -m <model>.gguf
   ```

4. Observe the missing `blk.32.attn_norm.weight` error.

## Test the fix

Run:

```bash
python tests/test_convert_hf_to_gguf.py
```

The regression tests cover:

- Config says one, tensors contain zero: 32 blocks plus a warning.
- Config and tensors both say one: 33 blocks.
- Config omits the count, tensors contain one: 33 blocks.

For manual verification, reconvert the affected checkpoint and confirm that the model reports 32 blocks and starts successfully.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, Codex

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
