### PR TITLE
ci : bundle HIP runtime DLLs with Windows ROCm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -836,6 +836,31 @@ jobs:
           $rocmVersionShort = ('${{ matrix.ROCM_VERSION }}'.Split('.')[0..1] -join '.')
           echo "ROCM_VERSION_SHORT=$rocmVersionShort" >> $env:GITHUB_ENV
 
+      - name: Bundle HIP runtime DLLs (amdhip64_7.dll + rocm_kpack.dll)
+        run: |
+          $ErrorActionPreference = "Stop"
+          # See issue https://github.com/ggml-org/llama.cpp/issues/26929.
+          # ggml-hip.dll loads amdhip64_7.dll at run time. The Adrenalin driver
+          # ships an amdhip64_7.dll in System32, which the loader searches before PATH,
+          # so a matching DLL from PATH cannot win. Copy amdhip64 next to the
+          # binaries (exe directory is searched before System32) so the correct
+          # runtime is used. rocm_kpack.dll is amdhip64_7's direct dependency, so
+          # copy the matching version too. rocblas/hipblaslt kernels resolve fine
+          # via PATH and are not copied.
+          $binPath = (rocm-sdk path --bin).Trim()
+          if (-not $binPath) { throw "rocm-sdk path --bin returned empty" }
+          write-host "ROCm bin path: $binPath"
+
+          $patterns = @("amdhip64_*.dll", "rocm_kpack.dll")
+          foreach ($pattern in $patterns) {
+            $files = Get-ChildItem -Path $binPath -Filter $pattern -ErrorAction SilentlyContinue
+            if (-not $files) { throw "no match for $pattern in $binPath" }
+            foreach ($f in $files) {
+              Copy-Item $f.FullName -Destination build\bin\ -Force
+              write-host "  copied $($f.Name)"
+            }
+          }
+
       - name: Pack artifacts
         run: |
           cp "LICENSE" "build\bin\"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -798,9 +798,8 @@ jobs:
           mkdir build
           cd build
           cmake .. `
-            -G "Unix Makefiles" `
+            -G "Ninja Multi-Config" `
             -DCMAKE_PREFIX_PATH="${env:HIP_PATH}" `
-            -DCMAKE_BUILD_TYPE=Release `
             -DGGML_BACKEND_DL=ON `
             -DGGML_NATIVE=OFF `
             -DGGML_CPU=ON `
@@ -817,11 +816,11 @@ jobs:
 
       - name: Verify HIP backend was built
         run: |
-          $hipDll = Get-ChildItem -Path build\bin -Filter "ggml-hip*.dll" -ErrorAction SilentlyContinue
+          $hipDll = Get-ChildItem -Path build\bin\Release -Filter "ggml-hip*.dll" -ErrorAction SilentlyContinue
           if (-not $hipDll) {
             Write-Host "##[error]ggml-hip*.dll was NOT produced. The HIP backend silently failed to build."
-            Write-Host "Contents of build\bin:"
-            Get-ChildItem build\bin | Format-Table -AutoSize
+            Write-Host "Contents of build\bin\Release:"
+            Get-ChildItem build\bin\Release | Format-Table -AutoSize
             exit 1
           }
           Write-Host "HIP backend artifact found:"
@@ -865,8 +864,8 @@ jobs:
 
       - name: Pack artifacts
         run: |
-          cp "LICENSE" "build\bin\"
-          7z a -snl llama-bin-win-rocm-${{ env.ROCM_VERSION_SHORT }}-${{ matrix.build }}.zip .\build\bin\*
+          cp "LICENSE" "build\bin\Release\"
+          7z a -snl llama-bin-win-rocm-${{ env.ROCM_VERSION_SHORT }}-${{ matrix.build }}.zip .\build\bin\Release\*
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -836,7 +836,7 @@ jobs:
           $rocmVersionShort = ('${{ matrix.ROCM_VERSION }}'.Split('.')[0..1] -join '.')
           echo "ROCM_VERSION_SHORT=$rocmVersionShort" >> $env:GITHUB_ENV
 
-      - name: Bundle HIP runtime DLLs (amdhip64_7.dll + rocm_kpack.dll)
+      - name: Bundle HIP runtime DLLs (amdhip64_7.dll, rocm_kpack.dll, amd_comgr.dll)
         run: |
           $ErrorActionPreference = "Stop"
           # See issue https://github.com/ggml-org/llama.cpp/issues/26929.
@@ -845,13 +845,15 @@ jobs:
           # so a matching DLL from PATH cannot win. Copy amdhip64 next to the
           # binaries (exe directory is searched before System32) so the correct
           # runtime is used. rocm_kpack.dll is amdhip64_7's direct dependency, so
-          # copy the matching version too. rocblas/hipblaslt kernels resolve fine
-          # via PATH and are not copied.
+          # copy the matching version too. amd_comgr is copied as well to keep it
+          # in sync with the bundled amdhip64, avoiding a version mismatch with a
+          # amd_comgr from System32.
+          # rocblas/hipblaslt kernels resolve fine via PATH and are not copied.
           $binPath = (rocm-sdk path --bin).Trim()
           if (-not $binPath) { throw "rocm-sdk path --bin returned empty" }
           write-host "ROCm bin path: $binPath"
 
-          $patterns = @("amdhip64_*.dll", "rocm_kpack.dll")
+          $patterns = @("amdhip64_7.dll", "rocm_kpack.dll", "amd_comgr.dll")
           foreach ($pattern in $patterns) {
             $files = Get-ChildItem -Path $binPath -Filter $pattern -ErrorAction SilentlyContinue
             if (-not $files) { throw "no match for $pattern in $binPath" }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -858,7 +858,7 @@ jobs:
             $files = Get-ChildItem -Path $binPath -Filter $pattern -ErrorAction SilentlyContinue
             if (-not $files) { throw "no match for $pattern in $binPath" }
             foreach ($f in $files) {
-              Copy-Item $f.FullName -Destination build\bin\ -Force
+              Copy-Item $f.FullName -Destination build\bin\Release -Force
               write-host "  copied $($f.Name)"
             }
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -742,6 +742,10 @@ jobs:
           name: llama-ui.zip
           path: tools/ui/dist
 
+      - name: Install Ninja
+        run: |
+          choco install ninja
+
       - name: ccache
         uses: ggml-org/ccache-action@v1.2.21
         with:
@@ -795,9 +799,7 @@ jobs:
 
       - name: Build
         run: |
-          mkdir build
-          cd build
-          cmake .. `
+          cmake -S . -B build `
             -G "Ninja Multi-Config" `
             -DCMAKE_PREFIX_PATH="${env:HIP_PATH}" `
             -DGGML_BACKEND_DL=ON `
@@ -812,7 +814,7 @@ jobs:
             -DHIP_PATH="${env:HIP_PATH}" `
             -DGGML_HIP_ROCWMMA_FATTN=ON `
             -DAMDGPU_TARGETS="${{ matrix.gpu_targets }}"
-          cmake --build . --config Release --parallel ${env:NUMBER_OF_PROCESSORS}
+          cmake --build build --config Release --parallel ${env:NUMBER_OF_PROCESSORS}
 
       - name: Verify HIP backend was built
         run: |


### PR DESCRIPTION
## Overview

Copy `amdhip64_7.dll` , `rocm_kpack.dll` and `amd_comgr.dll`  next to the llama.cpp binaries so the correct HIP runtime loads over the driver's copy in System32. Fixes #26929.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES: I used AI to help me to write the comment section and to better organize the PowerShell copy logic

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
