### PR TITLE
server: add disaggregated prefill via HTTP state handoff

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3558,6 +3558,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--prefill-url"}, "URL",
+        "base URL of a server running the same model, used for disaggregated prefill when a request sets \"prefill\": true (default: disabled)",
+        [](common_params & params, const std::string & value) {
+            params.prefill_url = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_PREFILL_URL"));
+    add_opt(common_arg(
         {"--media-path"}, "PATH",
         "directory for loading local media files; files can be accessed via file:// URLs using relative paths (default: disabled)",
         [](common_params & params, const std::string & value) {

--- a/common/common.h
+++ b/common/common.h
@@ -672,6 +672,7 @@ struct common_params {
     bool log_json = false;
 
     std::string slot_save_path;
+    std::string prefill_url; // base URL of the server that runs disaggregated prefill
     std::string media_path; // path to directory for loading media files
 
     float slot_prompt_similarity = 0.1f;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -17,6 +17,8 @@
 #include "mtmd.h"
 #include "mtmd-helper.h"
 
+#include <cpp-httplib/httplib.h> // client for disaggregated prefill
+
 #include <algorithm>
 #include <cstddef>
 #include <cinttypes>
@@ -38,6 +40,43 @@
 using json = nlohmann::ordered_json;
 
 constexpr int HTTP_POLLING_SECONDS = 1;
+
+// wire format of a serialized prefill state: magic, token count, tokens, raw sequence state
+constexpr uint32_t PREFILL_STATE_MAGIC           = 0x50524631; // "PRF1"
+constexpr int      PREFILL_CONNECT_TIMEOUT_SECS  = 10;
+constexpr int      PREFILL_RESPONSE_TIMEOUT_SECS = 3600;
+
+static std::string prefill_state_pack(const llama_tokens & tokens, const std::vector<uint8_t> & state) {
+    const uint32_t magic    = PREFILL_STATE_MAGIC;
+    const uint32_t n_tokens = tokens.size();
+
+    std::string out;
+    out.reserve(sizeof(magic) + sizeof(n_tokens) + n_tokens * sizeof(llama_token) + state.size());
+    out.append((const char *) &magic,    sizeof(magic));
+    out.append((const char *) &n_tokens, sizeof(n_tokens));
+    out.append((const char *) tokens.data(), n_tokens * sizeof(llama_token));
+    out.append((const char *) state.data(), state.size());
+    return out;
+}
+
+static bool prefill_state_unpack(const std::string & body, llama_tokens & tokens, std::vector<uint8_t> & state) {
+    uint32_t magic    = 0;
+    uint32_t n_tokens = 0;
+    if (body.size() < sizeof(magic) + sizeof(n_tokens)) {
+        return false;
+    }
+    memcpy(&magic,    body.data(),                 sizeof(magic));
+    memcpy(&n_tokens, body.data() + sizeof(magic), sizeof(n_tokens));
+
+    const size_t off = sizeof(magic) + sizeof(n_tokens) + (size_t) n_tokens * sizeof(llama_token);
+    if (magic != PREFILL_STATE_MAGIC || body.size() < off) {
+        return false;
+    }
+    tokens.resize(n_tokens);
+    memcpy(tokens.data(), body.data() + sizeof(magic) + sizeof(n_tokens), n_tokens * sizeof(llama_token));
+    state.assign(body.begin() + off, body.end());
+    return true;
+}
 
 static common_speculative_output_limits server_output_limits(const common_params & params) {
     if (params.embedding ||
@@ -1748,6 +1787,20 @@ private:
         // the per-request limit takes priority over the global one
         slot.n_predict_max = task.params.n_predict != -1 ? task.params.n_predict : params_base.n_predict;
 
+        if (!task.prefill_state.empty()) {
+            // the sequence state comes from the prefill server, install it so prompt processing reuses it as cache
+            slot.prompt_clear();
+            const size_t n = llama_state_seq_set_data_ext(ctx_tgt, task.prefill_state.data(), task.prefill_state.size(), slot.id, 0);
+            if (n != task.prefill_state.size()) {
+                slot.prompt_clear();
+                send_error(task, "Failed to apply the prefill state, no available space in KV cache", ERROR_TYPE_SERVER);
+                return false;
+            }
+            slot.prompt.tokens.insert(task.prefill_tokens);
+            SLT_INF(slot, "applied prefill state, n_tokens = %zu, size = %.3f MiB\n",
+                    task.prefill_tokens.size(), task.prefill_state.size() / (1024.0 * 1024.0));
+        }
+
         slot.task = std::make_unique<const server_task>(std::move(task));
 
         slot.state = slot.task->is_child()
@@ -2121,6 +2174,22 @@ private:
         }
 
         SLT_DBG(slot, "%s", "sending embeddings\n");
+
+        queue_results.send(std::move(res));
+    }
+
+    void send_prefill_state(const server_slot & slot) {
+        auto res = std::make_unique<server_task_result_prefill>();
+        res->id    = slot.task->id;
+        res->index = slot.task->index;
+
+        const size_t size = llama_state_seq_get_size_ext(ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_NONE);
+        res->state.resize(size);
+        llama_state_seq_get_data_ext(ctx_tgt, res->state.data(), size, slot.id, LLAMA_STATE_SEQ_FLAGS_NONE);
+        res->tokens = slot.prompt.tokens.get_text_tokens();
+
+        SLT_INF(slot, "sending prefill state, n_tokens = %zu, size = %.3f MiB\n",
+                res->tokens.size(), size / (1024.0 * 1024.0));
 
         queue_results.send(std::move(res));
     }
@@ -3698,6 +3767,14 @@ private:
                     return;
                 }
 
+                if (slot.task->prefill_only) {
+                    // the prompt is fully processed, return the serialized state instead of generating
+                    send_prefill_state(slot);
+                    slot.release();
+                    slot.i_batch = -1;
+                    return;
+                }
+
                 GGML_ASSERT(slot.task->need_sampling());
 
                 // prompt evaluated for next-token prediction
@@ -4136,7 +4213,45 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
 
     int32_t sse_ping_interval = params.sse_ping_interval;
 
+    // the x-prefill header makes this server run prompt processing only and return the serialized state
+    const bool prefill_only = req.headers.find("x-prefill") != req.headers.end();
+
+    // a request with "prefill": true delegates prompt processing to the server at --prefill-url
+    llama_tokens         prefill_tokens;
+    std::vector<uint8_t> prefill_state;
+
     try {
+        if (!prefill_only && json_value(data, "prefill", false)) {
+            if (params.prefill_url.empty()) {
+                throw std::runtime_error("\"prefill\": true requires the server to run with --prefill-url");
+            }
+            if (ctx_server.mctx != nullptr || !files.empty()) {
+                throw std::runtime_error("disaggregated prefill does not support multimodal prompts");
+            }
+
+            httplib::Client cli(params.prefill_url);
+            cli.set_connection_timeout(PREFILL_CONNECT_TIMEOUT_SECS, 0);
+            cli.set_read_timeout(PREFILL_RESPONSE_TIMEOUT_SECS, 0);
+
+            const json body = {
+                {"prompt",       data.at("prompt")},
+                {"cache_prompt", true},
+            };
+            const httplib::Headers prefill_headers = {{"x-prefill", "1"}};
+
+            const int64_t t_start = ggml_time_us();
+            auto r = cli.Post("/completions", prefill_headers, body.dump(), "application/json");
+            if (!r || r->status != 200) {
+                throw std::runtime_error(string_format("prefill server request failed, status = %d", r ? r->status : -1));
+            }
+            if (!prefill_state_unpack(r->body, prefill_tokens, prefill_state)) {
+                throw std::runtime_error("invalid prefill state received from the prefill server");
+            }
+            SRV_INF("received prefill state, n_tokens = %zu, size = %.3f MiB, t = %.2f ms\n",
+                    prefill_tokens.size(), prefill_state.size() / (1024.0 * 1024.0),
+                    (ggml_time_us() - t_start) / 1000.0);
+        }
+
         std::vector<server_task> tasks;
 
         const auto & prompt = data.at("prompt");
@@ -4170,10 +4285,26 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         auto delimiters = common_chat_msg_delimiters_parse(json_value(data, "message_delimiters", json::array()));
         delimiters.tokenize(ctx_server.vocab);
 
+        if ((prefill_only || !prefill_state.empty()) && inputs.size() != 1) {
+            throw std::runtime_error("disaggregated prefill supports a single prompt per request");
+        }
+
+        // the last prompt token stays unprocessed so the decode server computes it, obtaining the logits
+        // and advancing any recurrent state past the shipped position
+        if (prefill_only && inputs[0].size() > 1) {
+            inputs[0].keep_first(inputs[0].size() - 1);
+        }
+
         for (size_t i = 0; i < inputs.size(); i++) {
             server_task task = server_task(type);
 
             task.id = rd.get_new_id();
+
+            task.prefill_only = prefill_only;
+            if (!prefill_state.empty()) {
+                task.prefill_state  = std::move(prefill_state);
+                task.prefill_tokens = std::move(prefill_tokens);
+            }
 
             task.tokens = std::move(inputs[i]);
             task.params = server_schema::eval_llama_cmpl_schema(
@@ -4192,6 +4323,10 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             task.params.oaicompat_cmpl_id = completion_id;
             task.params.oaicompat_model   = meta->model_name;
 
+            if (prefill_only && task.params.n_cmpl > 1) {
+                throw std::runtime_error("disaggregated prefill supports a single completion per request");
+            }
+
             // prepare child tasks
             if (task.params.n_cmpl > 1) {
                 int n_children = task.params.n_cmpl - 1;
@@ -4206,6 +4341,25 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         rd.post_tasks(std::move(tasks));
     } catch (const std::exception & e) {
         res->error(format_error_response(e.what(), ERROR_TYPE_INVALID_REQUEST));
+        return res;
+    }
+
+    if (prefill_only) {
+        // the response body is the serialized state, not a completion
+        auto all_results = rd.wait_for_all(req.should_stop);
+        if (all_results.is_terminated) {
+            return res; // connection is closed
+        }
+        if (all_results.error) {
+            res->error(all_results.error->to_json());
+            return res;
+        }
+        GGML_ASSERT(all_results.results.size() == 1);
+        auto * result = dynamic_cast<server_task_result_prefill*>(all_results.results[0].get());
+        GGML_ASSERT(result != nullptr);
+        res->status       = 200;
+        res->content_type = "application/octet-stream";
+        res->data         = prefill_state_pack(result->tokens, result->state);
         return res;
     }
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -41,39 +41,40 @@ using json = nlohmann::ordered_json;
 
 constexpr int HTTP_POLLING_SECONDS = 1;
 
-// wire format of a serialized prefill state: magic, token count, tokens, raw sequence state
+// wire format of a serialized prefill state: magic, tokens blob size, server_tokens blob, raw sequence state
 constexpr uint32_t PREFILL_STATE_MAGIC           = 0x50524631; // "PRF1"
 constexpr int      PREFILL_CONNECT_TIMEOUT_SECS  = 10;
 constexpr int      PREFILL_RESPONSE_TIMEOUT_SECS = 3600;
 
-static std::string prefill_state_pack(const llama_tokens & tokens, const std::vector<uint8_t> & state) {
-    const uint32_t magic    = PREFILL_STATE_MAGIC;
-    const uint32_t n_tokens = tokens.size();
+static std::string prefill_state_pack(const std::vector<char> & tokens_blob, const std::vector<uint8_t> & state) {
+    const uint32_t magic  = PREFILL_STATE_MAGIC;
+    const uint32_t n_blob = tokens_blob.size();
 
     std::string out;
-    out.reserve(sizeof(magic) + sizeof(n_tokens) + n_tokens * sizeof(llama_token) + state.size());
-    out.append((const char *) &magic,    sizeof(magic));
-    out.append((const char *) &n_tokens, sizeof(n_tokens));
-    out.append((const char *) tokens.data(), n_tokens * sizeof(llama_token));
+    out.reserve(sizeof(magic) + sizeof(n_blob) + tokens_blob.size() + state.size());
+    out.append((const char *) &magic,  sizeof(magic));
+    out.append((const char *) &n_blob, sizeof(n_blob));
+    out.append(tokens_blob.data(), tokens_blob.size());
     out.append((const char *) state.data(), state.size());
     return out;
 }
 
-static bool prefill_state_unpack(const std::string & body, llama_tokens & tokens, std::vector<uint8_t> & state) {
-    uint32_t magic    = 0;
-    uint32_t n_tokens = 0;
-    if (body.size() < sizeof(magic) + sizeof(n_tokens)) {
+static bool prefill_state_unpack(const std::string & body, llama_tokens & tokens_packed, std::vector<uint8_t> & state) {
+    uint32_t magic  = 0;
+    uint32_t n_blob = 0;
+    if (body.size() < sizeof(magic) + sizeof(n_blob)) {
         return false;
     }
-    memcpy(&magic,    body.data(),                 sizeof(magic));
-    memcpy(&n_tokens, body.data() + sizeof(magic), sizeof(n_tokens));
+    memcpy(&magic,  body.data(),                 sizeof(magic));
+    memcpy(&n_blob, body.data() + sizeof(magic), sizeof(n_blob));
 
-    const size_t off = sizeof(magic) + sizeof(n_tokens) + (size_t) n_tokens * sizeof(llama_token);
-    if (magic != PREFILL_STATE_MAGIC || body.size() < off) {
+    const size_t off = sizeof(magic) + sizeof(n_blob) + (size_t) n_blob;
+    if (magic != PREFILL_STATE_MAGIC || body.size() < off || n_blob % sizeof(llama_token) != 0) {
         return false;
     }
-    tokens.resize(n_tokens);
-    memcpy(tokens.data(), body.data() + sizeof(magic) + sizeof(n_tokens), n_tokens * sizeof(llama_token));
+    // server_tokens::deserialize reads the blob as an array of token sized units
+    tokens_packed.resize(n_blob / sizeof(llama_token));
+    memcpy(tokens_packed.data(), body.data() + sizeof(magic) + sizeof(n_blob), n_blob);
     state.assign(body.begin() + off, body.end());
     return true;
 }
@@ -1796,9 +1797,9 @@ private:
                 send_error(task, "Failed to apply the prefill state, no available space in KV cache", ERROR_TYPE_SERVER);
                 return false;
             }
-            slot.prompt.tokens.insert(task.prefill_tokens);
+            slot.prompt.tokens = std::move(task.prefill_tokens);
             SLT_INF(slot, "applied prefill state, n_tokens = %zu, size = %.3f MiB\n",
-                    task.prefill_tokens.size(), task.prefill_state.size() / (1024.0 * 1024.0));
+                    slot.prompt.tokens.size(), task.prefill_state.size() / (1024.0 * 1024.0));
         }
 
         slot.task = std::make_unique<const server_task>(std::move(task));
@@ -2186,10 +2187,10 @@ private:
         const size_t size = llama_state_seq_get_size_ext(ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_NONE);
         res->state.resize(size);
         llama_state_seq_get_data_ext(ctx_tgt, res->state.data(), size, slot.id, LLAMA_STATE_SEQ_FLAGS_NONE);
-        res->tokens = slot.prompt.tokens.get_text_tokens();
+        res->tokens_blob = slot.prompt.tokens.serialize();
 
         SLT_INF(slot, "sending prefill state, n_tokens = %zu, size = %.3f MiB\n",
-                res->tokens.size(), size / (1024.0 * 1024.0));
+                slot.prompt.tokens.size(), size / (1024.0 * 1024.0));
 
         queue_results.send(std::move(res));
     }
@@ -4217,7 +4218,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
     const bool prefill_only = req.headers.find("x-prefill") != req.headers.end();
 
     // a request with "prefill": true delegates prompt processing to the server at --prefill-url
-    llama_tokens         prefill_tokens;
+    server_tokens        prefill_tokens;
     std::vector<uint8_t> prefill_state;
 
     try {
@@ -4244,9 +4245,11 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             if (!r || r->status != 200) {
                 throw std::runtime_error(string_format("prefill server request failed, status = %d", r ? r->status : -1));
             }
-            if (!prefill_state_unpack(r->body, prefill_tokens, prefill_state)) {
+            llama_tokens tokens_packed;
+            if (!prefill_state_unpack(r->body, tokens_packed, prefill_state)) {
                 throw std::runtime_error("invalid prefill state received from the prefill server");
             }
+            prefill_tokens = server_tokens::deserialize(tokens_packed, ctx_server.mctx != nullptr);
             SRV_INF("received prefill state, n_tokens = %zu, size = %.3f MiB, t = %.2f ms\n",
                     prefill_tokens.size(), prefill_state.size() / (1024.0 * 1024.0),
                     (ggml_time_us() - t_start) / 1000.0);
@@ -4359,7 +4362,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         GGML_ASSERT(result != nullptr);
         res->status       = 200;
         res->content_type = "application/octet-stream";
-        res->data         = prefill_state_pack(result->tokens, result->state);
+        res->data         = prefill_state_pack(result->tokens_blob, result->state);
         return res;
     }
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -174,7 +174,7 @@ struct server_task {
     // prefill_state and prefill_tokens carry a state received from a remote prefill server, applied to the slot before processing
     bool prefill_only = false;
     std::vector<uint8_t> prefill_state;
-    llama_tokens         prefill_tokens;
+    server_tokens        prefill_tokens;
 
     // used by SERVER_TASK_TYPE_METRICS
     bool metrics_reset_bucket = false;
@@ -639,11 +639,11 @@ struct server_prompt_cache {
 // used by disaggregated prefill, carries the serialized sequence state after prompt processing
 struct server_task_result_prefill : server_task_result {
     std::vector<uint8_t> state;
-    llama_tokens         tokens;
+    std::vector<char>    tokens_blob; // server_tokens::serialize output
     virtual json to_json() override {
         return json {
-            {"n_tokens", tokens.size()},
-            {"n_bytes",  state.size()},
+            {"n_tokens_blob", tokens_blob.size()},
+            {"n_bytes",       state.size()},
         };
     }
 };

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -169,6 +169,13 @@ struct server_task {
     };
     slot_action slot_action;
 
+    // used by disaggregated prefill
+    // prefill_only makes the task stop after prompt processing and return the serialized sequence state
+    // prefill_state and prefill_tokens carry a state received from a remote prefill server, applied to the slot before processing
+    bool prefill_only = false;
+    std::vector<uint8_t> prefill_state;
+    llama_tokens         prefill_tokens;
+
     // used by SERVER_TASK_TYPE_METRICS
     bool metrics_reset_bucket = false;
 
@@ -627,6 +634,18 @@ struct server_prompt_cache {
     bool load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_tgt, llama_context * ctx_dft, int32_t id_slot);
 
     void update();
+};
+
+// used by disaggregated prefill, carries the serialized sequence state after prompt processing
+struct server_task_result_prefill : server_task_result {
+    std::vector<uint8_t> state;
+    llama_tokens         tokens;
+    virtual json to_json() override {
+        return json {
+            {"n_tokens", tokens.size()},
+            {"n_bytes",  state.size()},
+        };
+    }
 };
 
 // used exclusively by router mode


### PR DESCRIPTION
## Overview

A server started with --prefill-url delegates prompt processing of requests that set prefill: true to a remote server running the same model. The prompt is forwarded with an x-prefill header, the remote returns the serialized sequence state and tokens as a binary body, and the state is applied to the slot when the task launches so the regular prompt cache path reuses it.

The prefill server stops one token early: recurrent state in hybrid models only exists at the last processed position, so shipping the state at n-1 lets the decode server compute the final token itself, obtaining the logits and advancing any recurrent state.

## Additional information

POC https://github.com/ggml-org/llama.cpp/issues/21266 based on @ngxson idea to simplify

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
