### PR TITLE
llama: lfm2/lfm2moe: enable tensor split

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1060,8 +1060,6 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
         case LLM_ARCH_NEMOTRON_H:
         case LLM_ARCH_NEMOTRON_H_MOE:
         case LLM_ARCH_GRANITE_HYBRID:
-        case LLM_ARCH_LFM2:
-        case LLM_ARCH_LFM2MOE:
         case LLM_ARCH_MINIMAX_01:
         case LLM_ARCH_MINIMAX_M2:
         case LLM_ARCH_MINIMAX_M3:

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -487,6 +487,10 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1, "ssm_out.weight");
         }
         if (std::regex_match(tensor_name, pattern_r_cache) || std::regex_match(tensor_name, pattern_s_cache)) {
+            if (ud->model->arch == LLM_ARCH_LFM2 || ud->model->arch == LLM_ARCH_LFM2MOE) {
+                // the LFM2 shortconv block runs fully mirrored, so its conv state must be mirrored too
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED, "");
+            }
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0, "ssm_out.weight");
         }
         if (std::regex_match(tensor_name, pattern_ssm_conv1d)) {


### PR DESCRIPTION
## Overview

Adds `--split-mode tensor` support for lfm2 / lfm2moe model family.

## Additional information

test-llama-archs passes for all archs, and reports Meta NMSE on the order of 1e-14 for both model types.

Ran llama-perplexity on a small corpus of markdown files in the repo, comparing KLD across --split-mode settings, no significant change:
| model | quant | PPL none | PPL tensor | Median KLD | Same top p | RMS dP |
|---|---|---|---|---|---|---|
| LFM2.5-2.6B | Q4_0 | 19.6816 | 19.642420 | 0.001227 | 97.686 ± 0.298 | 2.272 |
|  | Q4_K_M | 16.6961 | 16.498048 | 0.005373 | 94.431 ± 0.454 | 4.540 |
|  | Q5_K_M | 16.9132 | 16.807537 | 0.005183 | 94.784 ± 0.440 | 4.121 |
|  | Q6_K | 16.5061 | 16.427118 | 0.000943 | 97.137 ± 0.330 | 2.539 |
|  | Q8_0 | 15.9748 | 16.084346 | 0.000924 | 97.294 ± 0.321 | 2.080 |
|  | F16 | 16.1949 | 16.256477 | 0.000097 | 99.294 ± 0.166 | 0.789 |
|  | BF16 | 16.1949 | 16.256477 | 0.000097 | 99.294 ± 0.166 | 0.789 |
| LFM2.5-VL-3B | Q4_K_M | 10.0732 | 10.111448 | 0.001503 | 97.451 ± 0.312 | 1.424 |
|  | Q8_0 | 9.9161 | 9.915306 | 0.000333 | 98.549 ± 0.237 | 0.627 |
|  | BF16 | 9.8903 | 9.889950 | 0.000032 | 99.608 ± 0.124 | 0.201 |
| LFM2.5-8B-A1B | Q4_K_M | 16.0230 | 16.052731 | 0.015990 | 91.216 ± 0.561 | 5.544 |
|  | Q8_0 | 16.5763 | 16.477410 | 0.006487 | 93.725 ± 0.480 | 4.283 |
|  | BF16 | 16.6523 | 16.697652 | 0.001699 | 95.804 ± 0.397 | 2.765 |

Also tested performance:
| model | quant | pp4096 none | pp4096 tensor | pp %diff | tg512 none | tg512 tensor | tg %diff |
|---|---|---|---|---|---|---|---|
| LFM2.5-2.6B | Q4_0 | 10842.3 | 13834.5 | +27.6% | 280.9 | 304.3 | +8.3% |
|  | Q4_K_M | 10016.3 | 12969.7 | +29.5% | 251.2 | 286.2 | +14.0% |
|  | Q5_K_M | 9567.0 | 12591.3 | +31.6% | 230.2 | 269.3 | +17.0% |
|  | Q6_K | 8813.5 | 11800.3 | +33.9% | 190.2 | 235.7 | +23.9% |
|  | Q8_0 | 10600.9 | 13533.8 | +27.7% | 188.4 | 230.0 | +22.1% |
|  | F16 | 9829.8 | 13102.5 | +33.3% | 114.3 | 153.9 | +34.6% |
|  | BF16 | 10462.1 | 12970.7 | +24.0% | 114.0 | 153.6 | +34.7% |
| LFM2.5-VL-3B | Q4_K_M | 9690.6 | 12689.8 | +30.9% | 244.8 | 279.7 | +14.2% |
|  | Q8_0 | 10317.0 | 13359.5 | +29.5% | 187.0 | 228.7 | +22.3% |
|  | BF16 | 10483.4 | 12889.2 | +22.9% | 113.9 | 153.5 | +34.7% |
| LFM2.5-8B-A1B | Q4_K_M | 9257.6 | 11921.6 | +28.8% | 331.5 | 339.2 | +2.3% |
|  | Q8_0 | 9569.6 | 12545.2 | +31.1% | 259.2 | 293.5 | +13.3% |
|  | BF16 | 5777.9 | 3751.0 | -35.1% | 160.2 | 198.1 | +23.6% |



Tested on 2x RTX A5000 (NVLink & NCCL)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes
- AI usage disclosure: Yes: research, code, plus driving correctness and perf testing.
