### PR TITLE
Slow prefill on small KV quants fixed

### DIFF
--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -109,6 +109,101 @@ static __global__ void dequantize_block_q4_0(const void * __restrict__ vx, dst_t
     }
 }
 
+// #27109 fix: dedicated half2-vectorized q4_0 -> f16 (mirrors dequantize_block_q4_0
+// layout; float math identical, only writes are half2). Bypasses the slow generic
+// element-wise path that collapses prefill on Ampere when KV is dequantized to f16.
+static __global__ void dequantize_block_q4_0_f16(const void * __restrict__ vx, half * __restrict__ y, const int64_t nb32) {
+    const int64_t i  = blockIdx.x;
+    const int64_t tid = threadIdx.x; // assume 32 threads
+    const int64_t il = tid/8;        // 0..3
+    const int64_t ir = tid%8;        // 0..7
+    const int64_t ib = 8*i + ir;
+    if (ib >= nb32) {
+        return;
+    }
+
+    half * yb = y + 256*i + 32*ir + 4*il;
+    const block_q4_0 * x = (const block_q4_0 *)vx + ib;
+    const float d  = __half2float(x->d);
+    const float dm = -8.0f*d;
+    const uint8_t * q = x->qs + 4*il;
+
+    ((half2 *)(yb +  0))[0] = __floats2half2_rn(d*(q[0] & 0xF) + dm, d*(q[1] & 0xF) + dm);
+    ((half2 *)(yb +  0))[1] = __floats2half2_rn(d*(q[2] & 0xF) + dm, d*(q[3] & 0xF) + dm);
+    ((half2 *)(yb + 16))[0] = __floats2half2_rn(d*(q[0] >>  4) + dm, d*(q[1] >>  4) + dm);
+    ((half2 *)(yb + 16))[1] = __floats2half2_rn(d*(q[2] >>  4) + dm, d*(q[3] >>  4) + dm);
+}
+
+// #27109 fix: dedicated half2 f16 kernels for q4_1/q5_0/q5_1 (same math as the
+// reference dequantize_q* helpers, il/ir tiling like q4_0, half2 writes).
+static __global__ void dequantize_block_q4_1_f16(const void * __restrict__ vx, half * __restrict__ y, const int64_t nb32) {
+    const int64_t i = blockIdx.x;
+    const int64_t tid = threadIdx.x;
+    const int64_t il = tid/8, ir = tid%8;
+    const int64_t ib = 8*i + ir;
+    if (ib >= nb32) return;
+    half * yb = y + 256*i + 32*ir + 4*il;
+    const block_q4_1 * x = (const block_q4_1 *)vx + ib;
+    const float2 dm = __half22float2(x->dm);
+    const uint8_t * q = x->qs + 4*il;
+    ((half2 *)(yb +  0))[0] = __floats2half2_rn(dm.x*(q[0] & 0xF) + dm.y, dm.x*(q[1] & 0xF) + dm.y);
+    ((half2 *)(yb +  0))[1] = __floats2half2_rn(dm.x*(q[2] & 0xF) + dm.y, dm.x*(q[3] & 0xF) + dm.y);
+    ((half2 *)(yb + 16))[0] = __floats2half2_rn(dm.x*(q[0] >>  4) + dm.y, dm.x*(q[1] >>  4) + dm.y);
+    ((half2 *)(yb + 16))[1] = __floats2half2_rn(dm.x*(q[2] >>  4) + dm.y, dm.x*(q[3] >>  4) + dm.y);
+}
+
+static __global__ void dequantize_block_q5_0_f16(const void * __restrict__ vx, half * __restrict__ y, const int64_t nb32) {
+    const int64_t i = blockIdx.x;
+    const int64_t tid = threadIdx.x;
+    const int64_t il = tid/8, ir = tid%8;
+    const int64_t ib = 8*i + ir;
+    if (ib >= nb32) return;
+    half * yb = y + 256*i + 32*ir + 4*il;
+    const block_q5_0 * x = (const block_q5_0 *)vx + ib;
+    const float d = __half2float(x->d);
+    uint32_t qh; memcpy(&qh, x->qh, sizeof(qh));
+    const uint8_t * q = x->qs + 4*il;
+    float lo[4], hi[4];
+#pragma unroll
+    for (int l = 0; l < 4; ++l) {
+        const int p = 4*il + l;
+        const int xh_l = ((qh >> p)        << 4) & 0x10;
+        const int xh_h = ((qh >> (p + 12))     ) & 0x10;
+        lo[l] = (float)(((q[l] & 0xF) | xh_l) - 16) * d;
+        hi[l] = (float)(((q[l] >>  4) | xh_h) - 16) * d;
+    }
+    ((half2 *)(yb +  0))[0] = __floats2half2_rn(lo[0], lo[1]);
+    ((half2 *)(yb +  0))[1] = __floats2half2_rn(lo[2], lo[3]);
+    ((half2 *)(yb + 16))[0] = __floats2half2_rn(hi[0], hi[1]);
+    ((half2 *)(yb + 16))[1] = __floats2half2_rn(hi[2], hi[3]);
+}
+
+static __global__ void dequantize_block_q5_1_f16(const void * __restrict__ vx, half * __restrict__ y, const int64_t nb32) {
+    const int64_t i = blockIdx.x;
+    const int64_t tid = threadIdx.x;
+    const int64_t il = tid/8, ir = tid%8;
+    const int64_t ib = 8*i + ir;
+    if (ib >= nb32) return;
+    half * yb = y + 256*i + 32*ir + 4*il;
+    const block_q5_1 * x = (const block_q5_1 *)vx + ib;
+    const float2 dm = __half22float2(x->dm);
+    uint32_t qh; memcpy(&qh, x->qh, sizeof(qh));
+    const uint8_t * q = x->qs + 4*il;
+    float lo[4], hi[4];
+#pragma unroll
+    for (int l = 0; l < 4; ++l) {
+        const int p = 4*il + l;
+        const int xh_l = ((qh >> p)        << 4) & 0x10;
+        const int xh_h = ((qh >> (p + 12))     ) & 0x10;
+        lo[l] = (float)((q[l] & 0xF) | xh_l) * dm.x + dm.y;
+        hi[l] = (float)((q[l] >>  4) | xh_h) * dm.x + dm.y;
+    }
+    ((half2 *)(yb +  0))[0] = __floats2half2_rn(lo[0], lo[1]);
+    ((half2 *)(yb +  0))[1] = __floats2half2_rn(lo[2], lo[3]);
+    ((half2 *)(yb + 16))[0] = __floats2half2_rn(hi[0], hi[1]);
+    ((half2 *)(yb + 16))[1] = __floats2half2_rn(hi[2], hi[3]);
+}
+
 template<typename dst_t>
 static __global__ void dequantize_block_q4_1(const void * __restrict__ vx, dst_t * __restrict__ yy, int nb32) {
 
@@ -287,6 +382,28 @@ static void dequantize_row_q4_0_cuda(const void * vx, dst_t * y, const int64_t k
     const int nb32 = k / 32;
     const int nb = (k + 255) / 256;
     dequantize_block_q4_0<<<nb, 32, 0, stream>>>(vx, y, nb32);
+}
+
+// #27109 fix: launchers for the dedicated q4_0/q4_1/q5_0/q5_1 -> f16 kernels.
+static void dequantize_block_q4_0_f16_cuda(const void * vx, half * y, const int64_t k, cudaStream_t stream) {
+    const int nb32 = k / 32;
+    const int nb = (k + 255) / 256;
+    dequantize_block_q4_0_f16<<<nb, 32, 0, stream>>>(vx, y, nb32);
+}
+static void dequantize_block_q4_1_f16_cuda(const void * vx, half * y, const int64_t k, cudaStream_t stream) {
+    const int nb32 = k / 32;
+    const int nb = (k + 255) / 256;
+    dequantize_block_q4_1_f16<<<nb, 32, 0, stream>>>(vx, y, nb32);
+}
+static void dequantize_block_q5_0_f16_cuda(const void * vx, half * y, const int64_t k, cudaStream_t stream) {
+    const int nb32 = k / 32;
+    const int nb = (k + 255) / 256;
+    dequantize_block_q5_0_f16<<<nb, 32, 0, stream>>>(vx, y, nb32);
+}
+static void dequantize_block_q5_1_f16_cuda(const void * vx, half * y, const int64_t k, cudaStream_t stream) {
+    const int nb32 = k / 32;
+    const int nb = (k + 255) / 256;
+    dequantize_block_q5_1_f16<<<nb, 32, 0, stream>>>(vx, y, nb32);
 }
 
 template<typename dst_t>
@@ -519,12 +636,24 @@ to_fp16_cuda_t ggml_get_to_fp16_cuda(ggml_type type) {
         case GGML_TYPE_Q2_0:
             return dequantize_block_cont_cuda<QK2_0, QR2_0, dequantize_q2_0>;
         case GGML_TYPE_Q4_0:
+            if (fp16_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc)) {
+                return dequantize_block_q4_0_f16_cuda; // #27109 fix
+            }
             return dequantize_row_q4_0_cuda;
         case GGML_TYPE_Q4_1:
+            if (fp16_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc)) {
+                return dequantize_block_q4_1_f16_cuda; // #27109 fix
+            }
             return dequantize_row_q4_1_cuda;
         case GGML_TYPE_Q5_0:
