### PR TITLE
ggml-cpu : fix soft_max_back wrong output when dst aliases src1

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -5654,11 +5654,11 @@ static void ggml_compute_forward_soft_max_ext_back_f32(
 
         // linear runtime, no additional memory
         float dot_y_dy = 0;
-        ggml_vec_dot_f32  (nc, &dot_y_dy, 0, y, 0, dy, 0, 1);
-        ggml_vec_cpy_f32  (nc, dx, dy);
-        ggml_vec_acc1_f32 (nc, dx, -dot_y_dy);
-        ggml_vec_mul_f32  (nc, dx, dx, y);
-        ggml_vec_scale_f32(nc, dx, scale);
+        ggml_vec_dot_f32(nc, &dot_y_dy, 0, y, 0, dy, 0, 1);
+        // This is safe if dst aliases either source and matches the CUDA reference.
+        for (int i = 0; i < nc; i++) {
+            dx[i] = scale * (dy[i] - dot_y_dy) * y[i];
+        }
 
 #ifndef NDEBUG
         for (int i = 0; i < nc; ++i) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -277,6 +277,7 @@ if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   llama_build_and_test(test-opt.cpp)
 endif()
 llama_build_and_test(test-backend-ops.cpp)
+llama_build_and_test(test-soft-max-back.cpp)
 
 llama_build_and_test(test-model-load-cancel.cpp LABEL "model")
 llama_build_and_test(test-autorelease.cpp       LABEL "model")

--- a/tests/test-soft-max-back.cpp
+++ b/tests/test-soft-max-back.cpp
@@ -1,0 +1,102 @@
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "ggml-cpp.h"
+#include "ggml.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+static bool run_case(ggml_backend_t backend, const std::array<int64_t, 4> & ne, float scale, float & max_abs_err) {
+    ggml_init_params params = {
+        /* .mem_size   = */ 8*ggml_tensor_overhead() + ggml_graph_overhead(),
+        /* .mem_buffer = */ nullptr,
+        /* .no_alloc   = */ true,
+    };
+    ggml_context_ptr ctx(ggml_init(params));
+    GGML_ASSERT(ctx);
+
+    ggml_tensor * dy = ggml_new_tensor(ctx.get(), GGML_TYPE_F32, 4, ne.data());
+    ggml_tensor * y  = ggml_new_tensor(ctx.get(), GGML_TYPE_F32, 4, ne.data());
+    ggml_set_input(dy);
+    ggml_set_input(y);
+    ggml_set_output(dy);
+
+    ggml_tensor * dx = ggml_soft_max_ext_back(ctx.get(), dy, y, scale, 0.0f);
+    ggml_set_output(dx);
+
+    ggml_cgraph * graph = ggml_new_graph(ctx.get());
+    ggml_build_forward_expand(graph, dx);
+
+    ggml_gallocr_ptr galloc(ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend)));
+    if (!ggml_gallocr_alloc_graph(galloc.get(), graph)) {
+        fprintf(stderr, "graph allocation failed\n");
+        return false;
+    }
+    if (dx->data != y->data || dx->data == dy->data) {
+        fprintf(stderr, "allocator did not alias dst with src1\n");
+        return false;
+    }
+
+    const int64_t nc = ne[0];
+    const int64_t nr = ggml_nrows(dy);
+    const int64_t n  = ggml_nelements(dy);
+    std::vector<float> dy_data(n);
+    std::vector<float> y_data(n);
+    std::vector<float> expected(n);
+    std::vector<float> actual(n);
+
+    for (int64_t row = 0; row < nr; row++) {
+        float sum = 0.0f;
+        for (int64_t col = 0; col < nc; col++) {
+            const int64_t i = row*nc + col;
+            dy_data[i] = ((col + 3*row) % 17 - 8) * 0.125f;
+            y_data[i]  = 2.0f*(col + 1)/(nc*(nc + 1));
+            sum += dy_data[i]*y_data[i];
+        }
+        for (int64_t col = 0; col < nc; col++) {
+            const int64_t i = row*nc + col;
+            expected[i] = scale*(dy_data[i] - sum)*y_data[i];
+        }
+    }
+
+    ggml_backend_tensor_set(dy, dy_data.data(), 0, ggml_nbytes(dy));
+    ggml_backend_tensor_set(y, y_data.data(), 0, ggml_nbytes(y));
+    if (ggml_backend_graph_compute(backend, graph) != GGML_STATUS_SUCCESS) {
+        fprintf(stderr, "graph compute failed\n");
+        return false;
+    }
+    ggml_backend_tensor_get(dx, actual.data(), 0, ggml_nbytes(dx));
+
+    max_abs_err = 0.0f;
+    for (int64_t i = 0; i < n; i++) {
+        max_abs_err = std::max(max_abs_err, std::abs(expected[i] - actual[i]));
+    }
+    return max_abs_err <= 1e-6f;
+}
+
+int main() {
+    ggml_backend_load_all();
+    ggml_backend_ptr backend(ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr));
+    GGML_ASSERT(backend);
+
+    const std::array<std::array<int64_t, 4>, 2> cases = {{
+        {4, 2, 1, 1},
+        {1024, 4, 2, 1},
+    }};
+
+    int passed = 0;
+    for (const auto & ne : cases) {
+        float max_abs_err = 0.0f;
+        const bool ok = run_case(backend.get(), ne, 0.7f, max_abs_err);
+        printf("soft_max_back ne=[%lld,%lld,%lld,%lld] max_abs_err=%.9g %s\n",
+                (long long) ne[0], (long long) ne[1], (long long) ne[2], (long long) ne[3],
+                max_abs_err, ok ? "PASSED" : "FAILED");
+        passed += ok;
+    }
+
+    printf("%zu cases: %d passed, %zu failed\n", cases.size(), passed, cases.size() - passed);
+    return passed == (int) cases.size() ? 0 : 1;
+}


