### PR TITLE
server : add Prometheus histogram for request context sizes

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3538,6 +3538,22 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_METRICS"));
     add_opt(common_arg(
+        {"--metrics-ctx-buckets"}, "B1,B2,...",
+        string_format(
+            "context-size histogram bucket boundaries for /metrics (default: %s)",
+            "1024,4096,8192,16384,32768,65536,131072,262144"),
+        [](common_params & params, const std::string & value) {
+            params.metrics_ctx_buckets.clear();
+            for (auto & tok : string_split<std::string>(value, ',')) {
+                auto s = string_strip(tok);
+                if (!s.empty()) {
+                    params.metrics_ctx_buckets.push_back(std::stoull(s));
+                }
+            }
+            std::sort(params.metrics_ctx_buckets.begin(), params.metrics_ctx_buckets.end());
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_METRICS_CTX_BUCKETS"));
+    add_opt(common_arg(
         {"--props"},
         string_format("enable changing global properties via POST /props (default: %s)", params.endpoint_props ? "enabled" : "disabled"),
         [](common_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -653,6 +653,7 @@ struct common_params {
     bool endpoint_slots   = true;
     bool endpoint_props   = false; // only control POST requests, not GET
     bool endpoint_metrics = false;
+    std::vector<uint64_t> metrics_ctx_buckets = {1024, 4096, 8192, 16384, 32768, 65536, 131072, 262144};
 
     // enable built-in tools
     std::vector<std::string> server_tools;

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1077,6 +1077,7 @@ In *router mode* the query param `?model={model_id}` has to be set. This endpoin
 | `llamacpp:spec_decode_num_accepted_tokens_total` | Counter | Total draft tokens accepted by the target model (0 when spec-decode is off). |
 | `llamacpp:spec_decode_num_drafts_total` | Counter | Total speculative decoding verification steps (0 when spec-decode is off). |
 | `llamacpp:spec_decode_num_accepted_tokens_per_pos_total` | Counter | Accepted tokens per draft position (labeled `position="N"`; absent when spec-decode is off or before the first completed speculative request). |
+| `llamacpp:request_context_tokens` | Histogram | Distribution of context sizes (in tokens) across completed requests. Labeled with `model_name` and `model_alias`. Bucket boundaries configurable via `--metrics-ctx-buckets` (default: 1024,4096,8192,16384,32768,65536,131072,262144). |
 
 ### POST `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -486,6 +486,30 @@ struct server_metrics {
     void add_prompt_cached(uint64_t n_tokens) {
         n_prompt_cached += n_tokens;
     }
+
+    // context-size histogram (Prometheus cumulative buckets)
+    std::vector<uint64_t> ctx_buckets;
+    std::vector<uint64_t> ctx_bucket_counts;
+    uint64_t              ctx_total_count = 0;
+    uint64_t              ctx_total_sum   = 0;
+
+    void init_ctx_histogram(const std::vector<uint64_t> & boundaries) {
+        ctx_buckets = boundaries;
+        ctx_bucket_counts.assign(boundaries.size(), 0);
+    }
+
+    void record_ctx_histogram(uint64_t n_ctx_tokens) {
+        ctx_total_count++;
+        ctx_total_sum += n_ctx_tokens;
+        for (size_t i = 0; i < ctx_buckets.size(); i++) {
+            if (n_ctx_tokens <= ctx_buckets[i]) {
+                for (size_t j = i; j < ctx_buckets.size(); j++) {
+                    ctx_bucket_counts[j]++;
+                }
+                return;
+            }
+        }
+    }
 };
 
 //

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1365,6 +1365,7 @@ private:
         });
 
         metrics.init();
+        metrics.init_ctx_histogram(params_base.metrics_ctx_buckets);
 
         if (params_base.cache_idle_slots) {
             if (params_base.cache_ram_mib == 0) {
@@ -2433,6 +2434,8 @@ private:
                     res->n_processing_slots  = n_processing_slots;
                     res->n_tasks_deferred    = queue_tasks.queue_tasks_deferred_size();
                     res->metrics             = metrics;
+                    res->model_name          = model_name;
+                    res->model_aliases       = model_aliases;
 
                     if (task.metrics_reset_bucket) {
                         metrics.reset_bucket();
@@ -4006,6 +4009,8 @@ private:
         for (size_t i = 0; i < src.size(); i++) {
             dst[i] += src[i];
         }
+
+        metrics.record_ctx_histogram(slot.prompt.n_tokens());
     }
 };
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1610,6 +1610,31 @@ std::string server_task_result_metrics::to_metrics() {
         }
     }
 
+    // context-size histogram
+    if (!metrics.ctx_buckets.empty()) {
+        const std::string & mname  = model_name;
+        const std::string & malias = model_aliases.empty() ? mname : *model_aliases.begin();
+
+        prometheus << "# HELP llamacpp:request_context_tokens "
+                      "Distribution of context sizes (in tokens) across completed requests\n"
+                   << "# TYPE llamacpp:request_context_tokens histogram\n";
+        for (size_t i = 0; i < metrics.ctx_buckets.size(); i++) {
+            prometheus << "llamacpp:request_context_tokens_bucket{model_name=\"" << mname
+                       << "\",model_alias=\"" << malias
+                       << "\",le=\"" << metrics.ctx_buckets[i]
+                       << "\"} " << metrics.ctx_bucket_counts[i] << "\n";
+        }
+        prometheus << "llamacpp:request_context_tokens_bucket{model_name=\"" << mname
+                   << "\",model_alias=\"" << malias
+                   << "\",le=\"+Inf\"} " << metrics.ctx_total_count << "\n"
+                   << "llamacpp:request_context_tokens_sum{model_name=\"" << mname
+                   << "\",model_alias=\"" << malias
+                   << "\"} " << metrics.ctx_total_sum << "\n"
+                   << "llamacpp:request_context_tokens_count{model_name=\"" << mname
+                   << "\",model_alias=\"" << malias
+                   << "\"} " << metrics.ctx_total_count << "\n";
+    }
+
     return prometheus.str();
 }
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -497,6 +497,9 @@ struct server_task_result_metrics : server_task_result {
 
     server_metrics metrics;
 
+    std::string              model_name;
+    std::set<std::string>    model_aliases;
+
     // while we can also use std::vector<server_slot> this requires copying the slot object which can be quite messy
     // therefore, we use json to temporarily store the slot.to_json() result
     json slots_data = json::array();


### PR DESCRIPTION
## Overview

Adds a standard Prometheus histogram metric `llamacpp:request_context_tokens` to the `/metrics` endpoint, recording the distribution of context sizes (in tokens) across completed requests. Closes #27011.

Changes:

- New `--metrics-ctx-buckets B1,B2,...` CLI flag to configure bucket boundaries (default: `1024,4096,8192,16384,32768,65536,131072,262144`; env: `LLAMA_ARG_METRICS_CTX_BUCKETS`)
- Histogram fields and recording logic on `server_metrics` in `server-common.h`
- Prometheus output in `server_task_result_metrics::to_metrics()`, labeled with `model_name` and `model_alias`
- Only emitted when `--metrics` is enabled (existing gate)

Example output:

```
# HELP llamacpp:request_context_tokens Distribution of context sizes (in tokens) across completed requests
# TYPE llamacpp:request_context_tokens histogram
llamacpp:request_context_tokens_bucket{model_name="qwen3",model_alias="qwen3",le="1024"} 3
llamacpp:request_context_tokens_bucket{model_name="qwen3",model_alias="qwen3",le="4096"} 8
...
llamacpp:request_context_tokens_bucket{model_name="qwen3",model_alias="qwen3",le="+Inf"} 17
llamacpp:request_context_tokens_sum{model_name="qwen3",model_alias="qwen3"} 683947
llamacpp:request_context_tokens_count{model_name="qwen3",model_alias="qwen3"} 17
```

## Additional information

Test plan (all verified locally on an RTX 3090 with Muse-Glimmer-30B):

- [x] Server starts, `/metrics` returns histogram with correct cumulative buckets
- [x] Bucket counts increment correctly after requests
- [x] `--metrics-ctx-buckets` overrides defaults
- [x] Labels match `--alias` / model name
- [x] No output when `--metrics` is not set

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Claude Opus 4.6 was used to assist with conflict resolution during rebase onto latest master (upstream refactored `server_metrics` into `server-common.h` and Prometheus formatting into `to_metrics()`). All code was manually reviewed and tested before submission.
