### PR TITLE
mtmd: add JPEG XL decode via libjxl

### DIFF
--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -10,6 +10,8 @@ if (MTMD_VIDEO AND NOT LLAMA_SUBPROCESS)
     set(MTMD_VIDEO OFF CACHE BOOL "${MTMD_VIDEO_HELP}" FORCE)
 endif()
 
+option(MTMD_JXL "enable JPEG XL support via libjxl" OFF)
+
 find_package(Threads REQUIRED)
 
 add_library(mtmd
@@ -86,6 +88,14 @@ target_compile_features   (mtmd PRIVATE cxx_std_17)
 
 if (MTMD_VIDEO)
     target_compile_definitions(mtmd PRIVATE MTMD_VIDEO)
+endif()
+
+if (MTMD_JXL)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(JXL REQUIRED IMPORTED_TARGET libjxl libjxl_threads)
+    target_link_libraries(mtmd PRIVATE PkgConfig::JXL)
+    target_compile_definitions(mtmd PRIVATE MTMD_JXL)
+    message(STATUS "mtmd: JPEG XL support enabled (libjxl)")
 endif()
 
 if (BUILD_SHARED_LIBS)

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -33,6 +33,10 @@
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
 
+#ifdef MTMD_JXL
+#include "mtmd-jxl.h"
+#endif
+
 #ifdef MTMD_INTERNAL_HEADER
 #error "mtmd-helper is a public library outside of mtmd. it must not include internal headers"
 #endif
@@ -376,6 +380,24 @@ mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(mtmd_context * ctx, 
     if (!placeholder) {
         id = fnv_hash(buf, len);
     }
+
+#ifdef MTMD_JXL
+    // Check JXL before audio/stb_image. Raw JXL starts with 0xFF 0x0A, which is
+    // adjacent to the crude MPEG sync-word sniff in is_audio_file().
+    if (jxl_is_jxl(buf, len)) {
+        int nx = 0, ny = 0;
+        unsigned char * data = nullptr;
+        if (!jxl_decode_rgb(buf, len, &data, &nx, &ny)) {
+            LOG_ERR("%s: failed to decode JXL image\n", __func__);
+            return {nullptr, nullptr};
+        }
+        LOG_INF("%s: decoded JXL image (%d x %d)\n", __func__, nx, ny);
+        result = mtmd_bitmap_init(nx, ny, placeholder ? nullptr : data);
+        mtmd_bitmap_set_id(result, id.empty() ? nullptr : id.c_str());
+        free(data);
+        return {result, nullptr};
+    }
+#endif
 
     if (audio_helpers::is_audio_file((const char *)buf, len)) {
         std::vector<float> pcmf32;

--- a/tools/mtmd/mtmd-helper.h
+++ b/tools/mtmd/mtmd-helper.h
@@ -44,7 +44,7 @@ MTMD_API struct mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_file(mtm
 
 // helper function to construct a mtmd_bitmap from a buffer containing a file
 // supported formats:
-//     image: formats supported by stb_image: jpg, png, bmp, gif, etc.
+//     image: JPEG XL (when built with MTMD_JXL), plus stb_image: jpg, png, bmp, gif, etc.
 //     audio: formats supported by miniaudio: wav, mp3, flac
 // note:
 //   - for now, video input is only supported via C++ helper functions

--- a/tools/mtmd/mtmd-jxl.h
+++ b/tools/mtmd/mtmd-jxl.h
@@ -1,0 +1,122 @@
+#pragma once
+
+// JPEG XL decode helpers for libmtmd.
+// Guarded so llama.cpp still builds when MTMD_JXL is off.
+
+#ifdef MTMD_JXL
+
+#include <jxl/decode.h>
+#include <jxl/thread_parallel_runner.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+// Returns true if buf/len begins with a JPEG XL signature (codestream or container).
+static bool jxl_is_jxl(const unsigned char * buf, size_t len) {
+    const JxlSignature sig = JxlSignatureCheck(buf, len);
+    return sig == JXL_SIG_CODESTREAM || sig == JXL_SIG_CONTAINER;
+}
+
+// Decodes the first frame of a JXL image to 8-bit packed RGB (no alpha).
+// Caller frees *out with free(). Returns false on failure.
+static bool jxl_decode_rgb(const unsigned char * buf, size_t len,
+                           unsigned char ** out, int * width, int * height) {
+    *out = nullptr;
+    *width = 0;
+    *height = 0;
+
+    if (!buf || len == 0 || !jxl_is_jxl(buf, len)) {
+        return false;
+    }
+
+    JxlDecoder * dec = JxlDecoderCreate(nullptr);
+    if (!dec) {
+        return false;
+    }
+
+    void * runner = JxlThreadParallelRunnerCreate(
+        nullptr, JxlThreadParallelRunnerDefaultNumWorkerThreads());
+    if (runner) {
+        if (JxlDecoderSetParallelRunner(dec, JxlThreadParallelRunner, runner) != JXL_DEC_SUCCESS) {
+            JxlThreadParallelRunnerDestroy(runner);
+            runner = nullptr;
+        }
+    }
+
+    bool ok = false;
+    unsigned char * pixels = nullptr;
+
+    if (JxlDecoderSubscribeEvents(dec, JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE) != JXL_DEC_SUCCESS) {
+        goto cleanup;
+    }
+
+    if (JxlDecoderSetInput(dec, buf, len) != JXL_DEC_SUCCESS) {
+        goto cleanup;
+    }
+    JxlDecoderCloseInput(dec);
+
+    for (;;) {
+        const JxlDecoderStatus status = JxlDecoderProcessInput(dec);
+
+        if (status == JXL_DEC_ERROR || status == JXL_DEC_NEED_MORE_INPUT) {
+            break;
+        }
+
+        if (status == JXL_DEC_SUCCESS) {
+            ok = pixels != nullptr;
+            break;
+        }
+
+        if (status == JXL_DEC_BASIC_INFO) {
+            JxlBasicInfo info;
+            if (JxlDecoderGetBasicInfo(dec, &info) != JXL_DEC_SUCCESS) {
+                break;
+            }
+            if (info.xsize == 0 || info.ysize == 0) {
+                break;
+            }
+            *width  = (int) info.xsize;
+            *height = (int) info.ysize;
+            // UINT8 output is already nonlinear sRGB unless a custom CMS is set.
+            continue;
+        }
+
+        if (status == JXL_DEC_NEED_IMAGE_OUT_BUFFER) {
+            const JxlPixelFormat fmt = {3, JXL_TYPE_UINT8, JXL_NATIVE_ENDIAN, 0};
+            size_t buf_size = 0;
+            if (JxlDecoderImageOutBufferSize(dec, &fmt, &buf_size) != JXL_DEC_SUCCESS) {
+                break;
+            }
+            pixels = (unsigned char *) malloc(buf_size);
+            if (!pixels) {
+                break;
+            }
+            if (JxlDecoderSetImageOutBuffer(dec, &fmt, pixels, buf_size) != JXL_DEC_SUCCESS) {
+                break;
+            }
+            continue;
+        }
+
+        if (status == JXL_DEC_FULL_IMAGE) {
+            // First frame only; ignore subsequent animation frames.
+            ok = pixels != nullptr;
+            break;
+        }
+    }
+
+cleanup:
+    if (!ok && pixels) {
+        free(pixels);
+        pixels = nullptr;
+        *width = 0;
+        *height = 0;
+    }
+    *out = pixels;
+    JxlDecoderDestroy(dec);
+    if (runner) {
+        JxlThreadParallelRunnerDestroy(runner);
+    }
+    return ok && *out != nullptr && *width > 0 && *height > 0;
+}
+
+#endif // MTMD_JXL

--- a/tools/ui/src/lib/constants/supported-file-types.constants.ts
+++ b/tools/ui/src/lib/constants/supported-file-types.constants.ts
@@ -56,6 +56,10 @@ export const IMAGE_FILE_TYPES = {
 		extensions: [FileExtensionImage.JPG, FileExtensionImage.JPEG],
 		mimeTypes: [MimeTypeImage.JPEG]
 	},
+	[FileTypeImage.JXL]: {
+		extensions: [FileExtensionImage.JXL],
+		mimeTypes: [MimeTypeImage.JXL]
+	},
 	[FileTypeImage.PNG]: {
 		extensions: [FileExtensionImage.PNG],
 		mimeTypes: [MimeTypeImage.PNG]

--- a/tools/ui/src/lib/enums/files.enums.ts
+++ b/tools/ui/src/lib/enums/files.enums.ts
@@ -27,7 +27,8 @@ export enum FileTypeImage {
 	WEBP = 'webp',
 	SVG = 'svg',
 	HEIC = 'heic',
-	HEIF = 'heif'
+	HEIF = 'heif',
+	JXL = 'jxl'
 }
 
 export enum FileTypeAudio {
@@ -94,7 +95,8 @@ export enum FileExtensionImage {
 	WEBP = '.webp',
 	SVG = '.svg',
 	HEIC = '.heic',
-	HEIF = '.heif'
+	HEIF = '.heif',
+	JXL = '.jxl'
 }
 
 export enum FileExtensionAudio {
@@ -216,7 +218,8 @@ export enum MimeTypeImage {
 	ICO = 'image/x-icon',
 	ICO_MICROSOFT = 'image/vnd.microsoft.icon',
 	HEIC = 'image/heic',
-	HEIF = 'image/heif'
+	HEIF = 'image/heif',
+	JXL = 'image/jxl'
 }
 
 export enum MimeTypeText {

--- a/tools/ui/src/lib/utils/cap-img-size.ts
+++ b/tools/ui/src/lib/utils/cap-img-size.ts
@@ -29,6 +29,11 @@ export function capImageDataURLSize(
 
 			const mimeType = mimeMatch[1] as MimeTypeImage;
 
+			// Browsers cannot decode JPEG XL; send bytes through unchanged.
+			if (mimeType === MimeTypeImage.JXL) {
+				return resolve(base64UrlImage);
+			}
+
 			if (!Object.values(MimeTypeImage).includes(mimeType)) {
 				return reject(new Error(`Unsupported image MIME type: ${mimeType}`));
 			}

--- a/tools/ui/src/lib/utils/convert-files-to-extra.ts
+++ b/tools/ui/src/lib/utils/convert-files-to-extra.ts
@@ -1,3 +1,4 @@
+import { isJxlFile, normalizeJxlDataUrl } from './jxl';
 import { convertPDFToImage, convertPDFToText } from './pdf-processing';
 import { isSvgMimeType, svgBase64UrlToPngDataURL } from './svg-to-png';
 import { isLikelyTextFile, readFileAsText } from './text-files';
@@ -7,8 +8,18 @@ import { AttachmentType, FileTypeCategory, SpecialFileType } from '$lib/enums';
 import { modelsStore } from '$lib/stores/models.svelte';
 import { settingsStore } from '$lib/stores/settings.svelte';
 import type { ChatUploadedFile, DatabaseMessageExtra, FileProcessingResult } from '$lib/types';
-import { getFileTypeCategory } from '$lib/utils';
+import { getFileTypeCategory, getUploadedFileCategory } from '$lib/utils';
 import { toast } from 'svelte-sonner';
+
+function readFileAsDataURL(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+
+		reader.onload = () => resolve(reader.result as string);
+		reader.onerror = () => reject(reader.error);
+		reader.readAsDataURL(file);
+	});
+}
 
 function readFileAsBase64(file: File): Promise<string> {
 	return new Promise((resolve, reject) => {
@@ -50,30 +61,37 @@ export async function parseFilesToMessageExtras(
 			continue;
 		}
 
-		if (getFileTypeCategory(file.type) === FileTypeCategory.IMAGE) {
-			if (file.preview) {
+		if (getUploadedFileCategory(file) === FileTypeCategory.IMAGE || isJxlFile(file)) {
+			if (file.preview || isJxlFile(file)) {
 				let base64Url = file.preview;
 
-				if (isSvgMimeType(file.type)) {
+				if (isJxlFile(file)) {
+					base64Url = normalizeJxlDataUrl(
+						base64Url ?? (await readFileAsDataURL(file.file)),
+						file.name
+					);
+				} else if (isSvgMimeType(file.type)) {
 					try {
-						base64Url = await svgBase64UrlToPngDataURL(base64Url);
+						base64Url = await svgBase64UrlToPngDataURL(base64Url!);
 					} catch (error) {
 						console.error('Failed to convert SVG to PNG for database storage:', error);
 					}
 				} else if (isWebpMimeType(file.type)) {
 					try {
-						base64Url = await webpBase64UrlToPngDataURL(base64Url);
+						base64Url = await webpBase64UrlToPngDataURL(base64Url!);
 					} catch (error) {
 						console.error('Failed to convert WebP to PNG for database storage:', error);
 					}
 				}
 
-				extras.push({
-					base64Url,
-					name: file.name,
-					size: file.size,
-					type: AttachmentType.IMAGE
-				});
+				if (base64Url) {
+					extras.push({
+						base64Url,
+						name: file.name,
+						size: file.size,
+						type: AttachmentType.IMAGE
+					});
+				}
 			}
 		} else if (getFileTypeCategory(file.type) === FileTypeCategory.AUDIO) {
 			// Process audio files (MP3 and WAV)

--- a/tools/ui/src/lib/utils/file-type.ts
+++ b/tools/ui/src/lib/utils/file-type.ts
@@ -32,6 +32,7 @@ export function getFileTypeCategory(mimeType: string): FileTypeCategory | null {
 		case MimeTypeImage.SVG:
 		case MimeTypeImage.HEIC:
 		case MimeTypeImage.HEIF:
+		case MimeTypeImage.JXL:
 			return FileTypeCategory.IMAGE;
 
 		// Audio
@@ -122,6 +123,7 @@ export function getFileTypeCategoryByExtension(filename: string): FileTypeCatego
 		case FileExtensionImage.SVG:
 		case FileExtensionImage.HEIC:
 		case FileExtensionImage.HEIF:
+		case FileExtensionImage.JXL:
 			return FileTypeCategory.IMAGE;
 
 		// Audio
@@ -218,6 +220,13 @@ export function getFileTypeByExtension(filename: string): string | null {
 	}
 
 	return null;
+}
+
+export function getUploadedFileCategory(file: {
+	name: string;
+	type: string;
+}): FileTypeCategory | null {
+	return getFileTypeCategory(file.type) ?? getFileTypeCategoryByExtension(file.name);
 }
 
 export function isFileTypeSupported(filename: string, mimeType?: string): boolean {

--- a/tools/ui/src/lib/utils/index.ts
+++ b/tools/ui/src/lib/utils/index.ts
@@ -75,6 +75,7 @@ export { getPreviewText, generateConversationTitle } from './text';
 export {
 	getFileTypeCategory,
 	getFileTypeCategoryByExtension,
+	getUploadedFileCategory,
 	getFileTypeByExtension,
 	isFileTypeSupported
 } from './file-type';

--- a/tools/ui/src/lib/utils/jxl.ts
+++ b/tools/ui/src/lib/utils/jxl.ts
@@ -1,0 +1,24 @@
+import { FileExtensionImage, MimeTypeImage } from '$lib/enums';
+
+export function isJxlMimeType(mimeType: string): boolean {
+	return mimeType.trim().toLowerCase() === MimeTypeImage.JXL;
+}
+
+export function isJxlFile(file: File | { name: string; type: string }): boolean {
+	return isJxlMimeType(file.type) || file.name.toLowerCase().endsWith(FileExtensionImage.JXL);
+}
+
+/** Force image/jxl MIME on data URLs (browsers often omit it for .jxl files). */
+export function normalizeJxlDataUrl(dataUrl: string, filename: string): string {
+	if (!filename.toLowerCase().endsWith(FileExtensionImage.JXL)) {
+		return dataUrl;
+	}
+
+	const comma = dataUrl.indexOf(',');
+
+	if (comma < 0) {
+		return dataUrl;
+	}
+
+	return `data:${MimeTypeImage.JXL};base64,${dataUrl.slice(comma + 1)}`;
+}

--- a/tools/ui/src/lib/utils/modality-file-validation.ts
+++ b/tools/ui/src/lib/utils/modality-file-validation.ts
@@ -5,7 +5,7 @@
 
 import { FileTypeCategory } from '$lib/enums';
 import type { ModalityCapabilities } from '$lib/types';
-import { getFileTypeCategory } from '$lib/utils';
+import { getFileTypeCategory, getUploadedFileCategory } from '$lib/utils';
 
 /**
  * Check if a file type is supported by the given modalities
@@ -75,7 +75,7 @@ export function filterFilesByModalities(
 	const { hasAudio, hasVideo, hasVision } = capabilities;
 
 	for (const file of files) {
-		const category = getFileTypeCategory(file.type);
+		const category = getUploadedFileCategory(file);
 
 		let isSupported = true;
 		let reason = '';

--- a/tools/ui/src/lib/utils/process-uploaded-files.ts
+++ b/tools/ui/src/lib/utils/process-uploaded-files.ts
@@ -1,12 +1,13 @@
 import { heicFileToJpegDataURL, isHeicMimeType } from './heic-to-jpeg';
+import { isJxlFile, normalizeJxlDataUrl } from './jxl';
 import { convertPDFToText } from './pdf-processing';
 import { isSvgMimeType, svgBase64UrlToPngDataURL } from './svg-to-png';
 import { isWebpMimeType, webpBase64UrlToPngDataURL } from './webp-to-png';
 import { SETTINGS_KEYS } from '$lib/constants';
-import { FileTypeCategory } from '$lib/enums';
+import { FileTypeCategory, MimeTypeImage } from '$lib/enums';
 import { modelsStore } from '$lib/stores/models.svelte';
 import { settingsStore } from '$lib/stores/settings.svelte';
-import { getFileTypeCategory } from '$lib/utils';
+import { getUploadedFileCategory } from '$lib/utils';
 import { toast } from 'svelte-sonner';
 
 /**
@@ -44,6 +45,7 @@ function readFileAsUTF8(file: File): Promise<string> {
  *
  * This function processes various file types and generates appropriate previews:
  * - Images: Base64 data URLs with format normalization (SVG/WebP → PNG)
+ * - JPEG XL: kept as image/jxl data URLs (not converted)
  * - Text files: UTF-8 content extraction
  * - PDFs: Metadata only (processed later in conversion pipeline)
  * - Audio: Base64 data URLs for preview
@@ -68,11 +70,15 @@ export async function processFilesToChatUploaded(
 		};
 
 		try {
-			if (getFileTypeCategory(file.type) === FileTypeCategory.IMAGE) {
+			if (getUploadedFileCategory(file) === FileTypeCategory.IMAGE || isJxlFile(file)) {
 				let preview = await readFileAsDataURL(file);
 
-				// Normalize SVG and WebP to PNG, and HEIC to compressed JPEG, in previews
-				if (isSvgMimeType(file.type)) {
+				// browsers often report an empty type for .jxl, so set it here
+				const imageType = isJxlFile(file) ? MimeTypeImage.JXL : file.type;
+
+				if (isJxlFile(file)) {
+					preview = normalizeJxlDataUrl(preview, file.name);
+				} else if (isSvgMimeType(file.type)) {
 					try {
 						preview = await svgBase64UrlToPngDataURL(preview);
 					} catch (err) {
@@ -94,8 +100,8 @@ export async function processFilesToChatUploaded(
 					}
 				}
 
-				results.push({ ...base, preview });
-			} else if (getFileTypeCategory(file.type) === FileTypeCategory.PDF) {
+				results.push({ ...base, preview, type: imageType });
+			} else if (getUploadedFileCategory(file) === FileTypeCategory.PDF) {
 				// Extract text content from PDF for preview
 				try {
 					const textContent = await convertPDFToText(file);
@@ -126,12 +132,12 @@ export async function processFilesToChatUploaded(
 						duration: 8000
 					});
 				}
-			} else if (getFileTypeCategory(file.type) === FileTypeCategory.AUDIO) {
+			} else if (getUploadedFileCategory(file) === FileTypeCategory.AUDIO) {
 				// Generate preview URL for audio files
 				const preview = await readFileAsDataURL(file);
 
 				results.push({ ...base, preview });
-			} else if (getFileTypeCategory(file.type) === FileTypeCategory.VIDEO) {
+			} else if (getUploadedFileCategory(file) === FileTypeCategory.VIDEO) {
 				// Generate preview URL for video files
 				const preview = await readFileAsDataURL(file);
 


### PR DESCRIPTION
## Overview

This PR adds JPEG XL support to llama.cpp multimodal inference and the built-in web UI.

Build:
  cmake -B build -DMTMD_JXL=ON -DGGML_CUDA=ON -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_UI=ON
  cmake --build build --target llama-server

Requires: libjxl dev package (only when MTMD_JXL is ON)

## Additional information

Optional CMake flag: `-DMTMD_JXL=ON` (default OFF). Tested with llama-server web UI by uploading a `.jxl` file.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES - AI assisted the implementation of the JPEG XL compatibility work. I reviewed the changes, tested them myself, and I am responsible for this PR.