### PR TITLE
mtmd : trigger one-time inits for vision encoder at warmup

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -165,6 +165,8 @@ struct clip_ctx {
     clip_flash_attn_type flash_attn_type = CLIP_FLASH_ATTN_TYPE_AUTO;
     bool is_allocated = false;
 
+    int n_threads = 1;
+
     bool debug_output_embeddings = false;
 
     // for measuring memory usage
@@ -181,6 +183,7 @@ struct clip_ctx {
     clip_ctx(clip_context_params & ctx_params) {
         flash_attn_type = ctx_params.flash_attn_type;
         no_alloc = ctx_params.no_alloc;
+        n_threads = ctx_params.n_threads;
         backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
         if (!backend_cpu) {
             throw std::runtime_error("failed to initialize CPU backend");
@@ -3650,6 +3653,22 @@ struct clip_model_loader {
     static void warmup(clip_ctx & ctx_clip) {
         auto batch = get_dummy_batch(ctx_clip);
         warmup(ctx_clip, batch);
+        
+        // run a real encode so one-time backend inits happen at load, not on first request
+        // vision only, as audio dummy batches are not encodable
+        if (!ctx_clip.no_alloc && ctx_clip.model.modality == CLIP_MODALITY_VISION &&
+                ctx_clip.backend && ctx_clip.backend != ctx_clip.backend_cpu) {
+            LOG_INF("%s: running warmup encode, please wait ... (--no-warmup to disable)\n", __func__);
+            const int64_t t_start_us = ggml_time_us();
+            clip_encode_params params;
+            params.imgs = &batch;
+            params.n_threads = ctx_clip.n_threads;
+            if (clip_encode(&ctx_clip, &params)) {
+                LOG_INF("%s: warmup encode took %.2f ms\n", __func__, (ggml_time_us() - t_start_us) / 1000.0);
+            } else {
+                LOG_WRN("%s: warmup encode failed, image encoding may not work on this backend\n", __func__);
+            }
+        }
     }
 
     static void warmup(clip_ctx & ctx_clip, const clip_image_f32_batch & batch) {

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -3653,11 +3653,11 @@ struct clip_model_loader {
     static void warmup(clip_ctx & ctx_clip) {
         auto batch = get_dummy_batch(ctx_clip);
         warmup(ctx_clip, batch);
-        
+
         // run a real encode so one-time backend inits happen at load, not on first request
         // vision only, as audio dummy batches are not encodable
         if (!ctx_clip.no_alloc && ctx_clip.model.modality == CLIP_MODALITY_VISION &&
-                ctx_clip.backend && ctx_clip.backend != ctx_clip.backend_cpu) {
+                ctx_clip.backend != ctx_clip.backend_cpu) {
             LOG_INF("%s: running warmup encode, please wait ... (--no-warmup to disable)\n", __func__);
             const int64_t t_start_us = ggml_time_us();
             clip_encode_params params;

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -58,6 +58,7 @@ struct clip_context_params {
     bool no_alloc;
     mtmd_progress_callback progress_callback;
     void * progress_callback_user_data;
+    int n_threads = 1;
 };
 
 struct clip_init_result {

--- a/tools/mtmd/debug/mtmd-debug.cpp
+++ b/tools/mtmd/debug/mtmd-debug.cpp
@@ -58,6 +58,8 @@ int main(int argc, char ** argv) {
 
     common_init();
 
+    params.warmup = false;
+
     if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_MTMD, show_additional_info)) {
         return 1;
     }
@@ -88,8 +90,7 @@ int main(int argc, char ** argv) {
         mparams.print_timings    = true;
         mparams.n_threads        = params.cpuparams.n_threads;
         mparams.flash_attn_type  = params.flash_attn_type;
-        // no warmup, so the debug callback only sees the encode requested by the user
-        mparams.warmup           = false;
+        mparams.warmup           = params.warmup;
         mparams.image_min_tokens = params.image_min_tokens;
         mparams.image_max_tokens = params.image_max_tokens;
         {

--- a/tools/mtmd/debug/mtmd-debug.cpp
+++ b/tools/mtmd/debug/mtmd-debug.cpp
@@ -88,7 +88,8 @@ int main(int argc, char ** argv) {
         mparams.print_timings    = true;
         mparams.n_threads        = params.cpuparams.n_threads;
         mparams.flash_attn_type  = params.flash_attn_type;
-        mparams.warmup           = params.warmup;
+        // no warmup, so the debug callback only sees the encode requested by the user
+        mparams.warmup           = false;
         mparams.image_min_tokens = params.image_min_tokens;
         mparams.image_max_tokens = params.image_max_tokens;
         {

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -575,6 +575,7 @@ struct mtmd_context {
             /* no_alloc          */ no_alloc,
             /* progress_callback */ ctx_params.progress_callback,
             /* progress_callback_user_data */ ctx_params.progress_callback_user_data,
+            /* n_threads         */ ctx_params.n_threads,
         };
 
         auto res = clip_init(mmproj_fname, ctx_clip_params);


### PR DESCRIPTION
## Overview

Currently warmup for vision models doesn't launch any kernels, so the vision encoder's one-time inits happen on the first vision request, making the first request much slower than the subsequent ones. This change makes the warmup perform a real encode of a dummy image for models with a vision encoder to pay the init cost at model load instead.

Fixes #27147: first request processing times for my specific image inputs went roughly ~1.18s -> 0.75s +- 0.1s, with warm requests unchanged. `--no-warmup` restores old behaviour.

## Additional information

Two supporting changes:
- `n_threads` field is added to `clip_ctx`, so its value can be passed to `clip_encode`, allowing any CPU fallback ops to be executed with multiple threads
- `mtmd-debug` hardcodes warmup off so its debug callback only fires for user-requested encodes, as before

Full local CI (`ci/run.sh`) passes.

## Update (31Aug 2026)

- Rebased onto current master (`2d8d612`)
- CI runs successful on this exact commit on my fork: [CI (cpu)](https://github.com/sihanyu03/llama.cpp/actions/runs/33416717298) (build-cmake-pkg can't run on the fork so it fails), [Server](https://github.com/sihanyu03/llama.cpp/actions/runs/33416716948), and [CI (wasm)](https://github.com/sihanyu03/llama.cpp/actions/runs/33416717922)


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used to assist in hunting down the exact cause and drafting the implementation. All the lines were reviewed, edited, and hand-validated by me.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
