### PR TITLE
convert : read EAGLE-3 aux layer ids nested under eagle_config

### DIFF
--- a/conversion/llama.py
+++ b/conversion/llama.py
@@ -73,6 +73,9 @@ class LlamaModel(TextModel):
             # if present, else derive from the target layer count.
             target_num_layers = target_config["num_hidden_layers"]
             aux_layer_ids = eagle3_raw_config.get("eagle_aux_hidden_state_layer_ids")
+            if aux_layer_ids is None:
+                # EAGLE-3.1 checkpoints nest these under "eagle_config"
+                aux_layer_ids = (eagle3_raw_config.get("eagle_config") or {}).get("eagle_aux_hidden_state_layer_ids")
             if aux_layer_ids:
                 target_layers = aux_layer_ids
             else:


### PR DESCRIPTION
## Problem

`Eagle3Model` reads the aux hidden-state layer ids from the top level of the draft checkpoint's `config.json`:

```python
aux_layer_ids = eagle3_raw_config.get("eagle_aux_hidden_state_layer_ids")
```

EAGLE-3.1 checkpoints nest them under `eagle_config` instead, so the lookup returns `None` and conversion silently falls back to the heuristic `[2, n // 2, n - 3]`.

Example — [SyzygyResearch/DeepSeek-V4-Flash-EAGLE3.1](https://huggingface.co/SyzygyResearch/DeepSeek-V4-Flash-EAGLE3.1):

```json
{
  "architectures": ["LlamaForCausalLMEagle3"],
  "eagle_config": {
    "eagle_aux_hidden_state_layer_ids": [1, 21, 40],
    "use_aux_hidden_state": true
  }
}
```

The target has 43 layers, so the heuristic produces `[2, 21, 40]` while the checkpoint declares `[1, 21, 40]`. Two of the three match by coincidence; the first does not. The draft then reads a hidden state from a layer it was never trained on.

The failure is silent: conversion succeeds, the model loads, and only the acceptance rate reveals that something is wrong.

## Fix

Fall back to the nested location before applying the heuristic. The top-level lookup is tried first and is unchanged, so checkpoints that declare the ids at the root — or that declare none at all — behave exactly as before.

## Testing

Converted the checkpoint above with `--target-model-dir`. Before the change:

```
INFO:hf-to-gguf:EAGLE-3: target_layers = [2, 21, 40] (target model has 43 layers)
```

After:

```
INFO:hf-to-gguf:EAGLE-3: target_layers = [1, 21, 40] (target model has 43 layers)
```

Also verified that a checkpoint without `eagle_config` still takes the heuristic path.

## Note on scope

This fixes the metadata only. Serving that particular checkpoint end-to-end additionally requires EAGLE-3 aux-state capture for `deepseek_v4`, which is a separate concern and not addressed here (upstream vLLM does not implement it either — the model card ships an overlay for it).
