### PR TITLE
CUDA: size MMQ ids-path tail padding from the flattened row count, not ne11

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -203,7 +203,7 @@ void ggml_cuda_mul_mat_q(
     }
 
     const size_t nbytes_src1_q8_1 = ne12*n_expert_used*ne10_padded * y_block_size/y_values_per_block +
-        ggml_cuda_mmq_get_J_max(src0->type, fallback, cc, ne11) * sizeof(block_q8_1_mmq);
+        ggml_cuda_mmq_get_J_max(src0->type, fallback, cc, ne12*n_expert_used) * sizeof(block_q8_1_mmq);
     ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), nbytes_src1_q8_1);
     ggml_cuda_pool_alloc<float> src1_scale(ctx.pool());
     if (src0->type == GGML_TYPE_NVFP4 && use_native_fp4) {


### PR DESCRIPTION
## Overview

The `ids` branch of `ggml_cuda_mul_mat_q()` sizes the `src1_q8_1` allocation from two different row counts. The data term uses `ne12*n_expert_used`. The tail-padding term uses `ne11`. The correct value is already computed a few lines below as `ne11_flat`.

For MoE gate/up projections the activations are broadcast across experts, so `ne11 == 1`. `ggml_cuda_mmq_get_J_max()` with `ne11 == 1` computes `min(1,512) = 1`, then `1 - 1%8 = 0`, skips its loop and returns 0. The buffer gets no tail padding at all, while MMQ reads in tiles of up to `J_max = 512` rows and runs past the end.

`ffn_down` is affected too but less: it passes `ne11 = 8`, so padding is sized for 8 rows instead of `ne12*n_expert_used`.

The `!ids` branch above is correct, because there `ne11` really is the buffer's row count.

This patch uses `ne12*n_expert_used` for the padding term.

## Additional information

Hit this on a MoE vision model (256 experts, 8 used, q4_K gate/up) on sm_120 / CUDA 13.0 when a whole image was submitted as one 2040-token ubatch:

```
decoding image batch 1/1, n_tokens_batch = 2040
find_slot: non-consecutive token position 4 after 3 for sequence 0 with 2040 new tokens
ggml-cuda.cu:106: CUDA error
ggml_cuda_compute_forward: MUL_MAT_ID failed
CUDA error: an illegal memory access was encountered
  current device: 0, in function ggml_cuda_compute_forward at ggml-cuda.cu:2374
```

The failing node is `ffn_moe_gate`, with `ne2=2040 ne02=256 ne11=1 ne12=2040`, type q4_K, taking the mmq branch. The `find_slot` line also shows up on runs that do not crash, so it marks the path rather than the fault.

Notes for testing:

- `test-backend-ops` does not catch it. The over-read lands in padding rows the kernel discards, so output is unchanged and NMSE is unaffected. `compute-sanitizer --tool memcheck` does flag it.
- A passing run does not prove much. The overrun is a fixed size past the end, so it only faults when it crosses an unmapped page. The same request crashes on a fresh pool and passes after the pool has served a larger allocation.
- Extra memory is at most `512 * sizeof(block_q8_1_mmq)` = 72 KB per call, and does not grow with `ne12`.

Tested with 4 cold runs on the patched build (no fault) against 2 unpatched controls from the same tree (both fault).

May be related to #24399, #19705 and #18331. I have not reproduced those configurations, so this is a guess, but the `GGML_CUDA_FORCE_CUBLAS=ON` workaround in #24399 skips MMQ entirely and requantising changes the allocation size, which would both hide this.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used AI to investigate the crash, locate the cause and produce the patch. I have reviewed the change and can explain it.