### PR TITLE
server: fix case-sensitive HF file lookup breaking --gpt-oss-20b-default

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -4555,7 +4555,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         string_format("use gpt-oss-20b (note: can download weights from the internet)"),
         [](common_params & params) {
             params.model.hf_repo = "ggml-org/gpt-oss-20b-GGUF";
-            params.model.hf_file = "gpt-oss-20b-mxfp4.gguf";
+            params.model.hf_file = "gpt-oss-20b-MXFP4.gguf";
             params.port = 8013;
             params.n_ubatch = 2048;
             params.n_batch = 32768;

--- a/common/download.cpp
+++ b/common/download.cpp
@@ -10,6 +10,7 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <future>
@@ -662,6 +663,13 @@ static hf_cache::hf_file find_best_dspark(const hf_cache::hf_files & files,
     return find_best_sibling(files, model, "dspark-", tag);
 }
 
+static bool string_iequal(const std::string & a, const std::string & b) {
+    return a.size() == b.size() &&
+        std::equal(a.begin(), a.end(), b.begin(), [](unsigned char ca, unsigned char cb) {
+            return std::tolower(ca) == std::tolower(cb);
+        });
+}
+
 static bool gguf_filename_is_model(const std::string & filepath) {
     if (!string_ends_with(filepath, ".gguf")) {
         return false;
@@ -757,7 +765,7 @@ common_download_hf_plan common_download_get_hf_plan(const common_params_model & 
 
     if (!model.hf_file.empty()) {
         for (const auto & f : all) {
-            if (f.path == model.hf_file) {
+            if (string_iequal(f.path, model.hf_file)) {
                 primary = f;
                 break;
             }


### PR DESCRIPTION
## Overview

The gpt-oss-20b-GGUF repo's file is gpt-oss-20b-MXFP4.gguf (uppercase), but the --gpt-oss-20b-default preset hardcoded lowercase mxfp4, and the hf_file lookup in common_download_get_hf_plan used an exact case-sensitive match, so it always failed with "file not found in repository". Fixed the preset's casing and made the lookup case-insensitive so this can't recur if a repo's casing changes.

## Additional information

Fixes #27035.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO