### PR TITLE
llama: relax `equal_seqs` assert in `llm_graph_input_attn_cross::set_input`

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1030,7 +1030,12 @@ void llm_graph_input_attn_cross::set_input(const llama_ubatch * ubatch) {
     const int64_t n_tokens = ubatch->n_tokens;
 
     GGML_ASSERT(ggml_backend_buffer_is_host(cross_kq_mask->buffer));
-    GGML_ASSERT(!ubatch->equal_seqs()); // TODO: use ubatch->n_seqs instead of failing
+    // [PR #N] 1-token decode batch vacuously satisfies equal_seqs() (single token × single seq),
+    // but the loop below still iterates correctly (decode one token × encoder N positions, with
+    // seq-id routing through `ubatch->n_seq_id[i]`). The real "vacuously equal" failure mode
+    // would be ubatch->n_seqs == 0, which is already guarded by llama_decode callers. Drop the
+    // over-aggressive assert so encoder-decoder models (NLLB, MBART, T5-encoder-decoder, etc.)
+    // can run multi-seq batches that include 1-token decode steps.
 
     const auto fill_mask = [&](auto * data) {
         using T = std::remove_reference_t<decltype(*data)>;


### PR DESCRIPTION
## Overview

The decoder-cross-attention mask builder in `llama-graph.cpp` asserts `!ubatch->equal_seqs()` with a TODO comment. The check fires vacuously when a single seq has a single token, which is exactly what per-token decoder steps look like in batched encoder-decoder generation (NLLB, MBART, T5-encoder-decoder).

I hit this on NLLB-200-distilled-600M F16 (Pixel 6a, llama.cpp v0.24-era code): `llama_encode` on a 4-seq batch succeeds, then the first `llama_decode` (1-token decoder start) SIGABRTs inside `llm_graph_input_attn_cross::set_input` at the assert.

Looking at the loop right below the assert, it iterates `ubatch->n_seq_id[i]` correctly for seq-id routing against `cross->seq_ids_enc`. There's no actual correctness problem once the assert is gone - the function does the right thing. The TODO comment in the source already flags the check as over-aggressive.

After the fix the same workflow runs end-to-end: 4 translations in 4624ms (vs ~8000ms serial on the same device, 43% time savings). Same flow on macOS x86_64 with a `test-nllb-translate.cpp`-style harness: 3 short texts produce correct translations (hello→您好, world→世界, thanks→谢谢你).

The change is one file, six insertions, one deletion: the `assert` line is removed and replaced with a brief comment explaining when the path is actually entered and why the upstream `n_seqs != 0` guard in `llama_decode` is the real safety net.

## Additional information

Reproducer sketch (no harness committed in this PR because there isn't an existing `test-backend-ops` entry for encoder-decoder cross-attn):
- Load NLLB-200-distilled-600M F16 GGUF.
- Tokenize N source texts into one encoder batch.
- `llama_encode` on the batch.
- For each seq, `llama_decode` with a 1-token batch (decoder start).
- Without fix: SIGABRT inside `set_input` at the assert.
- With fix: N correct translations, real speedup vs serial.

Happy to add a `test-backend-ops` graph-input case in a follow-up if reviewers want CI coverage - it's a non-trivial addition because the cross-attn path needs an encoder-decoder graph spec that the existing test framework doesn't currently model. I left that out to keep this PR narrow and reviewable.

There are two more TODO-marked asserts in `llama-graph.cpp` (around lines 180 and 2686 last I checked) that look like the same over-aggressive pattern in the same input-construction path. I left those alone - same reason: out of scope for this PR, would rather keep the change focused.

Builds tested:
- Android arm64-v8a, NDK 29, `GGML_BACKEND_DL=ON`, `GGML_CPU_ALL_VARIANTS=ON` (Pixel 6a).
- macOS x86_64 with a NLLB-style harness.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **NO** AI-generated code in the diff. I used an AI assistant (Claude) to sanity-check my root-cause analysis (specifically whether `equal_seqs()` is vacuously true for 1-token decode batches) and to draft an initial outline for this PR description. The final description text, the `assert` removal, and the explanatory comment were all written by me after reproducing the bug on-device, reading the surrounding code, and verifying the fix on Pixel 6a and macOS. I take full responsibility for every line in the diff.