### PR TITLE
server: (router) require API key for non-GET /models requests

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -211,8 +211,11 @@ bool server_http_context::init(const common_params & params) {
             return true;
         }
 
-        // If path is public or a UI asset, skip validation
-        if (get_public_endpoints.count(req.path)) {
+        // If path is public or a UI asset, skip validation.
+        // GET only: in router mode /models also answers POST (add a model) and
+        // DELETE (remove one). Those change server state and must stay behind
+        // the API key, so matching on the path alone is not enough.
+        if (req.method == "GET" && get_public_endpoints.count(req.path)) {
             return true;
         }
 

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -33,6 +33,19 @@ def test_access_static_assets_without_api_key():
         assert res.status_code == 200, f"Expected 200 for {path}, got {res.status_code}"
 
 
+@pytest.mark.parametrize("method", ["POST", "DELETE"])
+def test_router_model_management_requires_api_key(method: str):
+    """/models is a public GET, but in router mode it also answers POST and
+    DELETE, which add and remove models. Those must still require the key."""
+    global server
+    server = ServerPreset.router()
+    server.api_key = TEST_API_KEY
+    server.start()
+    res = server.make_request(method, "/models", data={})
+    assert res.status_code == 401
+    assert res.body["error"]["type"] == "authentication_error"
+
+
 @pytest.mark.parametrize("api_key", [None, "invalid-key"])
 def test_incorrect_api_key(api_key: str):
     global server


### PR DESCRIPTION
<html><head></head><body><h2>Overview</h2><p>In router mode, <code inline="">/models</code> supports POST and DELETE in addition to GET. The API-key middleware treated the path as public without checking the request method, allowing POST and DELETE requests through without authentication. This change limits unauthenticated access to GET requests and adds a regression test.</p><h2>Additional information</h2><p>Verified by building <code inline="">llama-server</code> before and after the change in router mode (started with no model and with <code inline="">--api-key</code> set). Requests were sent without an API key:</p>
request (no key) | before | after
-- | -- | --
GET /models (control) | 200 | 200
POST /completions (control) | 401 | 401
POST /models {} | 400 | 401
DELETE /models?model=ghost | 500 | 401

<p>Before the fix, POST and DELETE reached the router handlers and returned their validation errors (<code inline="">400 "model must be a non-empty string"</code> and <code inline="">500 "model not found"</code>), confirming that they passed the authentication layer. After the fix, both requests are rejected with 401 before reaching a handler. The control requests confirm that public GET access remains unchanged and API-key enforcement still works for protected endpoints.</p><h2>Requirements</h2><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> I have read and agree with the <a href="https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md">contributing guidelines</a></p></li><li><p>AI usage disclosure: YES — I used Claude Code to explore the server authentication code and draft the one-line fix and test. I reviewed the change, verified it by building and testing before and after the fix, and can explain it.</p></li></ul></body></html>## Overview

In router mode, `/models` supports POST and DELETE in addition to GET. The API-key middleware treated the path as public without checking the request method, allowing POST and DELETE requests through without authentication. This change limits unauthenticated access to GET requests and adds a regression test.

## Additional information

Verified by building `llama-server` before and after the change in router mode (started with no model and with `--api-key` set). Requests were sent without an API key:

| request (no key)              | before | after |
| ----------------------------- | -----: | ----: |
| `GET /models` (control)       |    200 |   200 |
| `POST /completions` (control) |    401 |   401 |
| `POST /models {}`             |    400 |   401 |
| `DELETE /models?model=ghost`  |    500 |   401 |

Before the fix, POST and DELETE reached the router handlers and returned their validation errors (`400 "model must be a non-empty string"` and `500 "model not found"`), confirming that they passed the authentication layer. After the fix, both requests are rejected with 401 before reaching a handler. The control requests confirm that public GET access remains unchanged and API-key enforcement still works for protected endpoints.

## Requirements

* [x] I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES — I used Claude Code to explore the server authentication code and draft the one-line fix and test. I reviewed the change, verified it by building and testing before and after the fix, and can explain it.