### PR TITLE
tests : add prefill-shaped flash attention perf cases

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10256,6 +10256,15 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
         }
     }
 
+    // prefill-shaped attention (nb=512): the sweep above uses nb=1, which measures decode.
+    // hs=256 is covered by the correctness tests but not benchmarked; GQA 6 and head_dim 256
+    // match Qwen3.5/3.8-class hybrid attention layers.
+    for (int kv : { 4096, 8192, 16384, 32768, }) {
+        for (int hs : { 128, 256, }) {
+            test_cases.emplace_back(new test_flash_attn_ext(hs, hs, 4, {6, 1}, kv, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+        }
+    }
+
     for (int col : {8192, 16384, 32768, 65536, 131072, 262144, 524288}) {
         for (int rows : {1, 4, 16}){
             test_cases.emplace_back(new test_soft_max(GGML_TYPE_F32, {col, rows, 1, 1}, false,  false,  GGML_TYPE_F32, {1, 1}, 1.0f, 0.0f));


### PR DESCRIPTION
## Summary

Adds 8 prefill-shaped `FLASH_ATTN_EXT` cases to `make_test_cases_perf()`.

The existing flash-attention perf sweep is:

```cpp
for (int kv : { 4096, 8192, 16384, }) {
    for (int hs : { 64, 128, }) {
        for (int nr : { 1, 4, }) {
            test_cases.emplace_back(new test_flash_attn_ext(hs, hs, 8, {nr, 1}, kv, 1, ...));
```

Every case uses `nb = 1`, i.e. one token attending over the KV cache — **decode**. Nothing in the
perf suite measures attention at a prefill-sized batch, which has very different arithmetic
intensity. `hs = 256` is also absent: it is exercised by the correctness tests (it appears in the
`{40, 64, 72, 80, 96, 128, 192, 256, 320, 512, 576}` loop) but never benchmarked.

The two regimes are not close. Measured on AMD Radeon 8060S (gfx1151, Vulkan, RADV-equivalent
proprietary driver), f16 KV, GQA 6:

| kv | hs=128, nb=1 | hs=128, nb=512 | hs=256, nb=1 | hs=256, nb=512 |
|---:|---:|---:|---:|---:|
| 4096 | 1.55 TFLOPS | 6.63 TFLOPS | 1.66 TFLOPS | 6.68 TFLOPS |
| 8192 | 1.91 | 7.04 | 1.85 | 7.07 |
| 16384 | 2.06 | 6.98 | 1.15 | 6.66 |
| 32768 | 1.21 | 6.09 | 1.20 | 6.30 |

At `hs=256, kv=16384` the same shape reports **1.15 TFLOPS at nb=1 and 6.66 TFLOPS at nb=512** — a
5.8x gap between the two regimes. Only the first was previously visible, so a prefill-path
regression would not show up in the perf suite at all.

The added shapes (head_dim 256, 4 KV heads, GQA 6) match the full-attention layers of
Qwen3.5/3.8-class hybrid models, where most layers are linear attention and the remaining
full-attention layers use an unusually large head dim.

## Why it mattered in practice

While profiling long-prompt ingestion on this hardware, the stock `nb=1` numbers looked like a
3.3x throughput collapse between kv 8192 and 16384 and read as a prefill defect worth chasing.
Adding prefill-batch coverage showed prefill attention is in fact flat at 6.3-7.1 TFLOPS across a
4k-32k KV range, and that `hs=256` carries no penalty relative to `hs=128`. The decode numbers were
being misread as prefill numbers, which the suite gave no way to check.

## Cost

8 cases. `test-backend-ops perf` sizes its run count to roughly one second per case, so this adds
approximately 8 seconds per backend. No correctness cases are added or changed; `test` mode is
unaffected.

## Testing

- `test-backend-ops perf -o FLASH_ATTN_EXT` on Vulkan (gfx1151) — produced the table above
- builds clean with `GGML_VULKAN=OFF` and `GGML_VULKAN=ON`