+            if (fp16_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc)) {
+                return dequantize_block_q5_0_f16_cuda; // #27109 fix
+            }
             return dequantize_block_cont_cuda<QK5_0, QR5_0, dequantize_q5_0>;
         case GGML_TYPE_Q5_1:
+            if (fp16_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc)) {
+                return dequantize_block_q5_1_f16_cuda; // #27109 fix
+            }
             return dequantize_block_cont_cuda<QK5_1, QR5_1, dequantize_q5_1>;
         case GGML_TYPE_Q8_0:
             if (fp16_available(ggml_cuda_info().devices[ggml_cuda_get_device()].cc)) {


### PR DESCRIPTION
## Overview

I found an issue with quants, that they become very slow on prefill. Later I googled the exact issue. Found out that q_8 is working perfectly fine, but it did not compress enough memory for single gpu to use newest qwen 3.8 model. Tested each quant individually to get results, which were unsatisfactory:

All "after" numbers measured at the same ~9000 token prompt for a fair comparison. Before the fix the small quants collapse and time out at long prompts, so those are at shorter prompts:

| KV | before | after (~9000 tok prompt) |
|----|--------|--------------------------|
| q4_0 | 74 t/s | 1182 t/s |
| q4_1 | ~157 | 1175 |
| q5_0 | slow / timeout | 1167 |
| q5_1 | 125 | 1164 |
| q8_0 | 1159 (already fast) | 1159 |

At equal prompt length all quant KV types now run within ~2% of each other, so the fix makes them all as fast as q8_0.

Than tried reverse engineer to find the problem with opus 4.8. Because it is working on q_8 i decided that the fix will be easy, as AI can find patterns and apply similar patterns for smaller quants. q4_0 was successfull from the start, later I ran into issues with q4_1, q5_0, q5_1. It took several hours to recompile them (they also need GGML_CUDA_FA_ALL_QUANTS=ON to be enabled), but the issue was fixed. After re-testing at the same prompt length all quants run at about the same speed. Still though I think there is room for improvement, but for maximum memory squeeze and performance q4_0 looks like the sweet spot for now. For a little bit better quality use q8_0, or q5_1 which sits between q4_0 and q8_0 in quality.

## Additional information

Fixes #27109. Tested on 2x RTX 3090 with Qwen 3.8 27B, outputs are numerically correct.

llama.cpp prebuild for rtx 3090 lower Quants fast prefill fix (if you don't want to compile): https://github.com/Cybertiron/llama.cpp/releases/tag/b27109-quant-kv-fix

## Requirements

- [x] I have read and agree with the contributing guidelines
- AI usage disclosure: YES - the CUDA kernel code was written with AI (Opus 4.8). I found the problem, directed the debugging and tested/verified everything myself on my own 2x RTX 3090.
