### PR TITLE
vulkan: optimize ARM Mali subgroup warptiles

### DIFF
--- a/docs/backend/MALI_VULKAN.md
+++ b/docs/backend/MALI_VULKAN.md
@@ -91,10 +91,33 @@ ARM rates: pixel=4 texel=8 fma=128
 
 ## Emulator and simulator boundary
 
-llvmpipe and SwiftShader are useful for Vulkan API and shader correctness
-checks, but they do not emulate ARM Mali hardware, ARM shader-core properties,
-Mali scheduling, or Mali performance. Android Emulator GPU modes likewise do
-not provide a Mali-G720 driver contract.
+The Android Emulator can run generic software Vulkan with:
+
+```bash
+emulator @AVD -gpu swiftshader_indirect
+emulator @AVD -gpu lavapipe
+```
+
+It can also use `-gpu host`, which passes through the development host GPU;
+that is not Mali emulation. These modes require a desktop emulator host and
+do not reproduce the Android ARM Mali driver ABI.
+
+Mesa PanVK is an open Mali-family Vulkan driver on supported Linux hardware,
+but it is not the proprietary Android r44p1 driver used by the reference phone.
+It may help test generic Mali-family shader behavior, but it cannot stand in
+for this device's performance result.
+
+References:
+
+- https://developer.android.com/studio/run/emulator-acceleration
+- https://developer.android.com/studio/run/emulator-commandline
+- https://docs.mesa3d.org/panfrost.html
+
+llvmpipe, SwiftShader, and Android Emulator software modes are useful for
+Vulkan API and shader correctness checks, but they do not emulate ARM Mali
+hardware, ARM shader-core properties, Mali scheduling, or Mali performance.
+Android Emulator GPU modes likewise do not provide a Mali-G720 driver
+contract.
 
 Therefore:
 

--- a/docs/backend/MALI_VULKAN.md
+++ b/docs/backend/MALI_VULKAN.md
@@ -63,7 +63,17 @@ Record the device name, Vulkan API version, driver version, subgroup size,
 shader compiler versions, build commit, model quantization, and all benchmark
 samples. A single run is not sufficient for a tuning claim.
 
-The reference device for this change was:
+The backend keeps the generic 32-wide fallback for other architectures. For an ARM Mali device, the warptile configuration uses the device's actual subgroup size instead of forcing the 32-wide lower bound. This is guarded by both the ARM vendor architecture classification and the advertised ARM shader-core extension.
+
+On the reference Mali-G720 device, two five-sample runs with the same SmolLM2 Q4_K_M workload measured the following ranges:
+
+```text
+prompt/matmul:  generic 154.27 tok/s -> ARM subgroup 162.34 tok/s (+5.24%)
+generation:     generic  60.58 tok/s -> ARM subgroup  59.58 tok/s (-1.65%)
+```
+
+The generation result is not claimed as an improvement. More Mali devices and
+larger model/batch matrices are still needed before tuning this path further.
 
 ```text
 Mali-G720-Immortalis MC12

--- a/docs/backend/MALI_VULKAN.md
+++ b/docs/backend/MALI_VULKAN.md
@@ -89,6 +89,65 @@ ARM warps per core 64
 ARM rates: pixel=4 texel=8 fma=128
 ```
 
+## What counts as an optimization
+
+`GGML_VK_DEBUG=1` is a capability and dispatch diagnostic mode. It must not be
+used as a performance mode. The backend's `GGML_VK_PERF_LOGGER=1` mode uses
+Vulkan timestamp queries and is useful for locating slow nodes or fusions, but
+it adds synchronization and query overhead, so its wall-clock output is not a
+production benchmark.
+
+A change counts as a Mali optimization only when all of the following are
+checked:
+
+1. Vulkan timestamp GPU time decreases for the targeted workload, or the same
+   GPU time is achieved with fewer dispatches, submissions, barriers, or
+   intermediate buffers.
+2. The intended graph path is actually selected, confirmed by fusion/dispatch
+   logs rather than inferred from the device name.
+3. Correctness remains unchanged, including quantized matmul and gradient tests
+   where applicable.
+4. The result survives fixed-workload repeated runs in both execution orders.
+5. Prompt/matmul, generation/matvec, and first-token latency are reported
+   separately. A prompt-only win must not be reported as a decode win.
+6. Devices without the required ARM capability remain on the generic path.
+
+Recommended diagnostic run:
+
+```bash
+GGML_VK_PERF_LOGGER=1 GGML_VK_PERF_LOGGER_CONCURRENT=1 \
+  ./bin/llama-bench -m /path/to/model.gguf -ngl 99 -p 128 -n 128 -r 1 -o json
+```
+
+Recommended production benchmark run:
+
+```bash
+./bin/llama-bench -m /path/to/model.gguf \
+  -ngl 99 -p 128 -n 128 -r 5 -o json
+```
+
+The current submission has a subgroup-16 warptile result on the reference
+Mali-G720, but no stable generation improvement. It therefore does not claim a
+universal Mali speedup.
+
+## Submission-boundary experiment
+
+`GGML_VK_MAX_NODES_PER_SUBMIT` is an existing experiment knob for submission
+batching. On the reference device and SmolLM2 Q4_K_M (`-p 128 -n 128 -r 3`),
+changing it produced:
+
+```text
+nodes/submit   prompt tok/s   generation tok/s
+25             176.65         55.90
+50             159.34         60.44
+100            159.14         59.36
+200            152.37         56.09
+```
+
+This is not a default change: the result is workload-sensitive and does not
+improve both prompt and generation. It demonstrates why reducing submission
+boundaries or GPU steps must be evaluated with GPU timestamps and end-to-end
+latency together.
 ## Emulator and simulator boundary
 
 The Android Emulator can run generic software Vulkan with:

--- a/docs/backend/MALI_VULKAN.md
+++ b/docs/backend/MALI_VULKAN.md
@@ -1,0 +1,94 @@
+# ARM Mali Vulkan validation
+
+This document describes the capability and validation path for ARM Mali Vulkan devices.
+It does not treat a software Vulkan implementation as a Mali GPU emulator.
+
+## Runtime capability report
+
+Build llama.cpp with Vulkan support, then run:
+
+```bash
+GGML_VK_DEBUG=1 ./bin/llama-bench --list-devices
+```
+
+For an ARM Mali device, the Vulkan backend reports:
+
+- ARM Mali architecture classification
+- subgroup size
+- FP16 and integer dot-product availability
+- maximum compute shared memory
+- ARM shader core rates from `VK_ARM_shader_core_properties`
+- shader core count, warps per core, and mask from `VK_ARM_shader_core_builtins`
+- cooperative matrix status
+
+The ARM properties are queried only when the corresponding device extension is
+advertised. Devices without the extension remain on the generic path.
+
+References:
+
+- https://docs.vulkan.org/refpages/latest/refpages/source/VK_ARM_shader_core_builtins.html
+- https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM.html
+- https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderCorePropertiesARM.html
+
+## Correctness validation
+
+Run the Vulkan backend operation tests on the target device:
+
+```bash
+./bin/test-backend-ops test -b Vulkan0 -o ADD -j 1
+./bin/test-backend-ops test -b Vulkan0 -o SET_ROWS -j 1
+./bin/test-backend-ops grad -b Vulkan0 -o SET_ROWS -j 1
+```
+
+The Mali-G720 validation used for this change passed:
+
+```text
+ADD:            99/99 tests passed
+SET_ROWS:       319/319 tests passed
+SET_ROWS grad:  19626/19626 tests passed
+```
+
+## Model benchmark
+
+Use the same model, backend, batch sizes, and repetition count for every
+candidate tuning change:
+
+```bash
+./bin/llama-bench \
+  -m /path/to/model.gguf \
+  -ngl 99 -p 128 -n 128 -r 5 -o json
+```
+
+Record the device name, Vulkan API version, driver version, subgroup size,
+shader compiler versions, build commit, model quantization, and all benchmark
+samples. A single run is not sufficient for a tuning claim.
+
+The reference device for this change was:
+
+```text
+Mali-G720-Immortalis MC12
+Vulkan API 1.3.247
+ARM driver v1.r44p1
+subgroup size 16
+shared memory 32768 bytes
+integer dot product enabled
+cooperative matrix unavailable
+external host memory unavailable
+ARM shader core count 12
+ARM warps per core 64
+ARM rates: pixel=4 texel=8 fma=128
+```
+
+## Emulator and simulator boundary
+
+llvmpipe and SwiftShader are useful for Vulkan API and shader correctness
+checks, but they do not emulate ARM Mali hardware, ARM shader-core properties,
+Mali scheduling, or Mali performance. Android Emulator GPU modes likewise do
+not provide a Mali-G720 driver contract.
+
+Therefore:
+
+- software Vulkan can validate generic fallback behavior;
+- it cannot validate `VK_ARM_shader_core_properties` behavior;
+- it cannot validate Mali subgroup or workgroup performance;
+- real Mali devices remain required for Mali performance claims.

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -179,6 +179,7 @@ static constexpr vk::DeviceQueueCreateFlagBits eInternallySynchronizedKHR = vk::
 static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
 
 #define VK_VENDOR_ID_AMD 0x1002
+#define VK_VENDOR_ID_ARM 0x13b5
 #define VK_VENDOR_ID_APPLE 0x106b
 #define VK_VENDOR_ID_INTEL 0x8086
 #define VK_VENDOR_ID_NVIDIA 0x10de
