### PR TITLE
convert : support mixed FP8 and NVFP4 compressed-tensors

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -63,6 +63,17 @@ HparamsMatcher = Callable[[Path], bool]
 HparamsLoader = Callable[[Path], dict[str, Any]]
 
 
+def _is_compressed_tensors_nvfp4(quant_method: str | None, quant_format: str | None, groups: dict[str, Any]) -> bool:
+    if quant_method != "compressed-tensors":
+        return False
+    if quant_format == "nvfp4-pack-quantized":
+        return True
+    return quant_format == "mixed-precision" and any(
+        isinstance(group, dict) and group.get("format") == "nvfp4-pack-quantized"
+        for group in groups.values()
+    )
+
+
 class SentencePieceTokenTypes(IntEnum):
     NORMAL = 1
     UNKNOWN = 2
@@ -485,12 +496,8 @@ class ModelBase:
             elif quant_method == "compressed-tensors":
                 quant_format = quant_config["format"]
                 groups = quant_config["config_groups"]
-                nvfp4_compressed_tensors = (
-                    quant_format == "nvfp4-pack-quantized"
-                    or quant_format == "mixed-precision"
-                    and bool(groups)
-                    and all(g.get("format") == "nvfp4-pack-quantized" for g in groups.values() if isinstance(g, dict))
-                )
+                nvfp4_compressed_tensors = _is_compressed_tensors_nvfp4(quant_method, quant_format, groups)
+                mixed_nvfp4 = quant_format == "mixed-precision" and nvfp4_compressed_tensors
 
                 if len(groups) > 1 and not nvfp4_compressed_tensors:
                     raise NotImplementedError("Can't handle multiple config groups for compressed-tensors yet")
@@ -537,6 +544,41 @@ class ModelBase:
                             tensors_to_remove += [base_name + n for n in ("_packed", "_shape", "_scale")]
                             if (base_name + "_zero_point") in self.model_tensors:
                                 tensors_to_remove.append(base_name + "_zero_point")
+                elif mixed_nvfp4:
+                    supported_formats = {"float-quantized", "nvfp4-pack-quantized"}
+                    formats = {
+                        group.get("format")
+                        for group in groups.values()
+                        if isinstance(group, dict)
+                    }
+                    if not formats <= supported_formats:
+                        raise NotImplementedError(
+                            f"Unsupported compressed-tensors mixed-precision formats: {sorted(formats - supported_formats)}"
+                        )
+                    for group in groups.values():
+                        if not isinstance(group, dict) or group.get("format") != "float-quantized":
+                            continue
+                        weights = group["weights"]
+                        if not (
+                            weights.get("type") == "float"
+                            and weights.get("num_bits") == 8
+                            and weights.get("strategy") == "channel"
+                            and weights.get("group_size") is None
+                        ):
+                            raise NotImplementedError("Only per-channel FP8 is supported alongside compressed-tensors NVFP4")
+                    for name in self.model_tensors.keys():
+                        if not name.endswith(".weight_scale"):
+                            continue
+                        weight_name = name.removesuffix("_scale")
+                        if weight_name not in self.model_tensors:
+                            tensors_to_remove.append(name)
+                            continue
+                        w = self.model_tensors[weight_name]
+                        s = self.model_tensors[name]
+                        self.model_tensors[weight_name] = lambda w=w, s=s: dequant_simple(w(), s(), None)
+                        tensors_to_remove.append(name)
+                        if self._fp8_as_q8:
+                            self._fp8_dequantized.add(weight_name)
                 elif nvfp4_compressed_tensors:
                     # Don't error from compressed-tensors, we'll handle them in _generate_nvfp4_tensors
                     pass
@@ -751,8 +793,9 @@ class ModelBase:
             weight = LazyTorchTensor.to_eager(self.model_tensors[name]())
             scale = LazyTorchTensor.to_eager(self.model_tensors[scale_name]())
 
-            # Skip non-NVFP4 tensors (e.g. FP8 with per-channel 1D scales)
-            if scale.ndim < 2:
+            # NVFP4 weights are nibble-packed integer tensors. FP8 weights are
+            # floating point and may use either 1D or [rows, 1] channel scales.
+            if weight.is_floating_point() or scale.ndim < 2:
                 continue
 
             scale2 = LazyTorchTensor.to_eager(self.model_tensors.get(scale2_name, lambda: torch.tensor(1.0))())
@@ -854,12 +897,7 @@ class ModelBase:
 
         # Some models use per-tensor quant_algo (e.g. "MIXED_PRECISION" with
         # per-layer NVFP4/FP8) instead of a single global "NVFP4" value.
-        nvfp4_compressed_tensors = quant_method == "compressed-tensors" and (
-            quant_format == "nvfp4-pack-quantized"
-            or quant_format == "mixed-precision"
-            and bool(quant_groups)
-            and all(g.get("format") == "nvfp4-pack-quantized" for g in quant_groups.values() if isinstance(g, dict))
-        )
+        nvfp4_compressed_tensors = _is_compressed_tensors_nvfp4(quant_method, quant_format, quant_groups)
         if quant_algo != "NVFP4":
             if nvfp4_compressed_tensors:
                 quant_algo = "NVFP4"

