### PR TITLE
speculative : draft performance improvement (+10% t/s with deeper draft depth possible with this) + token rollback bugfix

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1296,6 +1296,19 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     // call to pair with, so it's stashed here until that next call fires.
     std::vector<std::vector<float>> pending_h;   // [n_seq][n_embd]
 
+    // catch-up rows deferred from process() and prepended to the first draft
+    // decode, which merges the two evals. Only for the single-head own-memory
+    // path; flushed standalone when drafting does not follow.
+    static constexpr int32_t defer_max = 64;
+    bool defer_enabled = false;
+    bool chain_graph   = false;
+    struct {
+        std::vector<llama_token>  tok;
+        std::vector<llama_pos>    pos;
+        std::vector<llama_seq_id> seq;
+        std::vector<float>        embd;
+    } defer;
+
     std::vector<int32_t> i_batch_beg;
     std::vector<int32_t> i_batch_end;
 
@@ -1345,9 +1358,10 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             s.reset(common_sampler_init(llama_get_model(ctx_dft), sparams));
         }
 
-        // offload draft sampling to the backend
+        // offload draft sampling to the backend (chained drafting outputs several
+        // rows per sequence, which backend sampling does not support)
         backend_chains.assign(n_seq, nullptr);
-        if (this->params.backend_sampling) {
+        if (this->params.backend_sampling && getenv("LLAMA_SPEC_CHAIN") == nullptr) {
             for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
                 llama_sampler * chain = llama_sampler_chain_init(llama_sampler_chain_default_params());
                 llama_sampler_chain_add(chain, llama_sampler_init_top_k(10));
@@ -1366,6 +1380,19 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
         chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
+
+        // experimental: merge the catch-up decode into the first draft decode (one eval
+        // less per round). Verified output stays identical, but draft acceptance drops
+        // (under investigation), so this is opt-in.
+        defer_enabled = !is_mem_shared && !chain_heads && getenv("LLAMA_SPEC_DEFER") != nullptr;
+
+        // experimental: draft all n_max tokens with one chained decode (in-graph argmax
+        // feeds each next step); replaces n_max sequential draft decodes
+        chain_graph = !is_mem_shared && !chain_heads && getenv("LLAMA_SPEC_CHAIN") != nullptr;
+        if (chain_graph) {
+            // the chain decode absorbs the deferred catch-up rows, one eval per round
+            defer_enabled = true;
+        }
 
         if (chain_heads) {
             this->params.n_max = std::min(this->params.n_max, n_mtp_layers);
@@ -1406,7 +1433,66 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         llama_batch_free(batch);
     }
 
+    // decode deferred catch-up rows standalone (no logits); used when no draft decode
+    // follows to absorb them
+    bool flush_deferred() {
+        if (defer.tok.empty()) {
+            return true;
+        }
+
+        auto * ctx_dft = this->params.ctx_dft;
+        const size_t row_bytes = (size_t) n_embd * sizeof(float);
+
+        common_batch_clear(batch);
+        for (size_t k = 0; k < defer.tok.size(); ++k) {
+            common_batch_add(batch, defer.tok[k], defer.pos[k], { defer.seq[k] }, false);
+            std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, defer.embd.data() + k * (size_t) n_embd, row_bytes);
+        }
+        defer.tok.clear();
+        defer.pos.clear();
+        defer.seq.clear();
+        defer.embd.clear();
+
+        const int32_t rc = llama_decode(ctx_dft, batch);
+        if (rc != 0) {
+            SPC_ERR("llama_decode(ctx_dft) deferred flush failed rc=%d\n", (int) rc);
+            return false;
+        }
+        return true;
+    }
+
+    // drop deferred rows of seq_id with pos >= pos_from; returns true if any dropped
+    bool drop_deferred_from(llama_seq_id seq_id, llama_pos pos_from) {
+        const size_t row_bytes = (size_t) n_embd * sizeof(float);
+
+        size_t w = 0;
+        for (size_t k = 0; k < defer.tok.size(); ++k) {
+            if (defer.seq[k] == seq_id && defer.pos[k] >= pos_from) {
+                continue;
+            }
+            if (w != k) {
+                defer.tok[w] = defer.tok[k];
+                defer.pos[w] = defer.pos[k];
+                defer.seq[w] = defer.seq[k];
+                std::memmove(defer.embd.data() + w * (size_t) n_embd,
+                             defer.embd.data() + k * (size_t) n_embd, row_bytes);
+            }
+            w++;
+        }
+
+        const bool dropped = w < defer.tok.size();
+        defer.tok.resize(w);
+        defer.pos.resize(w);
+        defer.seq.resize(w);
+        defer.embd.resize(w * (size_t) n_embd);
+
+        return dropped;
+    }
+
     void begin(llama_seq_id seq_id, const llama_tokens & prompt) override {
+        // note: the server calls begin() after the prefill decode, so stale defer
+        // rows are already handled by the position-rewind trim in process(). Rows
+        // that remain here belong to this prompt and feed the next draft decode.
         const int32_t N = (int32_t) prompt.size();
         if (N <= 0) {
             return;
@@ -1458,8 +1544,58 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
 
+        // deferred rows at or past the incoming batch positions are stale: either a
+        // new prompt rewound the sequence, or they hold candidates a later verify
+        // rejected. Drop them and clear matching draft cells before any decode.
+        if (defer_enabled && !defer.tok.empty()) {
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (i_batch_beg[seq_id] < 0) {
+                    continue;
+                }
+                const llama_pos pos_min_in = batch_in.pos[i_batch_beg[seq_id]];
+                if (drop_deferred_from(seq_id, pos_min_in)) {
+                    llama_memory_seq_rm(llama_get_memory(ctx_dft), seq_id, pos_min_in, -1);
+                }
+            }
+        }
+
         // if kv is shared with target (e.g Gemma4), then we can skip this catch-up decode
-        if (!is_mem_shared) {
+        if (!is_mem_shared && defer_enabled && n_tokens <= defer_max) {
+            // defer the catch-up rows; the first draft decode absorbs them, which saves
+            // one eval per round. Flush first if rows from an undrafted round remain.
+            if (!defer.tok.empty() && (int32_t) defer.tok.size() + n_tokens > defer_max) {
+                if (!flush_deferred()) {
+                    return false;
+                }
+            }
+
+            const size_t k0 = defer.tok.size();
+            defer.tok.resize(k0 + n_tokens);
+            defer.pos.resize(k0 + n_tokens);
+            defer.seq.resize(k0 + n_tokens);
+            defer.embd.resize((k0 + n_tokens) * (size_t) n_embd);
+
+            const float * h_tgt = llama_get_embeddings_nextn(ctx_tgt);
+            for (int k = 0; k < n_tokens; ++k) {
+                defer.tok[k0 + k] = batch_in.token[k];
+                defer.pos[k0 + k] = batch_in.pos[k];
+                defer.seq[k0 + k] = batch_in.seq_id[k][0];
+                // shift the tgt embeddings to the right by one position (see the non-deferred path)
+                if (k > 0) {
+                    std::memcpy(defer.embd.data() + (k0 + k) * (size_t) n_embd, h_tgt + (size_t) (k - 1) * n_embd, row_bytes);
+                }
+            }
+            for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+                if (i_batch_beg[seq_id] < 0) {
+                    continue;
+                }
+                std::memcpy(defer.embd.data() + (k0 + i_batch_beg[seq_id]) * (size_t) n_embd, pending_h[seq_id].data(), row_bytes);
+            }
+        } else if (!is_mem_shared) {
+            if (!flush_deferred()) {
+                return false;
+            }
+
             common_batch_clear(batch);
 
             for (int k = 0; k < n_tokens; ++k) {
@@ -1552,6 +1688,136 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         std::vector<bool> drafting(n_seq);
 
         const size_t row_bytes = (size_t) n_embd * sizeof(float);
+
+        bool any_drafting = false;
+        for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
+            any_drafting = any_drafting || dparams[seq_id].drafting;
+        }
+
+        // LLAMA_SPEC_DEFER=2 decodes deferred rows as a separate eval instead of
+        // merging them into the draft decode (debug mode for isolating merge effects)
+        static const bool defer_split_debug = [] {
+            const char * env = getenv("LLAMA_SPEC_DEFER");
+            return env != nullptr && atoi(env) == 2;
+        }();
+
+        // chained drafting: one decode drafts n_max tokens for a single sequence.
+        // this block must run before the generic defer merge below - it consumes
+        // the deferred rows itself and prepends them to the chain batch
+        if (chain_graph && any_drafting) {
+            llama_seq_id seq_one = -1;
+            int n_seq_drafting = 0;
+            for (llama_seq_id s = 0; s < (llama_seq_id) n_seq; ++s) {
+                if (dparams[s].drafting) {
+                    n_seq_drafting++;
+                    seq_one = s;
+                }
+            }
+
+            if (n_seq_drafting == 1) {
+                auto & dp = dparams[seq_one];
+                auto * smpl = smpls[seq_one].get();
+                common_sampler_reset(smpl);
+
+                // the caller can cap the depth per round (adaptive drafting)
+                const int n_chain = dp.n_max > 0 ? std::min(params.n_max, dp.n_max) : params.n_max;
+
+                // deferred rows at or past n_past hold candidates the verify
+                // rejected; the committed prefix ends at n_past - 1. Drop them.
+                drop_deferred_from(seq_one, dp.n_past);
+
+                // rows of other sequences cannot join a single-sequence chain
+                // batch; decode all remaining rows standalone in that case
+                bool defer_other = false;
+                for (size_t k = 0; k < defer.tok.size(); ++k) {
+                    defer_other = defer_other || defer.seq[k] != seq_one;
+                }
+                if (defer_other || defer_split_debug) {
+                    flush_deferred();
+                }
+
+                common_batch_clear(batch);
+
+                // deferred catch-up rows ride along, before the chain rows
+                const int n_catchup = (int) defer.tok.size();
+                for (int k = 0; k < n_catchup; ++k) {
+                    common_batch_add(batch, defer.tok[k], defer.pos[k], { defer.seq[k] }, false);
+                    std::memcpy(batch.embd + (size_t) k * n_embd, defer.embd.data() + (size_t) k * n_embd, row_bytes);
+                }
+                defer.tok.clear();
+                defer.pos.clear();
+                defer.seq.clear();
+                defer.embd.clear();
+
+                for (int j = 0; j < n_chain; ++j) {
+                    common_batch_add(batch, j == 0 ? dp.id_last : 0, dp.n_past + j, { seq_one }, true);
+                    if (j == 0) {
+                        std::memcpy(batch.embd + (size_t) n_catchup * n_embd, pending_h[seq_one].data(), row_bytes);
+                    } else {
+                        std::memset(batch.embd + (size_t) (n_catchup + j) * n_embd, 0, row_bytes);
+                    }
+                }
+
+                llama_set_mtp_chain(ctx_dft, true);
+                const int ret = llama_decode(ctx_dft, batch);
+                llama_set_mtp_chain(ctx_dft, false);
+
+                if (ret != 0) {
+                    SPC_ERR("llama_decode(chain) returned %d\n", ret);
+                    return;
+                }
+
+                // the chain samples greedily in-graph and emits [token id, top prob]
+                // pairs as 2-float rows, packed from the start of the logits buffer;
+                // no host-side sampling pass runs over the draft logits
+                const float * lp = llama_get_logits(ctx_dft);
+
+                auto & result = *dp.result;
+                for (int j = 0; j < n_chain; ++j) {
+                    const llama_token id = (llama_token) lp[2*j + 0];
+                    const float       p  =               lp[2*j + 1];
+
+                    SPC_DBG(" - seq_id %d, chain candidate %3d: %6d (%8.3f) '%s'\n",
+                            seq_one, j, id, p,
+                            common_token_to_piece(ctx_dft, id).c_str());
+
+                    if (p < params.p_min) {
+                        break;
+                    }
+
+                    result.push_back(id);
+
+                    if ((int) result.size() >= params.n_max) {
+                        break;
+                    }
+                }
+
+                if (dp.result->size() < (size_t) params.n_min) {
+                    dp.result->clear();
+                }
+                return;
+            }
+        }
+
+        // deferred catch-up rows ride along with the first draft decode. They carry
+        // earlier positions, so they must precede the draft rows: recurrent state
+        // advances in batch order. If nothing drafts this round they stay deferred
+        // and process() flushes them later.
+        if (any_drafting && !defer.tok.empty()) {
+            if (defer_split_debug) {
+                flush_deferred();
+                common_batch_clear(batch);
+            } else {
+                for (size_t k = 0; k < defer.tok.size(); ++k) {
+                    common_batch_add(batch, defer.tok[k], defer.pos[k], { defer.seq[k] }, false);
+                    std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, defer.embd.data() + k * (size_t) n_embd, row_bytes);
+                }
+                defer.tok.clear();
+                defer.pos.clear();
+                defer.seq.clear();
+                defer.embd.clear();
+            }
+        }
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
             auto & dp = dparams[seq_id];
@@ -2347,6 +2613,12 @@ common_params common_base_params_to_speculative(const common_params & params) {
         if (params_spec.backend_sampling) {
             result.n_outputs_max_per_seq = per_seq;
         }
+    }
+
+    // chained MTP drafting outputs logits for every chain step in one decode
+    if (getenv("LLAMA_SPEC_CHAIN") != nullptr) {
+        const int32_t per_seq = std::max(1, params_spec.n_max);
+        result.n_outputs_max = std::max(result.n_outputs_max, params.n_parallel * per_seq);
     }
 
     return result;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1381,11 +1381,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
         chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
 
-        // experimental: merge the catch-up decode into the first draft decode (one eval
-        // less per round). Verified output stays identical, but draft acceptance drops
-        // (under investigation), so this is opt-in.
-        defer_enabled = !is_mem_shared && !chain_heads && getenv("LLAMA_SPEC_DEFER") != nullptr;
-
         // experimental: draft all n_max tokens with one chained decode (in-graph argmax
         // feeds each next step); replaces n_max sequential draft decodes
         chain_graph = !is_mem_shared && !chain_heads && getenv("LLAMA_SPEC_CHAIN") != nullptr;
@@ -1694,13 +1689,6 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
             any_drafting = any_drafting || dparams[seq_id].drafting;
         }
 
-        // LLAMA_SPEC_DEFER=2 decodes deferred rows as a separate eval instead of
-        // merging them into the draft decode (debug mode for isolating merge effects)
-        static const bool defer_split_debug = [] {
-            const char * env = getenv("LLAMA_SPEC_DEFER");
-            return env != nullptr && atoi(env) == 2;
-        }();
-
         // chained drafting: one decode drafts n_max tokens for a single sequence.
         // this block must run before the generic defer merge below - it consumes
         // the deferred rows itself and prepends them to the chain batch
@@ -1719,7 +1707,7 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 auto * smpl = smpls[seq_one].get();
                 common_sampler_reset(smpl);
 
-                // the caller can cap the depth per round (adaptive drafting)
+                // dp.n_max caps the round so the draft fits the remaining context
                 const int n_chain = dp.n_max > 0 ? std::min(params.n_max, dp.n_max) : params.n_max;
 
                 // deferred rows at or past n_past hold candidates the verify
@@ -1732,8 +1720,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                 for (size_t k = 0; k < defer.tok.size(); ++k) {
                     defer_other = defer_other || defer.seq[k] != seq_one;
                 }
-                if (defer_other || defer_split_debug) {
-                    flush_deferred();
+                if (defer_other && !flush_deferred()) {
+                    return;
                 }
 
                 common_batch_clear(batch);
@@ -1804,19 +1792,14 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         // advances in batch order. If nothing drafts this round they stay deferred
         // and process() flushes them later.
         if (any_drafting && !defer.tok.empty()) {
-            if (defer_split_debug) {
-                flush_deferred();
-                common_batch_clear(batch);
-            } else {
-                for (size_t k = 0; k < defer.tok.size(); ++k) {
-                    common_batch_add(batch, defer.tok[k], defer.pos[k], { defer.seq[k] }, false);
-                    std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, defer.embd.data() + k * (size_t) n_embd, row_bytes);
-                }
-                defer.tok.clear();
-                defer.pos.clear();
-                defer.seq.clear();
-                defer.embd.clear();
+            for (size_t k = 0; k < defer.tok.size(); ++k) {
+                common_batch_add(batch, defer.tok[k], defer.pos[k], { defer.seq[k] }, false);
+                std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, defer.embd.data() + k * (size_t) n_embd, row_bytes);
             }
+            defer.tok.clear();
+            defer.pos.clear();
+            defer.seq.clear();
+            defer.embd.clear();
         }
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -6,11 +6,11 @@
 #include "ggml-cpp.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
-#include <atomic>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -1991,7 +1991,7 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
         return env != nullptr ? atoi(env) : 0;
     }();
     if (meta_dbg > 0) {
-        GGML_LOG_ERROR("meta: compute uid=%llu n_nodes=%d plan=%s\n",
+        GGML_LOG_DEBUG("meta: compute uid=%llu n_nodes=%d plan=%s\n",
                 (unsigned long long) cgraph->uid, cgraph->n_nodes,
                 plan == nullptr ? "MISS" : "hit");
     }
@@ -2010,6 +2010,7 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
             buf_ctx->stc_active = stc;
         }
         if (ok && plan->alloc_epoch != g_meta_alloc_epoch.load(std::memory_order_relaxed)) {
+            ok = plan->node_fps.size() == (size_t) cgraph->n_nodes;
             for (int i = 0; i < cgraph->n_nodes && ok; i++) {
                 ok = plan->node_fps[i] == ggml_backend_meta_shadow_fp::of(cgraph->nodes[i]);
             }

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -561,7 +561,7 @@ static ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend
     return buf_ctx->bufs[index].get();
 }
 