@@ -399,6 +400,7 @@ enum vk_device_architecture {
     INTEL_XE2,
     NVIDIA_PRE_TURING,
     NVIDIA_TURING,
+    ARM_MALI,
 };
 
 static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& device) {
@@ -515,6 +517,14 @@ static vk_device_architecture get_device_architecture(const vk::PhysicalDevice& 
             // Turing has 32, following architectures have 48
             if (sm_props.shaderWarpsPerSM == 32) {
                 return vk_device_architecture::NVIDIA_TURING;
+            }
+        }
+    } else if (props.vendorID == VK_VENDOR_ID_ARM) {
+        const std::vector<vk::ExtensionProperties> ext_props = device.enumerateDeviceExtensionProperties();
+        for (const auto & properties : ext_props) {
+            if (strcmp("VK_ARM_shader_core_properties", properties.extensionName) == 0 ||
+                strcmp("VK_ARM_shader_core_builtins", properties.extensionName) == 0) {
+                return vk_device_architecture::ARM_MALI;
             }
         }
     }
@@ -7111,6 +7121,8 @@ static void ggml_vk_print_gpu_info(size_t idx) {
     bool dot2_f16_support = false;
     bool ocp_microscaling_extension = false;
     bool shader_float8_extension = false;
+    bool arm_shader_core_properties_support = false;
+    bool arm_shader_core_builtins_support = false;
 
     for (auto properties : ext_props) {
         if (strcmp("VK_KHR_16bit_storage", properties.extensionName) == 0) {
@@ -7151,6 +7163,10 @@ static void ggml_vk_print_gpu_info(size_t idx) {
         } else if (strcmp("VK_VALVE_shader_mixed_float_dot_product", properties.extensionName) == 0 &&
                     !getenv("GGML_VK_DISABLE_DOT2")) {
             dot2_f16_support = true;
+        } else if (strcmp("VK_ARM_shader_core_properties", properties.extensionName) == 0) {
+            arm_shader_core_properties_support = true;
+        } else if (strcmp("VK_ARM_shader_core_builtins", properties.extensionName) == 0) {
+            arm_shader_core_builtins_support = true;
         }
     }
 
@@ -7166,6 +7182,8 @@ static void ggml_vk_print_gpu_info(size_t idx) {
     vk::PhysicalDeviceSubgroupProperties subgroup_props;
     vk::PhysicalDeviceDriverProperties driver_props;
     vk::PhysicalDeviceShaderIntegerDotProductPropertiesKHR shader_integer_dot_product_props;
+    vk::PhysicalDeviceShaderCorePropertiesARM arm_shader_core_props;
+    vk::PhysicalDeviceShaderCoreBuiltinsPropertiesARM arm_shader_core_builtins_props;
     props2.pNext = &props3;
     props3.pNext = &subgroup_props;
     subgroup_props.pNext = &driver_props;
@@ -7176,6 +7194,14 @@ static void ggml_vk_print_gpu_info(size_t idx) {
     if (integer_dot_product) {
         last_struct->pNext = (VkBaseOutStructure *)&shader_integer_dot_product_props;
         last_struct = (VkBaseOutStructure *)&shader_integer_dot_product_props;
+    }
+    if (device_architecture == vk_device_architecture::ARM_MALI && arm_shader_core_properties_support) {
+        last_struct->pNext = (VkBaseOutStructure *)&arm_shader_core_props;
+        last_struct = (VkBaseOutStructure *)&arm_shader_core_props;
+    }
+    if (device_architecture == vk_device_architecture::ARM_MALI && arm_shader_core_builtins_support) {
+        last_struct->pNext = (VkBaseOutStructure *)&arm_shader_core_builtins_props;
+        last_struct = (VkBaseOutStructure *)&arm_shader_core_builtins_props;
     }
 
     physical_device.getProperties2(&props2);
@@ -7322,9 +7348,19 @@ static void ggml_vk_print_gpu_info(size_t idx) {
 #endif
 
     std::string device_name = props2.properties.deviceName.data();
-    GGML_LOG_DEBUG("ggml_vulkan: %zu = %s (%s) | uma: %d | fp16: %s | bf16: %d | fp4: %d | warp size: %zu | shared memory: %d | int dot: %d | matrix cores: %s\n",
-              idx, device_name.c_str(), driver_props.driverName.data(), uma, fp16_str, bf16, fp4, subgroup_size,
+    const char * architecture_name = device_architecture == vk_device_architecture::ARM_MALI ? "ARM_MALI" : "generic";
+    GGML_LOG_DEBUG("ggml_vulkan: %zu = %s (%s) | arch: %s | uma: %d | fp16: %s | bf16: %d | fp4: %d | warp size: %zu | shared memory: %d | int dot: %d | matrix cores: %s\n",
+              idx, device_name.c_str(), driver_props.driverName.data(), architecture_name, uma, fp16_str, bf16, fp4, subgroup_size,
               props2.properties.limits.maxComputeSharedMemorySize, integer_dot_product, matrix_cores.c_str());
+    if (device_architecture == vk_device_architecture::ARM_MALI && arm_shader_core_properties_support) {
+        GGML_LOG_DEBUG("ggml_vulkan: ARM shader core rates: pixel=%u texel=%u fma=%u\n",
+                       arm_shader_core_props.pixelRate, arm_shader_core_props.texelRate, arm_shader_core_props.fmaRate);
+    }
+    if (device_architecture == vk_device_architecture::ARM_MALI && arm_shader_core_builtins_support) {
+        GGML_LOG_DEBUG("ggml_vulkan: ARM shader cores: count=%u warps_per_core=%u mask=0x%llx\n",
+                       arm_shader_core_builtins_props.shaderCoreCount, arm_shader_core_builtins_props.shaderWarpsPerCore,
+                       static_cast<unsigned long long>(arm_shader_core_builtins_props.shaderCoreMask));
+    }
 
     if (props2.properties.deviceType == vk::PhysicalDeviceType::eCpu) {
         GGML_LOG_DEBUG("ggml_vulkan: Warning: Device type is CPU. This is probably not the device you want.\n");

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4173,7 +4173,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     // some shaders have a minimum subgroup size
     const uint32_t subgroup_size_8 = std::max(device->subgroup_size, 8u);
     const uint32_t subgroup_size_16 = std::max(device->subgroup_size, 16u);
-    const uint32_t subgroup_size_32 = std::max(device->subgroup_size, 32u);
+    const uint32_t subgroup_size_32 = device->architecture == vk_device_architecture::ARM_MALI ? device->subgroup_size : std::max(device->subgroup_size, 32u);
 
     const uint32_t mul_mat_subgroup_size = (device->vendor_id == VK_VENDOR_ID_INTEL && device->subgroup_size_control) ? device->subgroup_min_size : device->subgroup_size;
     const uint32_t mul_mat_subgroup_size_8 = std::max(mul_mat_subgroup_size, 8u);


### PR DESCRIPTION
## Summary

- classify ARM devices exposing `VK_ARM_shader_core_properties` or `VK_ARM_shader_core_builtins` as `ARM_MALI`
- report ARM shader core rates and builtins through `GGML_VK_DEBUG=1 --list-devices`
- use the actual subgroup width for Mali warptile configuration while retaining the generic 32-wide fallback for other architectures
- document reproducible capability, correctness, benchmark, and emulator boundaries

## Evidence

Reference device:

```text
Mali-G720-Immortalis MC12
vendorID 0x13b5
Vulkan API 1.3.247
ARM driver v1.r44p1
subgroup size 16
max compute shared memory 32768 bytes
integer dot product enabled
VK_KHR_cooperative_matrix unavailable
VK_EXT_external_memory_host unavailable
VK_ARM shader core count 12
VK_ARM shader warps per core 64
ARM rates pixel=4 texel=8 fma=128
```

Correctness on Vulkan0:

```text
ADD:             99/99 tests passed
SET_ROWS:        319/319 tests passed
SET_ROWS grad:   19626/19626 tests passed
```

SmolLM2 Q4_K_M, `-ngl 99 -p 128 -n 128 -r 5`, two run orders:

```text
prompt/matmul: generic 154.27 tok/s -> ARM subgroup 162.34 tok/s (+5.24%)
generation:    generic  60.58 tok/s -> ARM subgroup  59.58 tok/s (-1.65%)
```

The prompt/matmul result is the measured optimization signal. Generation is
not claimed as an improvement. The test used Android Termux with the loader
workaround `LD_PRELOAD=/system/lib64/liblzma.so`; that workaround is not part
of this change.

## Emulator boundary

The Android Emulator can run generic software Vulkan with:

```bash
emulator @AVD -gpu swiftshader_indirect
emulator @AVD -gpu lavapipe
```

`-gpu host` passes through the development host GPU and is not Mali emulation.
Mesa PanVK is useful for Mali-family experiments on supported Linux hardware,
but is not the proprietary Android r44p1 driver. None of these options can
validate ARM Mali shader-core properties, Mali scheduling, or real Mali
performance. Real Mali devices remain required for the performance claim.

References:

- https://developer.android.com/studio/run/emulator-acceleration
- https://developer.android.com/studio/run/emulator-commandline
- https://docs.mesa3d.org/panfrost.html
