### PR TITLE
fix/cuda-f16-activation-scaling

### DIFF
--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -5,6 +5,46 @@
 
 #define CUDA_Q8_0_NE_ALIGN 2048
 
+static __global__ void reduce_f32_amax(const float * x, float * amax, const int64_t k) {
+    __shared__ float shared_values[32];
+    float value = 0.0f;
+    for (int64_t i = (int64_t) blockIdx.x * blockDim.x + threadIdx.x; i < k; i += (int64_t) blockDim.x * gridDim.x) {
+        value = fmaxf(value, fabsf(x[i]));
+    }
+    value = block_reduce<block_reduce_method::MAX>(value, shared_values);
+    if (threadIdx.x == 0) {
+        atomicMax((unsigned int *) amax, __float_as_uint(value));
+    }
+}
+
+static __global__ void finalize_f32_scale(float * scale) {
+    const float amax = *scale;
+    float value = 1.0f;
+    if (isfinite(amax)) {
+        while (amax > 32768.0f * value) {
+            value *= 2.0f;
+        }
+    }
+    *scale = value;
+}
+
+static __global__ void convert_f32_to_fp16_scaled(const float * x, half * y, const int64_t k, const float * scale) {
+    const float inv_scale = 1.0f / *scale;
+    for (int64_t i = (int64_t) blockIdx.x * blockDim.x + threadIdx.x; i < k; i += (int64_t) blockDim.x * gridDim.x) {
+        y[i] = __float2half(x[i] * inv_scale);
+    }
+}
+
+void ggml_cuda_f32_to_fp16_scaled(const float * x, half * y, const int64_t k, float * gemm_scalars, cudaStream_t stream) {
+    constexpr int block_size = 256;
+    const int num_blocks = std::min<int64_t>((k + block_size - 1) / block_size, 1024);
+    CUDA_CHECK(cudaMemsetAsync(gemm_scalars, 0, 2*sizeof(float), stream));
+    reduce_f32_amax<<<num_blocks, block_size, 0, stream>>>(x, gemm_scalars, k);
+    finalize_f32_scale<<<1, 1, 0, stream>>>(gemm_scalars);
+    convert_f32_to_fp16_scaled<<<num_blocks, block_size, 0, stream>>>(x, y, k, gemm_scalars);
+    CUDA_CHECK(cudaGetLastError());
+}
+
 template <int qk, int qr, dequantize_kernel_t dequantize_kernel, typename dst_t>
 static __global__ void dequantize_block(const void * __restrict__ vx, dst_t * __restrict__ y,
         const int64_t ne00, const int64_t ne01,

--- a/ggml/src/ggml-cuda/convert.cuh
+++ b/ggml/src/ggml-cuda/convert.cuh
@@ -12,6 +12,8 @@ typedef to_t_cuda_t<nv_bfloat16> to_bf16_cuda_t;
 
 to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type);
 
+void ggml_cuda_f32_to_fp16_scaled(const float * x, half * y, int64_t k, float * gemm_scalars, cudaStream_t stream);
+
 to_bf16_cuda_t ggml_get_to_bf16_cuda(ggml_type type);
 
 to_fp32_cuda_t ggml_get_to_fp32_cuda(ggml_type type);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1437,6 +1437,8 @@ static void ggml_cuda_mul_mat_cublas_impl(ggml_backend_cuda_context & ctx, const
 
     ggml_cuda_pool_alloc<cuda_t> src0_alloc(ctx.pool());
     ggml_cuda_pool_alloc<cuda_t> src1_alloc(ctx.pool());
+    ggml_cuda_pool_alloc<float> src1_gemm_scalars(ctx.pool());
+    bool src1_is_scaled = false;
 
     bool is_src0_cont_2 = ggml_is_contiguous_2(src0);
     bool is_src1_cont_2 = ggml_is_contiguous_2(src1);
@@ -1472,9 +1474,21 @@ static void ggml_cuda_mul_mat_cublas_impl(ggml_backend_cuda_context & ctx, const
         src1_alloc.alloc(ggml_nelements(src1));
 
         if (ggml_is_contiguously_allocated(src1)) {
-            const auto convert_func = traits::convert(src1->type);
-            GGML_ASSERT(convert_func != nullptr);
-            convert_func(src1->data, src1_alloc.get(), ggml_nelements(src1), main_stream);
+            if constexpr (compute_type == GGML_TYPE_F16) {
+                if (src1->type == GGML_TYPE_F32 && ggml_cuda_info().devices[ctx.device].cc == GGML_CUDA_CC_VOLTA) {
+                    src1_gemm_scalars.alloc(2);
+                    ggml_cuda_f32_to_fp16_scaled((const float *) src1->data, src1_alloc.get(), ggml_nelements(src1), src1_gemm_scalars.get(), main_stream);
+                    src1_is_scaled = true;
+                } else {
+                    const auto convert_func = traits::convert(src1->type);
+                    GGML_ASSERT(convert_func != nullptr);
+                    convert_func(src1->data, src1_alloc.get(), ggml_nelements(src1), main_stream);
+                }
+            } else {
+                const auto convert_func = traits::convert(src1->type);
+                GGML_ASSERT(convert_func != nullptr);
+                convert_func(src1->data, src1_alloc.get(), ggml_nelements(src1), main_stream);
+            }
             const size_t src1_bs = ggml_blck_size(src1->type);
             s11 *= src1_bs;
             s12 *= src1_bs;
@@ -1525,6 +1539,14 @@ static void ggml_cuda_mul_mat_cublas_impl(ggml_backend_cuda_context & ctx, const
             nbd2 /= sizeof(float) / sizeof(cuda_t);
             nbd3 /= sizeof(float) / sizeof(cuda_t);
         }
+    }
+
+    cublasPointerMode_t pointer_mode = CUBLAS_POINTER_MODE_HOST;
+    if (src1_is_scaled) {
+        CUBLAS_CHECK(cublasGetPointerMode(ctx.cublas_handle(), &pointer_mode));
+        CUBLAS_CHECK(cublasSetPointerMode(ctx.cublas_handle(), CUBLAS_POINTER_MODE_DEVICE));
+        alpha = src1_gemm_scalars.get();
+        beta = src1_gemm_scalars.get() + 1;
     }
 
     GGML_ASSERT(ne12 % ne02 == 0);
@@ -1607,6 +1629,10 @@ static void ggml_cuda_mul_mat_cublas_impl(ggml_backend_cuda_context & ctx, const
                 ne23,
                 cu_compute_type,
                 CUBLAS_GEMM_DEFAULT_TENSOR_OP));
+    }
+
+    if (src1_is_scaled) {
+        CUBLAS_CHECK(cublasSetPointerMode(ctx.cublas_handle(), pointer_mode));
     }
 
     // Convert output back to F32 if needed

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4354,6 +4354,27 @@ struct test_mul_mat : public test_case {
     }
 };
 