### PR DESCRIPTION
## Overview

`GGML_OP_SOFT_MAX_BACK` is in the list in `ggml_op_can_inplace` (`ggml/src/ggml-alloc.c`). Thus the graph allocator can make `dst` an alias of `src0` (dy) or an alias of `src1` (y).

The CPU code made the result in four steps:

```c
ggml_vec_cpy_f32  (nc, dx, dy);
ggml_vec_acc1_f32 (nc, dx, -dot_y_dy);
ggml_vec_mul_f32  (nc, dx, dx, y);
ggml_vec_scale_f32(nc, dx, scale);
```

If `dst` is an alias of `src1`, step 1 writes over `y`. Step 3 then reads the changed values of `y`. Thus the output is wrong, and there is no error message.

If `dst` is an alias of `src0`, the result is correct. The CUDA kernel does all of its reduction before it writes, so CUDA is already correct.

This change replaces the four steps with one loop. The loop reads both sources before it writes. This is correct for both aliases.

This is the same type of bug as #24305 (rms_norm_back).

## Additional information

The test is `tests/test-soft-max-back.cpp`. The test marks `dy` as a graph output. Thus the allocator cannot use `dy` for `dst`, and it makes `dst` an alias of `y`. The test then confirms that the alias is present before it compares any values. It calculates the expected values on the host.

For the run below I reverted only `ggml/src/ggml-cpu/ops.cpp` to master. I kept the new test.

Before the change:

```
soft_max_back ne=[4,2,1,1] max_abs_err=0.0612500012 FAILED
soft_max_back ne=[1024,4,2,1] max_abs_err=0.706823885 FAILED
2 cases: 0 passed, 2 failed
```

After the change:

```
soft_max_back ne=[4,2,1,1] max_abs_err=0 PASSED
soft_max_back ne=[1024,4,2,1] max_abs_err=1.45519152e-11 PASSED
2 cases: 2 passed, 0 failed
```

`test-backend-ops -b CPU -o SOFT_MAX_BACK` gives 24 passed and 0 failed.

CONTRIBUTING asks for a `test-backend-ops` case when you change a ggml operator. I could not put this test there. `test_case` allocates each tensor on its own and does not use `ggml_gallocr`. Thus it cannot make `dst` an alias of `src1`, and it cannot show the bug. This is why the test is a separate file. I can move the test if you prefer a different place for it.

This change is the same as ggml-org/ggml#1521. I will close that PR in favour of this one.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I use Claude Code CLI

