### PR TITLE
jinja : fix quadratic cost in gather_string_parts

### DIFF
--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -263,7 +263,7 @@ value binary_expression::execute_impl(context & ctx) {
             return res;
         }
         for (int64_t i = 0; i < repeat; ++i) {
-            res->val_str = res->val_str.append(str);
+            res->val_str.append(str);
         }
         return res;
     }

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -763,18 +763,22 @@ struct runtime {
         gather_string_parts_recursive(val, parts);
         // join consecutive parts with the same type
         auto & p = parts->val_str.parts;
-        if (!p.empty()) {
-            size_t w = 0;
-            for (size_t r = 1; r < p.size(); r++) {
-                if (p[w].is_input == p[r].is_input) {
-                    p[w].val += p[r].val;
-                } else if (++w != r) {
+        if (p.empty()) {
+            return parts;
+        }
+        size_t w = 0;
+        for (size_t r = 1; r < p.size(); r++) {
+            if (p[w].is_input == p[r].is_input) {
+                p[w].val += p[r].val;
+            } else {
+                w++;
+                if (w != r) {
                     // the guard is needed, self-move leaves the string in an unspecified state
                     p[w] = std::move(p[r]);
                 }
             }
-            p.resize(w + 1);
         }
+        p.resize(w + 1);
         return parts;
     }
 

--- a/common/jinja/runtime.h
+++ b/common/jinja/runtime.h
@@ -763,13 +763,17 @@ struct runtime {
         gather_string_parts_recursive(val, parts);
         // join consecutive parts with the same type
         auto & p = parts->val_str.parts;
-        for (size_t i = 1; i < p.size(); ) {
-            if (p[i].is_input == p[i - 1].is_input) {
-                p[i - 1].val += p[i].val;
-                p.erase(p.begin() + i);
-            } else {
-                i++;
+        if (!p.empty()) {
+            size_t w = 0;
+            for (size_t r = 1; r < p.size(); r++) {
+                if (p[w].is_input == p[r].is_input) {
+                    p[w].val += p[r].val;
+                } else if (++w != r) {
+                    // the guard is needed, self-move leaves the string in an unspecified state
+                    p[w] = std::move(p[r]);
+                }
             }
+            p.resize(w + 1);
         }
         return parts;
     }

--- a/common/jinja/string.cpp
+++ b/common/jinja/string.cpp
@@ -103,7 +103,7 @@ void string::mark_input_based_on(const string & other) {
     }
 }
 
-string string::append(const string & other) {
+string & string::append(const string & other) {
     for (const auto & part : other.parts) {
         parts.push_back(part);
     }

--- a/common/jinja/string.h
+++ b/common/jinja/string.h
@@ -47,7 +47,7 @@ struct string {
     // mark this string as input if other has ALL parts as input
     void mark_input_based_on(const string & other);
 
-    string append(const string & other);
+    string & append(const string & other);
 
     // in-place transformations
 

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -1,7 +1,6 @@
 #include <string>
 #include <iostream>
 #include <random>
-#include <chrono>
 #include <cstdlib>
 
 #include <nlohmann/json.hpp>
@@ -2088,40 +2087,6 @@ static void test_string_parts(testing & t) {
         }
     });
 
-    t.test("gather cost stays linear in the number of parts", [](testing & t) {
-        // gather a plain array of strings, so the cost of the engine itself is not measured
-        static auto secs = [](size_t n) -> double {
-            std::vector<jinja::value> items;
-            items.reserve(n);
-            for (size_t i = 0; i < n; i++) {
-                items.push_back(jinja::mk_val<jinja::value_string>(std::string("x")));
-            }
-            jinja::value arr = jinja::mk_val<jinja::value_array>(std::move(items));
-
-            // best of a few runs, the scheduler adds noise but never removes work
-            double best = 1e9;
-            for (int i = 0; i < 5; i++) {
-                const auto t0 = std::chrono::steady_clock::now();
-                jinja::value_string parts = jinja::runtime::gather_string_parts(arr);
-                const double dt = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
-                if (parts->val_str.parts.size() == 1 && dt < best) {
-                    best = dt;
-                }
-            }
-            return best;
-        };
-
-        const double t1 = secs(4000);
-        const double t2 = secs(16000);
-        const double ratio = t1 > 0.0 ? t2 / t1 : 0.0;
-
-        // 4x the parts costs about 4x when linear, it cost about 16x when quadratic
-        if (!t.assert_true("4x the parts must not cost more than 8x", ratio > 0.0 && ratio < 8.0)) {
-            t.log("4000 parts : " + std::to_string(t1) + "s");
-            t.log("16000 parts: " + std::to_string(t2) + "s");
-            t.log("ratio: " + std::to_string(ratio));
-        }
-    });
 }
 
 static void test_template_cpp(testing & t, const std::string & name, const std::string & tmpl, const json & vars, const std::string & expect) {

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <iostream>
 #include <random>
+#include <chrono>
 #include <cstdlib>
 
 #include <nlohmann/json.hpp>
@@ -33,6 +34,7 @@ static void test_array_methods(testing & t);
 static void test_object_methods(testing & t);
 static void test_hasher(testing & t);
 static void test_stats(testing & t);
+static void test_string_parts(testing & t);
 static void test_fuzzing(testing & t);
 
 static bool g_python_mode = false;
@@ -72,6 +74,7 @@ int main(int argc, char *argv[]) {
     if (!g_python_mode) {
         t.test("hasher", test_hasher);
         t.test("stats", test_stats);
+        t.test("string parts", test_string_parts);
         t.test("fuzzing", test_fuzzing);
     }
 
@@ -2054,6 +2057,70 @@ static void test_stats(testing & t) {
 
         t.assert_true("inner_key1[0] is used", val->at("nested")->at("inner_key1")->at(0)->stats.used);
         t.assert_true("inner_key2.a is used", val->at("nested")->at("inner_key2")->at("a")->stats.used);
+    });
+}
+
+static void test_string_parts(testing & t) {
+    static auto render = [](const std::string & tmpl, const json & vars) -> jinja::string {
+        jinja::lexer lexer;
+        auto lexer_res = lexer.tokenize(tmpl);
+
+        jinja::program ast = jinja::parse_from_tokens(lexer_res);
+
+        jinja::context ctx(tmpl);
+        jinja::global_from_json(ctx, vars, true);
+
+        jinja::runtime runtime(ctx);
+        return runtime.gather_string_parts(runtime.execute(ast))->as_string();
+    };
+
+    t.test("merge joins only the neighbours with the same type", [](testing & t) {
+        // "AB" comes from the input and merges, "-" comes from the template and must not
+        jinja::string res = render("{{ val.a }}{{ val.b }}-{{ val.c }}",
+                                   json{{"val", json{{"a", "A"}, {"b", "B"}, {"c", "C"}}}});
+
+        if (t.assert_true("3 parts after the merge", res.parts.size() == 3)) {
+            t.assert_true("part 0 is the merged input", res.parts[0].val == "AB" && res.parts[0].is_input);
+            t.assert_true("part 1 is from the template", res.parts[1].val == "-" && !res.parts[1].is_input);
+            t.assert_true("part 2 is input",             res.parts[2].val == "C" && res.parts[2].is_input);
+        } else {
+            t.log("parts: " + std::to_string(res.parts.size()) + ", rendered: " + json(res.str()).dump());
+        }
+    });
+
+    t.test("gather cost stays linear in the number of parts", [](testing & t) {
+        // gather a plain array of strings, so the cost of the engine itself is not measured
+        static auto secs = [](size_t n) -> double {
+            std::vector<jinja::value> items;
+            items.reserve(n);
+            for (size_t i = 0; i < n; i++) {
+                items.push_back(jinja::mk_val<jinja::value_string>(std::string("x")));
+            }
+            jinja::value arr = jinja::mk_val<jinja::value_array>(std::move(items));
+
+            // best of a few runs, the scheduler adds noise but never removes work
+            double best = 1e9;
+            for (int i = 0; i < 5; i++) {
+                const auto t0 = std::chrono::steady_clock::now();
+                jinja::value_string parts = jinja::runtime::gather_string_parts(arr);
+                const double dt = std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+                if (parts->val_str.parts.size() == 1 && dt < best) {
+                    best = dt;
+                }
+            }
+            return best;
+        };
+
+        const double t1 = secs(4000);
+        const double t2 = secs(16000);
+        const double ratio = t1 > 0.0 ? t2 / t1 : 0.0;
+
+        // 4x the parts costs about 4x when linear, it cost about 16x when quadratic
+        if (!t.assert_true("4x the parts must not cost more than 8x", ratio > 0.0 && ratio < 8.0)) {
+            t.log("4000 parts : " + std::to_string(t1) + "s");
+            t.log("16000 parts: " + std::to_string(t2) + "s");
+            t.log("ratio: " + std::to_string(ratio));
+        }
     });
 }
 


### PR DESCRIPTION
## Overview
Fix #26974

I made the issue and says the `vector::erase` loop in `gather_string_parts` as the cause, and says `string::append` returning by value was tested and ruled out at 4%. 

When I was fixing it I realize it is backwards. Both are quadratic, and in isolation `append` is the larger term. 

Two independent O(N^2) terms in the same function:

1. `gather_string_parts_recursive` calls `parts->val_str.append(str_val)` once per value. `string::append` ends in `return *this;` and returns `string` **by value**, so every call copies the whole accumulated parts vector. N calls over a vector growing to N.
2. The merge loop calls `vector::erase` inside the loop; each erase shifts the tail.

## Additional information
### Isolated cost of `gather_string_parts` (array of N one-part strings)

| N | baseline | merge fix only | append fix only | both |
|---:|---:|---:|---:|---:|
| 4,000 | 0.0682 | 0.0359 | - | 0.0002 |
| 8,000 | 0.2749 | 0.1534 | - | 0.0004 |
| 16,000 | 1.0913 | 0.5719 | - | 0.0008 |
| 32,000 | 4.3607 | 2.2778 | - | 0.0019 |
| **growth per 2x N** | **4.0** | **4.0** | **4.0** | **2.2** |

The merge fix alone halves the constant and leaves the function quadratic. Both changes are needed for it to become linear.

### End-to-end, `common_chat_templates_apply`

`models/templates/CohereForAI-c4ai-command-r-plus-tool_use.jinja`, unmodified, tools and
properties supplied the way a request supplies them:

| tools x props | baseline | merge fix only | both |
|---|---:|---:|---:|
| 5 x 5 | 0.030 | 0.029 | 0.028 |
| 20 x 20 | 0.427 | 0.221 | 0.207 |
| 40 x 30 | 2.454 | 0.663 | 0.585 |
| 50 x 50 | **9.158** | 1.440 | **1.237** |

The issue quoted 9.295 s at 50x50 on an older tree; 9.158 s here confirms it.

The end-to-end split differs from the isolated one (merge dominates here, append dominates there) because the shapes differ: the real path reaches the merge with a large parts vector built from comparatively few `append` calls.

I added the `++w != r` guard. Without it, `p[w] = std::move(p[r])` is a self-move whenever no merge has happened yet, and a self-moved `std::string` is left in an unspecified state. The first attempt at this patch omitted the guard and silently dropped 39 bytes of prompt.

### Test
I added a few regression tests for this fix, assited by Claude then reviewed manually, please remove them if this is not neccessary, I put them here to make sure my code was right, I did introduce a new dependency. :) 

`tests/test-jinja.cpp`, under `string parts`:

- *merge joins only the neighbours with the same type*: builds parts that alternate between input and template, asserts the merge produces exactly 3 parts with the right values and flags. Guards the self-move.
- *gather cost stays linear in the number of parts*: gathers an array of 4,000 then 16,000 strings, best of 5 each, asserts the 4x size costs less than 8x the time.

Measured ratios, 4x the parts:
| state | ratio | verdict |
|---|---:|---|
| no fixes | 16.13 | FAIL |
| merge fix only | 16.43 | FAIL |
| append fix only | 16.01 | FAIL |
| both fixes | ~4.2 | PASS |

Threshold 8.0 sits halfway between linear and quadratic in log terms. Ran 8 consecutive times on the patched tree with no flake. Costs about 1 ms when passing, about 1.2 s when failing.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, Claude is assited in test generation, then manually reviewed.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->