+struct test_mul_mat_large_input : public test_mul_mat {
+    const float b_max;
+
+    test_mul_mat_large_input(ggml_type type_a, int64_t n, float b_max)
+        : test_mul_mat(type_a, GGML_TYPE_F32, 512, n, 256, {1, 1}, {1, 1}), b_max(b_max) {}
+
+    std::string vars() override {
+        return test_mul_mat::vars() + ",b_max=" + std::to_string(b_max);
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            if (strcmp(t->name, "b") == 0) {
+                init_tensor_uniform(t, -b_max, b_max);
+            } else {
+                init_tensor_uniform(t, -0.01f, 0.01f);
+            }
+        }
+    }
+};
+
 // GGML_HINT_SRC0_IS_HADAMARD
 struct test_mul_mat_hadamard : public test_mul_mat {
     test_mul_mat_hadamard(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
@@ -8862,6 +8883,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 8192, 1, 5120, {128, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 8192, 512, 5120, {128, 1}, {1, 1}));
 #endif
+
+    test_cases.emplace_back(new test_mul_mat_large_input(GGML_TYPE_Q8_0, 63, 100000.0f));
+    test_cases.emplace_back(new test_mul_mat_large_input(GGML_TYPE_Q8_0, 64, 100000.0f));
+    test_cases.emplace_back(new test_mul_mat_large_input(GGML_TYPE_Q8_0, 64, 1000000.0f));
 
     for (ggml_type type_a : all_types) {
         for (int i = 1; i < 10; ++i) {


### PR DESCRIPTION
## Overview

for https://github.com/ggml-org/llama.cpp/issues/26044 

  This PR addresses the NaN issue reported in #26044 on NVIDIA Volta GPUs (sm_70).

  On two Tesla V100 32 GB GPUs, I consistently observed that the failure starts when the input reaches 64 tokens. This
  coincides with the backend dispatch boundary where ne11 < MMQ_DP4A_MAX_BATCH_SIZE (64) becomes false and the matrix
  multiplication switches from MMQ to the cuBLAS path.

  Further investigation localized the first non-finite result to the FFN down projection:

  ffn_out-2 = MUL_MAT(blk.2.ffn_down.weight, ffn_swiglu-2)

  The F32 input activations (ffn_swiglu-2) are still finite before this operation. In the cuBLAS F16 path, these
  activations are converted from F32 to F16 before the faster FP16 GEMM is executed. Some activation values are finite
  in F32 but exceed the maximum representable F16 value, so the conversion produces Inf. These values then propagate
  through the matrix multiplication and subsequent operations as Inf and NaN.

  The proposed fix protects this conversion with dynamic power-of-two scaling. It first computes the maximum absolute
  activation value (amax). If amax exceeds the safe F16 range, the activations are scaled down before the F32-to-F16
  conversion. The same scaling factor is then passed to cuBLAS through the GEMM alpha parameter, restoring the numerical
  scale of the output after the FP16 matrix multiplication.

  Using a power-of-two scale avoids introducing additional rounding from an arbitrary scaling factor. This restores the
  output magnitude, although it does not recover precision already lost in the F16 conversion.

  The workaround is restricted to contiguous F32 inputs used by cuBLAS F16 MUL_MAT operations on Volta (sm_70). It is
  not tied specifically to Qwen3, because the underlying issue occurs at the CUDA operator and F32-to-F16 conversion
  level.

  Compared with forcing the affected matrix multiplication to use F32, this approach retains the fast FP16 execution
  path. In my benchmarks:

  - Forcing F32 reduced throughput by approximately 21.97% at pp64 and 37.65% at pp512.
  - Dynamic activation scaling reduced throughput by approximately 2.76% at pp64 and 2.41% at pp512.

  With the scaling fix applied, the original importData reproducer produces a finite 4096-dimensional embedding, and
  subsequent canary requests in the same server process also remain finite. Compared with the all-F32 path, the
  reproduced embedding had:

  - Cosine similarity: 0.99999956
  - NMSE: 8.91e-7
  - Maximum absolute error: 0.0152

  The CUDA MUL_MAT backend test set also completed successfully with 1189/1189 tests passing.
## Additional information
  I found two related reports in the Qwen3-Embedding-8B community:

  - Qwen3-Embedding-8B discussion #27 (https://huggingface.co/Qwen/Qwen3-Embedding-8B/discussions/27)
  - Qwen3-Embedding-8B discussion #21 (https://huggingface.co/Qwen/Qwen3-Embedding-8B/discussions/21)

  Discussion #27 reports that inputs containing import produce all-NaN embeddings when the model is executed with
  torch.float16, while switching to torch.bfloat16 produces valid results.

  Discussion #21 reports a closely related failure involving token 474 (import) at the beginning of the input. A
  maintainer of Hugging Face Text Embeddings Inference later explained that the model was originally trained using BF16
  and that some hidden-state values can exceed the maximum representable FP16 value. Using BF16 avoids this overflow
  because BF16 has approximately the same exponent range as FP32, despite having fewer mantissa bits.

  These reports are consistent with my observations in llama.cpp. The input activation to the affected FFN down
  projection remains finite in F32, but some values exceed the FP16 maximum of 65504. In the affected llama.cpp CUDA
  path, the activation is converted from F32 to F16 before the cuBLAS GEMM call. The out-of-range values become Inf
  during this conversion and subsequently propagate through the matrix multiplication as Inf and NaN.

  Volta GPUs such as the Tesla V100 (sm_70) do not provide native BF16 Tensor Core execution. Therefore, the fast
  reduced-precision cuBLAS path used in this case relies on FP16 rather than BF16. This makes FP16 activation overflow
  observable on V100, although the underlying FP16 range limitation is not exclusive to Volta and has also been reported
  in other inference stacks when Qwen3-Embedding-8B is executed in FP16.

  This evidence supports the use of activation scaling before the F32-to-F16 conversion: it preserves the existing fast
  FP16 GEMM path while preventing finite F32 activation values from overflowing to Inf.


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES
  I used Codex to assist me throughout this investigation. This included locating the failure at the operator level,
  exploring the initial FP32 workaround, further identifying the numerical overflow during the F32-to-F16 conversion,
  implementing an experimental dynamic-scaling solution, and running the final tests.

  I also used Codex with GPT-5.6 sol to translate and polish text that I had originally written in Chinese. Writing a
  complete technical explanation in English is difficult for me, but the investigation, observations, conclusions, and
  supporting data described here reflect my own understanding of the issue.

  I have manually reviewed the proposed changes and test results, and I take responsibility for the submitted code and
  technical claims. I can explain the implementation and the reasoning behind it. I hope this investigation and the
  proposed fix can help resolve the issue.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
