### PR TITLE
llama: resolve -fa auto to off on Arm cores with i8mm+SVE (Neoverse V1/V2)

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -4,6 +4,7 @@
 #include "llama-arch.h"
 #include "llama-graph.h"
 #include "llama-impl.h"
+#include "ggml-cpu.h"
 #include "llama-batch.h"
 #include "llama-io.h"
 #include "llama-memory.h"
@@ -3597,6 +3598,33 @@ llama_context * llama_init_from_model(
         if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED) {
             LLAMA_LOG_ERROR("%s: quantized V cache requires flash_attn to be enabled\n", __func__);
             return nullptr;
+        }
+    }
+
+    // Arm cores with i8mm + SVE (Neoverse V1/V2, e.g. AWS Graviton3/4) run the tiled
+    // CPU flash-attention path substantially slower than the direct path.
+    // FlashAttention trades extra arithmetic for fewer memory round-trips, which is
+    // the right trade on a GPU. These cores pair a large private L2 with a big shared
+    // SLC, so for typical prefill the attention working set is already cache-resident:
+    // the traffic FA exists to avoid was never the bottleneck, and only the extra
+    // arithmetic remains. perf on Graviton4 shows the FA path retiring ~1.97x the
+    // instructions for identical work.
+    //
+    // Measured prefill, Qwen2.5-1.5B Q4_0, 16 threads, 512-token prompt:
+    //   Neoverse-V2 (c8g):  430 -> 854 tok/s with FA off  (1.99x)
+    //   Neoverse-V1 (c7g):  398 -> 615 tok/s with FA off  (1.55x)
+    //   Neoverse-N1 (c6g):  450 -> 441 tok/s with FA off  (0.98x; correctly excluded,
+    //                       N1 has neither i8mm nor SVE)
+    // The gap widens with context, reaching 5.20x at 8192 tokens on Neoverse-V2.
+    // On x86 (AVX2) the same change is a 4.7% loss, so this is Arm-specific.
+    // Data: https://github.com/ggml-org/llama.cpp/issues/27086
+    //
+    // CPU-only inference; GPU backends are unaffected. Override with -fa on.
+    if (params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_AUTO && model->devices.empty()) {
+        if (ggml_cpu_has_matmul_int8() && ggml_cpu_has_sve()) {
+            LLAMA_LOG_INFO("%s: disabling flash_attn by default on this Arm CPU "
+                           "(i8mm+SVE); pass -fa on to override\n", __func__);
+            params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
         }
     }
 


### PR DESCRIPTION
Makes `-fa auto` resolve to *off* on Arm CPUs that have both i8mm and SVE (Neoverse V1/V2 — e.g. AWS Graviton3/4), where the tiled CPU flash-attention path is substantially slower than the direct path.

Follow-up to #27086, which has the full analysis.

### Why

FlashAttention trades extra arithmetic for fewer round-trips to memory. That is the right trade on a GPU, where a small SRAM scratchpad is the binding constraint. Neoverse V1/V2 pair a large private L2 with a big shared SLC, so for typical prefill the attention working set is already cache-resident — the traffic FA exists to avoid was never the bottleneck, and only the extra arithmetic remains.

`perf` on Graviton4 confirms the mechanism: the FA path retires **~1.97× the instructions for identical work** (389.7B vs 197.9B), which tracks the throughput gap almost exactly. Note it also has the *higher* IPC (4.08 vs 3.49) — it efficiently executes work that did not need to happen, so IPC alone is misleading here.

### Measurements

Prefill, Qwen2.5-1.5B Q4_0, 16 threads, 512-token prompt, `*.4xlarge`:

| CPU | instance | `-fa auto` (before) | `-fa off` | ratio |
|---|---|---:|---:|---:|
| Neoverse-N1 | c6g | 450.2 | 440.9 | 0.98× — no win |
| Neoverse-V1 | c7g | 397.9 | 615.4 | **1.55×** |
| Neoverse-V2 | c8g | 430.4 | 854.2 | **1.99×** |

The advantage **grows with context** on Neoverse-V2 — 1.97× at 512 tokens, 2.64× at 1K, 3.45× at 2K, 4.31× at 4K, **5.20× at 8K**. No crossover found through 8K.

On x86 (i7-10870H, AVX2) the same change is a **4.7% loss**, so the effect is Arm-specific and a global CPU default flip would be wrong.

### Verification

Built and run on a real `c8g.4xlarge`. `auto` now tracks `off`:

| run | prefill tok/s (pp256, 16 threads) |
|---|---:|
| explicit `-fa on` | 361.81 |
| explicit `-fa off` | 519.57 |
| **`auto`, patched** | **515.85** |

`-fa on` still overrides correctly.

### Implementation notes

- Uses existing public API (`ggml_cpu_has_matmul_int8()`, `ggml_cpu_has_sve()`) — no MIDR parsing. The i8mm+SVE predicate happens to separate the measured set exactly: N1 has neither and is untouched.
- Guarded on `model->devices.empty()`, so CPU-only inference only; GPU backends are unaffected.
- Sits in the existing `-fa auto` resolution chain alongside the other conditional overrides, and logs when it fires.

### Scope and open questions

- **Neoverse-N2 / N3 / V3 match the predicate but were not measured.** I only had Graviton 2/3/4. If the maintainers would prefer a narrower rule, keying on MIDR part numbers for V1/V2 specifically is straightforward.
- Measured on one model family (Qwen2.5-1.5B) at Q4_0. A larger model is more bandwidth-bound and may behave differently.
- Whether the right long-term fix is a flat default or a context-length-dependent one is open — the data suggests flat is fine up to 8K, since the effect only strengthens.

Happy to adjust the predicate, narrow it to specific MIDRs, or add measurements if that would help.
