### PR TITLE
server: add disaggregated prompt prefill over RPC

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1161,7 +1161,7 @@ void common_print_available_devices() {
     }
 }
 
-static void add_rpc_devices(const std::string & servers) {
+std::vector<ggml_backend_dev_t> common_add_rpc_devices(const std::string & servers) {
     auto rpc_servers = string_split<std::string>(servers, ',');
     if (rpc_servers.empty()) {
         throw std::invalid_argument("no RPC servers specified");
@@ -1176,10 +1176,21 @@ static void add_rpc_devices(const std::string & servers) {
     if (!ggml_backend_rpc_add_server_fn) {
         throw std::invalid_argument("failed to find RPC add server function");
     }
+
+    std::vector<ggml_backend_dev_t> devices;
     for (const auto & server : rpc_servers) {
         auto reg = ggml_backend_rpc_add_server_fn(server.c_str());
+        if (!reg) {
+            throw std::invalid_argument(string_format("failed to connect to RPC server: %s", server.c_str()));
+        }
         ggml_backend_register(reg);
+        for (size_t i = 0; i < ggml_backend_reg_dev_count(reg); ++i) {
+            devices.push_back(ggml_backend_reg_dev_get(reg, i));
+        }
     }
+    devices.push_back(nullptr);
+
+    return devices;
 }
 
 bool common_params_to_map(int argc, char ** argv, llama_example ex, std::map<common_arg, std::string> & out_map) {
@@ -2630,10 +2641,20 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             {"--rpc"}, "SERVERS",
             "comma-separated list of RPC servers (host:port)",
             [](common_params & params, const std::string & value) {
-                add_rpc_devices(value);
+                common_add_rpc_devices(value);
                 GGML_UNUSED(params);
             }
         ).set_env("LLAMA_ARG_RPC"));
+        add_opt(common_arg(
+            {"--prefill-node"}, "HOST:PORT",
+            "RPC server used by a dedicated prompt prefill context; repeat for multiple nodes",
+            [](common_params & params, const std::string & value) {
+                if (std::find(params.prefill_nodes.begin(), params.prefill_nodes.end(), value) != params.prefill_nodes.end()) {
+                    throw std::invalid_argument(string_format("duplicate prefill node: %s", value.c_str()));
+                }
+                params.prefill_nodes.push_back(value);
+            }
+        ).set_env("LLAMA_ARG_PREFILL_NODE").set_examples({LLAMA_EXAMPLE_SERVER}));
     }
     add_opt(common_arg(
         {"--mlock"},

--- a/common/arg.h
+++ b/common/arg.h
@@ -126,6 +126,9 @@ bool common_params_parse(int argc, char ** argv, common_params & params, llama_e
 // load all backends and print the list of available (non-CPU) devices to stdout
 void common_print_available_devices();
 
+// register RPC servers and return their devices
+std::vector<ggml_backend_dev_t> common_add_rpc_devices(const std::string & servers);
+
 // parse input arguments from CLI into a map
 bool common_params_to_map(int argc, char ** argv, llama_example ex, std::map<common_arg, std::string> & out_map);
 

--- a/common/common.h
+++ b/common/common.h
@@ -461,6 +461,7 @@ struct common_params {
 
     // offload params
     std::vector<ggml_backend_dev_t> devices; // devices to use for offloading
+    std::vector<std::string> prefill_nodes;  // RPC servers used by dedicated prefill contexts
 
     int32_t n_gpu_layers       = -1;    // number of layers to store in VRAM, -1 is auto, <= -2 is all
     int32_t main_gpu           = 0;     // the GPU that is used for scratch and small tensors

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -72,6 +72,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-ctv, --cache-type-v TYPE` | KV cache data type for V<br/>allowed values: f32, f16, bf16, q8_0, q4_0, q4_1, iq4_nl, q5_0, q5_1<br/>(default: f16)<br/>(env: LLAMA_ARG_CACHE_TYPE_V) |
 | `-dt, --defrag-thold N` | KV cache defragmentation threshold (DEPRECATED)<br/>(env: LLAMA_ARG_DEFRAG_THOLD) |
 | `--rpc SERVERS` | comma-separated list of RPC servers (host:port)<br/>(env: LLAMA_ARG_RPC) |
+| `--prefill-node HOST:PORT` | RPC server used by a dedicated prompt prefill context; repeat for multiple nodes<br/>(env: LLAMA_ARG_PREFILL_NODE) |
 | `--mlock` | DEPRECATED in favor of `--load-mode`: force system to keep model in RAM rather than swapping or compressing<br/>(env: LLAMA_ARG_MLOCK) |
 | `--mmap, --no-mmap` | DEPRECATED in favor of `--load-mode`: whether to memory-map model. (if mmap disabled, slower load but may reduce pageouts if not using mlock)<br/>(env: LLAMA_ARG_MMAP) |
 | `-dio, --direct-io, -ndio, --no-direct-io` | DEPRECATED in favor of `--load-mode`: use DirectIO if available<br/>(env: LLAMA_ARG_DIO) |
@@ -386,6 +387,26 @@ docker run -p 8080:8080 -v /path/to/models:/models ghcr.io/ggml-org/llama.cpp:se
 # or, with CUDA:
 docker run -p 8080:8080 -v /path/to/models:/models --gpus all ghcr.io/ggml-org/llama.cpp:server-cuda -m models/7B/ggml-model.gguf -c 512 --host 0.0.0.0 --port 8080 --n-gpu-layers 99
 ```
+
+### Disaggregated prefill and decode
+
+`--prefill-node` creates one model and context for an RPC node. These contexts process prompt prefixes without occupying slots in the main decode context. Each completed prefix state is copied to host memory, restored into the main context, and continued from its final prompt token.
+
+Start `ggml-rpc-server` on each prefill node:
+
+```bash
+bin/ggml-rpc-server --host 192.168.1.108 --port 50052 -c
+```
+
+Then register the nodes with the main server:
+
+```bash
+bin/llama-server -m model.gguf \
+    --prefill-node 192.168.1.108:50052 \
+    --prefill-node 192.168.1.109:50052
+```
+
+The main model uses the normal local device selection. Each prefill node loads another full model copy. Requests with a reusable local prompt prefix stay on the main context. Speculative decoding, multimodal input, and LoRA adapters also use the main context.
 
 ## Using with CURL
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -8,6 +8,7 @@
 #include "server-stream.h"
 
 #include "build-info.h"
+#include "arg.h"
 #include "common.h"
 #include "fit.h"
 #include "llama.h"
@@ -18,11 +19,17 @@
 #include "mtmd-helper.h"
 
 #include <algorithm>
+#include <condition_variable>
 #include <cstddef>
 #include <cinttypes>
+#include <deque>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <filesystem>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <fstream>
 
@@ -778,6 +785,244 @@ struct server_slot {
     }
 };
 
+struct server_prefill_worker {
+    using result_callback = std::function<void(server_task &&)>;
+
+    int id = -1;
+
+    common_init_result_ptr llama_init;
+    llama_context * ctx = nullptr;
+
+    std::deque<server_task> tasks;
+    std::unordered_set<int> cancelled;
+
+    std::mutex mutex;
+    std::condition_variable condition;
+    std::thread thread;
+
+    result_callback callback;
+
+    bool running = false;
+    int id_active = -1;
+    int id_returning = -1;
+
+    ~server_prefill_worker() {
+        stop();
+    }
+
+    bool init(common_params params, const std::string & endpoint, int id_worker, result_callback callback_result) {
+        id = id_worker;
+        callback = std::move(callback_result);
+
+        try {
+            params.devices = common_add_rpc_devices(endpoint);
+        } catch (const std::exception & e) {
+            SRV_ERR("prefill worker %d failed to register node %s: %s\n", id, endpoint.c_str(), e.what());
+            return false;
+        }
+
+        params.prefill_nodes.clear();
+        params.fit_params = false;
+        params.embedding = false;
+        params.sampling.backend_sampling = false;
+        params.load_progress_callback = nullptr;
+        params.load_progress_callback_user_data = nullptr;
+
+        llama_init = common_init_from_params(params);
+        if (llama_init->model() == nullptr) {
+            SRV_ERR("prefill worker %d failed to load model '%s'\n", id, params.model.path.c_str());
+            return false;
+        }
+
+        ctx = llama_init->context();
+        if (ctx == nullptr) {
+            SRV_ERR("prefill worker %d failed to create context\n", id);
+            llama_init.reset();
+            return false;
+        }
+
+        running = true;
+        thread = std::thread([this]() { loop(); });
+
+        SRV_INF("prefill worker %d ready on %s\n", id, endpoint.c_str());
+        return true;
+    }
+
+    void stop() {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (!running) {
+                return;
+            }
+            running = false;
+            if (id_active >= 0) {
+                cancelled.insert(id_active);
+            }
+            tasks.clear();
+        }
+        condition.notify_all();
+
+        if (thread.joinable()) {
+            thread.join();
+        }
+
+        ctx = nullptr;
+        llama_init.reset();
+    }
+
+    bool submit(server_task && task) {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (!running) {
+                return false;
+            }
+            tasks.push_back(std::move(task));
+        }
+        condition.notify_one();
+        return true;
+    }
+
+    bool cancel(int id_task) {
+        server_task task;
+        bool found = false;
+        bool will_return = false;
+
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            for (auto it = tasks.begin(); it != tasks.end(); ++it) {
+                if (it->id == id_task) {
+                    task = std::move(*it);
+                    tasks.erase(it);
+                    cancelled.erase(id_task);
+                    found = true;
+                    break;
+                }
+            }
+
+            if (found) {
+                will_return = true;
+            } else if (id_active == id_task || id_returning == id_task) {
+                cancelled.insert(id_task);
+                will_return = true;
+            }
+        }
+
+        if (found) {
+            task.prefill_cancelled = true;
+            callback(std::move(task));
+        }
+
+        return will_return;
+    }
+
+    size_t pending() {
+        std::lock_guard<std::mutex> lock(mutex);
+        return tasks.size() + (id_active >= 0 ? 1 : 0);
+    }
+
+private:
+    bool is_cancelled(int id_task) {
+        std::lock_guard<std::mutex> lock(mutex);
+        return cancelled.find(id_task) != cancelled.end();
+    }
+
+    void process(server_task & task) {
+        const int32_t n_prefill = task.n_tokens() - 1;
+        const int32_t n_batch = llama_n_batch(ctx);
+
+        llama_memory_seq_rm(llama_get_memory(ctx), 0, -1, -1);
+
+        llama_batch batch = llama_batch_init(std::min(n_prefill, n_batch), 0, 1);
+
+        for (int32_t i = 0; i < n_prefill;) {
+            if (is_cancelled(task.id)) {
+                break;
+            }
+
+            const int32_t n_cur = std::min(n_prefill - i, n_batch);
+            common_batch_clear(batch);
+
+            for (int32_t j = 0; j < n_cur; ++j) {
+                common_batch_add(batch, task.tokens[i + j], i + j, { 0 }, false);
+            }
+
+            const int ret = llama_decode(ctx, batch);
+            if (ret != 0) {
+                task.prefill_error = string_format("llama_decode failed with code %d", ret);
+                break;
+            }
+
+            i += n_cur;
+        }
+
+        llama_batch_free(batch);
+
+        if (task.prefill_error.empty() && !is_cancelled(task.id)) {
+            const size_t size = llama_state_seq_get_size_ext(ctx, 0, LLAMA_STATE_SEQ_FLAGS_NONE);
+
+            try {
+                auto state = std::make_shared<server_prompt_cache_state>();
+                state->prompt.tokens = task.tokens.clone();
+                state->prompt.tokens.keep_first(n_prefill);
+                state->data.main.resize(size);
+
+                const size_t n = llama_state_seq_get_data_ext(
+                        ctx, state->data.main.data(), size, 0, LLAMA_STATE_SEQ_FLAGS_NONE);
+                if (n == size) {
+                    task.prefill_state = std::move(state);
+                    task.n_prefilled = n_prefill;
+                    task.prefill_bytes = size;
+                } else {
+                    task.prefill_error = string_format("state read failed (%zu / %zu)", n, size);
+                }
+            } catch (const std::bad_alloc & e) {
+                task.prefill_error = string_format("state allocation failed: %s", e.what());
+            }
+        } else {
+            llama_synchronize(ctx);
+        }
+
+        llama_memory_seq_rm(llama_get_memory(ctx), 0, -1, -1);
+        task.t_prefill_us = ggml_time_us() - task.t_prefill_start_us;
+    }
+
+    void loop() {
+        while (true) {
+            server_task task;
+
+            {
+                std::unique_lock<std::mutex> lock(mutex);
+                condition.wait(lock, [this]() { return !running || !tasks.empty(); });
+
+                if (!running) {
+                    return;
+                }
+
+                task = std::move(tasks.front());
+                tasks.pop_front();
+                id_active = task.id;
+            }
+
+            process(task);
+
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                task.prefill_cancelled = cancelled.erase(task.id) > 0;
+                id_active = -1;
+                id_returning = task.id;
+            }
+
+            callback(std::move(task));
+
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                cancelled.erase(id_returning);
+                id_returning = -1;
+            }
+        }
+    }
+};
+
 
 
 //
