### PR TITLE
llama : use int32_t for llama_sampler_chain_n return type

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -1348,7 +1348,7 @@ extern "C" {
     LLAMA_API struct llama_sampler * llama_sampler_chain_get(      struct llama_sampler * chain, int32_t i);
 
     // the total number of samplers in the chain
-    LLAMA_API int                    llama_sampler_chain_n  (const struct llama_sampler * chain);
+    LLAMA_API int32_t                llama_sampler_chain_n  (const struct llama_sampler * chain);
 
     // after removing a sampler, the chain will no longer own it, and it will not be freed when the chain is freed
     LLAMA_API struct llama_sampler * llama_sampler_chain_remove(   struct llama_sampler * chain, int32_t i);

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1006,7 +1006,7 @@ struct llama_sampler * llama_sampler_chain_remove(struct llama_sampler * chain, 
     return result;
 }
 
-int llama_sampler_chain_n(const struct llama_sampler * chain) {
+int32_t llama_sampler_chain_n(const struct llama_sampler * chain) {
     const auto * p = (const llama_sampler_chain *) chain->ctx;
 
     return p->samplers.size();


### PR DESCRIPTION
## Overview

Align `llama_sampler_chain_n` with the rest of the sampler chain API: `llama_sampler_chain_get` and `llama_sampler_chain_remove` already take `int32_t` indices, but `llama_sampler_chain_n` still returned a bare `int`. Per the discussion in #4574, the public API should prefer fixed-width signed integers. Changed the declaration in `include/llama.h` and the definition in `src/llama-sampler.cpp` to `int32_t`. All callers use `int` locals, which convert implicitly without loss, so no caller changes were needed.

## Additional information

- Related discussion: #4574 (maintainer-noted inconsistency: https://github.com/ggml-org/llama.cpp/issues/4574#issuecomment-5242747391)
- Complementary to #25892, which converts `llama_memory_seq_div` (d).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the change was reviewed line by line and compiled locally (`g++ -fsyntax-only -std=c++17`); I understand and take responsibility for every line submitted. The change was driven by the maintainer-noted inconsistency in #4574, which requires no behavioral change; as a type-only API alignment there is no functional regression test possible (the behavior is identical under both types).