### PR TITLE
common: share thread pools when `n_threads` differ

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1750,6 +1750,18 @@ struct ggml_threadpool_params ggml_threadpool_params_from_cpu_params(const commo
     return tpp;
 }
 
+namespace {
+
+bool can_share_threadpool(const ggml_threadpool_params & tpp1, const ggml_threadpool_params & tpp2) {
+    // n_threads does not matter -> we'll use what's larger
+    ggml_threadpool_params tpp_comparison = tpp1;
+    tpp_comparison.n_threads = tpp2.n_threads;
+
+    return ggml_threadpool_params_match(&tpp_comparison, &tpp2);
+}
+
+}  // namespace
+
 common_threadpools::~common_threadpools() {
     if (!free_fn) {
         return;
@@ -1778,7 +1790,9 @@ void common_threadpools::init(llama_context * ctx, const common_params & params)
     struct ggml_threadpool_params tpp =
             ggml_threadpool_params_from_cpu_params(params.cpuparams);
 
-    if (!ggml_threadpool_params_match(&tpp, &tpp_batch)) {
+    if (can_share_threadpool(tpp, tpp_batch)) {
+        tpp.n_threads = std::max(tpp.n_threads, tpp_batch.n_threads);
+    } else {
         threadpool_batch = ggml_threadpool_new_fn(&tpp_batch);
         if (!threadpool_batch) {
             COM_WRN("batch threadpool create failed : n_threads %d\n", tpp_batch.n_threads);


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

When running tools with `-t 8 -tb 4`, the code would previously create two thread pools: a pool with 8 threads and a pool with 4 threads.

The pool with 4 threads is unnecessary. We can simply use 4 threads from the pool with 8 threads. (The 4 other threads will go unused.)

Graph computations [use](https://github.com/ggml-org/llama.cpp/blob/ad1de39e0708e3ced9c71bb3c82d93a2c046a73f/src/llama-context.cpp#L2477) `n_threads` / `n_threads_batch` from the context, with the thread pool size being [the ceiling](https://github.com/ggml-org/llama.cpp/blob/ad1de39e0708e3ced9c71bb3c82d93a2c046a73f/ggml/src/ggml-cpu/ggml-cpu.c#L3408-L3411).

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Discovered while working on https://github.com/ggml-org/llama.cpp/issues/27039.

CC @ngxson who reviewed a related PR.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. All code written manually. Grok 4.6 helped me understand the code base.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