-static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_meta_simple_tensor_container & stc, ggml_tensor * tensor);
+static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_meta_simple_tensor_container & stc, const ggml_tensor * tensor);
 
 static struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index) {
     if (!ggml_backend_buffer_is_meta(tensor->buffer)) {
@@ -602,7 +602,7 @@ static struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct 
         it = stc->simple_tensors.end();
     }
     if (it == stc->simple_tensors.end()) {
-        if (ggml_backend_meta_buffer_init_tensor_impl(*stc, (ggml_tensor *) tensor) != GGML_STATUS_SUCCESS) {
+        if (ggml_backend_meta_buffer_init_tensor_impl(*stc, tensor) != GGML_STATUS_SUCCESS) {
             return nullptr;
         }
         it = stc->simple_tensors.find(tensor);
@@ -1276,7 +1276,7 @@ static void * ggml_backend_meta_buffer_get_base(ggml_backend_buffer_t buffer) {
     return (void *) 0x1000000000000000; // FIXME
 }
 
-static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_meta_simple_tensor_container & stc, ggml_tensor * tensor) {
+static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_meta_simple_tensor_container & stc, const ggml_tensor * tensor) {
     GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer));
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
     const size_t n_simple_bufs = ggml_backend_meta_buffer_n_bufs(tensor->buffer);

--- a/ggml/src/ggml-backend-meta.cpp
+++ b/ggml/src/ggml-backend-meta.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <atomic>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -396,9 +397,45 @@ static ggml_backend_buffer_type_t ggml_backend_meta_device_get_host_buffer_type(
 //
 
 // Container to hold the tensor slices per simple ggml backend buffer.
+// identifies the tensor state a shadow was built from. Graph rebuilds recycle
+// tensor structs at the same addresses, so pointer identity alone cannot prove a
+// cached shadow still describes the tensor.
+struct ggml_backend_meta_shadow_fp {
+    const void *  data;
+    const void *  view_src;
+    size_t        view_offs;
+    int64_t       ne[GGML_MAX_DIMS];
+    size_t        nb[GGML_MAX_DIMS];
+    int32_t       op;
+    int32_t       type;
+
+    static ggml_backend_meta_shadow_fp of(const ggml_tensor * t) {
+        ggml_backend_meta_shadow_fp fp = {};
+        fp.data      = t->data;
+        fp.view_src  = t->view_src;
+        fp.view_offs = t->view_offs;
+        for (int i = 0; i < GGML_MAX_DIMS; i++) {
+            fp.ne[i] = t->ne[i];
+            fp.nb[i] = t->nb[i];
+        }
+        fp.op   = (int32_t) t->op;
+        fp.type = (int32_t) t->type;
+        return fp;
+    }
+
+    bool operator==(const ggml_backend_meta_shadow_fp & o) const {
+        return memcmp(this, &o, sizeof(*this)) == 0;
+    }
+};
+
+struct ggml_backend_meta_shadow_entry {
+    std::vector<ggml_tensor *> tensors;
+    ggml_backend_meta_shadow_fp fp;
+};
+
 struct ggml_backend_meta_simple_tensor_container {
     std::vector<ggml_context_ptr> ctxs;
-    std::map<const ggml_tensor *, std::vector<ggml_tensor *>> simple_tensors;
+    std::map<const ggml_tensor *, ggml_backend_meta_shadow_entry> simple_tensors;
 
     ggml_backend_meta_simple_tensor_container(const ggml_init_params & params, const int n_simple) {
         ctxs.reserve(n_simple);
@@ -407,21 +444,70 @@ struct ggml_backend_meta_simple_tensor_container {
         }
     }
     ggml_backend_meta_simple_tensor_container() {}
+
+    void reset() {
+        for (ggml_context_ptr & ctx : ctxs) {
+            ggml_reset(ctx.get());
+        }
+        simple_tensors.clear();
+    }
 };
 
+// bumped whenever the allocator (re-)initializes any graph tensor; cached plans
+// re-check their node fingerprints when it moves
+static std::atomic<uint64_t> g_meta_alloc_epoch{1};
+
 struct ggml_backend_meta_buffer_context {
-    // FIXME
-    // Most tensors can simply be stored statically in their own buffer.
-    // Externally created views however also need a mapping to simple tensors but they use the buffer of the view source.
-    // If external views are simply using that buffer they will slowly deplete its memory.
-    // Current solution: rotating set of 2 "compute" containers to hold external views, works correctly for llama.cpp.
-    // Long-term: tie the lifetime of external views to the meta backend executing the graph instead,
-    //     currently not possible due to graph-external operations in the backend scheduler.
+    // Most tensors are stored statically in their own buffer. Graph tensors and
+    // external views get per-graph shadow containers keyed by cgraph uid: a
+    // container starts empty when its graph's plan is built, fills during the
+    // decomposition sweep, and dies whole on eviction. Shadows reference other
+    // shadows, so their lifetime must be the whole graph - per-entry replacement
+    // leaves dangling source pointers.
     ggml_backend_meta_simple_tensor_container stc_static;
-    ggml_backend_meta_simple_tensor_container stc_compute[2];
-    int stc_compute_index      = 0;
-    int stc_compute_index_next = 0;
+
+    static constexpr size_t N_GRAPH_STCS = 24;
+    std::vector<std::pair<uint64_t, std::unique_ptr<ggml_backend_meta_simple_tensor_container>>> stc_graphs;
+    ggml_backend_meta_simple_tensor_container * stc_active = nullptr; // sticky for post-compute readbacks
+
+    ggml_init_params stc_params = {};
+    int n_simple = 0;
+
     std::vector<ggml_backend_buffer_ptr> bufs;
+
+    ggml_backend_meta_simple_tensor_container * find_graph_stc(uint64_t uid) {
+        for (size_t i = 0; i < stc_graphs.size(); i++) {
+            if (stc_graphs[i].first == uid) {
+                // move to the back: eviction takes from the front
+                auto e = std::move(stc_graphs[i]);
+                stc_graphs.erase(stc_graphs.begin() + i);
+                stc_graphs.push_back(std::move(e));
+                return stc_graphs.back().second.get();
+            }
+        }
+        return nullptr;
+    }
+
+    ggml_backend_meta_simple_tensor_container * create_graph_stc(uint64_t uid) {
+        ggml_backend_meta_simple_tensor_container * stc = find_graph_stc(uid);
+        if (stc != nullptr) {
+            stc->reset();
+            return stc;
+        }
+        if (stc_graphs.size() >= N_GRAPH_STCS) {
+            auto victim = std::move(stc_graphs.front());
+            stc_graphs.erase(stc_graphs.begin());
+            if (stc_active == victim.second.get()) {
+                stc_active = nullptr;
+            }
+            victim.second->reset();
+            stc_graphs.emplace_back(uid, std::move(victim.second));
+        } else {
+            stc_graphs.emplace_back(uid,
+                    std::make_unique<ggml_backend_meta_simple_tensor_container>(stc_params, n_simple));
+        }
+        return stc_graphs.back().second.get();
+    }
 
     // FIXME
     // The size of the split state cache is unbounded and can theoretically grow infinitely large.
@@ -433,10 +519,12 @@ struct ggml_backend_meta_buffer_context {
 
     ggml_backend_meta_buffer_context(
             ggml_backend_meta_simple_tensor_container & stc_static,
-            ggml_backend_meta_simple_tensor_container & stc_compute_0,
-            ggml_backend_meta_simple_tensor_container & stc_compute_1,
+            const ggml_init_params & params_compute,
+            int n_simple,
             const std::vector<ggml_backend_buffer_t> & bufs)
-            : stc_static(std::move(stc_static)), stc_compute{std::move(stc_compute_0), std::move(stc_compute_1)} {
+            : stc_static(std::move(stc_static)),
+              stc_params(params_compute),
+              n_simple(n_simple) {
         this->bufs.reserve(bufs.size());
         for (ggml_backend_buffer_t buf : bufs) {
             this->bufs.emplace_back(buf);
@@ -445,11 +533,12 @@ struct ggml_backend_meta_buffer_context {
         debug = GGML_META_DEBUG ? atoi(GGML_META_DEBUG) : 0;
     }
 
+    // lookup-or-place semantics for split-state resolution
     ggml_backend_meta_simple_tensor_container & get_simple_tensor_container(const ggml_tensor * tensor) {
-        if (stc_static.simple_tensors.find(tensor) != stc_static.simple_tensors.end()) {
+        if (stc_active == nullptr || stc_static.simple_tensors.find(tensor) != stc_static.simple_tensors.end()) {
             return stc_static;
         }
-        return stc_compute[stc_compute_index];
+        return *stc_active;
     }
 };
 
@@ -472,17 +561,56 @@ static ggml_backend_buffer_t ggml_backend_meta_buffer_simple_buffer(ggml_backend
     return buf_ctx->bufs[index].get();
 }
 
+static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_meta_simple_tensor_container & stc, ggml_tensor * tensor);
+
 static struct ggml_tensor * ggml_backend_meta_buffer_simple_tensor(const struct ggml_tensor * tensor, size_t index) {
+    if (!ggml_backend_buffer_is_meta(tensor->buffer)) {
+        GGML_LOG_ERROR("%s: tensor '%s' op=%s buffer=%s view_src='%s'\n", __func__,
+                tensor->name, ggml_op_name(tensor->op),
+                tensor->buffer ? ggml_backend_buffer_name(tensor->buffer) : "(null)",
+                tensor->view_src ? tensor->view_src->name : "(none)");
+    }
     GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer));
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) tensor->buffer->context;
     GGML_ASSERT(index < buf_ctx->bufs.size());
 
-    ggml_backend_meta_simple_tensor_container & stc = buf_ctx->get_simple_tensor_container(tensor);
-    auto it = stc.simple_tensors.find(tensor);
-    if (it == stc.simple_tensors.end()) {
-        return nullptr;
+    // static tensors are created once and never recycled
+    {
+        auto it = buf_ctx->stc_static.simple_tensors.find(tensor);
+        if (it != buf_ctx->stc_static.simple_tensors.end()) {
+            return it->second.tensors[index];
+        }
     }
-    return it->second[index];
+
+    // graph tensors live in the active graph's shadow container, bound by the
+    // current compute (sticky afterwards for result readbacks). Entries are only
+    // created here, never replaced: plan-level fingerprint validation catches
+    // recycled tensor structs before the container is trusted.
+    ggml_backend_meta_simple_tensor_container * stc = buf_ctx->stc_active;
+    if (stc == nullptr) {
+        // reserve and warmup paths resolve shadows before any compute binds a
+        // graph container; give them the uid-0 scratch container
+        stc = buf_ctx->create_graph_stc(0);
+        buf_ctx->stc_active = stc;
+    }
+
+    auto it = stc->simple_tensors.find(tensor);
+    if (it != stc->simple_tensors.end() && !(it->second.fp == ggml_backend_meta_shadow_fp::of(tensor))) {
+        // recycled tensor struct: the stored shadow describes an older incarnation.
+        // The graph that owned it rebuilds anyway - its plan fingerprints changed.
+        stc->simple_tensors.erase(it);
+        it = stc->simple_tensors.end();
+    }
+    if (it == stc->simple_tensors.end()) {
+        if (ggml_backend_meta_buffer_init_tensor_impl(*stc, (ggml_tensor *) tensor) != GGML_STATUS_SUCCESS) {
+            return nullptr;
+        }
+        it = stc->simple_tensors.find(tensor);
+        if (it == stc->simple_tensors.end()) {
+            return nullptr;
+        }
+    }
+    return it->second.tensors[index];
 }
 
 static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(const struct ggml_tensor * tensor, bool assume_sync);
@@ -517,16 +645,22 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
 
     auto handle_generic = [&](const std::vector<ggml_backend_meta_split_state> & src_ss, bool scalar_only) -> ggml_backend_meta_split_state {
         ggml_backend_meta_split_state ret = {GGML_BACKEND_SPLIT_AXIS_NONE, {0}, {1}, 1};
+        bool any_src = false;
         for (size_t i = 0; i < GGML_MAX_SRC; i++) {
             if (tensor->src[i] == nullptr || tensor->src[i] == tensor) {
                 continue;
             }
+            any_src = true;
             if (ret.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
                 ret = src_ss[i];
             } else if (!split_states_equal(src_ss[i], ret)) {
                 ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
                 break;
             }
+        }
+        if (!any_src) {
+            // source-free generators (e.g. arange) produce the same data everywhere
+            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
         }
         if (ret.axis == GGML_BACKEND_SPLIT_AXIS_NONE) {
             ret = {GGML_BACKEND_SPLIT_AXIS_UNKNOWN, {0}, {1}, 1};
@@ -747,6 +881,15 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
     };
 
     auto handle_flash_attn_ext = [&](const std::vector<ggml_backend_meta_split_state> & src_ss) -> ggml_backend_meta_split_state {
+        // a fully mirrored attention layer (e.g. a replicated MTP draft layer)
+        // computes on every device without communication
+        if (src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
+            src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
+            src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED &&
+            (tensor->src[3] == nullptr || src_ss[3].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED) &&
+            (tensor->src[4] == nullptr || src_ss[4].axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED)) {
+            return {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
+        }
         GGML_ASSERT(                             src_ss[0].axis == GGML_BACKEND_SPLIT_AXIS_2);
         GGML_ASSERT(                             src_ss[1].axis == GGML_BACKEND_SPLIT_AXIS_2);
         GGML_ASSERT(                             src_ss[2].axis == GGML_BACKEND_SPLIT_AXIS_2);
@@ -813,6 +956,11 @@ static struct ggml_backend_meta_split_state ggml_backend_meta_get_split_state(
                 continue;
             }
             src_ss[i] = ggml_backend_meta_get_split_state(stc, tensor->src[i], /*assume_sync =*/ true);
+            // zero-sized sources carry no data to split; treat them as mirrored so ops
+            // that pad or concat them (e.g. the sampling dummy row) classify cleanly
+            if (src_ss[i].axis == GGML_BACKEND_SPLIT_AXIS_UNKNOWN && ggml_nelements(tensor->src[i]) == 0) {
+                src_ss[i] = {GGML_BACKEND_SPLIT_AXIS_MIRRORED, {0}, {1}, 1};
+            }
             GGML_ASSERT(src_ss[i].axis != GGML_BACKEND_SPLIT_AXIS_UNKNOWN);
         }
 
@@ -1171,6 +1319,10 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
         }
 
         ggml_tensor * t_ij = ggml_new_tensor(simple_ctx, tensor->type, GGML_MAX_DIMS, ne);
+        if (t_ij == nullptr) {
+            GGML_LOG_ERROR("%s: shadow container exhausted for tensor '%s'\n", __func__, tensor->name);
+            return GGML_STATUS_ALLOC_FAILED;
+        }
         t_ij->op = tensor->op;
         for (int i = 0; i < GGML_MAX_DIMS; i++) {
             t_ij->nb[i] = nb[i];
@@ -1243,7 +1395,7 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
         }
     }
 
-    stc.simple_tensors[tensor] = simple_tensors;
+    stc.simple_tensors[tensor] = { std::move(simple_tensors), ggml_backend_meta_shadow_fp::of(tensor) };
 
     return GGML_STATUS_SUCCESS;
 }
@@ -1251,8 +1403,18 @@ static enum ggml_status ggml_backend_meta_buffer_init_tensor_impl(ggml_backend_m
 static enum ggml_status ggml_backend_meta_buffer_init_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor) {
     GGML_ASSERT(ggml_backend_buffer_is_meta(buffer));
     ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buffer->context;
-    buf_ctx->stc_compute_index = buf_ctx->stc_compute_index_next;
-    return ggml_backend_meta_buffer_init_tensor_impl(buf_ctx->get_simple_tensor_container(tensor), tensor);
+
+    // static tensors keep their shadows in place. Graph tensors get their shadows
+    // when their graph's plan is built; here the allocation epoch moves so cached
+    // plans re-check their fingerprints, and the split-state cache is refreshed in
+    // allocation order - resolving it lazily at compute time can recurse through
+    // the whole ancestor chain and overflow the stack.
+    if (buf_ctx->stc_static.simple_tensors.find(tensor) != buf_ctx->stc_static.simple_tensors.end()) {
+        return ggml_backend_meta_buffer_init_tensor_impl(buf_ctx->stc_static, tensor);
+    }
+    g_meta_alloc_epoch.fetch_add(1, std::memory_order_relaxed);
+    ggml_backend_meta_get_split_state(tensor, /*assume_sync =*/ true);
+    return GGML_STATUS_SUCCESS;
 }
 
 static void ggml_backend_meta_buffer_set_tensor(ggml_backend_buffer_t buffer, ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
@@ -1505,14 +1667,14 @@ bool ggml_backend_buffer_is_meta(ggml_backend_buffer_t buf) {
 static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_backend_buffer_type_t buft, size_t size) {
     const size_t n_simple_bufts = ggml_backend_meta_buft_n_bufts(buft);
 
+    // one graph's shadows per world; graphs hold a few thousand nodes, so 64k
+    // tensor slots per simple buffer leave a wide margin at ~24 MiB per container
     const ggml_init_params params = {
-        /*.mem_size   =*/ 1024*1024*ggml_tensor_overhead(), // FIXME
+        /*.mem_size   =*/ 64*1024*ggml_tensor_overhead(),
         /*.mem_buffer =*/ nullptr,
         /*.no_alloc   =*/ true,
     };
     ggml_backend_meta_simple_tensor_container stc_static;
-    ggml_backend_meta_simple_tensor_container stc_compute_0(params, n_simple_bufts);
-    ggml_backend_meta_simple_tensor_container stc_compute_1(params, n_simple_bufts);
 
     size_t max_size = 0;
     std::vector<ggml_backend_buffer_t> bufs;
@@ -1522,7 +1684,7 @@ static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_bac
         GGML_ASSERT(bufs.back() != nullptr);
         max_size = std::max(max_size, ggml_backend_buffer_get_size(bufs.back()));
     }
-    ggml_backend_meta_buffer_context * buf_ctx = new ggml_backend_meta_buffer_context(stc_static, stc_compute_0, stc_compute_1, bufs);
+    ggml_backend_meta_buffer_context * buf_ctx = new ggml_backend_meta_buffer_context(stc_static, params, (int) n_simple_bufts, bufs);
 
     return ggml_backend_buffer_init(buft, ggml_backend_meta_buffer_iface, buf_ctx, max_size);
 }
@@ -1530,7 +1692,10 @@ static ggml_backend_buffer_t ggml_backend_meta_buffer_type_alloc_buffer(ggml_bac
 struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struct ggml_context * ctx, ggml_backend_buffer_type_t buft) {
     const size_t n_simple_bufts = ggml_backend_meta_buft_n_bufts(buft);
 
-    constexpr size_t compute_headroom = 16; // Maximum number of views per statically allocated tensor that can be created between evals.
+    // Maximum number of views per statically allocated tensor that can be created between evals.
+    // Recurrent-state rollback creates (n_rs_seq + 1) views per cache tensor per eval, so this
+    // bounds the usable speculative draft depth on hybrid models under tensor split.
+    constexpr size_t compute_headroom = 64;
     const ggml_init_params params_static = {
         /*.mem_size   =*/ ggml_get_mem_size(ctx),
         /*.mem_buffer =*/ nullptr,
@@ -1541,12 +1706,10 @@ struct ggml_backend_buffer * ggml_backend_meta_alloc_ctx_tensors_from_buft(struc
         /*.mem_buffer =*/ nullptr,
         /*.no_alloc   =*/ true,
     };
-    ggml_backend_meta_simple_tensor_container stc_static   (params_static,  n_simple_bufts);
-    ggml_backend_meta_simple_tensor_container stc_compute_0(params_compute, n_simple_bufts);
-    ggml_backend_meta_simple_tensor_container stc_compute_1(params_compute, n_simple_bufts);
+    ggml_backend_meta_simple_tensor_container stc_static(params_static, n_simple_bufts);
 
     std::vector<ggml_backend_buffer_t> bufs(n_simple_bufts, nullptr);
-    ggml_backend_meta_buffer_context * meta_buf_ctx = new ggml_backend_meta_buffer_context(stc_static, stc_compute_0, stc_compute_1, bufs);
+    ggml_backend_meta_buffer_context * meta_buf_ctx = new ggml_backend_meta_buffer_context(stc_static, params_compute, (int) n_simple_bufts, bufs);
 
     ggml_backend_buffer_t meta_buf = ggml_backend_buffer_init(buft, ggml_backend_meta_buffer_iface, meta_buf_ctx, 0);
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
@@ -1608,6 +1771,31 @@ struct ggml_backend_meta_context {
             bufs.resize(n_reduce_steps);
         }
     };
+    // one cached subgraph decomposition of a computed graph. Several live graphs can
+    // alternate (e.g. draft and verification evals of speculative decoding); caching
+    // per uid avoids re-deriving the decomposition on every alternation.
+    struct graph_plan {
+        uint64_t uid         = 0;
+        uint64_t alloc_epoch = 0; // g_meta_alloc_epoch at build/validation time
+        uint64_t last_used   = 0;
+        size_t   n_subgraphs = 0;
+
+        ggml_context_ptr ctx; // storage for the per-backend subgraph cgraphs
+        size_t ctx_size = 0;
+
+        // node fingerprints prove on reuse that the user graph's recycled tensor
+        // structs still describe the state the shadows were built from
+        std::vector<ggml_backend_meta_shadow_fp> node_fps;
+        std::vector<ggml_backend_buffer_t>       buffers; // meta buffers this graph touches
+
+        struct per_backend {
+            std::vector<cgraph_config> cgraphs;
+            std::vector<ggml_tensor *> nodes;
+        };
+        std::vector<per_backend> pb;
+    };
+    static constexpr size_t N_PLANS = 16;
+
     std::string                 name;
     std::vector<backend_config> backend_configs;
     ggml_context_ptr            ctx;
@@ -1617,8 +1805,9 @@ struct ggml_backend_meta_context {
     int                         max_nnodes    = 0;
     size_t                      max_tmp_size  = 0;
     size_t                      max_subgraphs = 0;
-    size_t                      n_subgraphs   = 0;
-    uint64_t                    uid           = 0;
+
+    graph_plan plans[N_PLANS];
+    uint64_t   plan_tick = 0;
 
     void *                               comm_ctx       = nullptr;
     ggml_backend_comm_allreduce_tensor_t comm_allreduce = nullptr;
@@ -1784,8 +1973,57 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
     const size_t n_backends = ggml_backend_meta_n_backends(backend);
     ggml_backend_meta_context * backend_ctx = (ggml_backend_meta_context *) backend->context;
 
-    // If the previous cgraph had a defined UID it can be used to skip rebuilding the subgraphs per simple backend.
-    const bool needs_rebuild = (cgraph->uid == 0) || (cgraph->uid != backend_ctx->uid);
+    // Look up a cached subgraph decomposition for this graph. Several live graphs can
+    // alternate under speculative decoding; a per-uid plan cache avoids re-deriving
+    // the decomposition and keeps the simple backends' own graph caches warm.
+    ggml_backend_meta_context::graph_plan * plan = nullptr;
+    if (cgraph->uid != 0) {
+        for (auto & p : backend_ctx->plans) {
+            if (p.uid == cgraph->uid) {
+                plan = &p;
+                break;
+            }
+        }
+    }
+
+    static const int meta_dbg = [] {
+        const char * env = getenv("GGML_META_DEBUG");
+        return env != nullptr ? atoi(env) : 0;
+    }();
+    if (meta_dbg > 0) {
+        GGML_LOG_ERROR("meta: compute uid=%llu n_nodes=%d plan=%s\n",
+                (unsigned long long) cgraph->uid, cgraph->n_nodes,
+                plan == nullptr ? "MISS" : "hit");
+    }
+
+    if (plan != nullptr) {
+        // bind this graph's shadow containers; an evicted container or a node
+        // whose recycled struct changed state invalidates the whole plan
+        bool ok = true;
+        for (ggml_backend_buffer_t buf : plan->buffers) {
+            ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buf->context;
+            ggml_backend_meta_simple_tensor_container * stc = buf_ctx->find_graph_stc(cgraph->uid);
+            if (stc == nullptr) {
+                ok = false;
+                break;
+            }
+            buf_ctx->stc_active = stc;
+        }
+        if (ok && plan->alloc_epoch != g_meta_alloc_epoch.load(std::memory_order_relaxed)) {
+            for (int i = 0; i < cgraph->n_nodes && ok; i++) {
+                ok = plan->node_fps[i] == ggml_backend_meta_shadow_fp::of(cgraph->nodes[i]);
+            }
+            if (ok) {
+                plan->alloc_epoch = g_meta_alloc_epoch.load(std::memory_order_relaxed);
+            }
+        }
+        if (!ok) {
+            plan->uid = 0; // rebuild into this slot below
+            plan = nullptr;
+        }
+    }
+
+    const bool needs_rebuild = plan == nullptr;
 
     bool max_nnodes_raised = false;
     if (cgraph->n_nodes > backend_ctx->max_nnodes) {
@@ -1799,26 +2037,29 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
         assert(needs_rebuild);
     }
 
+    std::vector<ggml_backend_buffer_t> used_buffers;
     if (needs_rebuild) {
-        std::set<ggml_backend_buffer_t> used_buffers;
-        for (int i = 0; i < cgraph->n_leafs; i++) {
-            if (ggml_backend_buffer_is_meta(cgraph->leafs[i]->buffer)) {
-                used_buffers.emplace(cgraph->leafs[i]->buffer);
+        // every graph gets fresh shadow containers: shadows reference each other,
+        // so partial reuse across graph generations dangles source pointers
+        {
+            auto add_buf = [&](ggml_backend_buffer_t buf) {
+                if (buf == nullptr || !ggml_backend_buffer_is_meta(buf)) {
+                    return;
+                }
+                if (std::find(used_buffers.begin(), used_buffers.end(), buf) == used_buffers.end()) {
+                    used_buffers.push_back(buf);
+                }
+            };
+            for (int i = 0; i < cgraph->n_leafs; i++) {
+                add_buf(cgraph->leafs[i]->buffer);
             }
-        }
-        for (int i = 0; i < cgraph->n_nodes; i++) {
-            if (ggml_backend_buffer_is_meta(cgraph->nodes[i]->buffer)) {
-                used_buffers.emplace(cgraph->nodes[i]->buffer);
+            for (int i = 0; i < cgraph->n_nodes; i++) {
+                add_buf(cgraph->nodes[i]->buffer);
             }
-        }
-        for (ggml_backend_buffer_t buf : used_buffers) {
-            ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buf->context;
-            buf_ctx->stc_compute_index_next = buf_ctx->stc_compute_index ^ 1;
-            ggml_backend_meta_simple_tensor_container & stc = buf_ctx->stc_compute[buf_ctx->stc_compute_index_next];
-            for (ggml_context_ptr & ctx : stc.ctxs) {
-                ggml_reset(ctx.get());
+            for (ggml_backend_buffer_t buf : used_buffers) {
+                ggml_backend_meta_buffer_context * buf_ctx = (ggml_backend_meta_buffer_context *) buf->context;
+                buf_ctx->stc_active = buf_ctx->create_graph_stc(cgraph->uid);
             }
-            stc.simple_tensors.clear();
         }
         size_t n_subgraphs  = 0;
         size_t max_tmp_size = 0;
@@ -1985,9 +2226,6 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
             GGML_ASSERT(i_start == cgraph->n_nodes);
         }
 
-        backend_ctx->uid         = cgraph->uid;
-        backend_ctx->n_subgraphs = n_subgraphs;
-
         if (max_tmp_size > backend_ctx->max_tmp_size) {
             for (size_t j = 0; j < n_backends; j++) {
                 auto & bcj = backend_ctx->backend_configs[j];
@@ -1998,25 +2236,19 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
             backend_ctx->max_tmp_size = max_tmp_size;
         }
 
+        // aux graph/node pools for the fallback AllReduce; shared per-eval scratch
         if (max_nnodes_raised || n_subgraphs > backend_ctx->max_subgraphs) {
             backend_ctx->max_subgraphs = std::max(backend_ctx->max_subgraphs, n_subgraphs);
             const size_t n_nodes_per_device = 3 * backend_ctx->n_reduce_steps; // tmp + ADD (+zeroing) graph per step and device
             const size_t n_cgraphs_per_device = 2 * backend_ctx->n_reduce_steps; // ADD ( + zeroing) graph per step and device
-            const size_t mem_per_device_graphs_main = backend_ctx->max_subgraphs*ggml_graph_overhead_custom(backend_ctx->max_nnodes, cgraph->grads);
             const size_t mem_per_device_graphs_aux = n_cgraphs_per_device*backend_ctx->max_subgraphs*ggml_graph_overhead_custom(1, cgraph->grads);
             const size_t mem_per_device_nodes_aux = n_nodes_per_device*backend_ctx->max_subgraphs*ggml_tensor_overhead();
             const ggml_init_params params = {
-                /*.mem_size   =*/ n_backends * (mem_per_device_graphs_main + mem_per_device_graphs_aux + mem_per_device_nodes_aux),
+                /*.mem_size   =*/ n_backends * (mem_per_device_graphs_aux + mem_per_device_nodes_aux),
                 /*.mem_buffer =*/ nullptr,
                 /*.no_alloc   =*/ true,
             };
             backend_ctx->ctx.reset(ggml_init(params));
-            for (size_t j = 0; j < n_backends; j++) {
-                auto & bcj = backend_ctx->backend_configs[j];
-                for (size_t i = 0; i < n_subgraphs; i++) {
-                    bcj.cgraphs[i].cgraph_main = ggml_new_graph_custom(backend_ctx->ctx.get(), cgraph->n_nodes, /*grads =*/ false);
-                }
-            }
             backend_ctx->cgraphs_aux.resize(n_backends*n_cgraphs_per_device*backend_ctx->max_subgraphs);
             for (size_t k = 0; k < backend_ctx->cgraphs_aux.size(); k++) {
                 backend_ctx->cgraphs_aux[k] = ggml_new_graph_custom(backend_ctx->ctx.get(), 1, cgraph->grads);
@@ -2024,6 +2256,51 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
             backend_ctx->nodes_aux.resize(n_backends*n_nodes_per_device*backend_ctx->max_subgraphs);
             for (size_t k = 0; k < backend_ctx->nodes_aux.size(); k++) {
                 backend_ctx->nodes_aux[k] = ggml_new_tensor_1d(backend_ctx->ctx.get(), GGML_TYPE_F32, 1);
+            }
+        }
+
+        // evict the least recently used plan and build into it; the subgraph cgraphs are
+        // owned by the plan so cached plans survive later rebuilds
+        if (plan == nullptr) {
+            plan = &backend_ctx->plans[0];
+            for (auto & p : backend_ctx->plans) {
+                if (p.uid == 0) {
+                    plan = &p;
+                    break;
+                }
+                if (p.last_used < plan->last_used) {
+                    plan = &p;
+                }
+            }
+        }
+        plan->uid         = cgraph->uid;
+        plan->alloc_epoch = g_meta_alloc_epoch.load(std::memory_order_relaxed);
+        plan->n_subgraphs = n_subgraphs;
+        plan->buffers     = used_buffers;
+        plan->node_fps.resize(cgraph->n_nodes);
+        for (int i = 0; i < cgraph->n_nodes; i++) {
+            plan->node_fps[i] = ggml_backend_meta_shadow_fp::of(cgraph->nodes[i]);
+        }
+        {
+            // recycle the evicted plan's storage when it is big enough; a fresh
+            // multi-MB allocation per rebuild costs real time on this hot path
+            const size_t mem_size = n_backends*n_subgraphs*ggml_graph_overhead_custom(cgraph->n_nodes, false) + ggml_graph_overhead();
+            if (plan->ctx == nullptr || plan->ctx_size < mem_size) {
+                const ggml_init_params params = {
+                    /*.mem_size   =*/ mem_size,
+                    /*.mem_buffer =*/ nullptr,
+                    /*.no_alloc   =*/ true,
+                };
+                plan->ctx.reset(ggml_init(params));
+                plan->ctx_size = mem_size;
+            } else {
+                ggml_reset(plan->ctx.get());
+            }
+        }
+        for (size_t j = 0; j < n_backends; j++) {
+            auto & bcj = backend_ctx->backend_configs[j];
+            for (size_t i = 0; i < n_subgraphs; i++) {
+                bcj.cgraphs[i].cgraph_main = ggml_new_graph_custom(plan->ctx.get(), cgraph->n_nodes, /*grads =*/ false);
             }
         }
 
@@ -2045,7 +2322,26 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
                 cgraph_ij->uid = ggml_graph_next_uid();
             }
         }
+
+        // store the built decomposition in the plan
+        plan->pb.assign(n_backends, {});
+        for (size_t j = 0; j < n_backends; j++) {
+            auto & bcj = backend_ctx->backend_configs[j];
+            plan->pb[j].nodes.assign(bcj.nodes.begin(), bcj.nodes.begin() + cgraph->n_nodes);
+            plan->pb[j].cgraphs.assign(bcj.cgraphs.begin(), bcj.cgraphs.begin() + n_subgraphs);
+        }
+    } else {
+        // cached plan: restore the working arrays
+        for (size_t j = 0; j < n_backends; j++) {
+            auto & bcj = backend_ctx->backend_configs[j];
+            std::copy(plan->pb[j].nodes.begin(),   plan->pb[j].nodes.end(),   bcj.nodes.begin());
+            std::copy(plan->pb[j].cgraphs.begin(), plan->pb[j].cgraphs.end(), bcj.cgraphs.begin());
+        }
     }
+
+    plan->last_used = ++backend_ctx->plan_tick;
+
+    const size_t n_subgraphs_exec = plan->n_subgraphs;
 
     size_t iga = 0; // i graph aux
     size_t ina = 0; // i node aux
@@ -2193,7 +2489,7 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
     };
 
 
-    for (size_t i = 0; i < backend_ctx->n_subgraphs; i++) {
+    for (size_t i = 0; i < n_subgraphs_exec; i++) {
         for (size_t j = 0; j < n_backends; j++) {
             auto & bcj = backend_ctx->backend_configs[j];
             const ggml_status status = ggml_backend_graph_compute_async(bcj.backend, bcj.cgraphs[i].cgraph_main);
@@ -2202,7 +2498,7 @@ static enum ggml_status ggml_backend_meta_graph_compute(ggml_backend_t backend, 
             }
         }
 
-        if (n_backends > 1 && i < backend_ctx->n_subgraphs - 1) {
+        if (n_backends > 1 && i < n_subgraphs_exec - 1) {
             bool backend_allreduce_success = false;
             if (backend_ctx->comm_ctx) {
                 std::vector<ggml_tensor *> nodes;

--- a/ggml/src/ggml-cuda/allreduce.cu
+++ b/ggml/src/ggml-cuda/allreduce.cu
@@ -224,9 +224,10 @@ static __global__ void ggml_cuda_ar_add_kernel(
 // Number of slots in the event / arrival ring.  Two slots is sufficient:
 // lockstep guarantees the two GPUs are at most one AR (or chunk) apart, so
 // slot[N%2] is always safe to reuse -- peer has already consumed slot[N%2]
-// from AR N-2 by the time we get to AR N.  acquire_slot's
-// cudaEventSynchronize on ev.ker for both devices makes that consumption
-// explicit before we overwrite host_buf[slot] for the new AR.
+// from AR N-2 by the time we get to AR N.  The copy-engine path makes that
+// explicit with acquire_slot's cudaEventSynchronize on ev.ker; the chunked
+// path relies on the in-kernel arrival handshake (see
+// ggml_cuda_ar_kernel_slot).
 static constexpr int GGML_CUDA_AR_POOL_SIZE = 2;
 
 // Maximum chunk size (bytes per GPU) handled by one chunked kernel launch.
@@ -305,6 +306,7 @@ struct ggml_cuda_ar_pipeline {
     size_t   copy_chunk_bytes;
     size_t   bf16_threshold; // tensors >= this size (bytes) are reduced via FP32->BF16 round-trip; 0 disables
     uint64_t call_count;
+    uint64_t kernel_call_count; // chunked-kernel path only; see ggml_cuda_ar_kernel_slot
 
     // Per-device resources.
     ggml_cuda_ar_host_mapping host_buf[GGML_CUDA_MAX_DEVICES];   // pinned staging (chunked kernel)
@@ -370,6 +372,24 @@ static ggml_cuda_ar_slot_info ggml_cuda_ar_acquire_slot(ggml_cuda_ar_pipeline * 
     }
 
     return { slot, (int) p->call_count };
+}
+
+// Chunked-kernel path slot assignment. No host synchronization: the arrival
+// handshake already serializes reuse of the 2-slot staging ring. The chain
+// runs through the intervening AR, not through the current one: before this
+// GPU's kernel T can launch, its kernel T-1 retired (same stream), and every
+// block of T-1 observed the peer's token T-1 in its phase-2 spin. The peer
+// signals T-1 from inside kernel T-1, which in its stream order means the
+// peer's kernel T-2 fully retired, including the phase-3 reads of the slot
+// that T reuses. This lets the host enqueue a full token's worth of
+// subgraphs and reductions ahead of the GPUs. Requires every chunked AR of
+// a device to launch on the same stream; the meta backend calls this
+// between subgraphs where that holds. Uses its own counter so tokens in
+// the arrival ring never mix with copy-engine slot bookkeeping.
+static ggml_cuda_ar_slot_info ggml_cuda_ar_kernel_slot(ggml_cuda_ar_pipeline * p) {
+    const int slot = static_cast<int>(p->kernel_call_count % GGML_CUDA_AR_POOL_SIZE);
+    p->kernel_call_count++;
+    return { slot, (int) p->kernel_call_count };
 }
 
 // Per-AR copy-engine chunk size: env-var override if set, else heuristic
@@ -539,7 +559,10 @@ void ggml_cuda_ar_pipeline_free(ggml_cuda_ar_pipeline * p) {
         return;
     }
 
-    // Drain all in-flight kernels before tearing down resources.
+    // Drain the AR streams before tearing down resources.  Chunked kernels
+    // run on the caller's compute streams and record no events, so the
+    // caller must synchronize its backends before freeing the pipeline;
+    // ggml_backend_cuda_comm_free runs at backend teardown where that holds.
     for (int i = 0; i < p->n_devices; ++i) {
         if (p->streams[i]) {
             ggml_cuda_set_device(p->devices[i]);
@@ -890,15 +913,14 @@ bool ggml_cuda_ar_allreduce(
         // since AR is a barrier here, same-stream ordering subsumes any
         // cross-stream event handshake that the copy-engine path needs, and
         // skips the cross-stream scheduling overhead that was hurting the
-        // small-tensor (tg) latency on the AR-stream variant.  Only ev.ker is
-        // still recorded at end-of-AR for acquire_slot's pool-wraparound check.
+        // small-tensor (tg) latency on the AR-stream variant.  No events are
+        // recorded; slot reuse safety comes from the arrival handshake.
         for (int64_t chunk_start = 0; chunk_start < ne; chunk_start += (int64_t) max_chunk_elems) {
             const size_t remaining_elems = (size_t) (ne - chunk_start);
             const size_t chunk_elems = remaining_elems < max_chunk_elems ? remaining_elems : max_chunk_elems;
             const size_t chunk_dst_bytes  = chunk_elems * input_type_size;
 
-            const auto [slot, token] = ggml_cuda_ar_acquire_slot(p);
-            const bool last_chunk = chunk_start + (int64_t) chunk_elems == ne;
+            const auto [slot, token] = ggml_cuda_ar_kernel_slot(p);
 
             for (int i = 0; i < n; ++i) {
                 const int peer = 1 - i;  // valid for n == 2 only
@@ -941,10 +963,6 @@ bool ggml_cuda_ar_allreduce(
 
 #undef LAUNCH_AR_KERNEL
                 CUDA_CHECK(cudaGetLastError());
-
-                if (last_chunk) {
-                    CUDA_CHECK(cudaEventRecord(p->ev_pool[i][slot].ker, stream));
-                }
             }
         }
     }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -117,6 +117,7 @@ llama_context::llama_context(
     cparams.embeddings              = params.embeddings;
     cparams.embeddings_nextn        = false;
     cparams.embeddings_nextn_masked = false;
+    cparams.mtp_chain               = false;
     cparams.offload_kqv             = params.offload_kqv;
     cparams.no_perf                 = params.no_perf;
     cparams.warmup                  = false;
@@ -599,7 +600,10 @@ void llama_context::sched_reserve() {
     LLAMA_LOG_DEBUG("%s: max_nodes = %zu\n", __func__, max_nodes);
 
     gf_res_prev.reset(new llm_graph_result(max_nodes));
+    gf_res_tg.reset(new llm_graph_result(max_nodes));
     gf_res_reserve.reset(new llm_graph_result(max_nodes));
+
+    gf_res_alloced = nullptr;
 
     sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, cparams.pipeline_parallel, cparams.op_offload));
 
@@ -671,6 +675,40 @@ void llama_context::sched_reserve() {
         }
     }
 
+    // experimental: dedicated scheduler for 1-token decode graphs, reserved with a
+    // 1-token-per-seq worst case; keeps draft and verification allocations warm at the
+    // same time. Requires meta-backend multi-graph support under tensor split, so it
+    // stays off unless LLAMA_SCHED_TG=1.
+    static const bool sched_tg_enable = [] {
+        const char * env = getenv("LLAMA_SCHED_TG");
+        return env != nullptr && atoi(env) != 0;
+    }();
+    if (sched_tg_enable && !model.hparams.no_alloc) {
+        sched_tg.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, cparams.pipeline_parallel, cparams.op_offload));
+
+        auto * gf = graph_reserve(n_seqs, n_seqs, n_seqs, mctx.get(), false, nullptr, sched_tg.get());
+        if (!gf) {
+            LLAMA_LOG_WARN("%s: failed to reserve the 1-token scheduler; falling back to a single scheduler\n", __func__);
+            sched_tg.reset();
+        }
+    }
+
+    // experimental: per-shape scheduler pool for small decode graphs. Every recurring
+    // batch shape keeps its own scheduler, allocation, and cached graph, so shapes
+    // alternating under speculative decoding stop evicting each other. Requires the
+    // meta backend's per-uid plan cache under tensor split; off unless
+    // LLAMA_SCHED_POOL=N (number of slots).
+    static const int sched_pool_env = [] {
+        const char * env = getenv("LLAMA_SCHED_POOL");
+        return env != nullptr ? atoi(env) : 0;
+    }();
+    if (sched_pool_env > 0 && !model.hparams.no_alloc) {
+        sched_pool_max = std::min(sched_pool_env, 16);
+    }
+
+    sched_active = sched.get();
+
+
     for (size_t i = 0; i < backend_ptrs.size(); ++i) {
         ggml_backend_t             backend = backend_ptrs[i];
         ggml_backend_buffer_type_t buft    = backend_buft[i];
@@ -708,6 +746,14 @@ void llama_context::synchronize() {
     }
 
     ggml_backend_sched_synchronize(sched.get());
+
+    if (sched_tg) {
+        ggml_backend_sched_synchronize(sched_tg.get());
+    }
+
+    for (auto & s : sched_pool) {
+        ggml_backend_sched_synchronize(s.sched.get());
+    }
 
     // FIXME: if multiple single tokens are evaluated without a synchronization,
     // the stats will be added to the prompt evaluation stats
@@ -805,10 +851,20 @@ bool llama_context::memory_update(bool optimize) {
                 }
         }
 
-        // reset the previous graph result to make sure that it won't be reused
+        // reset the previous graph results to make sure that they won't be reused
         // TODO: change the mctx->apply() to return information if a graph reserve is needed
         //       reset the graph result only if the memory module did reset the scheduler
         gf_res_prev->reset();
+        if (gf_res_tg) {
+            gf_res_tg->reset();
+        }
+        gf_res_alloced    = nullptr;
+        gf_res_alloced_tg = nullptr;
+
+        for (auto & s : sched_pool) {
+            s.gf_res->reset();
+            s.alloced = nullptr;
+        }
 
         if (!mctx->apply()) {
             LLAMA_LOG_ERROR("%s: failed to apply memory update\n", __func__);
@@ -1181,6 +1237,10 @@ void llama_context::set_nextn_layer_offset(int32_t offset) {
     cparams.nextn_layer_offset = offset;
 }
 
+void llama_context::set_mtp_chain(bool value) {
+    cparams.mtp_chain = value;
+}
+
 void llama_context::set_causal_attn(bool value) {
     LLAMA_LOG_DEBUG("%s: value = %d\n", __func__, value);
 
@@ -1213,17 +1273,26 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
 
     LLAMA_LOG_DEBUG("%s: seq_id = %d, sampler = %p\n", __func__, (int) seq_id, (void *) sampler);
 
+    // backend sampling needs unsplit logits. Under SPLIT_MODE_TENSOR that holds only
+    // when the output head is mirrored (LLAMA_META_MIRROR_OUTPUT=1): every device then
+    // holds full logits and the sampler graph runs replicated on all of them.
     if (sampler && model.split_mode() == LLAMA_SPLIT_MODE_TENSOR) {
-        static bool warned = false;
-        if (!warned) {
-            LLAMA_LOG_WARN("%s: backend sampling not supported with SPLIT_MODE_TENSOR; using CPU\n", __func__);
-            warned = true;
+        const ggml_tensor * out_w = model.output ? model.output : model.tok_embd;
+        const bool mirrored = out_w != nullptr &&
+            llama_meta_device_get_split_state(out_w, (void *) &model.get_split_state_ud).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED;
+        if (!mirrored) {
+            static bool warned = false;
+            if (!warned) {
+                LLAMA_LOG_WARN("%s: backend sampling with SPLIT_MODE_TENSOR needs a mirrored output head "
+                        "(LLAMA_META_MIRROR_OUTPUT=1); using CPU\n", __func__);
+                warned = true;
+            }
+            if (sampling.samplers.count(seq_id) > 0) {
+                sched_need_reserve = true;
+            }
+            sampling.samplers.erase(seq_id);
+            return false;
         }
-        if (sampling.samplers.count(seq_id) > 0) {
-            sched_need_reserve = true;
-        }
-        sampling.samplers.erase(seq_id);
-        return false;
     }
 
     const bool can_offload =
@@ -1329,29 +1398,105 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         return nullptr;
     }
 
-    auto * res = gf_res_prev.get();
+    // per-shape scheduler pool: each recurring small decode shape keeps its own
+    // scheduler and cached graph, so alternating shapes stay warm
+    sched_slot * slot = nullptr;
+    if (sched_pool_max > 0 && ubatch.n_tokens <= sched_pool_n_max) {
+        for (auto & s : sched_pool) {
+            if (s.n_tokens == ubatch.n_tokens && s.n_outputs == (uint32_t) n_outputs) {
+                slot = &s;
+                break;
+            }
+        }
+        if (slot == nullptr) {
+            if ((int) sched_pool.size() < sched_pool_max) {
+                sched_pool.emplace_back();
+                slot = &sched_pool.back();
+                const size_t max_nodes = graph_max_nodes(ubatch.n_tokens);
+                slot->sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(),
+                        backend_ptrs.size(), max_nodes, cparams.pipeline_parallel, cparams.op_offload));
+                slot->gf_res.reset(new llm_graph_result(max_nodes));
+            } else {
+                // reuse the least recently used slot for the new shape
+                slot = &sched_pool[0];
+                for (auto & s : sched_pool) {
+                    if (s.last_used < slot->last_used) {
+                        slot = &s;
+                    }
+                }
+                slot->gf_res->reset();
+                slot->alloced = nullptr;
+            }
+            slot->n_tokens  = ubatch.n_tokens;
+            slot->n_outputs = (uint32_t) n_outputs;
+        }
+        slot->last_used = ++sched_pool_tick;
+    }
+
+    // 1-token graphs run on a dedicated scheduler so that the draft and verification
+    // evals of speculative decoding do not evict each other's graph or allocation
+    const bool use_tg = slot == nullptr && sched_tg && gf_res_tg && ubatch.n_tokens == 1;
+
+    ggml_backend_sched_t sched_cur = slot ? slot->sched.get() : use_tg ? sched_tg.get() : sched.get();
+
+    auto * res = slot ? slot->gf_res.get() : use_tg ? gf_res_tg.get() : gf_res_prev.get();
     auto * gf  = res->get_gf();
+
+    llm_graph_result * & res_alloced = slot ? slot->alloced : use_tg ? gf_res_alloced_tg : gf_res_alloced;
+
+    sched_active = sched_cur;
 
     // the new graph parameters
     // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
     const auto gparams = graph_params(res, ubatch, mctx, gtype);
 
-    if (!graph_reuse_disable && res->can_reuse(gparams)) {
+    // experimental: also reuse a cached topology whose scheduler allocation went stale,
+    // by re-allocating it without a rebuild. Slower than a rebuild in practice; off
+    // unless LLAMA_GRAPH_REALLOC=1.
+    static const bool graph_realloc_enable = [] {
+        const char * env = getenv("LLAMA_GRAPH_REALLOC");
+        return env != nullptr && atoi(env) != 0;
+    }();
+
+    const char * path_dbg = "rebuild";
+
+    if (!graph_reuse_disable && res->can_reuse(gparams) && (res == res_alloced || graph_realloc_enable)) {
         //LLAMA_LOG_DEBUG("%s: reusing previous graph\n", __func__);
+
+        path_dbg = res == res_alloced ? "fast" : "realloc";
 
         // with pipeline parallelism, the previous graph_compute_async may still be running
         // on the GPU. we must synchronize before set_inputs to avoid overwriting input tensors
         // that the previous compute is still reading.
         if (cparams.pipeline_parallel) {
-            ggml_backend_sched_synchronize(sched.get());
+            ggml_backend_sched_synchronize(sched_cur);
+        }
+
+        if (res != res_alloced) {
+            // cached topology with a stale allocation: re-allocate the graph without
+            // rebuilding it. The node addresses do not change, so backend-side graph
+            // caches (subgraph splits, CUDA graphs) stay warm. The scheduler rewired
+            // the node sources to its now-dead split copies, so restore them first.
+            res->restore_srcs();
+
+            ggml_backend_sched_reset(sched_cur);
+            ggml_backend_sched_set_eval_callback(sched_cur, cparams.cb_eval, cparams.cb_eval_user_data);
+
+            if (!ggml_backend_sched_alloc_graph(sched_cur, gf)) {
+                LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
+                ret = GGML_STATUS_ALLOC_FAILED;
+                return nullptr;
+            }
+
+            res_alloced = res;
         }
 
         n_reused++;
     } else {
         res->reset();
 
-        ggml_backend_sched_reset(sched.get());
-        ggml_backend_sched_set_eval_callback(sched.get(), cparams.cb_eval, cparams.cb_eval_user_data);
+        ggml_backend_sched_reset(sched_cur);
+        ggml_backend_sched_set_eval_callback(sched_cur, cparams.cb_eval, cparams.cb_eval_user_data);
 
         //const auto t_start_us = ggml_time_us();
 
@@ -1365,11 +1510,16 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
             return nullptr;
         }
 
-        if (!ggml_backend_sched_alloc_graph(sched.get(), gf)) {
+        // capture the built node sources before the scheduler rewires them
+        res->snapshot_srcs();
+
+        if (!ggml_backend_sched_alloc_graph(sched_cur, gf)) {
             LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             ret = GGML_STATUS_ALLOC_FAILED;
             return nullptr;
         }
+
+        res_alloced = res;
     }
 
     // set the input data for the input tensors
@@ -1387,6 +1537,52 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         LLAMA_LOG_ERROR("%s: failed to compute graph, compute status: %d\n", __func__, status);
         ret = status;
         return nullptr;
+    }
+
+    // debug: per-eval logits checksum for localizing graph-reuse corruption
+    static const bool graph_debug_sum = [] {
+        const char * env = getenv("LLAMA_GRAPH_DEBUG_SUM");
+        return env != nullptr && atoi(env) != 0;
+    }();
+    if (graph_debug_sum) {
+        static int eval_no = 0;
+        eval_no++;
+        double sum = 0.0;
+        int64_t n = 0;
+        ggml_tensor * t_logits = res->get_logits();
+        if (t_logits != nullptr && ggml_nelements(t_logits) > 0) {
+            ggml_backend_sched_synchronize(sched_active);
+            // read the full first row: split buffers reject partial-row reads
+            n = t_logits->ne[0];
+            std::vector<float> row(n);
+            ggml_backend_tensor_get(t_logits, row.data(), 0, n*sizeof(float));
+            for (int64_t i = 0; i < std::min<int64_t>(n, 256); i++) {
+                sum += row[i];
+            }
+        }
+        double in_embd_sum = 0.0;
+        int64_t in_tok_sum = 0;
+        ggml_tensor * t_in_tok = res->get_inp_tokens();
+        if (t_in_tok != nullptr && ggml_nelements(t_in_tok) > 0) {
+            std::vector<int32_t> toks(ggml_nelements(t_in_tok));
+            ggml_backend_tensor_get(t_in_tok, toks.data(), 0, toks.size()*sizeof(int32_t));
+            for (int32_t v : toks) {
+                in_tok_sum += v;
+            }
+        }
+        ggml_tensor * t_in_embd = res->t_inp_embd;
+        if (t_in_embd != nullptr && ggml_nelements(t_in_embd) > 0) {
+            const int64_t ne = std::min<int64_t>(ggml_nelements(t_in_embd), 512);
+            std::vector<float> vals(ne);
+            ggml_backend_tensor_get(t_in_embd, vals.data(), 0, ne*sizeof(float));
+            for (float v : vals) {
+                in_embd_sum += v;
+            }
+        }
+        fprintf(stderr, "EVALSUM %d slot=%s path=%s n_tokens=%u n_out=%d in_tok=%lld in_embd=%.6f sum=%.6f\n",
+            eval_no, use_tg ? "tg" : "main", path_dbg, ubatch.n_tokens, this->n_outputs,
+            (long long) in_tok_sum, in_embd_sum, sum);
+        fflush(stderr);
     }
 
     ret = GGML_STATUS_SUCCESS;
@@ -1479,7 +1675,7 @@ int llama_context::encode(const llama_batch & batch_inp) {
 
     // extract logits
     if (logits.data && t_logits) {
-        ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched.get(), t_logits);
+        ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched_active, t_logits);
         GGML_ASSERT(backend_res != nullptr);
         GGML_ASSERT(logits.data != nullptr);
 
@@ -1488,7 +1684,7 @@ int llama_context::encode(const llama_batch & batch_inp) {
 
     // extract embeddings
     if (embd.data && t_embd) {
-        ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(sched.get(), t_embd);
+        ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(sched_active, t_embd);
         GGML_ASSERT(backend_embd != nullptr);
 
         switch (cparams.pooling_type) {
@@ -1543,7 +1739,7 @@ int llama_context::encode(const llama_batch & batch_inp) {
 
     // extract nextn embeddings (hidden state before the final output norm)
     if (embd_nextn.data && t_h_nextn && cparams.pooling_type == LLAMA_POOLING_TYPE_NONE) {
-        ggml_backend_t backend_h = ggml_backend_sched_get_tensor_backend(sched.get(), t_h_nextn);
+        ggml_backend_t backend_h = ggml_backend_sched_get_tensor_backend(sched_active, t_h_nextn);
         GGML_ASSERT(backend_h != nullptr);
 
         const uint32_t n_embd = hparams.n_embd_out();
@@ -1861,7 +2057,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
         // extract logits
         if (logits.data && t_logits && n_outputs > 0 && needs_raw_logits(ubatch, sampling.samplers)) {
-            ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched.get(), t_logits);
+            ggml_backend_t backend_res = ggml_backend_sched_get_tensor_backend(sched_active, t_logits);
             GGML_ASSERT(backend_res != nullptr);
             GGML_ASSERT(logits.data != nullptr);
 
@@ -1870,13 +2066,16 @@ int llama_context::decode(const llama_batch & batch_inp) {
             if (n_outputs) {
                 GGML_ASSERT( n_outputs_prev + n_outputs <= n_outputs_all);
                 GGML_ASSERT((n_outputs_prev + n_outputs)*n_vocab <= (int64_t) logits.size);
-                ggml_backend_tensor_get_async(backend_res, t_logits, logits_out, 0, n_outputs*n_vocab*sizeof(float));
+                // graphs can emit narrower per-row outputs than n_vocab (e.g. the
+                // MTP chain packs [token id, top prob] rows); copy what exists
+                const size_t nbytes = std::min<size_t>(ggml_nbytes(t_logits), (size_t) n_outputs*n_vocab*sizeof(float));
+                ggml_backend_tensor_get_async(backend_res, t_logits, logits_out, 0, nbytes);
             }
         }
 
         // extract embeddings
         if (embd.data && t_embd && n_outputs > 0) {
-            ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(sched.get(), t_embd);
+            ggml_backend_t backend_embd = ggml_backend_sched_get_tensor_backend(sched_active, t_embd);
             GGML_ASSERT(backend_embd != nullptr);
 
             switch (cparams.pooling_type) {
@@ -1944,7 +2143,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
             const int64_t offset = masked ? n_outputs_prev  : n_tokens_prev;
 
             if (embd_nextn.data && t_h_nextn && n_rows > 0 && cparams.pooling_type == LLAMA_POOLING_TYPE_NONE) {
-                ggml_backend_t backend_h = ggml_backend_sched_get_tensor_backend(sched.get(), t_h_nextn);
+                ggml_backend_t backend_h = ggml_backend_sched_get_tensor_backend(sched_active, t_h_nextn);
                 GGML_ASSERT(backend_h != nullptr);
 
                 const uint32_t n_embd  = hparams.n_embd_out();
@@ -1959,10 +2158,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
             const auto stride = n_vocab;
 
             // async copy the sampling data from the backend to the host
-            copy_tensor_async_rows(res->t_sampled,        sampling.sampled,    1,      n_outputs_prev, sched.get());
-            copy_tensor_async_rows(res->t_sampled_logits, sampling.logits,     stride, n_outputs_prev, sched.get(), &sampling.logits_count);
-            copy_tensor_async_rows(res->t_sampled_probs,  sampling.probs,      stride, n_outputs_prev, sched.get(), &sampling.probs_count);
-            copy_tensor_async_rows(res->t_candidates,     sampling.candidates, stride, n_outputs_prev, sched.get(), &sampling.candidates_count);
+            copy_tensor_async_rows(res->t_sampled,        sampling.sampled,    1,      n_outputs_prev, sched_active);
+            copy_tensor_async_rows(res->t_sampled_logits, sampling.logits,     stride, n_outputs_prev, sched_active, &sampling.logits_count);
+            copy_tensor_async_rows(res->t_sampled_probs,  sampling.probs,      stride, n_outputs_prev, sched_active, &sampling.probs_count);
+            copy_tensor_async_rows(res->t_candidates,     sampling.candidates, stride, n_outputs_prev, sched_active, &sampling.candidates_count);
         }
 
         n_outputs_prev += n_outputs;
@@ -2213,7 +2412,7 @@ void llama_context::extract_layer_inputs(const llm_graph_result * res, size_t to
         const size_t dst_offset = token_offset * row_floats;
         GGML_ASSERT(dst_offset + nfloats <= embd_layer_inp[il].size);
 
-        ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(sched.get(), t);
+        ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(sched_active, t);
         GGML_ASSERT(backend != nullptr);
         ggml_backend_tensor_get_async(backend, t, embd_layer_inp[il].data + dst_offset, 0, nbytes);
     }
@@ -2303,6 +2502,8 @@ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
         model.arch == LLM_ARCH_MINIMAX_01 ||
         model.arch == LLM_ARCH_MINIMAX_M3) {
         res = std::max<uint32_t>(n_tokens * 40, 32u * model.n_tensors());
+        // recurrent-state rollback snapshots add nodes per layer per tracked sequence
+        res += 4u*(cparams.n_rs_seq + 1)*model.hparams.n_layer();
     } else {
         res = std::max<uint32_t>(1024u, 8u*model.n_tensors());
         for (const auto & lora : model.loras) {
@@ -2393,7 +2594,8 @@ static void ubatch_prepare_reserve(
 }
 
 ggml_cgraph * llama_context::graph_reserve(
-        uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only, size_t * sizes) {
+        uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only, size_t * sizes,
+        ggml_backend_sched_t sched_use) {
     LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
     GGML_ASSERT(n_outputs >= 1);
 
@@ -2402,10 +2604,23 @@ ggml_cgraph * llama_context::graph_reserve(
         LLAMA_LOG_DEBUG("%s: making n_tokens a multiple of n_seqs - n_tokens = %u, n_seqs = %u, n_outputs = %u\n", __func__, n_tokens, n_seqs, n_outputs);
     }
 
-    ggml_backend_sched_reset(sched.get());
+    if (sched_use == nullptr) {
+        sched_use = sched.get();
+    }
 
-    // when the scheduler is reset, we cannot reuse the old graph, so we reset the previous graph result to prevent that
-    gf_res_prev->reset();
+    // the graph build callback pins ops through the active scheduler
+    sched_active = sched_use;
+
+    ggml_backend_sched_reset(sched_use);
+
+    // when a scheduler is reset, we cannot reuse its old graph, so we reset the matching graph result to prevent that
+    if (sched_use == sched.get()) {
+        gf_res_prev->reset();
+        gf_res_alloced = nullptr;
+    } else if (gf_res_tg) {
+        gf_res_tg->reset();
+        gf_res_alloced_tg = nullptr;
+    }
 
     // store the n_outputs as it is, and restore it afterwards
     // TODO: not sure if needed, might simplify in the future by removing this
@@ -2431,11 +2646,11 @@ ggml_cgraph * llama_context::graph_reserve(
     // initialize scheduler with the specified graph
     if (split_only) {
         if (sizes) {
-            ggml_backend_sched_reserve_size(sched.get(), gf, sizes);
+            ggml_backend_sched_reserve_size(sched_use, gf, sizes);
         } else {
-            ggml_backend_sched_split_graph(sched.get(), gf);
+            ggml_backend_sched_split_graph(sched_use, gf);
         }
-    } else if (!ggml_backend_sched_reserve(sched.get(), gf)) {
+    } else if (!ggml_backend_sched_reserve(sched_use, gf)) {
         GGML_ASSERT(!sizes);
         LLAMA_LOG_ERROR("%s: failed to allocate compute buffers\n", __func__);
         return nullptr;
@@ -2487,7 +2702,7 @@ ggml_status llama_context::graph_compute(
         set_n_threads_fn.second(set_n_threads_fn.first, n_threads);
     }
 
-    auto status = ggml_backend_sched_graph_compute_async(sched.get(), gf);
+    auto status = ggml_backend_sched_graph_compute_async(sched_active ? sched_active : sched.get(), gf);
     if (status != GGML_STATUS_SUCCESS) {
         LLAMA_LOG_ERROR("%s: ggml_backend_sched_graph_compute_async failed with error %d\n", __func__, status);
     }
@@ -2515,7 +2730,7 @@ llm_graph_cb llama_context::graph_get_cb() const {
                 for (const auto & backend : backends) {
                     if (ggml_backend_get_device(backend.get()) == dev_layer) {
                         if (ggml_backend_supports_op(backend.get(), cur)) {
-                            ggml_backend_sched_set_tensor_backend(sched.get(), cur, backend.get());
+                            ggml_backend_sched_set_tensor_backend(sched_active ? sched_active : sched.get(), cur, backend.get());
                         }
                     }
                 }
@@ -3780,6 +3995,10 @@ void llama_set_embeddings_layer_inp(llama_context * ctx, uint32_t lid, bool valu
 
 void llama_set_nextn_layer_offset(llama_context * ctx, int32_t offset) {
     ctx->set_nextn_layer_offset(offset);
+}
+
+void llama_set_mtp_chain(llama_context * ctx, bool value) {
+    ctx->set_mtp_chain(value);
 }
 
 llama_memory_t llama_get_memory(const struct llama_context * ctx) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1250,8 +1250,10 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
     // holds full logits and the sampler graph runs replicated on all of them.
     if (sampler && model.split_mode() == LLAMA_SPLIT_MODE_TENSOR) {
         const ggml_tensor * out_w = model.output ? model.output : model.tok_embd;
+        // the ggml callback signature takes a mutable userdata pointer, but the callback only reads it
+        auto * split_state_ud = const_cast<llama_meta_device_get_split_state_userdata *>(&model.get_split_state_ud);
         const bool mirrored = out_w != nullptr &&
-            llama_meta_device_get_split_state(out_w, (void *) &model.get_split_state_ud).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED;
+            llama_meta_device_get_split_state(out_w, split_state_ud).axis == GGML_BACKEND_SPLIT_AXIS_MIRRORED;
         if (!mirrored) {
             static bool warned = false;
             if (!warned) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -600,7 +600,6 @@ void llama_context::sched_reserve() {
     LLAMA_LOG_DEBUG("%s: max_nodes = %zu\n", __func__, max_nodes);
 
     gf_res_prev.reset(new llm_graph_result(max_nodes));
-    gf_res_tg.reset(new llm_graph_result(max_nodes));
     gf_res_reserve.reset(new llm_graph_result(max_nodes));
 
     gf_res_alloced = nullptr;
@@ -675,24 +674,6 @@ void llama_context::sched_reserve() {
         }
     }
 
-    // experimental: dedicated scheduler for 1-token decode graphs, reserved with a
-    // 1-token-per-seq worst case; keeps draft and verification allocations warm at the
-    // same time. Requires meta-backend multi-graph support under tensor split, so it
-    // stays off unless LLAMA_SCHED_TG=1.
-    static const bool sched_tg_enable = [] {
-        const char * env = getenv("LLAMA_SCHED_TG");
-        return env != nullptr && atoi(env) != 0;
-    }();
-    if (sched_tg_enable && !model.hparams.no_alloc) {
-        sched_tg.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), max_nodes, cparams.pipeline_parallel, cparams.op_offload));
-
-        auto * gf = graph_reserve(n_seqs, n_seqs, n_seqs, mctx.get(), false, nullptr, sched_tg.get());
-        if (!gf) {
-            LLAMA_LOG_WARN("%s: failed to reserve the 1-token scheduler; falling back to a single scheduler\n", __func__);
-            sched_tg.reset();
-        }
-    }
-
     // experimental: per-shape scheduler pool for small decode graphs. Every recurring
     // batch shape keeps its own scheduler, allocation, and cached graph, so shapes
     // alternating under speculative decoding stop evicting each other. Requires the
@@ -707,7 +688,6 @@ void llama_context::sched_reserve() {
     }
 
     sched_active = sched.get();
-
 
     for (size_t i = 0; i < backend_ptrs.size(); ++i) {
         ggml_backend_t             backend = backend_ptrs[i];
@@ -746,10 +726,6 @@ void llama_context::synchronize() {
     }
 
     ggml_backend_sched_synchronize(sched.get());
-
-    if (sched_tg) {
-        ggml_backend_sched_synchronize(sched_tg.get());
-    }
 
     for (auto & s : sched_pool) {
         ggml_backend_sched_synchronize(s.sched.get());
@@ -855,11 +831,7 @@ bool llama_context::memory_update(bool optimize) {
         // TODO: change the mctx->apply() to return information if a graph reserve is needed
         //       reset the graph result only if the memory module did reset the scheduler
         gf_res_prev->reset();
-        if (gf_res_tg) {
-            gf_res_tg->reset();
-        }
-        gf_res_alloced    = nullptr;
-        gf_res_alloced_tg = nullptr;
+        gf_res_alloced = nullptr;
 
         for (auto & s : sched_pool) {
             s.gf_res->reset();
@@ -1433,16 +1405,12 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         slot->last_used = ++sched_pool_tick;
     }
 
-    // 1-token graphs run on a dedicated scheduler so that the draft and verification
-    // evals of speculative decoding do not evict each other's graph or allocation
-    const bool use_tg = slot == nullptr && sched_tg && gf_res_tg && ubatch.n_tokens == 1;
+    ggml_backend_sched_t sched_cur = slot ? slot->sched.get() : sched.get();
 
-    ggml_backend_sched_t sched_cur = slot ? slot->sched.get() : use_tg ? sched_tg.get() : sched.get();
-
-    auto * res = slot ? slot->gf_res.get() : use_tg ? gf_res_tg.get() : gf_res_prev.get();
+    auto * res = slot ? slot->gf_res.get() : gf_res_prev.get();
     auto * gf  = res->get_gf();
 
-    llm_graph_result * & res_alloced = slot ? slot->alloced : use_tg ? gf_res_alloced_tg : gf_res_alloced;
+    llm_graph_result * & res_alloced = slot ? slot->alloced : gf_res_alloced;
 
     sched_active = sched_cur;
 
@@ -1450,45 +1418,17 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
     // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
     const auto gparams = graph_params(res, ubatch, mctx, gtype);
 
-    // experimental: also reuse a cached topology whose scheduler allocation went stale,
-    // by re-allocating it without a rebuild. Slower than a rebuild in practice; off
-    // unless LLAMA_GRAPH_REALLOC=1.
-    static const bool graph_realloc_enable = [] {
-        const char * env = getenv("LLAMA_GRAPH_REALLOC");
-        return env != nullptr && atoi(env) != 0;
-    }();
-
-    const char * path_dbg = "rebuild";
-
-    if (!graph_reuse_disable && res->can_reuse(gparams) && (res == res_alloced || graph_realloc_enable)) {
+    // res == res_alloced: a matching topology alone is not enough, the graph must also
+    // still hold its scheduler allocation. Everywhere the scheduler is reset, the
+    // matching res_alloced is set back to null.
+    if (!graph_reuse_disable && res->can_reuse(gparams) && res == res_alloced) {
         //LLAMA_LOG_DEBUG("%s: reusing previous graph\n", __func__);
-
-        path_dbg = res == res_alloced ? "fast" : "realloc";
 
         // with pipeline parallelism, the previous graph_compute_async may still be running
         // on the GPU. we must synchronize before set_inputs to avoid overwriting input tensors
         // that the previous compute is still reading.
         if (cparams.pipeline_parallel) {
             ggml_backend_sched_synchronize(sched_cur);
-        }
-
-        if (res != res_alloced) {
-            // cached topology with a stale allocation: re-allocate the graph without
-            // rebuilding it. The node addresses do not change, so backend-side graph
-            // caches (subgraph splits, CUDA graphs) stay warm. The scheduler rewired
-            // the node sources to its now-dead split copies, so restore them first.
-            res->restore_srcs();
-
-            ggml_backend_sched_reset(sched_cur);
-            ggml_backend_sched_set_eval_callback(sched_cur, cparams.cb_eval, cparams.cb_eval_user_data);
-
-            if (!ggml_backend_sched_alloc_graph(sched_cur, gf)) {
-                LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
-                ret = GGML_STATUS_ALLOC_FAILED;
-                return nullptr;
-            }
-
-            res_alloced = res;
         }
 
         n_reused++;
@@ -1509,9 +1449,6 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
             ret = GGML_STATUS_FAILED;
             return nullptr;
         }
-
-        // capture the built node sources before the scheduler rewires them
-        res->snapshot_srcs();
 
         if (!ggml_backend_sched_alloc_graph(sched_cur, gf)) {
             LLAMA_LOG_ERROR("%s: failed to allocate graph\n", __func__);
@@ -1537,52 +1474,6 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
         LLAMA_LOG_ERROR("%s: failed to compute graph, compute status: %d\n", __func__, status);
         ret = status;
         return nullptr;
-    }
-
-    // debug: per-eval logits checksum for localizing graph-reuse corruption
-    static const bool graph_debug_sum = [] {
-        const char * env = getenv("LLAMA_GRAPH_DEBUG_SUM");
-        return env != nullptr && atoi(env) != 0;
-    }();
-    if (graph_debug_sum) {
-        static int eval_no = 0;
-        eval_no++;
-        double sum = 0.0;
-        int64_t n = 0;
-        ggml_tensor * t_logits = res->get_logits();
-        if (t_logits != nullptr && ggml_nelements(t_logits) > 0) {
-            ggml_backend_sched_synchronize(sched_active);
-            // read the full first row: split buffers reject partial-row reads
-            n = t_logits->ne[0];
-            std::vector<float> row(n);
-            ggml_backend_tensor_get(t_logits, row.data(), 0, n*sizeof(float));
-            for (int64_t i = 0; i < std::min<int64_t>(n, 256); i++) {
-                sum += row[i];
-            }
-        }
-        double in_embd_sum = 0.0;
-        int64_t in_tok_sum = 0;
-        ggml_tensor * t_in_tok = res->get_inp_tokens();
-        if (t_in_tok != nullptr && ggml_nelements(t_in_tok) > 0) {
-            std::vector<int32_t> toks(ggml_nelements(t_in_tok));
-            ggml_backend_tensor_get(t_in_tok, toks.data(), 0, toks.size()*sizeof(int32_t));
-            for (int32_t v : toks) {
-                in_tok_sum += v;
-            }
-        }
-        ggml_tensor * t_in_embd = res->t_inp_embd;
-        if (t_in_embd != nullptr && ggml_nelements(t_in_embd) > 0) {
-            const int64_t ne = std::min<int64_t>(ggml_nelements(t_in_embd), 512);
-            std::vector<float> vals(ne);
-            ggml_backend_tensor_get(t_in_embd, vals.data(), 0, ne*sizeof(float));
-            for (float v : vals) {
-                in_embd_sum += v;
-            }
-        }
-        fprintf(stderr, "EVALSUM %d slot=%s path=%s n_tokens=%u n_out=%d in_tok=%lld in_embd=%.6f sum=%.6f\n",
-            eval_no, use_tg ? "tg" : "main", path_dbg, ubatch.n_tokens, this->n_outputs,
-            (long long) in_tok_sum, in_embd_sum, sum);
-        fflush(stderr);
     }
 
     ret = GGML_STATUS_SUCCESS;
@@ -2617,9 +2508,6 @@ ggml_cgraph * llama_context::graph_reserve(
     if (sched_use == sched.get()) {
         gf_res_prev->reset();
         gf_res_alloced = nullptr;
-    } else if (gf_res_tg) {
-        gf_res_tg->reset();
-        gf_res_alloced_tg = nullptr;
     }
 
     // store the n_outputs as it is, and restore it afterwards

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -116,6 +116,7 @@ struct llama_context {
     void set_embeddings_nextn(bool value, bool masked);
     void set_embeddings_layer_inp(uint32_t lid, bool enable);
     void set_nextn_layer_offset(int32_t offset);
+    void set_mtp_chain(bool value);
     void set_causal_attn(bool value);
     void set_warmup(bool value);
 
@@ -248,8 +249,10 @@ public:
     ggml_status graph_compute(ggml_cgraph * gf, bool batched);
 
     // reserve a graph with a dummy ubatch of the specified size
+    // sched_use selects the target scheduler; nullptr means the main one
     ggml_cgraph * graph_reserve(
-        uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only = false, size_t * sizes = nullptr);
+        uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only = false, size_t * sizes = nullptr,
+        ggml_backend_sched_t sched_use = nullptr);
 
     bool set_sampler(llama_seq_id seq_id, llama_sampler * sampler);
 
@@ -343,6 +346,33 @@ private:
 
     ggml_backend_sched_ptr sched;
 
+    // dedicated scheduler for 1-token decode graphs. Draft and verification evals of
+    // speculative decoding alternate between two graph shapes; with one scheduler each
+    // eval evicts the other shape's allocation and pays a full re-split. Routing
+    // 1-token ubatches here keeps both allocations warm.
+    ggml_backend_sched_ptr sched_tg;
+
+    // per-shape scheduler pool for small decode graphs (LLAMA_SCHED_POOL=N). Each
+    // recurring batch shape keeps its own scheduler and cached graph, so alternating
+    // shapes reuse warm allocations, splits, and backend graph plans instead of
+    // re-splitting through one scheduler.
+    struct sched_slot {
+        uint32_t n_tokens  = 0;
+        uint32_t n_outputs = 0;
+        uint64_t last_used = 0;
+        ggml_backend_sched_ptr sched;
+        std::unique_ptr<llm_graph_result> gf_res;
+        llm_graph_result * alloced = nullptr;
+    };
+    std::vector<sched_slot> sched_pool;
+    uint64_t sched_pool_tick  = 0;
+    int      sched_pool_max   = 0;  // 0 = pool off
+    uint32_t sched_pool_n_max = 32; // shapes up to this many tokens use the pool
+
+    // the scheduler that computed the most recent graph; readback of result tensors
+    // must query this one
+    ggml_backend_sched_t sched_active = nullptr;
+
     bool sched_need_reserve = true;
 
     ggml_backend_t backend_cpu = nullptr;
@@ -364,7 +394,16 @@ private:
     std::vector<ggml_backend_buffer_type_t> backend_buft;
     std::vector<size_t>                     backend_buf_exp_size; // expected buffer sizes
 
+    // two cached graph topologies: during speculative decoding, draft (1-token) and
+    // verification evals alternate between two graph shapes; with a single cached
+    // graph each eval evicts the other shape and most evals pay a full rebuild.
+    // 1-token ubatches use gf_res_tg, everything else gf_res_prev. Only one of the
+    // two is allocated in the scheduler at a time (gf_res_alloced); switching slots
+    // re-allocates the cached graph but skips rebuilding it.
     llm_graph_result_ptr gf_res_prev;
+    llm_graph_result_ptr gf_res_tg;
+    llm_graph_result *   gf_res_alloced    = nullptr; // last result allocated in sched
+    llm_graph_result *   gf_res_alloced_tg = nullptr; // last result allocated in sched_tg
     llm_graph_result_ptr gf_res_reserve;
 
     // host buffer for the model output (logits and embeddings)

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -346,12 +346,6 @@ private:
 
     ggml_backend_sched_ptr sched;
 
-    // dedicated scheduler for 1-token decode graphs. Draft and verification evals of
-    // speculative decoding alternate between two graph shapes; with one scheduler each
-    // eval evicts the other shape's allocation and pays a full re-split. Routing
-    // 1-token ubatches here keeps both allocations warm.
-    ggml_backend_sched_ptr sched_tg;
-
     // per-shape scheduler pool for small decode graphs (LLAMA_SCHED_POOL=N). Each
     // recurring batch shape keeps its own scheduler and cached graph, so alternating
     // shapes reuse warm allocations, splits, and backend graph plans instead of
@@ -394,16 +388,8 @@ private:
     std::vector<ggml_backend_buffer_type_t> backend_buft;
     std::vector<size_t>                     backend_buf_exp_size; // expected buffer sizes
 
-    // two cached graph topologies: during speculative decoding, draft (1-token) and
-    // verification evals alternate between two graph shapes; with a single cached
-    // graph each eval evicts the other shape and most evals pay a full rebuild.
-    // 1-token ubatches use gf_res_tg, everything else gf_res_prev. Only one of the
-    // two is allocated in the scheduler at a time (gf_res_alloced); switching slots
-    // re-allocates the cached graph but skips rebuilding it.
     llm_graph_result_ptr gf_res_prev;
-    llm_graph_result_ptr gf_res_tg;
-    llm_graph_result *   gf_res_alloced    = nullptr; // last result allocated in sched
-    llm_graph_result *   gf_res_alloced_tg = nullptr; // last result allocated in sched_tg
+    llm_graph_result *   gf_res_alloced = nullptr; // last result allocated in sched
     llm_graph_result_ptr gf_res_reserve;
 
     // host buffer for the model output (logits and embeddings)

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -35,6 +35,7 @@ struct llama_cparams {
     bool embeddings;
     bool embeddings_nextn;        // also extract the hidden state before the final output norm
     bool embeddings_nextn_masked; // extract for only rows where batch.logits != 0
+    bool mtp_chain;               // DECODER_MTP: chain rows in-graph from the first row's inputs
     bool causal_attn;
     bool offload_kqv;
     bool flash_attn;

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -100,6 +100,11 @@ LLAMA_API void llama_set_embeddings_nextn(struct llama_context * ctx, bool value
 // chain multiple trained NextN heads. Default 0 (first head).
 LLAMA_API void llama_set_nextn_layer_offset(struct llama_context * ctx, int32_t offset);
 
+// Run the DECODER_MTP graph in chained mode: the batch's first row carries the
+// real (token, h) inputs and each following row's inputs come from the previous
+// row's in-graph argmax and hidden state. One decode drafts n_tokens tokens.
+LLAMA_API void llama_set_mtp_chain(struct llama_context * ctx, bool value);
+
 // mirrors:
 // LLAMA_API float * llama_get_embeddings(struct llama_context * ctx);
 LLAMA_API float * llama_get_embeddings_nextn(struct llama_context * ctx);

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1376,28 +1376,6 @@ void llm_graph_result::set_outputs(const llm_graph_params & params) {
     }
 }
 
-void llm_graph_result::snapshot_srcs() {
-    const int n_nodes = ggml_graph_n_nodes(gf);
-    pristine_srcs.resize((size_t) n_nodes * GGML_MAX_SRC);
-    for (int i = 0; i < n_nodes; i++) {
-        ggml_tensor * node = ggml_graph_node(gf, i);
-        for (int j = 0; j < GGML_MAX_SRC; j++) {
-            pristine_srcs[(size_t) i * GGML_MAX_SRC + j] = node->src[j];
-        }
-    }
-}
-
-void llm_graph_result::restore_srcs() {
-    const int n_nodes = ggml_graph_n_nodes(gf);
-    GGML_ASSERT(pristine_srcs.size() == (size_t) n_nodes * GGML_MAX_SRC);
-    for (int i = 0; i < n_nodes; i++) {
-        ggml_tensor * node = ggml_graph_node(gf, i);
-        for (int j = 0; j < GGML_MAX_SRC; j++) {
-            node->src[j] = pristine_srcs[(size_t) i * GGML_MAX_SRC + j];
-        }
-    }
-}
-
 bool llm_graph_result::can_reuse(const llm_graph_params & params) {
     if (!this->params.allow_reuse(params)) {
         if (debug > 1) {

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1376,6 +1376,28 @@ void llm_graph_result::set_outputs(const llm_graph_params & params) {
     }
 }
 
+void llm_graph_result::snapshot_srcs() {
+    const int n_nodes = ggml_graph_n_nodes(gf);
+    pristine_srcs.resize((size_t) n_nodes * GGML_MAX_SRC);
+    for (int i = 0; i < n_nodes; i++) {
+        ggml_tensor * node = ggml_graph_node(gf, i);
+        for (int j = 0; j < GGML_MAX_SRC; j++) {
+            pristine_srcs[(size_t) i * GGML_MAX_SRC + j] = node->src[j];
+        }
+    }
+}
+
+void llm_graph_result::restore_srcs() {
+    const int n_nodes = ggml_graph_n_nodes(gf);
+    GGML_ASSERT(pristine_srcs.size() == (size_t) n_nodes * GGML_MAX_SRC);
+    for (int i = 0; i < n_nodes; i++) {
+        ggml_tensor * node = ggml_graph_node(gf, i);
+        for (int j = 0; j < GGML_MAX_SRC; j++) {
+            node->src[j] = pristine_srcs[(size_t) i * GGML_MAX_SRC + j];
+        }
+    }
+}
+
 bool llm_graph_result::can_reuse(const llm_graph_params & params) {
     if (!this->params.allow_reuse(params)) {
         if (debug > 1) {

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -914,13 +914,6 @@ public:
 
     llm_graph_input_i * add_input(llm_graph_input_ptr input);
 
-    // the scheduler rewires node sources to its own split-input copies, which die on the
-    // next scheduler reset. To re-allocate a cached graph after other graphs used the
-    // scheduler, snapshot the sources right after the build and restore them before the
-    // re-allocation re-splits the graph.
-    void snapshot_srcs();
-    void restore_srcs();
-
     void add_fused_node(llm_graph_fused_node result);
 
     const std::vector<llm_graph_fused_node> & get_fused_nodes() const { return fused_nodes; }
@@ -953,9 +946,6 @@ public:
     ggml_cgraph * gf;
 
     int64_t max_nodes;
-
-    // node sources as built, before scheduler rewiring; see snapshot_srcs()
-    std::vector<ggml_tensor *> pristine_srcs;
 
 private:
     // keep a copy of the previous graph parameters

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -778,6 +778,11 @@ struct llm_graph_params {
     // return true if the "other" params would result in a graph with the same topology as with the current params
     //   having the same topology allows us to reuse the graph in some cases
     bool allow_reuse(const llm_graph_params & other) const {
+        static const bool dbg_reuse = [] {
+            const char * env = getenv("LLAMA_GRAPH_RESULT_DEBUG");
+            return env != nullptr && atoi(env) > 1;
+        }();
+
         // first check the ubatch
         bool can_reuse_ubatch =
             ubatch.equal_seqs() == other.ubatch.equal_seqs() &&
@@ -791,16 +796,33 @@ struct llm_graph_params {
                 (ubatch.token && other.ubatch.token && ubatch.embd && other.ubatch.embd)
             );
 
+        if (dbg_reuse && !can_reuse_ubatch) {
+            fprintf(stderr, "allow_reuse: ubatch shape eq=%d/%d nt=%d/%d nst=%d/%d ns=%d/%d nsu=%d/%d tok=%d/%d embd=%d/%d\n",
+                    (int) ubatch.equal_seqs(), (int) other.ubatch.equal_seqs(),
+                    (int) ubatch.n_tokens, (int) other.ubatch.n_tokens,
+                    (int) ubatch.n_seq_tokens, (int) other.ubatch.n_seq_tokens,
+                    (int) ubatch.n_seqs, (int) other.ubatch.n_seqs,
+                    (int) ubatch.n_seqs_unq, (int) other.ubatch.n_seqs_unq,
+                    ubatch.token != nullptr, other.ubatch.token != nullptr,
+                    ubatch.embd != nullptr, other.ubatch.embd != nullptr);
+        }
+
         // when we split the batch using "equal_seqs" we have to verify that the participating sequences are the same
         //   the reason is because the set of attention streams would be different for different sequences
         if (can_reuse_ubatch && ubatch.equal_seqs()) {
             if (!ubatch.data) {
                 // if the old ubatch does not own it's data, then we cannot guarantee that it is still alive, and
                 //   therefore we cannot perform the sequence id check. normally should never happen
+                if (dbg_reuse) {
+                    fprintf(stderr, "allow_reuse: stored ubatch does not own data\n");
+                }
                 can_reuse_ubatch = false;
             } else {
                 for (uint32_t s = 0; s < ubatch.n_seqs_unq; ++s) {
                     can_reuse_ubatch &= ubatch.seq_id_unq[s] == other.ubatch.seq_id_unq[s];
+                }
+                if (dbg_reuse && !can_reuse_ubatch) {
+                    fprintf(stderr, "allow_reuse: seq_id_unq mismatch\n");
                 }
             }
         }
@@ -810,6 +832,9 @@ struct llm_graph_params {
         }
 
         if (n_outputs != other.n_outputs) {
+            if (dbg_reuse) {
+                fprintf(stderr, "allow_reuse: n_outputs %d != %d\n", (int) n_outputs, (int) other.n_outputs);
+            }
             return false;
         }
 
@@ -840,6 +865,7 @@ struct llm_graph_params {
             cparams.embeddings              == other.cparams.embeddings              &&
             cparams.embeddings_nextn        == other.cparams.embeddings_nextn        &&
             cparams.embeddings_nextn_masked == other.cparams.embeddings_nextn_masked &&
+            cparams.mtp_chain               == other.cparams.mtp_chain               &&
             cparams.causal_attn             == other.cparams.causal_attn             &&
             arch  == other.arch  &&
             gtype == other.gtype &&
@@ -888,6 +914,13 @@ public:
 
     llm_graph_input_i * add_input(llm_graph_input_ptr input);
 
+    // the scheduler rewires node sources to its own split-input copies, which die on the
+    // next scheduler reset. To re-allocate a cached graph after other graphs used the
+    // scheduler, snapshot the sources right after the build and restore them before the
+    // re-allocation re-splits the graph.
+    void snapshot_srcs();
+    void restore_srcs();
+
     void add_fused_node(llm_graph_fused_node result);
 
     const std::vector<llm_graph_fused_node> & get_fused_nodes() const { return fused_nodes; }
@@ -920,6 +953,9 @@ public:
     ggml_cgraph * gf;
 
     int64_t max_nodes;
+
+    // node sources as built, before scheduler rewiring; see snapshot_srcs()
+    std::vector<ggml_tensor *> pristine_srcs;
 
 private:
     // keep a copy of the previous graph parameters

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -511,13 +511,20 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         }
 
         // output
+        // LLAMA_META_MIRROR_OUTPUT=1 keeps the output head whole on every device. Logits
+        // are then mirrored instead of vocab-split, which lets backend sampling run under
+        // the meta backend. Costs one extra head copy of VRAM per device.
+        static const bool mirror_output = [] {
+            const char * env = getenv("LLAMA_META_MIRROR_OUTPUT");
+            return env != nullptr && atoi(env) != 0;
+        }();
         if (std::regex_match(tensor_name, pattern_output_weight)) {
-            return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1);
+            return get_tensor_config_impl(mirror_output ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_1);
         }
         if (std::regex_match(tensor_name, pattern_output_bias)) {
             const ggml_tensor * output_weight = ud->model->get_tensor("output.weight");
             GGML_ASSERT(output_weight != nullptr);
-            return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0);
+            return get_tensor_config_impl(mirror_output ? GGML_BACKEND_SPLIT_AXIS_MIRRORED : GGML_BACKEND_SPLIT_AXIS_0);
         }
 
         // everything else

--- a/src/models/delta-net-base.cpp
+++ b/src/models/delta-net-base.cpp
@@ -499,10 +499,18 @@ ggml_tensor * llm_build_delta_net_base::build_conv_state(
         // this logic assumes that the last (n_rs_seq + 1) tokens of a sequence in a batch are inside
         //   the same ubatch, which `split_equal()` guarantees via its n_keep_tail argument
 
-        const int64_t K = (int64_t) cparams.n_rs_seq + 1;
+        const int64_t n_tok = conv_input->ne[0] - conv_states->ne[0];
+
+        // slot s holds the conv state as of s tokens back. A batch with n_tok tokens defines
+        // slots 0..n_tok. Deeper slots keep their previous content: an earlier, larger batch
+        // may have written them, and a rollback that returns to that batch's position still
+        // reads them (test-recurrent-state-rollback). The old full-depth loop overwrote those
+        // slots with clamped duplicates of slot n_tok. The gated-delta-net snapshot write has
+        // the same bound.
+        const int64_t K = std::min<int64_t>((int64_t) cparams.n_rs_seq, n_tok) + 1;
 
         for (int64_t t = 1; t <= K; ++t) {
-            const int64_t s_idx  = std::max<int64_t>(0, conv_input->ne[0] - conv_states->ne[0] - K + t);
+            const int64_t s_idx  = n_tok - K + t;
             const int64_t s_slot = K - t;
 
             ggml_tensor * conv_state_last =

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -486,57 +486,6 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_ffn(ggml_tensor * cur, cons
     return cur;
 }
 
-// per-step causal masks for the chained MTP draft: one [n_kv, GGML_KQ_MASK_PAD]
-// mask per chain step, filled through the stock mask builder with a 1-token
-// view of the ubatch row
-struct llm_graph_input_mtp_chain_masks : public llm_graph_input_i {
-    llm_graph_input_mtp_chain_masks(const llama_kv_cache_context * mctx, bool causal) : mctx(mctx), causal(causal) {}
-    virtual ~llm_graph_input_mtp_chain_masks() = default;
-
-    void set_input(const llama_ubatch * ubatch) override {
-        for (size_t j = 0; j < masks.size(); ++j) {
-            llama_ubatch ub = *ubatch;
-            ub.n_tokens     = 1;
-            ub.n_seq_tokens = 1;
-            ub.n_seqs       = 1;
-            ub.n_seqs_unq   = 1;
-            ub.token        = ubatch->token ? ubatch->token + j : nullptr;
-            ub.pos          = ubatch->pos + j;
-            ub.n_seq_id     = ubatch->n_seq_id + j;
-            ub.seq_id       = ubatch->seq_id + j;
-            ub.seq_id_unq   = ubatch->seq_id_unq;
-            ub.seq_idx      = ubatch->seq_idx;
-            ub.output       = ubatch->output + j;
-
-            mctx->set_input_kq_mask(masks[j], &ub, causal);
-
-            static const bool dbg = getenv("LLAMA_CHAIN_DEBUG") != nullptr;
-            if (dbg) {
-                int64_t n_open = 0;
-                const int64_t n_kv = masks[j]->ne[0];
-                if (masks[j]->type == GGML_TYPE_F16) {
-                    const ggml_fp16_t * d = (const ggml_fp16_t *) masks[j]->data;
-                    for (int64_t i = 0; i < n_kv; ++i) {
-                        n_open += ggml_fp16_to_fp32(d[i]) == 0.0f;
-                    }
-                } else {
-                    const float * d = (const float *) masks[j]->data;
-                    for (int64_t i = 0; i < n_kv; ++i) {
-                        n_open += d[i] == 0.0f;
-                    }
-                }
-                fprintf(stderr, "CHAINMASK j=%zu pos=%d open=%lld/%lld\n", j, (int) ub.pos[0], (long long) n_open, (long long) n_kv);
-                fflush(stderr);
-            }
-        }
-    }
-
-    const llama_kv_cache_context * mctx;
-    bool causal;
-
-    std::vector<ggml_tensor *> masks;
-};
-
 // LLM_GRAPH_TYPE_DECODER_MTP draft head for Qwen3.5/3.6 dense series
 llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_graph_params & params)
     : llm_graph_context(params) {
@@ -597,19 +546,11 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
 
     // chained drafting: rows 1..n-1 take their inputs from the previous row's
     // in-graph argmax and hidden state, so one decode drafts n_tokens tokens
-    {
-        static const bool dbg = getenv("LLAMA_CHAIN_DEBUG") != nullptr;
-        if (dbg) {
-            fprintf(stderr, "CHAINGRAPH mtp_chain=%d n_tokens=%d n_seqs=%d token=%d\n",
-                (int) cparams.mtp_chain, (int) n_tokens, (int) ubatch.n_seqs, ubatch.token != nullptr);
-            fflush(stderr);
-        }
-    }
     if (cparams.mtp_chain && n_tokens > 1 && ubatch.n_seqs_unq == 1 && ubatch.token) {
         const auto * mctx_kv = static_cast<const llama_kv_cache_context *>(mctx);
 
-        // per-step causal masks: row j of the stock kq mask (this tree pads masks to
-        // exactly n_tokens rows, so plain row views work)
+        // per-step causal masks: row j of the stock kq mask (the mask builder pads
+        // masks to exactly n_tokens rows, so plain row views work)
         ggml_tensor * kq_mask = inp_attn->get_kq_mask();
         const int64_t n_kv = kq_mask->ne[0];
 
@@ -746,9 +687,10 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
 
             // drafting rarely picks tokens outside the leading vocabulary range
             // (BPE ids correlate with frequency), so the chain can run a small
-            // sub-head instead of the full one and pad the tail of the logits to
-            // -1e9. The full-vocab verify on the target decides acceptance, so
-            // this only narrows what gets drafted, never what gets committed.
+            // sub-head instead of the full one. The full-vocab verify on the target
+            // decides acceptance, so this only narrows what gets drafted, never what
+            // gets committed. The emitted probability normalizes over the sub-head
+            // only, so it reads slightly high against --spec-draft-p-min.
             // LLAMA_SPEC_CHAIN_SUB sets the width; 0 restores the full head.
             static const int64_t n_sub_env = [] {
                 const char * env = getenv("LLAMA_SPEC_CHAIN_SUB");

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -1,5 +1,6 @@
 #include "models.h"
 #include "llama-memory-recurrent.h"
+#include "llama-kv-cache.h"
 
 void llama_model_qwen35::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
@@ -485,6 +486,57 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_ffn(ggml_tensor * cur, cons
     return cur;
 }
 
+// per-step causal masks for the chained MTP draft: one [n_kv, GGML_KQ_MASK_PAD]
+// mask per chain step, filled through the stock mask builder with a 1-token
+// view of the ubatch row
+struct llm_graph_input_mtp_chain_masks : public llm_graph_input_i {
+    llm_graph_input_mtp_chain_masks(const llama_kv_cache_context * mctx, bool causal) : mctx(mctx), causal(causal) {}
+    virtual ~llm_graph_input_mtp_chain_masks() = default;
+
+    void set_input(const llama_ubatch * ubatch) override {
+        for (size_t j = 0; j < masks.size(); ++j) {
+            llama_ubatch ub = *ubatch;
+            ub.n_tokens     = 1;
+            ub.n_seq_tokens = 1;
+            ub.n_seqs       = 1;
+            ub.n_seqs_unq   = 1;
+            ub.token        = ubatch->token ? ubatch->token + j : nullptr;
+            ub.pos          = ubatch->pos + j;
+            ub.n_seq_id     = ubatch->n_seq_id + j;
+            ub.seq_id       = ubatch->seq_id + j;
+            ub.seq_id_unq   = ubatch->seq_id_unq;
+            ub.seq_idx      = ubatch->seq_idx;
+            ub.output       = ubatch->output + j;
+
+            mctx->set_input_kq_mask(masks[j], &ub, causal);
+
+            static const bool dbg = getenv("LLAMA_CHAIN_DEBUG") != nullptr;
+            if (dbg) {
+                int64_t n_open = 0;
+                const int64_t n_kv = masks[j]->ne[0];
+                if (masks[j]->type == GGML_TYPE_F16) {
+                    const ggml_fp16_t * d = (const ggml_fp16_t *) masks[j]->data;
+                    for (int64_t i = 0; i < n_kv; ++i) {
+                        n_open += ggml_fp16_to_fp32(d[i]) == 0.0f;
+                    }
+                } else {
+                    const float * d = (const float *) masks[j]->data;
+                    for (int64_t i = 0; i < n_kv; ++i) {
+                        n_open += d[i] == 0.0f;
+                    }
+                }
+                fprintf(stderr, "CHAINMASK j=%zu pos=%d open=%lld/%lld\n", j, (int) ub.pos[0], (long long) n_open, (long long) n_kv);
+                fflush(stderr);
+            }
+        }
+    }
+
+    const llama_kv_cache_context * mctx;
+    bool causal;
+
+    std::vector<ggml_tensor *> masks;
+};
+
 // LLM_GRAPH_TYPE_DECODER_MTP draft head for Qwen3.5/3.6 dense series
 llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_graph_params & params)
     : llm_graph_context(params) {
@@ -539,6 +591,218 @@ llama_model_qwen35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
     ggml_tensor * inp_out_ids = build_inp_out_ids();
 
     auto * inp_attn = build_attn_inp_kv();
+
+    const float kq_scale_c = hparams.f_attention_scale == 0.0f
+            ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
+
+    // chained drafting: rows 1..n-1 take their inputs from the previous row's
+    // in-graph argmax and hidden state, so one decode drafts n_tokens tokens
+    {
+        static const bool dbg = getenv("LLAMA_CHAIN_DEBUG") != nullptr;
+        if (dbg) {
+            fprintf(stderr, "CHAINGRAPH mtp_chain=%d n_tokens=%d n_seqs=%d token=%d\n",
+                (int) cparams.mtp_chain, (int) n_tokens, (int) ubatch.n_seqs, ubatch.token != nullptr);
+            fflush(stderr);
+        }
+    }
+    if (cparams.mtp_chain && n_tokens > 1 && ubatch.n_seqs_unq == 1 && ubatch.token) {
+        const auto * mctx_kv = static_cast<const llama_kv_cache_context *>(mctx);
+
+        // per-step causal masks: row j of the stock kq mask (this tree pads masks to
+        // exactly n_tokens rows, so plain row views work)
+        ggml_tensor * kq_mask = inp_attn->get_kq_mask();
+        const int64_t n_kv = kq_mask->ne[0];
+
+        ggml_tensor * tok_embd_w = layer.nextn.embed_tokens ? layer.nextn.embed_tokens : model.tok_embd;
+
+        ggml_tensor * k_idxs = inp_attn->get_k_idxs();
+        ggml_tensor * v_idxs = inp_attn->get_v_idxs();
+
+        // normalize and project the token/hidden inputs into the block input
+        // (norm -> eh_proj); rows are independent through this projection
+        auto build_proj = [&](ggml_tensor * tok_in, ggml_tensor * h_in) -> ggml_tensor * {
+            ggml_tensor * h_norm_b = build_norm(h_in, layer.nextn.hnorm, nullptr, LLM_NORM_RMS, il);
+            ggml_tensor * e_norm_b = build_norm(tok_in, layer.nextn.enorm, nullptr, LLM_NORM_RMS, il);
+
+            return build_lora_mm(layer.nextn.eh_proj, ggml_concat(ctx0, e_norm_b, h_norm_b, 0), layer.nextn.eh_proj_s);
+        };
+
+        // one MTP block over `width` projected rows starting at batch row `row0`;
+        // returns the post-ffn hidden state. The K/V stores are expanded, so a
+        // caller that only needs the rows' cache side effects can ignore the result.
+        auto build_block = [&](ggml_tensor * cur_in, int64_t row0, int64_t width) -> ggml_tensor * {
+            ggml_tensor * cur_b = cur_in;
+
+            ggml_tensor * inpSA_b = cur_b;
+
+            cur_b = build_norm(cur_b, layer.attn_norm, nullptr, LLM_NORM_RMS, il);
+
+            ggml_tensor * Qfull_b = build_lora_mm(layer.wq, cur_b, layer.wq_s);
+
+            ggml_tensor * Q_b = ggml_view_3d(ctx0, Qfull_b,
+                    n_embd_head, n_head, width,
+                    ggml_element_size(Qfull_b) * n_embd_head * 2,
+                    ggml_element_size(Qfull_b) * n_embd_head * 2 * n_head,
+                    0);
+            Q_b = build_norm(Q_b, layer.attn_q_norm, nullptr, LLM_NORM_RMS, il);
+
+            ggml_tensor * gate_b = ggml_view_3d(ctx0, Qfull_b,
+                    n_embd_head, n_head, width,
+                    ggml_element_size(Qfull_b) * n_embd_head * 2,
+                    ggml_element_size(Qfull_b) * n_embd_head * 2 * n_head,
+                    ggml_element_size(Qfull_b) * n_embd_head);
+            gate_b = ggml_cont_2d(ctx0, gate_b, n_embd_head * n_head, width);
+
+            ggml_tensor * K_b = build_lora_mm(layer.wk, cur_b, layer.wk_s);
+            K_b = ggml_reshape_3d(ctx0, K_b, n_embd_head, n_head_kv, width);
+            K_b = build_norm(K_b, layer.attn_k_norm, nullptr, LLM_NORM_RMS, il);
+
+            ggml_tensor * V_b = build_lora_mm(layer.wv, cur_b, layer.wv_s);
+            V_b = ggml_reshape_3d(ctx0, V_b, n_embd_head, n_head_kv, width);
+
+            // M-RoPE positions are section-major: [dim0 x n_tokens, dim1 x n_tokens, ...]
+            ggml_tensor * pos_b = ggml_cont(ctx0, ggml_view_2d(ctx0, inp_pos, width, 4,
+                    (size_t) n_tokens*inp_pos->nb[0], (size_t) row0*inp_pos->nb[0]));
+            pos_b = ggml_reshape_1d(ctx0, pos_b, 4*width);
+
+            Q_b = ggml_rope_multi(ctx0, Q_b, pos_b, nullptr,
+                    n_rot, sections, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow);
+            K_b = ggml_rope_multi(ctx0, K_b, pos_b, nullptr,
+                    n_rot, sections, rope_type, n_ctx_orig, freq_base, freq_scale,
+                    ext_factor, attn_factor, beta_fast, beta_slow);
+
+            ggml_build_forward_expand(gf, Q_b);
+            ggml_build_forward_expand(gf, V_b);
+            ggml_build_forward_expand(gf, K_b);
+
+            // store these rows' K/V so later rows attend to them through the cache
+            ggml_tensor * k_idx_b = ggml_view_1d(ctx0, k_idxs, width, row0*k_idxs->nb[0]);
+            ggml_tensor * v_idx_b = ggml_view_1d(ctx0, v_idxs, width, row0*v_idxs->nb[0]);
+            ggml_build_forward_expand(gf, mctx_kv->cpy_k(ctx0, K_b, k_idx_b, il));
+            ggml_build_forward_expand(gf, mctx_kv->cpy_v(ctx0, V_b, v_idx_b, il));
+
+            ggml_tensor * k_view = mctx_kv->get_k(ctx0, il);
+            ggml_tensor * v_view = mctx_kv->get_v(ctx0, il);
+
+            ggml_tensor * mask_b = ggml_view_2d(ctx0, kq_mask, n_kv, width, kq_mask->nb[1], (size_t) row0*kq_mask->nb[1]);
+
+            cur_b = build_attn_mha(Q_b, k_view, v_view, nullptr, mask_b, nullptr, nullptr, kq_scale_c, il);
+
+            cur_b = ggml_mul(ctx0, cur_b, ggml_sigmoid(ctx0, gate_b));
+            cur_b = build_lora_mm(layer.wo, cur_b, layer.wo_s);
+
+            cur_b = ggml_add(ctx0, cur_b, inpSA_b);
+
+            ggml_tensor * ffn_res_b = cur_b;
+            cur_b = build_norm(cur_b, layer.attn_post_norm, nullptr, LLM_NORM_RMS, il);
+
+            cur_b = build_ffn(cur_b,
+                    layer.ffn_up,   nullptr, layer.ffn_up_s,
+                    layer.ffn_gate, nullptr, layer.ffn_gate_s,
+                    layer.ffn_down, nullptr, layer.ffn_down_s,
+                    nullptr,
+                    LLM_FFN_SILU, LLM_FFN_PAR, il);
+
+            cur_b = ggml_add(ctx0, cur_b, ffn_res_b);
+
+            return cur_b;
+        };
+
+        // leading rows without outputs are deferred catch-up rows carrying real batch
+        // inputs; they only contribute their K/V. The chain starts at the first output row.
+        int64_t n_catchup = 0;
+        while (n_catchup < n_tokens && ubatch.output && ubatch.output[n_catchup] == 0) {
+            n_catchup++;
+        }
+        const int64_t n_chain = n_tokens - n_catchup;
+        GGML_ASSERT(n_chain >= 1);
+
+        // project the whole ubatch in one pass, exactly like the stock path: the
+        // host-buffer inputs must reach split ops as full leaf tensors, not views.
+        // Slices of the projected result are sched-allocated and safe to split.
+        ggml_tensor * proj_all = build_proj(tok_embd, h_embd);
+
+        if (n_catchup > 0) {
+            ggml_tensor * proj_c = ggml_view_2d(ctx0, proj_all, proj_all->ne[0], n_catchup, proj_all->nb[1], 0);
+            build_block(proj_c, 0, n_catchup);
+        }
+
+        ggml_tensor * proj_cur = ggml_view_2d(ctx0, proj_all, proj_all->ne[0], 1, proj_all->nb[1], (size_t) n_catchup*proj_all->nb[1]);
+
+        ggml_tensor * logits_all = nullptr;
+        ggml_tensor * h_all      = nullptr;
+
+        for (int64_t j = 0; j < n_chain; ++j) {
+            ggml_tensor * cur_j = build_block(proj_cur, n_catchup + j, 1);
+
+            ggml_tensor * head_norm_w2 = layer.nextn.shared_head_norm
+                    ? layer.nextn.shared_head_norm
+                    : model.output_norm;
+            ggml_tensor * h_next_j = build_norm(cur_j, head_norm_w2, nullptr, LLM_NORM_RMS, -1);
+
+            ggml_tensor * head_w2 = layer.nextn.shared_head_head ? layer.nextn.shared_head_head : model.output;
+            ggml_tensor * head_s2 = layer.nextn.shared_head_head ? layer.nextn.shared_head_head_s : model.output_s;
+
+            // drafting rarely picks tokens outside the leading vocabulary range
+            // (BPE ids correlate with frequency), so the chain can run a small
+            // sub-head instead of the full one and pad the tail of the logits to
+            // -1e9. The full-vocab verify on the target decides acceptance, so
+            // this only narrows what gets drafted, never what gets committed.
+            // LLAMA_SPEC_CHAIN_SUB sets the width; 0 restores the full head.
+            static const int64_t n_sub_env = [] {
+                const char * env = getenv("LLAMA_SPEC_CHAIN_SUB");
+                return env != nullptr ? atoll(env) : 32768;
+            }();
+
+            ggml_tensor * logits_j;
+            if (n_sub_env > 0 && n_sub_env < head_w2->ne[1]) {
+                ggml_tensor * head_sub = ggml_view_2d(ctx0, head_w2,
+                        head_w2->ne[0], n_sub_env, head_w2->nb[1], 0);
+                logits_j = ggml_mul_mat(ctx0, head_sub, h_next_j);
+                if (head_s2 != nullptr) {
+                    logits_j = ggml_mul(ctx0, logits_j, head_s2);
+                }
+            } else {
+                logits_j = build_lora_mm(head_w2, h_next_j, head_s2);
+            }
+
+            // the chain samples greedily in-graph; the host only needs the picked
+            // token and its probability. Emit them as a 2-float "logits" row per
+            // step: [token id, top prob]. This removes the per-step host sampling
+            // pass and the full-width logits transfer.
+            ggml_tensor * id_j = ggml_argmax(ctx0, logits_j);
+            ggml_tensor * probs_j = ggml_soft_max(ctx0, logits_j);
+            ggml_tensor * p_j = ggml_get_rows(ctx0,
+                    ggml_reshape_2d(ctx0, probs_j, 1, probs_j->ne[0]), id_j);
+            p_j = ggml_reshape_2d(ctx0, p_j, 1, 1);
+            ggml_tensor * id_f = ggml_cast(ctx0, ggml_reshape_2d(ctx0, id_j, 1, 1), GGML_TYPE_F32);
+            ggml_tensor * out_j = ggml_concat(ctx0, id_f, p_j, 0);
+
+            logits_all = logits_all == nullptr ? out_j : ggml_concat(ctx0, logits_all, out_j, 1);
+            h_all      = h_all      == nullptr ? h_next_j : ggml_concat(ctx0, h_all, h_next_j, 1);
+
+            if (j + 1 < n_chain) {
+                // feed the argmax token and hidden state into the next step
+                ggml_tensor * tok_j = ggml_get_rows(ctx0, tok_embd_w, id_j);
+                proj_cur = build_proj(tok_j, h_next_j);
+            }
+        }
+
+        cb(h_all, "h_nextn", -1);
+        res->t_h_nextn = h_all;
+        ggml_build_forward_expand(gf, h_all);
+
+        // the chain logits rows are exactly the output rows; expand a view of out_ids
+        // so the unused input still gets allocated before set_inputs writes it
+        ggml_build_forward_expand(gf, ggml_view_1d(ctx0, inp_out_ids, inp_out_ids->ne[0], 0));
+
+        cb(logits_all, "result_output", -1);
+        res->t_logits = logits_all;
+        ggml_build_forward_expand(gf, logits_all);
+
+        return;
+    }
 
     ggml_tensor * h_norm = build_norm(h_embd, layer.nextn.hnorm, nullptr, LLM_NORM_RMS, il);
     cb(h_norm, "mtp_hnorm", il);


### PR DESCRIPTION
## Overview
Implemented draft improvements that make higher draft depth faster. For my setup, draft depth 3 was the best. With the changes, draft depth 5 delivers ~10% more t/s than draft depth 3.

My setup: Qwen3.8-27B Q8_0, 2x RTX 5090, llama.cpp draft-mtp speculative decoding, `-sm tensor -fa on -c 32768 -np 1`, temperature 0.

| change | how it works | t/s change / improvement |
|---|---|---|
| Draft all tokens in one decode (`LLAMA_SPEC_CHAIN=1`) | Before: one GPU call per draft token, plus a CPU round trip after each call to pick the token. Now: one GPU call produces all draft tokens and picks them on the GPU. | ~+2-6 t/s |
| Return 2 numbers per draft token instead of the full score list | The GPU sends back only the picked token and its probability, not scores for all 151k vocab entries. The draft also scores only the 32k most common tokens (`LLAMA_SPEC_CHAIN_SUB`); the main model still checks against the full vocabulary, so output does not change. | ~+5-11 t/s |
| Keep a full copy of the output layer on each GPU (`LLAMA_META_MIRROR_OUTPUT=1`) | Before, the layer was split across the two GPUs and every check step needed GPU-to-GPU traffic to combine the halves. Costs one layer of extra VRAM per GPU, removes that traffic. | ~+5-8 t/s |
| Keep a prepared work plan per batch size (`LLAMA_SCHED_POOL=N`) | The same few batch sizes repeat every round. Before, each one overwrote the previous one's plan, so almost every step re-planned from scratch. | ~+5 t/s |
| Remember how work was split across the GPUs | Splitting a step's work between the two GPUs was recomputed every time. A repeated step now reuses the stored split. | No negative impact and makes the other improvement possible |
| Remove extra synchronization from the GPU-to-GPU add | The two GPUs already wait for each other inside the kernel; the extra per-chunk sync events only added overhead. | ~+3 t/s |
| **Bug fix**: wrong state after undoing tokens | When the server rolled tokens back, short batches had overwritten the saved states it rolled back to. | Bugfix |

## Additional information

"Remember how work was split across the GPUs" and "Remove extra synchronization" are always-on, other changes are behind a flag.

Benchmarks:

Test script starts each binary with (`-sm tensor -fa on -c 32768 -np 1
--spec-type draft-mtp`, depth per config), `GGML_CUDA_PDL=1`,
temperature 0. 

It runs four fixed workloads - code_gen (fresh code),
code_edit (modify given code), code_echo (verbatim rewrite), prose -
and takes generation t/s from the server's own timings.

| Config | Depth | Round results | Mean |
|---|---|---|---|
| Upstream b10444, official binary | 3 | 143.6, 149.6 | 146.6 |
| Upstream b10441, local toolchain (control) | 3 | 143.2, 141.2 | 142.2 |
| **PR build, chain config** | 5 | 161.8, 158.9 | **160.4** |

With no environment variables set, behavior is unchanged

Chain config = `LLAMA_SPEC_CHAIN=1 LLAMA_META_MIRROR_OUTPUT=1
LLAMA_SCHED_POOL=8`, `--spec-draft-n-max 5`.

| Category | Control n3 | PR chain n5 | Change |
|---|---|---|---|
| code_gen | 138.2 | 148.4 | **+7.4%** |
| code_edit | 137.7 | 150.6 | **+9.4%** |
| code_echo | 169.9 | 217.4 | **+28.0%** |
| prose | 123.0 | 125.3 | +1.9% |
| **mixed avg** | **142.2** | **160.4** | **+12.8%** |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Used AI coding agent to search for code that had the highest chance to yield performance gains, had it implement the code in this PR under my review and test it against benchmarks. 