@@ -834,6 +1079,10 @@ private:
 
     common_speculative_init_result_ptr spec_init;
 
+    std::vector<std::unique_ptr<server_prefill_worker>> prefill_workers;
+    std::unordered_map<int, server_prefill_worker *> prefill_pending;
+    std::unordered_set<int> prefill_cancelled;
+
     common_context_seq_rm_type ctx_tgt_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
     common_context_seq_rm_type ctx_dft_seq_rm_type = COMMON_CONTEXT_SEQ_RM_TYPE_NO;
 
@@ -878,6 +1127,10 @@ private:
     int64_t t_last_load_progress_ms = 0;
 
     void destroy() {
+        prefill_workers.clear();
+        prefill_pending.clear();
+        prefill_cancelled.clear();
+
         spec.reset();
         spec_init.reset();
 
@@ -949,6 +1202,16 @@ private:
         const bool is_resume = sleeping;
 
         params_base = params;
+        if (!params_base.prefill_nodes.empty() && params_base.devices.empty()) {
+            for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
+                auto * dev = ggml_backend_dev_get(i);
+                const auto * reg_name = ggml_backend_reg_name(ggml_backend_dev_backend_reg(dev));
+                if (ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_CPU && std::string(reg_name) != "RPC") {
+                    params_base.devices.push_back(dev);
+                }
+            }
+            params_base.devices.push_back(nullptr);
+        }
         const auto output_limits = server_output_limits(params_base);
         params_base.n_outputs_max = output_limits.total;
         params_base.n_outputs_max_per_seq = output_limits.per_seq;
