### PR TITLE
convert: fix get block count error for Nemotron 3 Ultra

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1126,6 +1126,8 @@ class ModelBase:
         except KeyError:
             raise NotImplementedError(f'Architecture {arch!r} not supported!') from None
 
+    def get_block_count(self) -> Any:
+        return self.find_hparam(["n_layers", "num_hidden_layers", "n_layer", "num_layers"])
 
 class TextModel(ModelBase):
     model_type = ModelType.TEXT
@@ -1142,7 +1144,7 @@ class TextModel(ModelBase):
             # move the text_config to the root level
             self.hparams = {**self.hparams, **self.hparams["text_config"]}
 
-        self.block_count = self.find_hparam(["n_layers", "num_hidden_layers", "n_layer", "num_layers"])
+        self.block_count = self.get_block_count()
         self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
 
         self.rope_parameters = self.hparams.get("rope_parameters", self.hparams.get("rope_scaling")) or {}

--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1126,8 +1126,6 @@ class ModelBase:
         except KeyError:
             raise NotImplementedError(f'Architecture {arch!r} not supported!') from None
 
-    def get_block_count(self) -> Any:
-        return self.find_hparam(["n_layers", "num_hidden_layers", "n_layer", "num_layers"])
 
 class TextModel(ModelBase):
     model_type = ModelType.TEXT
@@ -1144,7 +1142,7 @@ class TextModel(ModelBase):
             # move the text_config to the root level
             self.hparams = {**self.hparams, **self.hparams["text_config"]}
 
-        self.block_count = self.get_block_count()
+        self.block_count = self.find_hparam(["n_layers", "num_hidden_layers", "n_layer", "num_layers"])
         self.tensor_map = gguf.get_tensor_name_map(self.model_arch, self.block_count)
 
         self.rope_parameters = self.hparams.get("rope_parameters", self.hparams.get("rope_scaling")) or {}

--- a/conversion/nemotron.py
+++ b/conversion/nemotron.py
@@ -497,3 +497,11 @@ class NemotronHModel(GraniteHybridModel):
             experts = [k for d in self._experts for k in d.keys()]
             if len(experts) > 0:
                 raise ValueError(f"Unprocessed experts: {experts}")
+
+    def get_block_count(self) -> Any:
+        types = self.find_hparam(["layers_block_type"], True)
+
+        if types is not None:
+            return len(types)
+
+        return super().get_block_count()

--- a/conversion/nemotron.py
+++ b/conversion/nemotron.py
@@ -204,7 +204,9 @@ class NemotronHModel(GraniteHybridModel):
         # calling the parent __init__. This is because the parent constructor
         # uses self.model_arch to build the tensor name map, and all MoE-specific
         # mappings would be missed if it were called with the default non-MoE arch.
-        hparams = ModelBase.load_hparams(args[0], self.is_mistral_format)
+        hparams = kwargs.pop("hparams", None)
+        if hparams is None:
+            hparams = ModelBase.load_hparams(args[0], self.is_mistral_format)
         has_moe_params = (
             "num_experts_per_tok" in hparams
             or (isinstance(hparams.get("llm_config"), dict) and "num_experts_per_tok" in hparams["llm_config"])
@@ -212,8 +214,11 @@ class NemotronHModel(GraniteHybridModel):
         if has_moe_params:
             self.model_arch = gguf.MODEL_ARCH.NEMOTRON_H_MOE
             self.is_moe = True
+        layers_block_type = hparams.get("layers_block_type")
+        if layers_block_type is not None:
+            hparams["num_hidden_layers"] = len(layers_block_type)
 
-        super().__init__(*args, **kwargs)
+        super().__init__(*args, hparams=hparams, **kwargs)
 
         # Save the top-level head_dim for later
         self.head_dim = self.hparams.get("head_dim", self.hparams.get("attention_head_dim"))
@@ -497,11 +502,3 @@ class NemotronHModel(GraniteHybridModel):
             experts = [k for d in self._experts for k in d.keys()]
             if len(experts) > 0:
                 raise ValueError(f"Unprocessed experts: {experts}")
-
-    def get_block_count(self) -> Any:
-        types = self.find_hparam(["layers_block_type"], True)
-
-        if types is not None:
-            return len(types)
-
-        return super().get_block_count()


### PR DESCRIPTION
## Overview

It shows the below error while converting [nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4).

> $ python3 convert_hf_to_gguf.py --verbose --dry-run NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
INFO:hf-to-gguf:Loading model: NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4
INFO:hf-to-gguf:Model architecture: NemotronHForCausalLM
INFO:hf-to-gguf:gguf: loading model weight map from 'model.safetensors.index.json'
INFO:hf-to-gguf:gguf: indexing model part 'model-00001-of-00113.safetensors'
...
INFO:hf-to-gguf:heuristics detected bfloat16 tensor dtype, setting --outtype bf16
INFO:gguf.gguf_writer:gguf: This GGUF file is for Little Endian only
Traceback (most recent call last):
  File "/home/rock_chen/Downloads/llama.cpp/convert_hf_to_gguf.py", line 307, in <module>
    main()
  File "llama.cpp/convert_hf_to_gguf.py", line 281, in main
    model_instance = model_class(dir_model, output_type, fname_out,
  File "llama.cpp/conversion/nemotron.py", line 216, in __init__
    super().__init__(*args, **kwargs)
  File "llama.cpp/conversion/granite.py", line 299, in __init__
    super().__init__(*args, **kwargs)
  File "llama.cpp/conversion/mamba.py", line 115, in __init__
    super().__init__(dir_model, *args, hparams=hparams, **kwargs)
  File "llama.cpp/conversion/llama.py", line 36, in __init__
    super().__init__(*args, **kwargs)
  File "llama.cpp/conversion/base.py", line 1145, in __init__
    self.block_count = self.find_hparam(["n_layers", "num_hidden_layers", "n_layer", "num_layers"])
  File "llama.cpp/conversion/granite.py", line 361, in find_hparam
    return Mamba2Model.find_hparam(self, keys, *args, **kwargs)
  File "llama.cpp/conversion/base.py", line 204, in find_hparam
    raise KeyError(f"could not find any of: {keys}")
KeyError: "could not find any of: ['n_layers', 'num_hidden_layers', 'n_layer', 'num_layers', 'mamba_n_layers', 'mamba_num_hidden_layers', 'mamba_n_layer', 'mamba_num_layers']"

In [configuration_nemotron_h.py](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/blob/main/configuration_nemotron_h.py), it explains
>         num_hidden_layers (`int`, *optional*):
>            Number of hidden layers in the Transformer encoder. This parameter is deprecated and only kept for
>            backward compatibility. The number of layers is now determined by the length of `layers_block_type`.

So I followed this instruction in this commit for NemotronH. Note that when layers_block_type isn't available, the script would also try legacy way for backward compatibility.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

-   I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: YES. AI was used for data search and code review.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
