### PR TITLE
vulkan: add runtime cache and Termux compatibility fixes

### DIFF
--- a/ggml/src/ggml-opt.cpp
+++ b/ggml/src/ggml-opt.cpp
@@ -486,7 +486,14 @@ static void ggml_opt_build(ggml_opt_context_t opt_ctx) {
     }
 
     // gb_grad == graph backward gradients, forward pass, then backward pass to calculate gradients.
-    opt_ctx->gb_grad = ggml_graph_dup(opt_ctx->ctx_compute, opt_ctx->gf, /*force_grads =*/ true);
+    // ggml_graph_dup() keeps the forward graph's capacity, but ggml_build_backward_expand() appends
+    // the grad nodes to the same graph; for large attention graphs the backward graph is up to ~3x
+    // the forward graph, so allocate extra capacity here
+    {
+        struct ggml_cgraph * gb = ggml_new_graph_custom(opt_ctx->ctx_compute, 6*opt_ctx->gf->size, /*grads =*/ true);
+        ggml_graph_cpy(opt_ctx->gf, gb);
+        opt_ctx->gb_grad = gb;
+    }
     ggml_build_backward_expand(opt_ctx->ctx_compute, opt_ctx->gb_grad, opt_ctx->grad_accs.data());
 
     if (opt_ctx->buf_static) {
@@ -501,7 +508,12 @@ static void ggml_opt_build(ggml_opt_context_t opt_ctx) {
     GGML_ASSERT(opt_ctx->build_type_alloc == GGML_OPT_BUILD_TYPE_OPT);
 
     // gb_opt == graph backward optimize, forward pass, then backward pass to calculate gradients, then optimizer step.
-    opt_ctx->gb_opt = ggml_graph_dup(opt_ctx->ctx_compute, opt_ctx->gb_grad, /*force_grads =*/ true);
+    // like gb_grad above, allocate extra capacity for the per-param optimizer step nodes
+    {
+        struct ggml_cgraph * gb = ggml_new_graph_custom(opt_ctx->ctx_compute, opt_ctx->gb_grad->size + 16*n_param, /*grads =*/ true);
+        ggml_graph_cpy(opt_ctx->gb_grad, gb);
+        opt_ctx->gb_opt = gb;
+    }
 
     opt_ctx->opt_step_params = ggml_new_tensor_1d(opt_ctx->ctx_cpu, GGML_TYPE_F32, need_momenta ? 7 : 2);
     ggml_tensor * adamw_params = opt_ctx->opt_step_params;

--- a/ggml/src/ggml-vulkan/CMakeLists.txt
+++ b/ggml/src/ggml-vulkan/CMakeLists.txt
@@ -174,6 +174,9 @@ if (Vulkan_FOUND)
         message(STATUS "vulkan-shaders-gen toolchain file: ${HOST_CMAKE_TOOLCHAIN_FILE}")
     endif()
 
+    # Termux/Android: libc++ not linked by default for ELF executables
+    list(APPEND VULKAN_SHADER_GEN_CMAKE_ARGS -DCMAKE_EXE_LINKER_FLAGS=-lc++_shared)
+
     ExternalProject_Add(
         vulkan-shaders-gen
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1,5 +1,6 @@
 #include "ggml-vulkan.h"
 #include <vulkan/vulkan_core.h>
+#include <fstream>
 #if defined(GGML_VULKAN_RUN_TESTS) || defined(GGML_VULKAN_CHECK_RESULTS)
 #include <chrono>
 #include "ggml-cpu.h"
@@ -777,6 +778,10 @@ struct vk_device_struct {
     // runs with no lock held, so different pipelines can compile in parallel.
     // Lock order is device->mutex -> compile_mutex, never the reverse.
     std::mutex compile_mutex;
+
+    // Pipeline cache for Vulkan shader compilation
+    vk::PipelineCache pipeline_cache;
+    std::string pipeline_cache_path;
     std::condition_variable compile_cv;
 
     vk::PhysicalDevice physical_device;
@@ -1109,6 +1114,19 @@ struct vk_device_struct {
 
     ~vk_device_struct() {
         VK_LOG_DEBUG("destroy device " << name);
+
+        // Save pipeline cache
+        if (pipeline_cache) {
+            auto data = device.getPipelineCacheData(pipeline_cache);
+            if (!data.empty()) {
+                std::ofstream ofs(pipeline_cache_path, std::ios::binary);
+                if (ofs) {
+                    ofs.write(reinterpret_cast<const char*>(data.data()), data.size());
+                    VK_LOG_DEBUG("Saved pipeline cache to " << pipeline_cache_path << " (" << data.size() << " bytes)");
+                }
+            }
+            device.destroyPipelineCache(pipeline_cache);
+        }
 
         device.destroyFence(fence);
 
@@ -3026,7 +3044,7 @@ static void ggml_vk_create_pipeline_func(vk_device& device, vk_pipeline& pipelin
 #endif
 
     try {
-        pipeline->pipeline = device->device.createComputePipeline(VK_NULL_HANDLE, compute_pipeline_create_info).value;
+        pipeline->pipeline = device->device.createComputePipeline(device->pipeline_cache, compute_pipeline_create_info).value;
     } catch (const vk::SystemError& e) {
         std::cerr << "ggml_vulkan: Compute pipeline creation failed for " << pipeline->name << std::endl;
         std::cerr << "ggml_vulkan: " << e.what() << std::endl;
@@ -6938,6 +6956,44 @@ static vk_device ggml_vk_get_device(size_t idx) {
         if (device->device_fault) {
             device->pfn_vkGetDeviceFaultInfoEXT = (PFN_vkGetDeviceFaultInfoEXT)
                 vkGetDeviceProcAddr(device->device, "vkGetDeviceFaultInfoEXT");
+        }
+
+        // Initialize pipeline cache
+        {
+            // Use GGML_VK_PIPELINE_CACHE_DIR env var or default to ~/.cache/ggml-vulkan-pipeline.bin
+            const char* cache_dir = getenv("GGML_VK_PIPELINE_CACHE_DIR");
+            std::string cache_path;
+            if (cache_dir) {
+                cache_path = std::string(cache_dir) + "/ggml-vulkan-pipeline.bin";
+            } else {
+                const char* home = getenv("HOME");
+                if (home) {
+                    cache_path = std::string(home) + "/.cache/ggml-vulkan-pipeline.bin";
+                }
+            }
+            if (!cache_path.empty()) {
+                device->pipeline_cache_path = cache_path;
+                std::ifstream ifs(cache_path, std::ios::binary | std::ios::ate);
+                if (ifs) {
+                    size_t size = ifs.tellg();
+                    ifs.seekg(0);
+                    std::vector<uint8_t> data(size);
+                    ifs.read(reinterpret_cast<char*>(data.data()), size);
+                    vk::PipelineCacheCreateInfo pcci(vk::PipelineCacheCreateFlags{}, data.size(), data.data());
+                    try {
+                        device->pipeline_cache = device->device.createPipelineCache(pcci);
+                        VK_LOG_DEBUG("Loaded pipeline cache from " << cache_path << " (" << size << " bytes)");
+                    } catch (const vk::SystemError& e) {
+                        // Cache might be corrupted or from a different driver version
+                        VK_LOG_DEBUG("Failed to load pipeline cache: " << e.what() << ", creating new one");
+                        device->pipeline_cache = device->device.createPipelineCache({});
+                    }
+                } else {
+                    device->pipeline_cache = device->device.createPipelineCache({});
+                }
+            } else {
+                device->pipeline_cache = device->device.createPipelineCache({});
+            }
         }
 
         // Queues
@@ -17916,10 +17972,11 @@ static void ggml_backend_vk_device_get_props(ggml_backend_dev_t dev, struct ggml
     props->type        = ggml_backend_vk_device_get_type(dev);
     props->device_id   = ctx->pci_bus_id.empty() ? nullptr : ctx->pci_bus_id.c_str();
     ggml_backend_vk_device_get_memory(dev, &props->memory_free, &props->memory_total);
+    auto device = ggml_vk_get_device(ctx->device);
     props->caps = {
         /* .async                 = */ true,
         /* .host_buffer           = */ true,
-        /* .buffer_from_host_ptr  = */ false,
+        /* .buffer_from_host_ptr  = */ device->external_memory_host,
         /* .events                = */ true,
         /* .mmap_support          = */ !ctx->is_integrated_gpu,
     };

--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -6934,6 +6934,21 @@ static void ggml_compute_backward(
                 // noop
             }
         } break;
+        case GGML_OP_SET_ROWS: {
+            // SET_ROWS: writes src0 (rows) into a view of src2 (state buffer, e.g. KV cache)
+            // at positions src1; the node itself is the (view of) src2
+            // gradient flows only into src0 (the written rows), gathered from the
+            // accumulated gradient of the cache at the written positions
+            if (src0_needs_grads) {
+                ggml_add_or_set(ctx, cgraph, isrc0, ggml_get_rows(ctx, grad, src1));
+            }
+            if (src1_needs_grads) {
+                // noop (indices not differentiable)
+            }
+            if (src2_needs_grads) {
+                // noop (dst is a state buffer, not a parameter)
+            }
+        } break;
         case GGML_OP_DIAG_MASK_INF: {
             if (src0_needs_grads) {
                 /* ggml_diag_mask_inf_impl() shouldn't be here */
@@ -7263,6 +7278,7 @@ void ggml_build_backward_expand(
             case GGML_OP_CPY:           // gradients in CPY target are irrelevant
             case GGML_OP_GET_ROWS:      // row indices not differentiable
             case GGML_OP_GET_ROWS_BACK: // same as for GET_ROWS
+            case GGML_OP_SET_ROWS:      // row indices not differentiable, cache dst is state
             case GGML_OP_ROPE:          // positions not differentiable
                 ignore_src[1] = true;
                 break;
@@ -7283,8 +7299,11 @@ void ggml_build_backward_expand(
         }
 
         // inplace operations are currently not supported
+        // SET_ROWS writes into a view of a state buffer (e.g. KV cache); the backward
+        // pass handles it by routing gradients only into the written rows (src0)
         GGML_ASSERT(!node->view_src || node->op == GGML_OP_CPY || node->op == GGML_OP_VIEW ||
-            node->op == GGML_OP_RESHAPE || node->op == GGML_OP_PERMUTE || node->op == GGML_OP_TRANSPOSE);
+            node->op == GGML_OP_RESHAPE || node->op == GGML_OP_PERMUTE || node->op == GGML_OP_TRANSPOSE ||
+            node->op == GGML_OP_SET_ROWS);
 
         const size_t ihash = ggml_hash_find(&cgraph->visited_hash_set, node);
         GGML_ASSERT(ihash != GGML_HASHSET_FULL);


### PR DESCRIPTION
## Summary

This is a clean replacement for the abandoned Mali G720 draft PR. It is based directly on current `ggml-org/llama.cpp:master` and does not carry the old PR lineage.

The change groups the current iteration work for:

- Vulkan pipeline-cache persistence, controlled by `GGML_VK_PIPELINE_CACHE_DIR`.
- Termux/Android linking of the external `vulkan-shaders-gen` executable with `libc++_shared`.
- Reporting `buffer_from_host_ptr` only when the Vulkan device actually exposes external host memory support.
- Backward propagation through `GGML_OP_SET_ROWS` for written rows while treating cache destinations and indices as non-differentiable.
- Additional graph capacity for optimizer backward/optimization graph expansion.

## Validation record

Environment: Android 16 / Termux / AArch64 / Clang 23.1.0.

Passed:

- `cmake --build build-cpu-train --target ggml-base -j1`
- `cmake --build build-cpu-train --target llama llama-bench -j1`
- Vulkan shader-generator executable built successfully.
- `git diff --check`

Blocked:

- Full Vulkan backend build was attempted with `cmake --build build-vk --target llama-cli test-backend-ops llama-bench -j1` and a second existing Vulkan configuration.
- Both configurations reached shader generation but failed in the installed `glslc/shaderc` while compiling `flash_attn_cm2`:

  `shaderc: internal error: compilation succeeded but failed to optimize: Invalid capability operand: 5447`

This is recorded as an environment/toolchain blocker; it is not reported as a successful Vulkan build or device validation.

Not included:

- Device benchmark claims.
- Mali-specific architecture tuning from the abandoned PR.
- Local Termux launcher and investigation notes.

## Scope

This PR is a draft until the Vulkan build is reproduced with a compatible shaderc/glslc toolchain and the pipeline-cache and external-host-buffer paths are exercised on the target device.
