### PR TITLE
model : optimize DSA RoPE, remove some ggml_concat

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -184,6 +184,9 @@ void llm_graph_input_rope_freq_trail::set_input(const llama_ubatch * ubatch) {
     const int64_t n_pair_rot  = n_rot/2;
     const int64_t n_pair_nope = n_pair - n_pair_rot;
 
+    float corr_dims[2];
+    ggml_rope_yarn_corr_dims(n_rot, rp.n_ctx_orig, rp.freq_base, rp.beta_fast, rp.beta_slow, corr_dims);
+
     std::vector<float> data(n_pair);
 
     for (int64_t ic = 0; ic < n_pair_nope; ++ic) {
@@ -191,12 +194,18 @@ void llm_graph_input_rope_freq_trail::set_input(const llama_ubatch * ubatch) {
         data[ic] = INFINITY;
     }
 
-    // theta depends on n_dims, so divide out the change from n_rot to n_embd_head
-    // jc is the pair index inside the trailing block
     for (int64_t ic = n_pair_nope; ic < n_pair; ++ic) {
         const int64_t jc = ic - n_pair_nope;
 
-        data[ic] = std::pow(freq_base, 2.0*jc/n_rot - 2.0*ic/n_embd_head);
+        const double freq = std::pow((double) rp.freq_base, -2.0*jc/n_rot);
+
+        // yarn interpolation, same as rope_yarn_ramp() in ggml. it only depends on the dim
+        // index, so the whole mix collapses into a per-dim scale of theta
+        const double y    = ((double) jc - corr_dims[0]) / std::max(0.001f, corr_dims[1] - corr_dims[0]);
+        const double ramp = 1.0 - std::min(1.0, std::max(0.0, y));
+        const double mix  = ramp*rp.ext_factor;
+
+        data[ic] = (float) (1.0 / (freq*(rp.freq_scale*(1.0 - mix) + mix)));
     }
 
     ggml_backend_tensor_set(freq_factors, data.data(), 0, n_pair*ggml_element_size(freq_factors));
@@ -2411,15 +2420,15 @@ ggml_tensor * llm_graph_context::build_inp_attn_scale() const {
     return cur;
 }
 
-ggml_tensor * llm_graph_context::build_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base) const {
+ggml_tensor * llm_graph_context::build_rope_freq_trail(
+        int64_t n_embd_head, int64_t n_rot, const llm_rope_params & rp) const {
     GGML_ASSERT(n_rot > 0 && n_rot <= n_embd_head);
     GGML_ASSERT(n_rot % 2 == 0 && n_embd_head % 2 == 0);
 
-    // unsupported case (not used in practice by any known models)
-    GGML_ASSERT(ext_factor == 0.0f);
+    // NEOX pairs (i, i + n_dims/2), which crosses the nope/rope border after widening
     GGML_ASSERT(rope_type == LLAMA_ROPE_TYPE_NORM);
 
-    auto inp = std::make_unique<llm_graph_input_rope_freq_trail>(n_embd_head, n_rot, freq_base);
+    auto inp = std::make_unique<llm_graph_input_rope_freq_trail>(n_embd_head, n_rot, rp);
 
     auto & cur = inp->freq_factors;
 

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -172,6 +172,36 @@ void llm_graph_input_attn_temp::set_input(const llama_ubatch * ubatch) {
     }
 }
 
+void llm_graph_input_rope_freq_trail::set_input(const llama_ubatch * ubatch) {
+    GGML_UNUSED(ubatch);
+
+    if (!freq_factors) {
+        return;
+    }
+
+    // freq factors are indexed by pair, ie. i0/2
+    const int64_t n_pair      = n_embd_head/2;
+    const int64_t n_pair_rot  = n_rot/2;
+    const int64_t n_pair_nope = n_pair - n_pair_rot;
+
+    std::vector<float> data(n_pair);
+
+    for (int64_t ic = 0; ic < n_pair_nope; ++ic) {
+        // theta becomes 0 here, so the dim is not rotated
+        data[ic] = INFINITY;
+    }
+
+    // theta depends on n_dims, so divide out the change from n_rot to n_embd_head
+    // jc is the pair index inside the trailing block
+    for (int64_t ic = n_pair_nope; ic < n_pair; ++ic) {
+        const int64_t jc = ic - n_pair_nope;
+
+        data[ic] = std::pow(freq_base, 2.0*jc/n_rot - 2.0*ic/n_embd_head);
+    }
+
+    ggml_backend_tensor_set(freq_factors, data.data(), 0, n_pair*ggml_element_size(freq_factors));
+}
+
 void llm_graph_input_pos_bucket::set_input(const llama_ubatch * ubatch) {
     if (pos_bucket) {
         const int64_t n_tokens = ubatch->n_tokens;
@@ -2375,6 +2405,27 @@ ggml_tensor * llm_graph_context::build_inp_attn_scale() const {
     cur = ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, 1, 1, n_tokens);
     ggml_set_input(cur);
     ggml_set_name(cur, "attn_scale");
+
+    res->add_input(std::move(inp));
+
+    return cur;
+}
+
+ggml_tensor * llm_graph_context::build_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base) const {
+    GGML_ASSERT(n_rot > 0 && n_rot <= n_embd_head);
+    GGML_ASSERT(n_rot % 2 == 0 && n_embd_head % 2 == 0);
+
+    // unsupported case (not used in practice by any known models)
+    GGML_ASSERT(ext_factor == 0.0f);
+    GGML_ASSERT(rope_type == LLAMA_ROPE_TYPE_NORM);
+
+    auto inp = std::make_unique<llm_graph_input_rope_freq_trail>(n_embd_head, n_rot, freq_base);
+
+    auto & cur = inp->freq_factors;
+
+    cur = ggml_new_tensor_1d(ctx0, GGML_TYPE_F32, n_embd_head/2);
+    ggml_set_input(cur);
+    ggml_set_name(cur, "rope_freq_trail");
 
     res->add_input(std::move(inp));
 

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -183,10 +183,30 @@ public:
     const float    f_attn_temp_offset;
 };
 
+// rope parameters needed to precompute per-dim frequencies
+struct llm_rope_params {
+    float   freq_base;
+    float   freq_scale;
+    float   ext_factor;
+    float   attn_factor;
+    float   beta_fast;
+    float   beta_slow;
+    int32_t n_ctx_orig;
+
+    bool operator==(const llm_rope_params & o) const {
+        return freq_base  == o.freq_base  && freq_scale  == o.freq_scale  &&
+               ext_factor == o.ext_factor && attn_factor == o.attn_factor &&
+               beta_fast  == o.beta_fast  && beta_slow   == o.beta_slow   &&
+               n_ctx_orig == o.n_ctx_orig;
+    }
+};
+
+// the whole per-dim frequency is baked in here, YaRN included, so that rope can run with
+// freq_base = 1, ie. theta_base = pos. INFINITY on the nope dims makes theta 0 there
 class llm_graph_input_rope_freq_trail : public llm_graph_input_i {
 public:
-    llm_graph_input_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base)
-        : n_embd_head(n_embd_head), n_rot(n_rot), freq_base(freq_base) {}
+    llm_graph_input_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, const llm_rope_params & rp)
+        : n_embd_head(n_embd_head), n_rot(n_rot), rp(rp) {}
     virtual ~llm_graph_input_rope_freq_trail() = default;
 
     void set_input(const llama_ubatch * ubatch) override;
@@ -198,9 +218,9 @@ public:
 
     ggml_tensor * freq_factors = nullptr; // F32 [n_embd_head/2]
 
-    const int64_t n_embd_head;
-    const int64_t n_rot;
-    const float   freq_base;
+    const int64_t         n_embd_head;
+    const int64_t         n_rot;
+    const llm_rope_params rp;
 };
 
 class llm_graph_input_pos_bucket : public llm_graph_input_i {
@@ -1147,7 +1167,8 @@ struct llm_graph_context {
 
     // used by DSA models (like deepseek4), to do rope with head layout [nope | rope]
     // this generates the freq_factors tensor, used by ggml_rope_ext
-    ggml_tensor * build_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base) const;
+    // call ggml_rope_ext with n_dims = n_embd_head, freq_base = 1 and no yarn params
+    ggml_tensor * build_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, const llm_rope_params & rp) const;
 
     //
     // attention

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -183,6 +183,26 @@ public:
     const float    f_attn_temp_offset;
 };
 
