### PR TITLE
fix(convert): qwen3_5 hybrid linear-attention tensors - ssm_conv1d kernel dim + in_proj_a/b layout

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -575,8 +575,17 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
                 data_torch = self._reorder_v_heads(data_torch, 0, num_k_heads, num_v_per_k, head_v_dim)
 
             elif ".in_proj_b." in name or ".in_proj_a." in name:
-                # Beta/Alpha weight: reorder rows (num_v_heads, head_dim=1)
-                data_torch = self._reorder_v_heads(data_torch, 0, num_k_heads, num_v_per_k, 1)
+                # Alpha/Beta. HF stores either the already-expanded
+                # [num_v_heads, dim] (v = k*v_per_k + j, k-major) or the flat
+                # k-head representation [num_k_heads*dim, 1] that must be
+                # expanded. GGUF layout: [dim, num_v_heads] k-major.
+                if data_torch.ndim == 2 and data_torch.shape[0] == num_v_heads:
+                    data_torch = torch.transpose(data_torch, 0, 1).contiguous()
+                else:
+                    data = data_torch.squeeze(-1)
+                    data = data.reshape(num_k_heads, -1)
+                    data = data.repeat_interleave(num_v_per_k, dim=0)
+                    data_torch = data.T.contiguous()
 
             elif ".A_log" in name or ".dt_bias" in name or ".dt_proj" in name:
                 # A_log / dt_bias: 1D parameters with num_v_heads elements
@@ -588,13 +597,20 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
                     data_torch = self._reorder_v_heads(data_torch, -1, num_k_heads, num_v_per_k, 1)
 
             elif ".conv1d" in name:
-                # Conv1d kernel: reorder only the V channel portion
+                # Conv1d kernel: reorder only the V channel portion.
+                # The tensor is [dim, kernel] after squeeze(); the head reorder
+                # must preserve the kernel dim (Qwen3.5 hybrid arch).
                 data = data_torch.squeeze()
                 qk_channels = head_k_dim * num_k_heads * 2
                 qk_part = data[:qk_channels]
                 v_part = data[qk_channels:]
-                v_part = self._reorder_v_heads(v_part, 0, num_k_heads, num_v_per_k, head_v_dim)
-                data_torch = torch.cat([qk_part, v_part], dim=0)
+                k = v_part.shape[-1]
+                v_part = (
+                    v_part.reshape(num_k_heads, num_v_per_k, head_v_dim, k)
+                    .permute(1, 0, 2, 3)
+                    .reshape(-1, k)
+                )
+                data_torch = torch.cat([qk_part, v_part], dim=0).unsqueeze(1)
 
             elif ".out_proj." in name:
                 # Out projection weight: reorder columns (input dimension)


### PR DESCRIPTION
- [x] I have read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] This is a **bug fix**
- [x] I have updated the relevant documentation (none needed - no public API change)
- [x] I have tested the changes locally (Qwen3.5-9B converted and loaded successfully with llama-server)

## Details

Fixes #27019: `convert_hf_to_gguf.py` fails on Qwen3.5 (qwen3_5 hybrid) with `RuntimeError: shape '[16, 2, 1, 1]' is invalid for input of size 65536`.

Two tensor-layout issues in `conversion/qwen.py`:

1. **ssm_conv1d**: HF layout `[dim, 1, kernel]` (squeezed to `[dim, kernel]`); the V-channel head reorder must preserve the kernel dim - reshape `(num_k_heads, num_v_per_k, head_v_dim, kernel)` before permute, otherwise the element count mismatches (`[16, 2, 128, 1]` vs the actual size).

2. **in_proj_a / in_proj_b**: HF stores the already-expanded `[num_v_heads, dim]` (v = k*v_per_k + j, k-major), GGUF expects `[dim, num_v_heads]`; the old code assumed per-v-head `head_dim=1` rows and failed on the reshape. New code: 2D `[num_v_heads, dim]` -> transpose; flat `[num_k_heads*dim, 1]` fallback -> expand each k-head row to its v_per_k copies, then transpose.

Reference layouts (working quant): ssm_alpha/ssm_beta `[4096, 32]`, ssm_conv1d `[4, 8192]`; k-major v ordering matches `get_tensor_meta_split` grouping `{{n_k_heads, head_ratio}}` in llama-model.cpp.

Additional note (not a code change): Qwen3.5 checkpoints need `--no-mtp` - the MTP mixin can add a speculative block (33 blocks vs expected 32).

## Verification

- `Qwen/Qwen3.5-9B` converted with `--no-mtp --no-lazy` and loaded in llama-server (model load + generation OK).
- Tensor dims match the reference unsloth GGUF for all ssm tensors.