### PR TITLE
grammar : accept repetitions of exactly MAX_REPETITION_THRESHOLD

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -491,7 +491,7 @@ const char * llama_grammar_parser::parse_sequence(
             total_rules = min_times;
         }
 
-        if (n_prev_rules * total_rules >= MAX_REPETITION_THRESHOLD) {
+        if (n_prev_rules * total_rules > MAX_REPETITION_THRESHOLD) {
             throw std::runtime_error("number of rules that are going to be repeated multiplied by the new repetition exceeds sane defaults, please reduce the number of repetitions or rule complexity");
         }
 

--- a/tests/test-grammar-parser.cpp
+++ b/tests/test-grammar-parser.cpp
@@ -132,6 +132,13 @@ static void verify_parsing(const char *grammar_bytes, const std::vector<std::pai
     }
 }
 
+static void verify_success(const char * grammar_bytes) {
+    fprintf(stderr, "Testing expected success:%s\n", grammar_bytes);
+    llama_grammar_parser result;
+    result.parse(grammar_bytes);
+    assert(!result.rules.empty() && "should have succeeded");
+}
+
 static void verify_failure(const char * grammar_bytes) {
     fprintf(stderr, "Testing expected failure:%s\n", grammar_bytes);
     llama_grammar_parser result;
@@ -163,6 +170,22 @@ int main()
 
     verify_failure(R"""(
         root ::= "a"{5000,6000}
+    )""");
+
+    // Boundary: repetitions of exactly MAX_REPETITION_THRESHOLD (2000) must parse.
+    // The clamp in parse_sequence only kicks in strictly above the threshold, so
+    // handle_repetitions has to accept the threshold itself (used to abort via >=).
+    verify_success(R"""(
+        root ::= "a"{0,2000}
+    )""");
+
+    verify_success(R"""(
+        root ::= "a"{2000}
+    )""");
+
+    // Nested products above the threshold must still be rejected.
+    verify_failure(R"""(
+        root ::= ("a"{0,50}){0,50}
     )""");
 
     verify_parsing(R"""(


### PR DESCRIPTION
## Problem

A grammar repetition of **exactly** `MAX_REPETITION_THRESHOLD` (2000) crashes with an uncaught `std::runtime_error`, while both 1999 and 2001 work:

- `"a"{0,1999}` → parses and expands normally
- `"a"{0,2001}` → the parse-side clamp in `parse_sequence` kicks in (`max_times > MAX_REPETITION_THRESHOLD` → unbounded), so it parses
- `"a"{0,2000}` → passes the parse-side check (2000 is not `>` 2000), then `handle_repetitions` throws because its guard uses `>=`:

```cpp
if (n_prev_rules * total_rules >= MAX_REPETITION_THRESHOLD) {
    throw std::runtime_error(...);
}
```

The practical impact: any JSON schema with `"maxLength": 2000` (a very natural round number to pick) makes `json_schema_to_grammar` emit `.{0,2000}` and aborts the process, e.g. via `llama-completion -j '<schema>'`:

```
libc++abi: terminating due to uncaught exception of type std::runtime_error:
failed to parse grammar
```

This is the boundary case of #25746, and appears to be an off-by-one left over from the clamp introduced for #27087: the two checks disagree about whether the threshold value itself is allowed.

## Fix

Make `handle_repetitions` agree with the parse-side clamp by using a strict comparison, so the threshold value itself expands normally. Values above the threshold keep their existing behavior (clamped to unbounded at parse time for a single repetition, rejected for nested products).

## Tests

Added to `tests/test-grammar-parser.cpp`:

- `"a"{0,2000}` and `"a"{2000}` must parse (previously failed)
- `("a"{0,50}){0,50}` (nested product 2500 > threshold) must still be rejected

Verified locally on macOS (arm64): the new tests pass, the previously crashing JSON schema (`"maxLength": 2000`) now generates valid constrained output, and the nested-product rejection still triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
