### PR TITLE
api: expose selected layer input pooling

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -1050,6 +1050,56 @@ extern "C" {
     // otherwise: float[n_embd] (1-dimensional)
     LLAMA_API float * llama_get_embeddings_seq(struct llama_context * ctx, llama_seq_id seq_id);
 
+    // Experimental: enable extraction of the input hidden state for transformer layer `lid`.
+    // This is intended for research probes and is disabled in normal inference.
+    LLAMA_API void llama_set_embeddings_layer_inp(struct llama_context * ctx, uint32_t lid, bool value);
+
+    // Experimental: get selected-layer input hidden states from the last decode.
+    // Shape is [n_tokens, n_embd] for the active decode buffer.
+    LLAMA_API float * llama_get_embeddings_layer_inp(struct llama_context * ctx, uint32_t lid);
+
+    enum llama_prefill_probe_pooling {
+        LLAMA_PREFILL_PROBE_POOLING_MEAN  = 0,
+        LLAMA_PREFILL_PROBE_POOLING_FINAL = 1,
+        LLAMA_PREFILL_PROBE_POOLING_MAX   = 2,
+    };
+
+    struct llama_prefill_probe_result {
+        uint32_t layer;
+        int32_t  token_start;
+        int32_t  token_end;
+        int32_t  pooling;
+        int32_t  hidden_dim;
+        int32_t  output_dim;
+        bool     projected;
+        bool     scored;
+        float    score;
+        double   synchronize_seconds;
+        double   pooling_seconds;
+        double   projection_seconds;
+        double   scoring_seconds;
+        bool     windowed_capture;
+        int32_t  source_row_start;
+        int32_t  source_row_end;
+        uint64_t copied_bytes;
+    };
+
+    // Experimental: compact selected-layer prompt hidden states inside llama.cpp.
+    // The layer input buffer must have been enabled with llama_set_embeddings_layer_inp()
+    // before decode/eval. This pools rows [token_start, token_end) and optionally applies
+    // a row-major projection matrix [output_dim, n_embd].
+    LLAMA_API bool llama_prefill_probe_pool(
+            struct llama_context * ctx,
+                     uint32_t   layer,
+                      int32_t   token_start,
+                      int32_t   token_end,
+                      int32_t   pooling,
+                const float   * projection,
+                      int32_t   output_dim,
+                const float   * logistic_weights,
+                      float   * output_vector,
+            struct llama_prefill_probe_result * result);
+
     //
     // backend sampling API [EXPERIMENTAL]
     // note: use only if the llama_context was created with at least one llama_sampler_seq_config

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -19,6 +19,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 //
 // llama_context
@@ -3794,6 +3795,102 @@ float * llama_get_embeddings_layer_inp(llama_context * ctx, uint32_t lid) {
     ctx->synchronize();
 
     return ctx->get_embeddings_layer_inp(lid);
+}
+
+bool llama_prefill_probe_pool(
+        llama_context * ctx,
+        uint32_t        layer,
+        int32_t         token_start,
+        int32_t         token_end,
+        int32_t         pooling,
+        const float *   projection,
+        int32_t         output_dim,
+        const float *   logistic_weights,
+        float *         output_vector,
+        llama_prefill_probe_result * result) {
+    if (!ctx || !output_vector || !result || token_start < 0 || token_end <= token_start) {
+        return false;
+    }
+
+    const int32_t hidden_dim = (int32_t) ctx->get_model().hparams.n_embd;
+    const bool projected = projection != nullptr && output_dim > 0;
+    const int32_t actual_output_dim = projected ? output_dim : hidden_dim;
+
+    *result = {};
+    result->layer = layer;
+    result->token_start = token_start;
+    result->token_end = token_end;
+    result->pooling = pooling;
+    result->hidden_dim = hidden_dim;
+    result->output_dim = actual_output_dim;
+    result->projected = projected;
+    result->scored = logistic_weights != nullptr;
+    result->source_row_start = token_start;
+    result->source_row_end = token_end;
+
+    const int64_t sync_start_us = ggml_time_us();
+    ctx->synchronize();
+    result->synchronize_seconds = double(ggml_time_us() - sync_start_us) / 1000000.0;
+
+    const float * data = ctx->get_embeddings_layer_inp(layer);
+    if (!data) {
+        return false;
+    }
+
+    std::vector<float> pooled((size_t) hidden_dim, pooling == LLAMA_PREFILL_PROBE_POOLING_MAX ? -std::numeric_limits<float>::infinity() : 0.0f);
+    const int64_t pool_start_us = ggml_time_us();
+    const int32_t count = token_end - token_start;
+    for (int32_t row = token_start; row < token_end; ++row) {
+        const float * src = data + int64_t(row) * hidden_dim;
+        if (pooling == LLAMA_PREFILL_PROBE_POOLING_FINAL) {
+            if (row == token_end - 1) {
+                std::memcpy(pooled.data(), src, (size_t) hidden_dim * sizeof(float));
+            }
+        } else if (pooling == LLAMA_PREFILL_PROBE_POOLING_MAX) {
+            for (int32_t col = 0; col < hidden_dim; ++col) {
+                pooled[col] = std::max(pooled[col], src[col]);
+            }
+        } else {
+            for (int32_t col = 0; col < hidden_dim; ++col) {
+                pooled[col] += src[col];
+            }
+        }
+    }
+    if (pooling != LLAMA_PREFILL_PROBE_POOLING_FINAL && pooling != LLAMA_PREFILL_PROBE_POOLING_MAX) {
+        const float inv_count = 1.0f / float(count);
+        for (float & value : pooled) {
+            value *= inv_count;
+        }
+    }
+    result->pooling_seconds = double(ggml_time_us() - pool_start_us) / 1000000.0;
+
+    const int64_t proj_start_us = ggml_time_us();
+    if (projected) {
+        for (int32_t out = 0; out < output_dim; ++out) {
+            const float * weights = projection + int64_t(out) * hidden_dim;
+            double acc = 0.0;
+            for (int32_t col = 0; col < hidden_dim; ++col) {
+                acc += double(weights[col]) * double(pooled[col]);
+            }
+            output_vector[out] = float(acc);
+        }
+    } else {
+        std::memcpy(output_vector, pooled.data(), (size_t) hidden_dim * sizeof(float));
+    }
+    result->projection_seconds = double(ggml_time_us() - proj_start_us) / 1000000.0;
+
+    if (logistic_weights) {
+        const int64_t score_start_us = ggml_time_us();
+        double logit = double(logistic_weights[actual_output_dim]);
+        for (int32_t idx = 0; idx < actual_output_dim; ++idx) {
+            logit += double(logistic_weights[idx]) * double(output_vector[idx]);
+        }
+        result->score = float(1.0 / (1.0 + std::exp(-logit)));
+        result->scoring_seconds = double(ggml_time_us() - score_start_us) / 1000000.0;
+    }
+
+    result->copied_bytes = (uint64_t) count * (uint64_t) hidden_dim * sizeof(float);
+    return true;
 }
 
 bool llama_set_sampler(llama_context * ctx, llama_seq_id seq_id, llama_sampler * smpl) {


### PR DESCRIPTION
## Overview

Adds a small C API for two related capabilities.

First, it exposes selected transformer-layer input states through `llama.h`, so external runtimes can inspect the layer input buffer after prompt evaluation.

Second, it adds a helper for pooling a chosen token range from that layer into a compact vector. This is useful when an application wants a lightweight model-state signal for routing, confidence checks, or local/cloud fallback decisions without copying the full hidden-state matrix into application code.

## Additional information

- Exposes selected-layer input-state capture through `llama_set_embeddings_layer_inp(...)` and `llama_get_embeddings_layer_inp(...)`.
- Adds `llama_prefill_probe_pool(...)` to pool a token range from a selected layer.
- Supports mean, final-token, and max pooling.
- Supports optional projection, so callers can return a smaller vector than the full hidden size.
- Supports optional logistic scoring over the pooled/projected vector.
- Returns shape and timing metadata through `llama_prefill_probe_result`.
- Verified locally with a macOS + Metal build, exported symbols in `libllama.dylib`, and an external ctypes caller.
- This PR does not change prompt evaluation itself. The pooling helper runs after normal evaluation using the selected-layer input buffer that llama.cpp already produced.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: YES