@@ -1240,6 +1503,36 @@ private:
             spec_init.reset();
             ctx_dft   = nullptr;
             model_dft = nullptr;
+        }
+
+        if (!params_base.prefill_nodes.empty()) {
+            if (spec) {
+                SRV_WRN("%s", "disaggregated prefill is disabled while speculative decoding is enabled\n");
+            } else if (mctx != nullptr) {
+                SRV_WRN("%s", "disaggregated prefill is disabled for multimodal models\n");
+            } else if (!params_base.lora_adapters.empty()) {
+                SRV_WRN("%s", "disaggregated prefill is disabled while LoRA adapters are loaded\n");
+            } else {
+                for (size_t i = 0; i < params_base.prefill_nodes.size(); ++i) {
+                    auto params_pfx = params_base;
+                    params_pfx.n_ctx = llama_n_ctx(ctx_tgt);
+                    params_pfx.n_batch = llama_n_batch(ctx_tgt);
+                    params_pfx.n_ubatch = llama_n_ubatch(ctx_tgt);
+
+                    auto worker = std::make_unique<server_prefill_worker>();
+                    if (!worker->init(
+                                std::move(params_pfx),
+                                params_base.prefill_nodes[i],
+                                i,
+                                [this](server_task && task) {
+                                    queue_tasks.post(std::move(task));
+                                })) {
+                        prefill_workers.clear();
+                        return false;
+                    }
+                    prefill_workers.push_back(std::move(worker));
+                }
+            }
         }
 
         for (int i = 0; i < params_base.n_parallel; i++) {
@@ -1712,6 +2005,8 @@ private:
             send_error(task, "Prompt contains invalid tokens", ERROR_TYPE_INVALID_REQUEST);
             return false;
         }
