### PR TITLE
common : load the draft model from the draft model path

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2302,7 +2302,7 @@ common_speculative_init_result::common_speculative_init_result(
         model_path = params.speculative.draft.mparams.path;
         LOG_INF("%s: loading draft model '%s'\n", __func__, model_path.c_str());
 
-        llama_model * model_dft = llama_model_load_from_file(params.model.path.c_str(), mparams);
+        llama_model * model_dft = llama_model_load_from_file(model_path.c_str(), mparams);
         if (model_dft == NULL) {
             LOG_ERR("%s: failed to load draft model, '%s'\n", __func__, model_path.c_str());
             return;


### PR DESCRIPTION
`common_speculative_init_result` computes the draft model path, logs it, and then passes the **target** model path to `llama_model_load_from_file`:

```cpp
model_path = params.speculative.draft.mparams.path;
LOG_INF("%s: loading draft model '%s'\n", __func__, model_path.c_str());

llama_model * model_dft = llama_model_load_from_file(params.model.path.c_str(), mparams);
```

So with `-md <draft.gguf> --spec-type draft-dflash` (or any draft-based spec type routed through this init), the target model is silently loaded a second time as the "draft". Depending on available memory this either:

- fails draft context creation and **silently disables speculative decoding** (generation proceeds at baseline speed with no indication beyond a fitting-time warning), or
- doubles the target model's memory footprint.

The log line above makes it look like the correct file was loaded, which makes the no-op hard to notice — we only caught it because with/without `-md` benchmarked identically.

## Fix

Load the draft path that was computed on the line above (one line).

## Validation

Muse-Glimmer-30B-UD-Q3_K_XL + `dflash-kquant.gguf` (unsloth GGUFs), Apple M5 24 GB, Metal backend, `llama-server --spec-type draft-dflash --spec-draft-n-max 15`:

| | draft_n / draft_accepted | generation |
|---|---|---|
| before | absent (spec silently off); t/s identical with and without `-md` | 3.5–5 t/s |
| after | e.g. 2067 / 461 (chat, 22%) up to 735 / 548 (code continuation, 75%) | up to 19.5 t/s on high-acceptance workloads |

Acceptance-rate range is workload-dependent as expected for a block drafter; the point of the table is that draft stats exist at all and the speedup appears only after the fix.
