### PR TITLE
unicode: stop shared pre-tokenizer regex from blowing the stack

### DIFF
--- a/src/unicode.cpp
+++ b/src/unicode.cpp
@@ -735,6 +735,161 @@ static std::vector<size_t> unicode_regex_split_custom_qwen35(const std::string &
     return bpe_offsets;
 }
 
+// Long letter runs in this shared pre-tokenizer regex can overflow recursive std::regex.
+static std::vector<size_t> unicode_regex_split_custom_deepseek_hunyuan_joyai(const std::string & text, const std::vector<size_t> & offsets) {
+    std::vector<size_t> bpe_offsets;
+    bpe_offsets.reserve(offsets.size());
+
+    const auto cpts = unicode_cpts_from_utf8(text);
+
+    size_t start = 0;
+    for (auto offset : offsets) {
+        const size_t offset_ini = start;
+        const size_t offset_end = start + offset;
+        assert(offset_end <= cpts.size());
+        start = offset_end;
+
+        static const uint32_t OUT_OF_RANGE = 0xFFFFFFFF;
+        auto get_cpt = [&] (const size_t pos) -> uint32_t {
+            return (offset_ini <= pos && pos < offset_end) ? cpts[pos] : OUT_OF_RANGE;
+        };
+
+        auto get_flags = [&] (const size_t pos) -> unicode_cpt_flags {
+            return (offset_ini <= pos && pos < offset_end) ? unicode_cpt_flags_from_cpt(cpts[pos]) : unicode_cpt_flags{};
+        };
+
+        auto is_ascii_letter = [&] (const size_t pos) -> bool {
+            const uint32_t cpt = get_cpt(pos);
+            return ('A' <= cpt && cpt <= 'Z') || ('a' <= cpt && cpt <= 'z');
+        };
+
+        auto is_letter_or_mark = [&] (const size_t pos) -> bool {
+            const auto flags = get_flags(pos);
+            return flags.is_letter || flags.is_accent_mark;
+        };
+
+        auto is_punctuation_or_symbol = [&] (const size_t pos) -> bool {
+            const uint32_t cpt = get_cpt(pos);
+            const auto flags = get_flags(pos);
+            // The collapsed property maps omit '~'.
+            return cpt != '~' && (flags.is_punctuation || flags.is_symbol);
+        };
+
+        size_t prev_end = offset_ini;
+        auto add_token = [&] (const size_t end) {
+            assert(prev_end <= end && end <= offset_end);
+            if (prev_end < end) {
+                bpe_offsets.push_back(end - prev_end);
+            }
+            prev_end = end;
+        };
+
+        for (size_t pos = offset_ini; pos < offset_end; ) {
+            const uint32_t cpt = get_cpt(pos);
+            const auto flags = get_flags(pos);
+
+            // regex: [!"#$%&'()*+,\-./:;<=>?@\[\\\]^_`{|}~][A-Za-z]+
+            const bool is_ascii_punctuation =
+                ('!' <= cpt && cpt <= '/') ||
+                (':' <= cpt && cpt <= '@') ||
+                ('[' <= cpt && cpt <= '`') ||
+                ('{' <= cpt && cpt <= '~');
+            if (is_ascii_punctuation && is_ascii_letter(pos + 1)) {
+                pos += 2;
+                while (is_ascii_letter(pos)) {
+                    ++pos;
+                }
+                add_token(pos);
+                continue;
+            }
+
+            // regex: [^\r\n\p{L}\p{P}\p{S}]?[\p{L}\p{M}]+
+            const bool optional_prefix =
+                cpt != '\r' && cpt != '\n' &&
+                !flags.is_letter && !is_punctuation_or_symbol(pos) &&
+                is_letter_or_mark(pos + 1);
+            if (is_letter_or_mark(pos) || optional_prefix) {
+                if (optional_prefix) {
+                    ++pos;
+                }
+                while (is_letter_or_mark(pos)) {
+                    ++pos;
+                }
+                add_token(pos);
+                continue;
+            }
+
+            // regex: <space>?[\p{P}\p{S}]+[\r\n]*
+            size_t punctuation_pos = pos;
+            if (cpt == ' ' && is_punctuation_or_symbol(pos + 1)) {
+                ++punctuation_pos;
+            }
+            if (is_punctuation_or_symbol(punctuation_pos)) {
+                pos = punctuation_pos + 1;
+                while (is_punctuation_or_symbol(pos)) {
+                    ++pos;
+                }
+                while (get_cpt(pos) == '\r' || get_cpt(pos) == '\n') {
+                    ++pos;
+                }
+                add_token(pos);
+                continue;
+            }
+
+            size_t num_whitespaces = 0;
+            size_t last_end_r_or_n = 0;
+            while (get_flags(pos + num_whitespaces).is_whitespace) {
+                const uint32_t cpt2 = get_cpt(pos + num_whitespaces);
+                if (cpt2 == '\r' || cpt2 == '\n') {
+                    last_end_r_or_n = pos + num_whitespaces + 1;
+                }
+                ++num_whitespaces;
+            }
+
+            // regex: \s*[\r\n]+
+            if (last_end_r_or_n > 0) {
+                pos = last_end_r_or_n;
+                add_token(pos);
+                continue;
+            }
+
+            // regex: \s+(?!\S)
+            if (num_whitespaces > 1 && get_cpt(pos + num_whitespaces) != OUT_OF_RANGE) {
+                pos += num_whitespaces - 1;
+                add_token(pos);
+                continue;
+            }
+
+            // regex: \s+
+            if (num_whitespaces > 0) {
+                pos += num_whitespaces;
+                add_token(pos);
+                continue;
+            }
+
+            // Preserve number groups split by earlier regex passes.
+            size_t unmatched_end = pos + 1;
+            while (unmatched_end < offset_end) {
+                const uint32_t next_cpt = get_cpt(unmatched_end);
+                const auto next_flags = get_flags(unmatched_end);
+                const bool next_optional_prefix =
+                    next_cpt != '\r' && next_cpt != '\n' &&
+                    !next_flags.is_letter && !is_punctuation_or_symbol(unmatched_end) &&
+                    is_letter_or_mark(unmatched_end + 1);
+                if (next_flags.is_whitespace || is_letter_or_mark(unmatched_end) ||
+                    is_punctuation_or_symbol(unmatched_end) || next_optional_prefix) {
+                    break;
+                }
+                ++unmatched_end;
+            }
+            pos = unmatched_end;
+            add_token(pos);
+        }
+    }
+
+    return bpe_offsets;
+}
+
 template <typename CharT>
 static std::vector<size_t> unicode_regex_split_stl(const std::basic_string<CharT> & text, const std::basic_string<CharT> & regex, const std::vector<size_t> & offsets) {
     using BidirIt = typename std::basic_string<CharT>::const_iterator;
@@ -1062,6 +1217,9 @@ static std::vector<size_t> unicode_regex_split_custom(const std::string & text, 
     } else if (
            regex_expr == "(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])|[^\\r\\n\\p{L}\\p{N}]?[\\p{L}\\p{M}]+|\\p{N}| ?[^\\s\\p{L}\\p{M}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+") {
         bpe_offsets = unicode_regex_split_custom_qwen35(text, offsets);
+    } else if (
+           regex_expr == "[!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~][A-Za-z]+|[^\r\n\\p{L}\\p{P}\\p{S}]?[\\p{L}\\p{M}]+| ?[\\p{P}\\p{S}]+[\r\n]*|\\s*[\r\n]+|\\s+(?!\\S)|\\s+") {
+        bpe_offsets = unicode_regex_split_custom_deepseek_hunyuan_joyai(text, offsets);
     } else if (regex_expr == "\\p{Han}+") {
         // K2's first pattern - handle all K2 patterns together
         bpe_offsets = unicode_regex_split_custom_kimi_k2(text, offsets);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -172,6 +172,7 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     endif()
 
     llama_build(test-gbnf-validator.cpp)
+    llama_build_and_test(test-unicode-regex-split.cpp)
 
     # build test-tokenizer-1-bpe target once and add many tests
     llama_build(test-tokenizer-1-bpe.cpp)

--- a/tests/test-unicode-regex-split.cpp
+++ b/tests/test-unicode-regex-split.cpp
@@ -1,0 +1,50 @@
+#include "../src/unicode.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static const std::string shared_regex =
+    "[!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~][A-Za-z]+|[^\r\n\\p{L}\\p{P}\\p{S}]?[\\p{L}\\p{M}]+| ?[\\p{P}\\p{S}]+[\r\n]*|\\s*[\r\n]+|\\s+(?!\\S)|\\s+";
+
+static std::vector<std::string> split(const std::string & text, const std::string & regex) {
+    return unicode_regex_split(text, {
+        "\\p{N}{1,3}",
+        u8"[\u4e00-\u9fa5\u3040-\u309f\u30a0-\u30ff]+",
+        regex,
+    }, false);
+}
+
+int main() {
+    const std::vector<std::string> cases = {
+        "Hello, world! DeepSeek tokenizer regression.\n",
+        " leading words\twith whitespace  and trailing spaces   \n",
+        u8"cafe\u0301 caf\u00e9 na\u00efve \u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac\n",
+        u8"\u4e2d\u6587\u6bb5\u843d\u3002\u3072\u3089\u304c\u306a\u3001\u30ab\u30bf\u30ab\u30ca\uff01\n",
+        "~A ~~ !Z $value _name 1234 999999\r\n",
+        "json {\"tool\":\"read_file\",\"path\":\"/tmp/example\"}\n",
+        "blank-lines-follow\r\n\r\n\nend\n",
+    };
+
+    // Wrap the regex to bypass the custom handler.
+    const std::string fallback_regex = "(?:" + shared_regex + ")";
+    for (size_t i = 0; i < cases.size(); ++i) {
+        const auto custom = split(cases[i], shared_regex);
+        const auto fallback = split(cases[i], fallback_regex);
+        if (custom != fallback) {
+            fprintf(stderr, "Shared regex mismatch for case %zu: custom=%zu fallback=%zu\n", i, custom.size(), fallback.size());
+            return 1;
+        }
+    }
+
+    const std::string long_letters(131072, 'Z');
+    for (const auto & text : { long_letters, "!" + long_letters }) {
+        const auto pieces = split(text, shared_regex);
+        if (pieces.size() != 1 || pieces[0] != text) {
+            fprintf(stderr, "Shared regex long-run mismatch: input=%zu pieces=%zu\n", text.size(), pieces.size());
+            return 1;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Overview

DeepSeek V4 Flash 0731 shares a pre-tokenizer regex with the DeepSeek V3, Hunyuan Dense, and JoyAI presets. Without a custom implementation, it falls back to `std::regex`.

Long letter runs can trigger recursive backtracking in libstdc++, accumulating tens of thousands of stack frames and crashing a server thread before inference starts.

This change routes the exact regex through a non-recursive scanner while preserving Unicode property handling and number grouping from earlier passes.

## Additional information

Validation performed:

- Compared short inputs against `std::regex`.
- Verified identical output before and after the change: 8,624 token IDs for a 17,368-byte DeepSeek V4 Flash 0731 corpus.
- Verified that 51,294-byte, 51,295-byte, and 128 KiB letter runs complete without crashing.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI usage disclosure: YES — AI was used to help create the initial version of this change. I completed the final implementation and verified the test results.