+
+        apply_prefill_state(slot, task);
 
         SLT_DBG(slot, "launching slot : %s\n", safe_json_to_str(slot.to_json()).c_str());
 
@@ -2286,6 +2581,106 @@ private:
                 cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024);
     }
 
+    int get_cached_prefix(const server_task & task) const {
+        if (!task.params.cache_prompt) {
+            return 0;
+        }
+
+        int n_cached = 0;
+        for (const auto & slot : slots) {
+            if (!slot.is_processing()) {
+                n_cached = std::max<int>(n_cached, slot.prompt.tokens.get_common_prefix(task.tokens));
+            }
+        }
+
+        if (prompt_cache) {
+            for (const auto & state : prompt_cache->states) {
+                n_cached = std::max<int>(n_cached, state.prompt.tokens.get_common_prefix(task.tokens));
+            }
+        }
+
+        return n_cached;
+    }
+
+    bool try_dispatch_prefill(server_task & task) {
+        if (prefill_workers.empty() || task.prefill_attempted || task.type != SERVER_TASK_TYPE_COMPLETION) {
+            return false;
+        }
+        if (spec || mctx != nullptr || !params_base.lora_adapters.empty() || !task.params.lora.empty()) {
+            return false;
+        }
+        if (task.tokens.has_mtmd || task.n_tokens() < 2 || task.n_tokens() >= slots.front().n_ctx) {
+            return false;
+        }
+
+        const int32_t n_prefill = task.n_tokens() - 1;
+        const int32_t n_cached = std::min(n_prefill, get_cached_prefix(task));
+        if (n_cached > 1 || !task.tokens.validate(ctx_tgt)) {
+            return false;
+        }
+
+        server_prefill_worker * worker = prefill_workers.front().get();
+        size_t pending_min = worker->pending();
+        for (size_t i = 1; i < prefill_workers.size(); ++i) {
+            const size_t pending = prefill_workers[i]->pending();
+            if (pending < pending_min) {
+                pending_min = pending;
+                worker = prefill_workers[i].get();
+            }
+        }
+
+        task.prefill_attempted = true;
+        task.t_prefill_start_us = ggml_time_us();
+        const int id_task = task.id;
+        prefill_pending.emplace(id_task, worker);
+
+        if (!worker->submit(std::move(task))) {
+            prefill_pending.erase(id_task);
+            task.prefill_attempted = false;
+            task.t_prefill_start_us = 0;
+            return false;
+        }
+
+        SRV_DBG("delegated task %d to prefill worker %d, queued = %zu\n", id_task, worker->id, pending_min);
+        return true;
+    }
+
+    void apply_prefill_state(server_slot & slot, server_task & task) {
+        if (!task.prefill_state) {
+            return;
+        }
+
+        const int n_remote = task.prefill_state->prompt.tokens.get_common_prefix(task.tokens);
+        const int n_local = task.params.cache_prompt
+            ? slot.prompt.tokens.get_common_prefix(task.tokens)
+            : 0;
+
+        if (n_remote > n_local) {
+            slot.prompt_clear();
+
+            const auto & data = task.prefill_state->data.main;
+            const size_t n = llama_state_seq_set_data_ext(
+                    ctx_tgt, data.data(), data.size(), slot.id, LLAMA_STATE_SEQ_FLAGS_NONE);
+            if (n != data.size()) {
+                task.prefill_error = "failed to restore prefill state";
+                task.n_prefilled = 0;
+                slot.prompt_clear();
+                SRV_WRN("failed to restore prefill state for task %d; falling back to local processing\n", task.id);
+            } else {
+                slot.prompt = task.prefill_state->prompt.clone();
+                SRV_INF("restored task %d from prefill, tokens = %d, size = %.2f MiB, time = %.2f ms\n",
+                        task.id, n_remote, task.prefill_bytes / (1024.0 * 1024.0), task.t_prefill_us / 1000.0);
+                SRV_DBG("%s", "__TEST_TAG_PREFILL_RESTORED__\n");
+            }
+        } else {
+            SRV_DBG("discarded prefill state for task %d, remote prefix = %d, local prefix = %d\n",
+                    task.id, n_remote, n_local);
+            task.n_prefilled = 0;
+        }
+
+        task.prefill_state.reset();
+    }
+
     void process_single_task(server_task && task) {
         switch (task.type) {
             case SERVER_TASK_TYPE_COMPLETION:
@@ -2299,6 +2694,22 @@ private:
                         if (!tokenize_cli_input(task)) {
                             break;
                         }
+                    }
+
+                    if (task.prefill_attempted) {
+                        prefill_pending.erase(task.id);
+                        const bool was_cancelled = task.prefill_cancelled || prefill_cancelled.erase(task.id) > 0;
+                        if (was_cancelled) {
+                            break;
+                        }
+                        if (!task.prefill_error.empty()) {
+                            SRV_WRN("prefill failed for task %d: %s; falling back to local processing\n",
+                                    task.id, task.prefill_error.c_str());
+                        } else if (task.n_prefilled > 0) {
+                            metrics.add_prompt(task.n_prefilled, task.t_prefill_us);
+                        }
+                    } else if (try_dispatch_prefill(task)) {
+                        break;
                     }
 
                     const int id_task = task.id;
@@ -2361,6 +2772,14 @@ private:
                 } break;
             case SERVER_TASK_TYPE_CANCEL:
                 {
+                    auto it_prefill = prefill_pending.find(task.id_target);
+                    if (it_prefill != prefill_pending.end()) {
+                        prefill_cancelled.insert(task.id_target);
+                        if (!it_prefill->second->cancel(task.id_target)) {
+                            prefill_pending.erase(it_prefill);
+                        }
+                    }
+
                     // release slot linked with the task id
                     for (auto & slot : slots) {
                         if (slot.task && slot.task->id == task.id_target) {
@@ -3033,7 +3452,11 @@ private:
 
                     // TODO: maybe move branch to outside of this loop in the future
                     if (slot.state == SLOT_STATE_STARTED) {
-                        slot.stats.update_prompt_start();
+                        if (slot.task->t_prefill_start_us > 0) {
+                            slot.stats.t_start = slot.task->t_prefill_start_us;
+                        } else {
+                            slot.stats.update_prompt_start();
+                        }
 
                         slot.state = SLOT_STATE_PROCESSING_PROMPT;
 
@@ -3055,6 +3478,7 @@ private:
 
                         // keep track how many tokens we can reuse from the previous state
                         int n_past = 0;
+                        int32_t n_prefilled = slot.task->n_prefilled;
 
                         // empty prompt passed -> release the slot and send empty response
                         if (input_tokens.empty()) {
@@ -3107,7 +3531,17 @@ private:
                                 return;
                             }
 
-                            if (slot.task->params.cache_prompt) {
+                            if (n_prefilled > 0) {
+                                n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
+                                if (n_past != n_prefilled) {
+                                    SLT_WRN(slot,
+                                            "restored prefill prefix mismatch, expected = %d, actual = %d; falling back to local processing\n",
+                                            n_prefilled, n_past);
+                                    slot.prompt_clear();
+                                    n_prefilled = 0;
+                                    n_past = 0;
+                                }
+                            } else if (slot.task->params.cache_prompt) {
                                 // reuse any previously computed tokens that are common with the new prompt
                                 n_past = slot.prompt.tokens.get_common_prefix(input_tokens);
 
@@ -3239,7 +3673,7 @@ private:
                                     SLT_WRN(slot, "%s\n", st1.str().c_str());
                                 }
 
-                                if (pos_min >= pos_min_thold) {
+                                if (n_prefilled == 0 && pos_min >= pos_min_thold) {
                                     // search for a context checkpoint
                                     const auto it = std::find_if(
                                         slot.prompt.checkpoints.rbegin(),
@@ -3299,10 +3733,10 @@ private:
                             SLT_WRN(slot, "n_past was set to %d\n", n_past);
                         }
 
-                        slot.stats.n_prompt_cached    = n_past;
-                        slot.stats.n_prompt_processed = 0;
+                        slot.stats.n_prompt_cached    = std::max(0, n_past - n_prefilled);
+                        slot.stats.n_prompt_processed = n_prefilled;
 
-                        metrics.add_prompt_cached(n_past);
+                        metrics.add_prompt_cached(slot.stats.n_prompt_cached);
 
                         slot.prompt.tokens.keep_first(n_past);
 

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <list>
 #include <map>
+#include <memory>
 
 // TODO: prevent including the whole server-common.h as we only use server_tokens
 #include "server-common.h"
@@ -133,6 +134,8 @@ struct task_result_state {
         bool filter_tool_calls = false);
 };
 
+struct server_prompt_cache_state;
+
 struct server_task {
     int id = -1; // to be filled by server_queue
 
@@ -152,6 +155,15 @@ struct server_task {
     // used by SERVER_TASK_TYPE_INFERENCE
     task_params   params;
     server_tokens tokens;
+
+    bool prefill_attempted = false;
+    bool prefill_cancelled = false;
+    int32_t n_prefilled = 0;
+    int64_t t_prefill_start_us = 0;
+    int64_t t_prefill_us = 0;
+    size_t prefill_bytes = 0;
+    std::string prefill_error;
+    std::shared_ptr<server_prompt_cache_state> prefill_state;
 
     // only used by CLI, this allow tokenizing CLI inputs on server side
     // we need this because mtmd_context and vocab are not accessible outside of server_context

--- a/tools/server/tests/unit/test_prefill.py
+++ b/tools/server/tests/unit/test_prefill.py
@@ -1,0 +1,103 @@
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+from utils import *
+
+
+def start_rpc_server():
+    server_bin = Path(os.environ.get("LLAMA_SERVER_BIN_PATH", "../../../build/bin/llama-server")).resolve()
+    rpc_bin = Path(os.environ.get("GGML_RPC_SERVER_BIN_PATH", server_bin.with_name("ggml-rpc-server")))
+    if not rpc_bin.is_file():
+        pytest.skip("ggml-rpc-server is not built")
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    rpc = subprocess.Popen(
+        [str(rpc_bin), "--host", "127.0.0.1", "--port", str(port), "--device", "CPU"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    for _ in range(100):
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                return rpc, port
+        except OSError:
+            if rpc.poll() is not None:
+                pytest.fail("ggml-rpc-server exited during startup")
+            time.sleep(0.01)
+
+    rpc.terminate()
+    rpc.wait(timeout=5)
+    pytest.fail("ggml-rpc-server did not start")
+
+
+def test_disaggregated_prefill_matches_local_and_preserves_cache():
+    sentence = (
+        "Once upon a time in a land far away, a traveler crossed the mountains "
+        "to find a hidden library and asked the keeper for a story."
+    )
+    prompt = f"{sentence} {sentence}"
+    request = {
+        "prompt": prompt,
+        "n_predict": 16,
+        "seed": 42,
+        "temperature": 0.0,
+        "cache_prompt": False,
+        "return_tokens": True,
+    }
+
+    local = ServerPreset.tinyllama2()
+    local.start()
+    expected = local.make_request("POST", "/completion", data=request)
+    local.stop()
+
+    rpc, port = start_rpc_server()
+    server = ServerPreset.tinyllama2()
+    server.prefill_nodes = [f"127.0.0.1:{port}"]
+    server.debug = True
+    fd, server.log_path = tempfile.mkstemp(suffix=".log")
+    os.close(fd)
+
+    try:
+        server.start()
+        actual = server.make_request("POST", "/completion", data=request)
+        multiple = server.make_request("POST", "/completion", data={
+            **request,
+            "n_predict": 2,
+            "n_cmpl": 2,
+        })
+        cached = server.make_request("POST", "/completion", data={
+            **request,
+            "prompt": prompt + " Then it rested.",
+            "n_predict": 1,
+            "cache_prompt": True,
+        })
+        server.stop()
+
+        assert actual.status_code == 200
+        assert actual.body["content"] == expected.body["content"]
+        assert actual.body["tokens"] == expected.body["tokens"]
+        assert actual.body["timings"]["prompt_n"] == expected.body["timings"]["prompt_n"]
+        assert actual.body["timings"]["prompt_n"] > 128
+        assert multiple.status_code == 200
+        assert len(multiple.body) == 2
+        assert cached.status_code == 200
+        assert cached.body["timings"]["cache_n"] > 1
+
+        with open(server.log_path) as log:
+            log_content = log.read()
+            assert log_content.count("__TEST_TAG_PREFILL_RESTORED__") == 2
+    finally:
+        server.stop()
+        rpc.terminate()
+        rpc.wait(timeout=5)
+        os.remove(server.log_path)

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -121,6 +121,7 @@ class ServerProcess:
     mcp_servers_config: str | None = None
     mcp_servers_json: str | None = None
     cors_origins: str | None = None
+    prefill_nodes: List[str] | None = None
 
     # session variables
     process: subprocess.Popen | None = None
@@ -182,6 +183,9 @@ class ServerProcess:
             server_args.extend(["--models-preset", self.models_preset])
         if self.cors_origins:
             server_args.extend(["--cors-origins", self.cors_origins])
+        if self.prefill_nodes:
+            for node in self.prefill_nodes:
+                server_args.extend(["--prefill-node", node])
         if self.n_batch:
             server_args.extend(["--batch-size", self.n_batch])
         if self.n_ubatch:


### PR DESCRIPTION
## Overview

Adds `--prefill-node` support to run prompt prefill on dedicated RPC workers without occupying main decode slots. Prefilled state is restored for local decoding, with load balancing, cancellation, prompt-cache integration, fallback handling. I also added a bit of documentation and tests.


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

Solves #21266 