### PR TITLE
cuda : allow mixed K/V types in flash attention

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -355,6 +355,54 @@ static bool ggml_cuda_fattn_kv_type_supported(ggml_type type) {
     }
 }
 
+#ifdef GGML_CUDA_FA_ALL_QUANTS
+static bool ggml_cuda_fattn_vec_type_supported(ggml_type type) {
+    switch (type) {
+        case GGML_TYPE_F16:
+        case GGML_TYPE_BF16:
+        case GGML_TYPE_Q4_0:
+        case GGML_TYPE_Q4_1:
+        case GGML_TYPE_Q5_0:
+        case GGML_TYPE_Q5_1:
+        case GGML_TYPE_Q8_0:
+            return true;
+        default:
+            return false;
+    }
+}
+#endif // GGML_CUDA_FA_ALL_QUANTS
+
+// The vector kernel is instantiated only for the K/V type combinations listed in
+// ggml_cuda_flash_attn_ext_vec. The MMA and tile kernels convert K and V to FP16 and work for
+// any combination, so a missing vector instance must not disable FlashAttention altogether.
+static bool ggml_cuda_fattn_vec_instance_available(ggml_type type_K, ggml_type type_V) {
+    // FATTN_VEC_CASE dispatches F32 K/V onto the F16 instances.
+    if (type_K == GGML_TYPE_F32) {
+        type_K = GGML_TYPE_F16;
+    }
+    if (type_V == GGML_TYPE_F32) {
+        type_V = GGML_TYPE_F16;
+    }
+
+#ifdef GGML_CUDA_FA_ALL_QUANTS
+    return ggml_cuda_fattn_vec_type_supported(type_K) && ggml_cuda_fattn_vec_type_supported(type_V);
+#else
+    if (type_K != type_V) {
+        return false;
+    }
+
+    switch (type_K) {
+        case GGML_TYPE_F16:
+        case GGML_TYPE_BF16:
+        case GGML_TYPE_Q4_0:
+        case GGML_TYPE_Q8_0:
+            return true;
+        default:
+            return false;
+    }
+#endif // GGML_CUDA_FA_ALL_QUANTS
+}
+
 static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const ggml_tensor * dst) {
 #ifndef FLASH_ATTN_AVAILABLE
     GGML_UNUSED(device); GGML_UNUSED(dst);
@@ -439,12 +487,6 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
             return BEST_FATTN_KERNEL_NONE;
     }
 
-#ifndef GGML_CUDA_FA_ALL_QUANTS
-    if (K->type != V->type) {
-        return BEST_FATTN_KERNEL_NONE;
-    }
-#endif // GGML_CUDA_FA_ALL_QUANTS
-
     if (!ggml_cuda_fattn_kv_type_supported(K->type) || !ggml_cuda_fattn_kv_type_supported(V->type)) {
         return BEST_FATTN_KERNEL_NONE;
     }
@@ -455,7 +497,8 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
     // For small batch sizes the vector kernel may be preferable over the kernels optimized for large batch sizes:
     // 192 satisfies % 64 == 0 but has no vec instance (DKQ != DV); force it onto the MMA path.
-    const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && Q->ne[0] != 192 && K->ne[1] % FATTN_KQ_STRIDE == 0;
+    const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && Q->ne[0] != 192 && K->ne[1] % FATTN_KQ_STRIDE == 0 &&
+        ggml_cuda_fattn_vec_instance_available(K->type, V->type);
 
     // If Turing tensor cores are available, use them:
     if (turing_mma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 72) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9807,6 +9807,21 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // mixed K/V cache types: the vector kernel is instantiated only for a subset of type
+    // combinations, the remaining ones have to reach the same result through the MMA/tile kernels.
+    // nb == 1 exercises the vector path, nb == 32 the batched one.
+    for (int nb : { 1, 32, }) {
+        for (ggml_type type_K : { GGML_TYPE_F16, GGML_TYPE_Q8_0, GGML_TYPE_Q4_0, }) {
+            for (ggml_type type_V : { GGML_TYPE_F16, GGML_TYPE_Q8_0, GGML_TYPE_Q4_0, }) {
+                if (type_K == type_V) {
+                    continue; // same-type combinations are covered above
+                }
+                test_cases.emplace_back(new test_flash_attn_ext(
+                            128, 128, 4, {1, 1}, 512, nb, true, false, 0, 0, GGML_PREC_F32, type_K, type_V));
+            }
+        }
+    }
+
     for (int hsk : { 40, 64, 72, 80, 96, 128, 192, 256, 320, 512, 576 }) {
         for (int hsv : { 40, 64, 72, 80, 96, 128, 192, 256, 512 }) {
             if (hsk != 192 && hsk != 320 && hsk != 576 && hsk != hsv) continue;


### PR DESCRIPTION
## Overview

If `-ctk` and `-ctv` are different types, CUDA turns flash attention off completely and
every attention node runs on CPU. Prompt processing gets around 30x slower with no
warning at all. The check in `ggml_cuda_get_best_fattn_kernel` is:

```c
#ifndef GGML_CUDA_FA_ALL_QUANTS
    if (K->type != V->type) {
        return BEST_FATTN_KERNEL_NONE;
    }
#endif
```

That rule only applies to the vec kernel, since it is templated on
`<D, type_K, type_V>`. MMA and tile are not. Both call `launch_fattn` with
`need_f16_K = true, need_f16_V = true`, which converts K and V seperately via
`ggml_get_to_fp16_nc_cuda`, so they work for any pair. The check is written for one
kernel but it rejects the op for all of them.

This puts the check in `can_use_vector_kernel` instead. Every `return BEST_FATTN_KERNEL_VEC`
is already behind that flag, so pairs with no vec instance fall through to MMA or tile
instead of leaving the GPU. No new kernels or template instances, no build default changes.

## Additional information

RTX 4090, Nanbeige 4.2 3B Q8_0, `-ngl 99 -fa 1 -p 512 -r 2`, pp512 t/s:

| K / V | before | after |
| --- | ---: | ---: |
| q8_0 / q8_0 | 11250 | 11150 |
| f16 / q8_0 | 379 | 11582 |
| q8_0 / q4_0 | 358 | 11234 |
| q4_0 / q8_0 | 381 | 11274 |

All six mixed pairs end up in the same range. Same type pairs are unchanged. tg64 on
mixed pairs goes from about 79 to about 104 t/s.

Perplexity on wikitext-2, `-c 512 --chunks 16`: same type pairs are identical before and
after (f16/f16 30.7341, q8_0/q8_0 30.8691). q4_0/q8_0 goes from 31.0011 to 31.0677,
which is expected since the work moved from CPU into the CUDA MMA kernel.

Added 12 mixed K/V cases to `test-backend-ops`. The existing FA cases always pass the same
type for K and V, so that's why this never came up. `-o FLASH_ATTN_EXT -b CUDA0` passes.

Worth looking at:

- The new tests don't fail before this. CUDA reports the op as unsupported so they get
  skipped. Not really a red to green test.
- I did not run the full local CI.
- Only tested this on one GPU. The `can_use_vector_kernel` change also feeds the Volta,
  RDNA4 and MFMA branches which I couldn't test.

Related: #20866 is the same bug, it was closed with the
`-DGGML_CUDA_FA_ALL_QUANTS=ON` workaround. #24485 asked to make that the default, closed
as not planned. #24981 added mixed K/V tests, closed with no review. None of them changed
the dispatch.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. I used Claude to trace the dispatch path, write the fix and
  test cases, and run the benchmarks and perplexity runs. I reviewed the change and can
  explain it.
