### PR TITLE
gguf: reject malformed tensor dims, metadata keys, string lengths, and zero layer counts

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -672,9 +672,10 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
                     ok = ok && gr.read(info.t.ne[j]);
                 }
 
-                // check that all ne are non-negative
-                if (info.t.ne[j] < 0) {
-                    GGML_LOG_ERROR("%s: tensor '%s' dimension %" PRIu32 " has invalid number of elements: %" PRIi64 " < 0\n",
+                // check that all ne are positive (zero-sized tensors are
+                // invalid and would divide by zero in the size checks below)
+                if (info.t.ne[j] <= 0) {
+                    GGML_LOG_ERROR("%s: tensor '%s' dimension %" PRIu32 " must be positive, got %" PRIi64 "\n",
                         __func__, info.t.name, j, info.t.ne[j]);
                     ok = false;
                     break;


### PR DESCRIPTION
## Overview

`gguf_init_from_file_impl` dies with SIGFPE (integer division by zero,
no error message) when a GGUF tensor declares a zero dimension, e.g.
shape [4, 0]: the negative-dimension check passes, then
`INT64_MAX / ne[1]` divides by zero in the size-representability check.
A 96-byte file (header + one tensor info, dims [4, 0]) crashes the
process on load. This PR rejects non-positive dimensions with a
structured error.

Also verified against current master while preparing this PR: two
related findings from the same differential-fuzzing campaign are
already fixed upstream (empty metadata keys are rejected with an error;
declared string lengths are bounded by `GGUF_MAX_STRING_LENGTH` and the
remaining file bytes), and `block_count = 0` now trips a clear
`GGML_ASSERT(n_layer_all > 0)` instead of the previous opaque abort.
This PR therefore contains only the zero-dimension fix, which remains
outstanding.

Repro: `zero_dim` (96 bytes): header + one tensor info (n_dims=2,
dims=[4,0], dtype=f32). Before: SIGFPE. After:
`gguf_init_from_reader: tensor 't.weight' dimension 1 must be positive, got 0`.

## Additional information

Found by differential fuzzing of GGUF loaders (tiny inert reproducers;
crash/availability defect, no memory-safety claim). Also reproduced on
b5998/b5999/b7999. Reports archived at
https://github.com/voidwest/embersec-research (research/embersec/comparative/disclosure/).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - prepared with AI assistance under the
  direction of a human researcher; the human is responsible for all
  submitted changes.
