### PR TITLE
add supports_op-guard for rpc as stability fix

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1903,7 +1903,12 @@ static ggml_backend_buffer_type_t ggml_backend_rpc_device_get_buffer_type(ggml_b
 
 static bool ggml_backend_rpc_device_supports_op(ggml_backend_dev_t dev, const struct ggml_tensor * op) {
     GGML_UNUSED(dev);
-    GGML_UNUSED(op);
+
+    // Use the non-CUB CUDA limit until RPC can query the remote backend.
+    if ((op->op == GGML_OP_TOP_K || op->op == GGML_OP_ARGSORT) && op->src[0]->ne[0] > 1024) {
+        return false;
+    }
+
     //TODO: call the remote backend and cache the results
     return true;
 }


### PR DESCRIPTION
## Overview

add stability patch for rpc backend to fallback to another.
Right now ggml_backend_rpc_device_supports_op is commented as "Todo", which always returns true until fixed and is planned to add requests and caching as planned solution.
_"//TODO: call the remote backend and cache the results"_

For ggml_backend_rpc_device_supports_op not requesting the supports_op decision from the actual rpc remote backend, it is assuming all are there.
This will result in a crash in some cases. This will render some guards for supports_op decisions useless. As assuming the ops are always there, it is better to fallback in this cases to expand the compatibility.

On HIP, GGML_CUDA_USE_CUB is never defined (ggml/src/ggml-cuda/common.cuh), so top_k and argsort always take the bitonic path

originating issues are referenced in #24177, #26746

## Additional information

The patch will reject top_k and argsort with ne[0] > 1024, so the scheduler has to check for another backend.

Trade off is that cuda-rpc gets said operations rejected conservatively on wide top_k/argsort input with more than 1024 elements in dimension 0 

In a specific case for me it fixed the crash of my own issue:
It results for deepseek-v4-flash-0731 to fail with rpc workers. The prefill fails after n_tokens 4096.

## Requirements

none specific. 

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) YES
- AI usage disclosure: YES, I am not fond of PRs in general with a high frequently updated git and unaware of the workflow. I did the instructions with OpenAI.