--- a/tests/test-conversion-base.py
+++ b/tests/test-conversion-base.py
@@ -1,0 +1,75 @@
+from typing import Any
+
+import torch
+
+from conversion.base import ModelBase, _is_compressed_tensors_nvfp4
+
+
+MIXED_CONFIG: dict[str, Any] = {
+    "quant_method": "compressed-tensors",
+    "format": "mixed-precision",
+    "config_groups": {
+        "fp8": {
+            "format": "float-quantized",
+            "weights": {
+                "type": "float",
+                "num_bits": 8,
+                "strategy": "channel",
+                "group_size": None,
+            },
+        },
+        "nvfp4": {
+            "format": "nvfp4-pack-quantized",
+            "weights": {
+                "type": "float",
+                "num_bits": 4,
+                "strategy": "tensor_group",
+                "group_size": 16,
+            },
+        },
+    },
+}
+
+
+def test_detects_nvfp4_group_in_mixed_precision_config():
+    assert _is_compressed_tensors_nvfp4(
+        MIXED_CONFIG["quant_method"],
+        MIXED_CONFIG["format"],
+        MIXED_CONFIG["config_groups"],
+    )
+
+
+def test_dequantizes_fp8_tensors_remaining_after_nvfp4_repack():
+    model = object.__new__(ModelBase)
+    model.hparams = {"quantization_config": MIXED_CONFIG}
+    model._is_nvfp4 = True
+    model._fp8_as_q8 = True
+    model._fp8_dequantized = set()
+    model.model_tensors = {
+        "model.layers.0.self_attn.q_proj.weight": lambda: torch.tensor(
+            [[1.0, 2.0], [3.0, 4.0]], dtype=torch.float8_e4m3fn
+        ),
+        "model.layers.0.self_attn.q_proj.weight_scale": lambda: torch.tensor([[0.5], [0.25]]),
+    }
+
+    model.dequant_model()
+
+    weight_name = "model.layers.0.self_attn.q_proj.weight"
+    assert set(model.model_tensors) == {weight_name}
+    weight = model.model_tensors[weight_name]()
+    assert weight.dtype == torch.float32
+    torch.testing.assert_close(weight, torch.tensor([[0.5, 1.0], [0.75, 1.0]]))
+    assert model._fp8_dequantized == {weight_name}
+
+
+def test_nvfp4_repacking_skips_fp8_with_2d_channel_scale():
+    model = object.__new__(ModelBase)
+    model.hparams = {}
+    model.model_tensors = {
+        "lm_head.weight": lambda: torch.ones((2, 2), dtype=torch.float8_e4m3fn),
+        "lm_head.weight_scale": lambda: torch.ones((2, 1)),
+    }
+
+    model._generate_nvfp4_tensors()
+
+    assert set(model.model_tensors) == {"lm_head.weight", "lm_head.weight_scale"}


### PR DESCRIPTION
## Overview

Support mixed-precision compressed-tensors checkpoints that combine per-channel FP8 and packed NVFP4 weights. This enables conversion of `unsloth/Qwen3.8-27B-NVFP4`, whose attention and output tensors use FP8 while most MLP tensors use NVFP4.

Before this change, conversion fails with:

```text
NotImplementedError: Can't handle multiple config groups for compressed-tensors yet
```

## Additional information

Changes:

- Detect NVFP4 when any mixed-precision config group uses `nvfp4-pack-quantized`.
- Repack packed integer NVFP4 tensors while leaving floating-point FP8 tensors for dequantization.
- Handle 1D and rows-by-1 FP8 channel scales while preserving `--fp8-as-q8` behavior.
- Reject unsupported mixed formats and FP8 layouts.
- Add regression tests for mixed-group detection, FP8 dequantization, and 2D FP8 scale classification.

Validation:

- `uv run pytest -q tests/test-conversion-base.py`: 3 passed.
- `flake8 conversion/base.py tests/test-conversion-base.py`: passed.
- `ty 0.0.35 check`: no errors; existing unused-ignore warnings remain.
- CUDA SM120 build of `llama-server`, `llama-cli`, and `llama-gguf-split`: passed.
- Full conversion of `unsloth/Qwen3.8-27B-NVFP4` with `--fp8-as-q8`, with and without MTP: passed.
- 128K-context `llama-server` load and generation on RTX 5070 Ti using Q4_0 KV cache: passed.
- Embedded MTP speculative decoding with draft lengths 1 through 4: passed.

Supersedes #26407. This version targets current `master`, narrows the change to Qwen3.8 conversion, and includes validation on the exact checkpoint.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Codex assisted with implementation, test design, validation, and PR preparation.