+class llm_graph_input_rope_freq_trail : public llm_graph_input_i {
+public:
+    llm_graph_input_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base)
+        : n_embd_head(n_embd_head), n_rot(n_rot), freq_base(freq_base) {}
+    virtual ~llm_graph_input_rope_freq_trail() = default;
+
+    void set_input(const llama_ubatch * ubatch) override;
+
+    bool can_reuse(const llm_graph_params & params) override {
+        GGML_UNUSED(params);
+        return true;
+    }
+
+    ggml_tensor * freq_factors = nullptr; // F32 [n_embd_head/2]
+
+    const int64_t n_embd_head;
+    const int64_t n_rot;
+    const float   freq_base;
+};
+
 class llm_graph_input_pos_bucket : public llm_graph_input_i {
 public:
     llm_graph_input_pos_bucket(const llama_hparams & hparams) : hparams(hparams) {}
@@ -1124,6 +1144,10 @@ struct llm_graph_context {
     ggml_tensor * build_inp_pos_bucket_enc() const;
     ggml_tensor * build_inp_pos_bucket_dec() const;
     ggml_tensor * build_pos_bias(ggml_tensor * pos_bucket, ggml_tensor * attn_rel_b) const;
+
+    // used by DSA models (like deepseek4), to do rope with head layout [nope | rope]
+    // this generates the freq_factors tensor, used by ggml_rope_ext
+    ggml_tensor * build_rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base) const;
 
     //
     // attention

--- a/src/models/deepseek32.cpp
+++ b/src/models/deepseek32.cpp
@@ -180,9 +180,10 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
 
     const int64_t n_indexer_head = hparams.indexer_n_head;
     const int64_t n_embd_indexer_head = hparams.indexer_head_size;
-    const int64_t n_embd_indexer_head_rope = hparams.n_rot();
-    const int64_t n_embd_indexer_head_nope = n_embd_indexer_head - n_embd_indexer_head_rope;
     const uint32_t n_indexer_top_k = hparams.indexer_top_k;
+
+    // the indexer head layous is [rope | nope]
+    GGML_ASSERT(hparams.n_rot() <= n_embd_indexer_head);
 
     const uint32_t kv_lora_rank = hparams.n_lora_kv;
 
@@ -233,28 +234,11 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
                 ggml_tensor * indexer_q = ggml_mul_mat(ctx0, model.layers[il].indexer_attn_q_b, qr);
                 cb(indexer_q, "indexer_q", il);
 
-                // split into {n_embd_indexer_head_rope, n_indexer_head, n_tokens}
-                ggml_tensor * indexer_q_pe =
-                    ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_rope, n_indexer_head, n_tokens,
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head) * n_indexer_head, 0);
-                cb(indexer_q_pe, "indexer_q_pe", il);
-
-                // and {n_embd_indexer_head_nope, n_indexer_head, n_tokens}
-                ggml_tensor * indexer_q_nope =
-                    ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_nope, n_indexer_head, n_tokens,
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head) * n_indexer_head,
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head_nope));
-                cb(indexer_q_nope, "indexer_q_nope", il);
-
-                indexer_q_pe = ggml_rope_ext(ctx0, indexer_q_pe, inp_pos, nullptr, n_rot,
+                // {n_embd_indexer_head, n_indexer_head, n_tokens}
+                indexer_q = ggml_reshape_3d(ctx0, indexer_q, n_embd_indexer_head, n_indexer_head, n_tokens);
+                indexer_q = ggml_rope_ext(ctx0, indexer_q, inp_pos, nullptr, n_rot,
                                      LLAMA_ROPE_TYPE_NEOX, n_ctx_orig, freq_base, freq_scale,
                                      ext_factor, attn_factor, beta_fast, beta_slow);
-                cb(indexer_q_pe, "indexer_q_pe", il);
-
-                // {n_embd_indexer_head_rope + n_embd_indexer_head_nope, n_head, n_tokens}
-                indexer_q = ggml_concat(ctx0, indexer_q_pe, indexer_q_nope, 0);
                 cb(indexer_q, "indexer_q", il);
 
                 ggml_tensor * indexer_k = ggml_mul_mat(ctx0, model.layers[il].indexer_attn_k, cur);
@@ -263,28 +247,11 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
                 indexer_k = build_norm(indexer_k, model.layers[il].indexer_k_norm, model.layers[il].indexer_k_norm_b, LLM_NORM, il);
                 cb(indexer_k, "indexer_k", il);
 
-                // split into {n_embd_indexer_head_rope, 1, n_tokens}
-                ggml_tensor * indexer_k_pe =
-                    ggml_view_3d(ctx0, indexer_k, n_embd_indexer_head_rope, 1, n_tokens,
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head) * 1, 0);
-                cb(indexer_k_pe, "indexer_k_pe", il);
-
-                // and {n_embd_indexer_head_nope, 1, n_tokens}
-                ggml_tensor * indexer_k_nope =
-                    ggml_view_3d(ctx0, indexer_k, n_embd_indexer_head_nope, 1, n_tokens,
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head) * 1,
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head_nope));
-                cb(indexer_k_nope, "indexer_k_nope", il);
-
-                indexer_k_pe = ggml_rope_ext(ctx0, indexer_k_pe, inp_pos, nullptr, n_rot,
+                // {n_embd_indexer_head, 1, n_tokens}
+                indexer_k = ggml_reshape_3d(ctx0, indexer_k, n_embd_indexer_head, 1, n_tokens);
+                indexer_k = ggml_rope_ext(ctx0, indexer_k, inp_pos, nullptr, n_rot,
                                      LLAMA_ROPE_TYPE_NEOX, n_ctx_orig, freq_base, freq_scale,
                                      ext_factor, attn_factor, beta_fast, beta_slow);
-                cb(indexer_k_pe, "indexer_k_pe", il);
-
-                // {n_embd_indexer_head_rope + n_embd_indexer_head_nope, 1, n_tokens}
-                indexer_k = ggml_concat(ctx0, indexer_k_pe, indexer_k_nope, 0);
                 cb(indexer_k, "indexer_k", il);
 
                 // perform Hadamard transform on indexer q and k

--- a/src/models/deepseek4.cpp
+++ b/src/models/deepseek4.cpp
@@ -8,15 +8,15 @@
 #include <string>
 
 ggml_tensor * llama_model_deepseek4::graph::rope_freq_trail(
-        int64_t n_embd_head, int64_t n_rot, float freq_base_l) const {
+        int64_t n_embd_head, int64_t n_rot, const llm_rope_params & rp) const {
     for (const auto & e : rope_freq_trail_cache) {
-        if (std::get<0>(e) == n_embd_head && std::get<1>(e) == n_rot && std::get<2>(e) == freq_base_l) {
+        if (std::get<0>(e) == n_embd_head && std::get<1>(e) == n_rot && std::get<2>(e) == rp) {
             return std::get<3>(e);
         }
     }
 
-    ggml_tensor * cur = build_rope_freq_trail(n_embd_head, n_rot, freq_base_l);
-    rope_freq_trail_cache.emplace_back(n_embd_head, n_rot, freq_base_l, cur);
+    ggml_tensor * cur = build_rope_freq_trail(n_embd_head, n_rot, rp);
+    rope_freq_trail_cache.emplace_back(n_embd_head, n_rot, rp, cur);
 
     return cur;
 }
@@ -36,40 +36,23 @@ ggml_tensor * llama_model_deepseek4::graph::build_rope_trail(
              bool     backward) const {
     GGML_ASSERT(cur->ne[0] == n_embd_head);
 
-    if (ext_factor_l == 0.0f) {
-        // rope scales all dims by mscale, also the ones it does not rotate
-        GGML_ASSERT(attn_factor_l == 1.0f);
+    // rope scales all dims by mscale, also the ones it does not rotate
+    const float mscale = ext_factor_l != 0.0f
+        ? attn_factor_l*(1.0f + 0.1f*logf(1.0f/freq_scale_l))
+        : attn_factor_l;
+    GGML_ASSERT(fabsf(mscale - 1.0f) < 1e-5f);
 
-        ggml_tensor * freq = rope_freq_trail(n_embd_head, n_rot, freq_base_l);
+    const llm_rope_params rp = {
+        freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l,
+        beta_fast_l, beta_slow_l, n_ctx_orig_l,
+    };
 
-        return backward
-            ? ggml_rope_ext_back(ctx0, cur, pos, freq, n_embd_head, rope_type, n_ctx_orig_l,
-                    freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l)
-            : ggml_rope_ext     (ctx0, cur, pos, freq, n_embd_head, rope_type, n_ctx_orig_l,
-                    freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
-    }
+    ggml_tensor * freq = rope_freq_trail(n_embd_head, n_rot, rp);
 
-    // YaRN is active, the freq factors trick does not work, so split the head
-    const int64_t n_nope  = n_embd_head - n_rot;
-    const int64_t n_heads = cur->ne[1];
-    const int64_t n_pos   = cur->ne[2];
-
-    ggml_tensor * nope = ggml_view_3d(ctx0, cur, n_nope, n_heads, n_pos,
-            ggml_row_size(cur->type, n_embd_head),
-            ggml_row_size(cur->type, n_embd_head)*n_heads,
-            0);
-    ggml_tensor * pe = ggml_view_3d(ctx0, cur, n_rot, n_heads, n_pos,
-            ggml_row_size(cur->type, n_embd_head),
-            ggml_row_size(cur->type, n_embd_head)*n_heads,
-            ggml_row_size(cur->type, n_nope));
-
-    pe = backward
-        ? ggml_rope_ext_back(ctx0, pe, pos, nullptr, n_rot, rope_type, n_ctx_orig_l,
-                freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l)
-        : ggml_rope_ext     (ctx0, pe, pos, nullptr, n_rot, rope_type, n_ctx_orig_l,
-                freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
-
-    return ggml_concat(ctx0, nope, pe, 0);
+    // the frequencies are baked into freq, so rope only has to do theta = pos/freq
+    return backward
+        ? ggml_rope_ext_back(ctx0, cur, pos, freq, n_embd_head, rope_type, 0, 1.0f, 1.0f, 0.0f, mscale, 0.0f, 0.0f)
+        : ggml_rope_ext     (ctx0, cur, pos, freq, n_embd_head, rope_type, 0, 1.0f, 1.0f, 0.0f, mscale, 0.0f, 0.0f);
 }
 
 static float dsv4_rope_attn_factor(float freq_scale, float ext_factor) {

--- a/src/models/deepseek4.cpp
+++ b/src/models/deepseek4.cpp
@@ -7,6 +7,71 @@
 #include <stdexcept>
 #include <string>
 
+ggml_tensor * llama_model_deepseek4::graph::rope_freq_trail(
+        int64_t n_embd_head, int64_t n_rot, float freq_base_l) const {
+    for (const auto & e : rope_freq_trail_cache) {
+        if (std::get<0>(e) == n_embd_head && std::get<1>(e) == n_rot && std::get<2>(e) == freq_base_l) {
+            return std::get<3>(e);
+        }
+    }
+
+    ggml_tensor * cur = build_rope_freq_trail(n_embd_head, n_rot, freq_base_l);
+    rope_freq_trail_cache.emplace_back(n_embd_head, n_rot, freq_base_l, cur);
+
+    return cur;
+}
+
+ggml_tensor * llama_model_deepseek4::graph::build_rope_trail(
+        ggml_tensor * cur,
+        ggml_tensor * pos,
+          int64_t     n_embd_head,
+          int64_t     n_rot,
+          int32_t     n_ctx_orig_l,
+            float     freq_base_l,
+            float     freq_scale_l,
+            float     ext_factor_l,
+            float     attn_factor_l,
+            float     beta_fast_l,
+            float     beta_slow_l,
+             bool     backward) const {
+    GGML_ASSERT(cur->ne[0] == n_embd_head);
+
+    if (ext_factor_l == 0.0f) {
+        // rope scales all dims by mscale, also the ones it does not rotate
+        GGML_ASSERT(attn_factor_l == 1.0f);
+
+        ggml_tensor * freq = rope_freq_trail(n_embd_head, n_rot, freq_base_l);
+
+        return backward
+            ? ggml_rope_ext_back(ctx0, cur, pos, freq, n_embd_head, rope_type, n_ctx_orig_l,
+                    freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l)
+            : ggml_rope_ext     (ctx0, cur, pos, freq, n_embd_head, rope_type, n_ctx_orig_l,
+                    freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
+    }
+
+    // YaRN is active, the freq factors trick does not work, so split the head
+    const int64_t n_nope  = n_embd_head - n_rot;
+    const int64_t n_heads = cur->ne[1];
+    const int64_t n_pos   = cur->ne[2];
+
+    ggml_tensor * nope = ggml_view_3d(ctx0, cur, n_nope, n_heads, n_pos,
+            ggml_row_size(cur->type, n_embd_head),
+            ggml_row_size(cur->type, n_embd_head)*n_heads,
+            0);
+    ggml_tensor * pe = ggml_view_3d(ctx0, cur, n_rot, n_heads, n_pos,
+            ggml_row_size(cur->type, n_embd_head),
+            ggml_row_size(cur->type, n_embd_head)*n_heads,
+            ggml_row_size(cur->type, n_nope));
+
+    pe = backward
+        ? ggml_rope_ext_back(ctx0, pe, pos, nullptr, n_rot, rope_type, n_ctx_orig_l,
+                freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l)
+        : ggml_rope_ext     (ctx0, pe, pos, nullptr, n_rot, rope_type, n_ctx_orig_l,
+                freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
+
+    return ggml_concat(ctx0, nope, pe, 0);
+}
+
 static float dsv4_rope_attn_factor(float freq_scale, float ext_factor) {
     if (ext_factor == 0.0f) {
         return 1.0f;
@@ -473,7 +538,6 @@ ggml_tensor * llama_model_deepseek4::graph::build_hca_compressed_kv_from_state(
         const char * name,
         int il) const {
     const int64_t n_embd_head_rope = hparams.n_rot();
-    const int64_t n_embd_head_nope = n_embd_head - n_embd_head_rope;
     const int64_t n_blocks         = comp_pos ? comp_pos->ne[0] : 0;
 
     GGML_ASSERT(n_blocks > 0);
@@ -501,21 +565,9 @@ ggml_tensor * llama_model_deepseek4::graph::build_hca_compressed_kv_from_state(
     comp = build_norm(comp, norm, nullptr, LLM_NORM_RMS, il);
     cb(comp, name, il);
 
-    ggml_tensor * comp_nope = ggml_view_3d(ctx0, comp, n_embd_head_nope, 1, n_blocks,
-            ggml_row_size(comp->type, n_embd_head),
-            ggml_row_size(comp->type, n_embd_head),
-            0);
-    ggml_tensor * comp_pe = ggml_view_3d(ctx0, comp, n_embd_head_rope, 1, n_blocks,
-            ggml_row_size(comp->type, n_embd_head),
-            ggml_row_size(comp->type, n_embd_head),
-            ggml_row_size(comp->type, n_embd_head_nope));
-
-    comp_pe = ggml_rope_ext(ctx0, comp_pe, comp_pos, nullptr, n_embd_head_rope, rope_type, n_ctx_orig,
+    comp = build_rope_trail(comp, comp_pos, n_embd_head, n_embd_head_rope, n_ctx_orig,
             hparams.dsv4_compress_rope_base, freq_scale, ext_factor,
             dsv4_rope_attn_factor(freq_scale, ext_factor), beta_fast, beta_slow);
-    cb(comp_pe, name, il);
-
-    comp = ggml_concat(ctx0, comp_nope, comp_pe, 0);
     cb(comp, name, il);
 
     return comp;
@@ -532,7 +584,6 @@ ggml_tensor * llama_model_deepseek4::graph::build_overlap_compressed_kv_from_sta
         const char * name,
         int il) const {
     const int64_t n_embd_head_rope = hparams.n_rot();
-    const int64_t n_embd_head_nope = n_embd_head - n_embd_head_rope;
     const int64_t n_blocks         = comp_pos ? comp_pos->ne[0] : 0;
 
     GGML_ASSERT(n_blocks > 0);
@@ -585,21 +636,9 @@ ggml_tensor * llama_model_deepseek4::graph::build_overlap_compressed_kv_from_sta
     comp = build_norm(comp, norm, nullptr, LLM_NORM_RMS, il);
     cb(comp, name, il);
 
-    ggml_tensor * comp_nope = ggml_view_3d(ctx0, comp, n_embd_head_nope, 1, n_blocks,
-            ggml_row_size(comp->type, n_embd_head),
-            ggml_row_size(comp->type, n_embd_head),
-            0);
-    ggml_tensor * comp_pe = ggml_view_3d(ctx0, comp, n_embd_head_rope, 1, n_blocks,
-            ggml_row_size(comp->type, n_embd_head),
-            ggml_row_size(comp->type, n_embd_head),
-            ggml_row_size(comp->type, n_embd_head_nope));
-
-    comp_pe = ggml_rope_ext(ctx0, comp_pe, comp_pos, nullptr, n_embd_head_rope, rope_type, n_ctx_orig,
+    comp = build_rope_trail(comp, comp_pos, n_embd_head, n_embd_head_rope, n_ctx_orig,
             hparams.dsv4_compress_rope_base, freq_scale, ext_factor,
             dsv4_rope_attn_factor(freq_scale, ext_factor), beta_fast, beta_slow);
-    cb(comp_pe, name, il);
-
-    comp = ggml_concat(ctx0, comp_nope, comp_pe, 0);
     cb(comp, name, il);
 
     return comp;
@@ -616,7 +655,6 @@ ggml_tensor * llama_model_deepseek4::graph::build_lid_top_k(
     const auto & inp_lid = inp_dsv4->get_lid();
     const int64_t n_embd_indexer_head      = hparams.indexer_head_size;
     const int64_t n_embd_indexer_head_rope = hparams.n_rot();
-    const int64_t n_embd_indexer_head_nope = n_embd_indexer_head - n_embd_indexer_head_rope;
     const int64_t n_indexer_head           = hparams.indexer_n_head;
     const int64_t nt                       = cur->ne[1];
 
@@ -628,21 +666,11 @@ ggml_tensor * llama_model_deepseek4::graph::build_lid_top_k(
     indexer_q = ggml_reshape_3d(ctx0, indexer_q, n_embd_indexer_head, n_indexer_head, nt);
     cb(indexer_q, "lid_q", il);
 
-    ggml_tensor * indexer_q_nope = ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_nope, n_indexer_head, nt,
-            ggml_row_size(indexer_q->type, n_embd_indexer_head),
-            ggml_row_size(indexer_q->type, n_embd_indexer_head)*n_indexer_head,
-            0);
-    ggml_tensor * indexer_q_pe = ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_rope, n_indexer_head, nt,
-            ggml_row_size(indexer_q->type, n_embd_indexer_head),
-            ggml_row_size(indexer_q->type, n_embd_indexer_head)*n_indexer_head,
-            ggml_row_size(indexer_q->type, n_embd_indexer_head_nope));
-
-    indexer_q_pe = ggml_rope_ext(ctx0, indexer_q_pe, inp_pos, nullptr, n_embd_indexer_head_rope,
-            rope_type, n_ctx_orig, hparams.dsv4_compress_rope_base, freq_scale,
+    indexer_q = build_rope_trail(indexer_q, inp_pos, n_embd_indexer_head, n_embd_indexer_head_rope,
+            n_ctx_orig, hparams.dsv4_compress_rope_base, freq_scale,
             ext_factor, dsv4_rope_attn_factor(freq_scale, ext_factor), beta_fast, beta_slow);
-    cb(indexer_q_pe, "lid_q_pe", il);
+    cb(indexer_q, "lid_q_pe", il);
 
-    indexer_q = ggml_concat(ctx0, indexer_q_nope, indexer_q_pe, 0);
     indexer_q = llama_mul_mat_hadamard(ctx0, indexer_q, inp_lid.k_rot);
     cb(indexer_q, "lid_q_rot", il);
 
@@ -915,7 +943,6 @@ ggml_tensor * llama_model_deepseek4::graph::build_attention_impl(
 
     const int64_t n_embd_head      = hparams.n_embd_head_k();
     const int64_t n_embd_head_rope = hparams.n_rot();
-    const int64_t n_embd_head_nope = n_embd_head - n_embd_head_rope;
     const int64_t n_groups         = hparams.dsv4_o_group_count;
     const int64_t n_heads_group    = n_head / n_groups;
     const int64_t o_lora_rank      = hparams.dsv4_o_lora_rank;
@@ -945,18 +972,8 @@ ggml_tensor * llama_model_deepseek4::graph::build_attention_impl(
     q = ggml_rms_norm(ctx0, q, norm_rms_eps);
     cb(q, "q_norm", il);
 
-    ggml_tensor * q_nope = ggml_view_3d(ctx0, q, n_embd_head_nope, n_head, nt,
-            ggml_row_size(q->type, n_embd_head),
-            ggml_row_size(q->type, n_embd_head)*n_head,
-            0);
-    ggml_tensor * q_pe = ggml_view_3d(ctx0, q, n_embd_head_rope, n_head, nt,
-            ggml_row_size(q->type, n_embd_head),
-            ggml_row_size(q->type, n_embd_head)*n_head,
-            ggml_row_size(q->type, n_embd_head_nope));
-    q_pe = ggml_rope_ext(ctx0, q_pe, inp_pos, nullptr, n_embd_head_rope, rope_type, n_ctx_orig_l,
+    q = build_rope_trail(q, inp_pos, n_embd_head, n_embd_head_rope, n_ctx_orig_l,
             freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
-    cb(q_pe, "q_pe", il);
-    q = ggml_concat(ctx0, q_nope, q_pe, 0);
     cb(q, "q", il);
 
     ggml_tensor * kv = build_lora_mm(layer.wkv, cur);
@@ -964,18 +981,8 @@ ggml_tensor * llama_model_deepseek4::graph::build_attention_impl(
     kv = ggml_reshape_3d(ctx0, kv, n_embd_head, 1, nt);
     cb(kv, "kv_norm", il);
 
-    ggml_tensor * kv_nope = ggml_view_3d(ctx0, kv, n_embd_head_nope, 1, nt,
-            ggml_row_size(kv->type, n_embd_head),
-            ggml_row_size(kv->type, n_embd_head),
-            0);
-    ggml_tensor * kv_pe = ggml_view_3d(ctx0, kv, n_embd_head_rope, 1, nt,
-            ggml_row_size(kv->type, n_embd_head),
-            ggml_row_size(kv->type, n_embd_head),
-            ggml_row_size(kv->type, n_embd_head_nope));
-    kv_pe = ggml_rope_ext(ctx0, kv_pe, inp_pos, nullptr, n_embd_head_rope, rope_type, n_ctx_orig_l,
+    kv = build_rope_trail(kv, inp_pos, n_embd_head, n_embd_head_rope, n_ctx_orig_l,
             freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
-    cb(kv_pe, "kv_pe", il);
-    kv = ggml_concat(ctx0, kv_nope, kv_pe, 0);
     cb(kv, "kv", il);
 
     const int64_t ratio = hparams.dsv4_compress_ratios[il];
@@ -1245,17 +1252,9 @@ ggml_tensor * llama_model_deepseek4::graph::build_attention_impl(
     }
 
     out = ggml_reshape_3d(ctx0, out, n_embd_head, n_head, nt);
-    ggml_tensor * out_nope = ggml_view_3d(ctx0, out, n_embd_head_nope, n_head, nt,
-            ggml_row_size(out->type, n_embd_head),
-            ggml_row_size(out->type, n_embd_head)*n_head,
-            0);
-    ggml_tensor * out_pe = ggml_view_3d(ctx0, out, n_embd_head_rope, n_head, nt,
-            ggml_row_size(out->type, n_embd_head),
-            ggml_row_size(out->type, n_embd_head)*n_head,
-            ggml_row_size(out->type, n_embd_head_nope));
-    out_pe = ggml_rope_ext_back(ctx0, out_pe, inp_pos, nullptr, n_embd_head_rope, rope_type, n_ctx_orig_l,
-            freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l);
-    out = ggml_concat(ctx0, out_nope, out_pe, 0);
+    out = build_rope_trail(out, inp_pos, n_embd_head, n_embd_head_rope, n_ctx_orig_l,
+            freq_base_l, freq_scale_l, ext_factor_l, attn_factor_l, beta_fast_l, beta_slow_l,
+            /*backward =*/ true);
     cb(out, "attn_derope", il);
 
     out = ggml_reshape_3d(ctx0, out, o_group_dim, n_groups, nt);

--- a/src/models/glm-dsa.cpp
+++ b/src/models/glm-dsa.cpp
@@ -216,9 +216,10 @@ llama_model_glm_dsa::graph::graph(const llama_model & model, const llm_graph_par
 
     const int64_t n_indexer_head = hparams.indexer_n_head;
     const int64_t n_embd_indexer_head = hparams.indexer_head_size;
-    const int64_t n_embd_indexer_head_rope = hparams.n_rot();
-    const int64_t n_embd_indexer_head_nope = n_embd_indexer_head - n_embd_indexer_head_rope;
     const uint32_t n_indexer_top_k = hparams.indexer_top_k;
+
+    // the indexer head layout is [rope | nope]
+    GGML_ASSERT(hparams.n_rot() <= n_embd_indexer_head);
 
     const uint32_t kv_lora_rank = hparams.n_lora_kv;
 
@@ -273,28 +274,11 @@ llama_model_glm_dsa::graph::graph(const llama_model & model, const llm_graph_par
                 ggml_tensor * indexer_q = ggml_mul_mat(ctx0, model.layers[il].indexer_attn_q_b, qr);
                 cb(indexer_q, "indexer_q", il);
 
-                // split into {n_embd_indexer_head_rope, n_indexer_head, n_tokens}
-                ggml_tensor * indexer_q_pe =
-                    ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_rope, n_indexer_head, n_tokens,
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head) * n_indexer_head, 0);
-                cb(indexer_q_pe, "indexer_q_pe", il);
-
-                // and {n_embd_indexer_head_nope, n_indexer_head, n_tokens}
-                ggml_tensor * indexer_q_nope =
-                    ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_nope, n_indexer_head, n_tokens,
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head) * n_indexer_head,
-                                 ggml_row_size(indexer_q->type, n_embd_indexer_head_nope));
-                cb(indexer_q_nope, "indexer_q_nope", il);
-
-                indexer_q_pe = ggml_rope_ext(ctx0, indexer_q_pe, inp_pos, nullptr, n_rot,
+                // {n_embd_indexer_head, n_indexer_head, n_tokens}
+                indexer_q = ggml_reshape_3d(ctx0, indexer_q, n_embd_indexer_head, n_indexer_head, n_tokens);
+                indexer_q = ggml_rope_ext(ctx0, indexer_q, inp_pos, nullptr, n_rot,
                                      LLAMA_ROPE_TYPE_NORM, n_ctx_orig, freq_base, freq_scale,
                                      ext_factor, attn_factor, beta_fast, beta_slow);
-                cb(indexer_q_pe, "indexer_q_pe", il);
-
-                // {n_embd_indexer_head_rope + n_embd_indexer_head_nope, n_head, n_tokens}
-                indexer_q = ggml_concat(ctx0, indexer_q_pe, indexer_q_nope, 0);
                 cb(indexer_q, "indexer_q", il);
 
                 ggml_tensor * indexer_k = ggml_mul_mat(ctx0, model.layers[il].indexer_attn_k, cur);
@@ -303,28 +287,11 @@ llama_model_glm_dsa::graph::graph(const llama_model & model, const llm_graph_par
                 indexer_k = build_norm(indexer_k, model.layers[il].indexer_k_norm, model.layers[il].indexer_k_norm_b, LLM_NORM, il);
                 cb(indexer_k, "indexer_k", il);
 
-                // split into {n_embd_indexer_head_rope, 1, n_tokens}
-                ggml_tensor * indexer_k_pe =
-                    ggml_view_3d(ctx0, indexer_k, n_embd_indexer_head_rope, 1, n_tokens,
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head) * 1, 0);
-                cb(indexer_k_pe, "indexer_k_pe", il);
-
-                // and {n_embd_indexer_head_nope, 1, n_tokens}
-                ggml_tensor * indexer_k_nope =
-                    ggml_view_3d(ctx0, indexer_k, n_embd_indexer_head_nope, 1, n_tokens,
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head),
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head) * 1,
-                                 ggml_row_size(indexer_k->type, n_embd_indexer_head_nope));
-                cb(indexer_k_nope, "indexer_k_nope", il);
-
-                indexer_k_pe = ggml_rope_ext(ctx0, indexer_k_pe, inp_pos, nullptr, n_rot,
+                // {n_embd_indexer_head, 1, n_tokens}
+                indexer_k = ggml_reshape_3d(ctx0, indexer_k, n_embd_indexer_head, 1, n_tokens);
+                indexer_k = ggml_rope_ext(ctx0, indexer_k, inp_pos, nullptr, n_rot,
                                      LLAMA_ROPE_TYPE_NORM, n_ctx_orig, freq_base, freq_scale,
                                      ext_factor, attn_factor, beta_fast, beta_slow);
-                cb(indexer_k_pe, "indexer_k_pe", il);
-
-                // {n_embd_indexer_head_rope + n_embd_indexer_head_nope, 1, n_tokens}
-                indexer_k = ggml_concat(ctx0, indexer_k_pe, indexer_k_nope, 0);
                 cb(indexer_k, "indexer_k", il);
 
                 // perform Hadamard transform on indexer q and k

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -1165,6 +1165,25 @@ struct llama_model_deepseek4 : public llama_model_base {
         graph(const llm_graph_params & params) : llm_graph_context(params) {}
         graph(const llama_model & model, const llm_graph_params & params);
 
+        ggml_tensor * rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base) const;
+
+        mutable std::vector<std::tuple<int64_t, int64_t, float, ggml_tensor *>> rope_freq_trail_cache;
+
+        // rope the trailing n_rot dims of each head of cur {n_embd_head, n_heads, n_pos}
+        ggml_tensor * build_rope_trail(
+                ggml_tensor * cur,
+                ggml_tensor * pos,
+                  int64_t     n_embd_head,
+                  int64_t     n_rot,
+                  int32_t     n_ctx_orig_l,
+                    float     freq_base_l,
+                    float     freq_scale_l,
+                    float     ext_factor_l,
+                    float     attn_factor_l,
+                    float     beta_fast_l,
+                    float     beta_slow_l,
+                     bool     backward = false) const;
+
         ggml_tensor * build_hc_pre(
                 ggml_tensor * x,
                 ggml_tensor * hc_fn,

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -1165,9 +1165,9 @@ struct llama_model_deepseek4 : public llama_model_base {
         graph(const llm_graph_params & params) : llm_graph_context(params) {}
         graph(const llama_model & model, const llm_graph_params & params);
 
-        ggml_tensor * rope_freq_trail(int64_t n_embd_head, int64_t n_rot, float freq_base) const;
+        ggml_tensor * rope_freq_trail(int64_t n_embd_head, int64_t n_rot, const llm_rope_params & rp) const;
 
-        mutable std::vector<std::tuple<int64_t, int64_t, float, ggml_tensor *>> rope_freq_trail_cache;
+        mutable std::vector<std::tuple<int64_t, int64_t, llm_rope_params, ggml_tensor *>> rope_freq_trail_cache;
 
         // rope the trailing n_rot dims of each head of cur {n_embd_head, n_heads, n_pos}
         ggml_tensor * build_rope_trail(


### PR DESCRIPTION
## Overview

DSA indexer head layout is:
- [rope | nope]: used by ds3.2 and glm-dsa --> now simply use n_rot instead of ggml_concat
- [nope | rope]: used by dsv4 --> now requires building freq_factors as input, still cheaper than doing ggml_concat on large tensors

Next PR: apply same fix to dflash

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
