### PR TITLE
examples: share thread pools between target and drafter

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1275,7 +1275,7 @@ struct common_init_result::impl {
 
     // note: the order in which model, context, etc. are declared matters because their destructors will be called bottom-to-top
 
-    common_threadpools threadpools;
+    std::shared_ptr<common_threadpools> threadpools;
 
     llama_model_ptr   model;
     llama_context_ptr context;
@@ -1381,7 +1381,13 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
 
     set_process_priority(params.cpuparams.priority);
 
-    pimpl->threadpools.init(lctx, params);
+    if (params.threadpools) {
+        pimpl->threadpools = params.threadpools;
+    } else {
+        pimpl->threadpools = std::make_shared<common_threadpools>();
+        pimpl->threadpools->init(params.cpuparams, params.cpuparams_batch);
+    }
+    pimpl->threadpools->attach(lctx);
 }
 
 llama_model * common_init_result::model() {
@@ -1734,6 +1740,8 @@ struct llama_context_params common_context_params_to_llama(const common_params &
 // Threadpool utils
 //
 
+namespace {
+
 struct ggml_threadpool_params ggml_threadpool_params_from_cpu_params(const common_cpu_params & params) {
     struct ggml_threadpool_params tpp;
 
@@ -1749,8 +1757,6 @@ struct ggml_threadpool_params ggml_threadpool_params_from_cpu_params(const commo
 
     return tpp;
 }
-
-namespace {
 
 bool can_share_threadpool(const ggml_threadpool_params & tpp1, const ggml_threadpool_params & tpp2) {
     // n_threads does not matter -> we'll use what's larger
@@ -1770,11 +1776,11 @@ common_threadpools::~common_threadpools() {
     free_fn(threadpool_batch);
 }
 
-void common_threadpools::init(llama_context * ctx, const common_params & params) {
+void common_threadpools::init(const common_cpu_params & cpu_params, const common_cpu_params & cpu_params_batch) {
     GGML_ASSERT(!threadpool);
     GGML_ASSERT(!threadpool_batch);
 
-    COM_INF("llama threadpool init, n_threads = %d\n", (int) params.cpuparams.n_threads);
+    COM_INF("llama threadpool init, n_threads = %d\n", (int) cpu_params.n_threads);
 
     auto * cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
     if (!cpu_dev) {
@@ -1786,9 +1792,9 @@ void common_threadpools::init(llama_context * ctx, const common_params & params)
     free_fn = (decltype(ggml_threadpool_free) *) ggml_backend_reg_get_proc_address(reg, "ggml_threadpool_free");
 
     struct ggml_threadpool_params tpp_batch =
-            ggml_threadpool_params_from_cpu_params(params.cpuparams_batch);
+            ggml_threadpool_params_from_cpu_params(cpu_params_batch);
     struct ggml_threadpool_params tpp =
-            ggml_threadpool_params_from_cpu_params(params.cpuparams);
+            ggml_threadpool_params_from_cpu_params(cpu_params);
 
     if (can_share_threadpool(tpp, tpp_batch)) {
         tpp.n_threads = std::max(tpp.n_threads, tpp_batch.n_threads);
@@ -1810,7 +1816,9 @@ void common_threadpools::init(llama_context * ctx, const common_params & params)
         threadpool_batch = nullptr;
         return;
     }
+}
 
+void common_threadpools::attach(llama_context * ctx) {
     llama_attach_threadpool(ctx, threadpool, threadpool_batch);
 }
 

--- a/common/common.h
+++ b/common/common.h
@@ -77,6 +77,27 @@ int32_t common_cpu_get_num_physical_cores();
 int32_t common_cpu_get_num_math();
 
 //
+// Threadpool utils
+//
+
+struct common_threadpools {
+    common_threadpools() = default;
+    ~common_threadpools();
+
+    common_threadpools(const common_threadpools &) = delete;
+    common_threadpools & operator=(const common_threadpools &) = delete;
+
+    void init(const common_cpu_params & cpu_params, const common_cpu_params & cpu_params_batch);
+    void attach(llama_context * ctx);
+
+private:
+    ggml_threadpool * threadpool       = nullptr;
+    ggml_threadpool * threadpool_batch = nullptr;
+
+    decltype(ggml_threadpool_free) * free_fn = nullptr;
+};
+
+//
 // Common params
 //
 
@@ -477,6 +498,8 @@ struct common_params {
 
     common_cpu_params cpuparams;
     common_cpu_params cpuparams_batch;
+
+    std::shared_ptr<common_threadpools> threadpools;
 
     ggml_backend_sched_eval_callback cb_eval = nullptr;
     void * cb_eval_user_data                 = nullptr;
@@ -940,28 +963,6 @@ std::string common_get_model_endpoint();
 
 // for testing purposes
 char * common_get_model_or_exit(int, char*[]);
-
-//
-// Threadpool utils
-//
-
-struct ggml_threadpool_params ggml_threadpool_params_from_cpu_params(const common_cpu_params & params);
-
-struct common_threadpools {
-    common_threadpools() = default;
-    ~common_threadpools();
-
-    common_threadpools(const common_threadpools &) = delete;
-    common_threadpools & operator=(const common_threadpools &) = delete;
-
-    void init(llama_context * ctx, const common_params & params);
-
-private:
-    ggml_threadpool * threadpool       = nullptr;
-    ggml_threadpool * threadpool_batch = nullptr;
-
-    decltype(ggml_threadpool_free) * free_fn = nullptr;
-};
 
 //
 // Context utils

--- a/examples/speculative/speculative.cpp
+++ b/examples/speculative/speculative.cpp
@@ -79,6 +79,15 @@ int main(int argc, char ** argv) {
     llama_context * ctx_tgt = NULL;
     llama_context * ctx_dft = NULL;
 
+    // create threadpools
+    common_cpu_params cpu_params_threadpool = params.cpuparams;
+    cpu_params_threadpool.n_threads = std::max(params.cpuparams.n_threads, params.speculative.draft.cpuparams.n_threads);
+    common_cpu_params cpu_params_threadpool_batch = params.cpuparams_batch;
+    cpu_params_threadpool_batch.n_threads = std::max(params.cpuparams_batch.n_threads, params.speculative.draft.cpuparams_batch.n_threads);
+
+    params.threadpools = std::make_shared<common_threadpools>();
+    params.threadpools->init(cpu_params_threadpool, cpu_params_threadpool_batch);
+
     // load the target model
     auto llama_init_tgt = common_init_from_params(params);
 


### PR DESCRIPTION
## Overview

Refs #27039

This PR updates the `speculative` example to share thread pools between the target and the draft model contexts.

How it works:

1. The example now first creates a shared `common_threadpools` object.
2. It passes it to `common_init_from_params()` via `common_params.threadpools`.
3. If `common_params.threadpools` is set, the model contexts now use those thread pools.

If the general approach is okay, I'll make a similar change to `common_speculative_init_result` in a follow-up PR.

## Additional information

As we can see [here](https://github.com/ggml-org/llama.cpp/blob/adb55e5148dc93bcdca7212a2d1df3ccc422959a/src/llama-context.cpp#L1113-L1120), it's already supported to attach one thread pool to multiple contexts.

It's safe to share thread pools between the target and draft models because they never compute concurrently.

As we already saw in #27138, it's also safe to attach a thread pool with more threads than a context will use.

CC @ngxson who reviewed a related PR.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. All code written manually. Grok 4.6 helped me understand the code base.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
