### PR TITLE
vulkan : return GGML_STATUS_FAILED on device loss instead of aborting

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -865,6 +865,10 @@ struct vk_device_struct {
     bool device_fault {};
     PFN_vkGetDeviceFaultInfoEXT pfn_vkGetDeviceFaultInfoEXT {};
 
+    // set when the device is lost
+    // once set, graph_compute returns GGML_STATUS_FAILED until the backend is recreated
+    bool device_lost {};
+
     bool serialize_submissions {};
 
     const ggml_cgraph * diag_cgraph {};
@@ -15802,7 +15806,12 @@ static void ggml_vk_cleanup(ggml_backend_vk_context * ctx) {
     // discard any unsubmitted command buffers
     ctx->compute_ctx.reset();
     // wait for any pending command buffers to finish
-    ggml_vk_synchronize(ctx);
+    // this runs from the backend destructor, so it must not throw
+    try {
+        ggml_vk_synchronize(ctx);
+    } catch (const vk::SystemError &) {
+        ctx->device->device_lost = true;
+    }
 
     ggml_vk_graph_cleanup(ctx);
 
@@ -16395,9 +16404,18 @@ static void ggml_backend_vk_synchronize(ggml_backend_t backend) {
     VK_LOG_DEBUG("ggml_backend_vk_synchronize()");
     ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
 
-    ggml_vk_synchronize(ctx);
+    if (ctx->device->device_lost) {
+        return;
+    }
 
-    ggml_vk_graph_cleanup(ctx);
+    // cannot report an error from here, so just record the loss
+    try {
+        ggml_vk_synchronize(ctx);
+
+        ggml_vk_graph_cleanup(ctx);
+    } catch (const vk::DeviceLostError &) {
+        ctx->device->device_lost = true;
+    }
 }
 
 static bool ggml_vk_is_empty(ggml_tensor * node) {
@@ -16943,7 +16961,7 @@ static int32_t find_first_set(uint32_t x) {
     return ret;
 }
 
-static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
+static ggml_status ggml_backend_vk_graph_compute_impl(ggml_backend_t backend, ggml_cgraph * cgraph) {
     VK_LOG_DEBUG("ggml_backend_vk_graph_compute(" << cgraph->n_nodes << " nodes)");
     ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
 
@@ -17405,6 +17423,28 @@ static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cg
     return GGML_STATUS_SUCCESS;
 
     UNUSED(backend);
+}
+
+static ggml_status ggml_backend_vk_graph_compute(ggml_backend_t backend, ggml_cgraph * cgraph) {
+    ggml_backend_vk_context * ctx = (ggml_backend_vk_context *)backend->context;
+
+    if (ctx->device->device_lost) {
+        GGML_LOG_ERROR("%s: device %s was lost by an earlier submission - recreate the backend to recover\n",
+                __func__, ctx->device->name.c_str());
+        return GGML_STATUS_FAILED;
+    }
+
+    try {
+        return ggml_backend_vk_graph_compute_impl(backend, cgraph);
+    } catch (const vk::DeviceLostError &) {
+        // a lost device invalidates every object created from it, so fail all later calls too
+        ctx->device->device_lost = true;
+        GGML_LOG_ERROR("%s: device %s was lost - recreate the backend to recover\n", __func__, ctx->device->name.c_str());
+        return GGML_STATUS_FAILED;
+    } catch (const vk::SystemError & e) {
+        GGML_LOG_ERROR("%s: Vulkan error on %s: %s\n", __func__, ctx->device->name.c_str(), e.what());
+        return GGML_STATUS_FAILED;
+    }
 }
 
 // Sort the graph for improved parallelism.


### PR DESCRIPTION
## Overview

When a Vulkan device is lost mid-graph, `vulkan.hpp` throws `vk::DeviceLostError` out of `ggml_backend_vk_graph_compute`. Nothing catches it, so it unwinds through `llama_decode`, which is `extern "C"`, and the whole process aborts:

```
terminate called after throwing an instance of 'vk::DeviceLostError'
  what():  vk::Queue::submit: ErrorDeviceLost
```

The caller cannot defend against this. There is no status to inspect and nothing to catch - the application is gone.

This catches the error and returns `GGML_STATUS_FAILED` instead, so a lost device fails the call rather than the process.

A lost device invalidates every object created from it, so the flag is sticky and lives on `vk_device`, not on the backend context: several contexts can share one device and none of them are usable afterwards. Once it is set, every later `graph_compute` returns `GGML_STATUS_FAILED` immediately until the backend is recreated.

Two more places needed the same treatment for that to hold:

- `ggml_backend_vk_synchronize` returns `void` and can see the same loss, so it records the flag and leaves the reporting to the next `graph_compute`.
- `ggml_vk_cleanup` runs from the backend destructor, where a throw aborts just as hard, so its `ggml_vk_synchronize` call is wrapped too.

No interface change, no other backend touched.

This is the pattern Metal already uses - `has_error` in `ggml-metal-context.m`, with the same comment about the backend having to be recreated. This brings Vulkan in line with it.

## Additional information

**Where I hit it:** Intel Lunar Lake integrated graphics (`Intel(R) Graphics (LNL)`), Mesa Vulkan, `xe` kernel driver. One HTTP request is enough: prefill ~10,200 tokens of a 26B model with all layers resident. Kernel side, one line per abort:

```
xe 0000:00:02.0: [drm] Tile0: GT0: Timedout job: seqno=308, ... in fono [3416904]
```

**The trigger is the driver's job watchdog**, not anything ggml does wrong. Raising `job_timeout_ms` from 5000 to 10000 and changing nothing else let the identical prompt finish (471.6 s, no abort). Anything that overruns the per-job deadline will do it, so this is not specific to my hardware - any driver with a watchdog can lose a device this way.

**It cannot be avoided from the caller side.** Each of these was tried against the same reproducer:

| Tried | Result |
|---|---|
| `op_offload` off, all layers resident | still aborts |
| `n_ubatch` 512 -> 128 | still aborts |
| `GGML_VK_MAX_NODES_PER_SUBMIT` 100 -> 25 | still aborts |
| `GGML_VK_DISABLE_COOPMAT=1`, `GGML_VK_DISABLE_COOPMAT2=1` | still aborts |
| `n_batch` 2048 -> 256, three runs | one completed, two aborted |

The last row is the telling one: the same setting both survives and dies, so no parameter reliably keeps a job under the deadline.

To be clear about what this does and does not do: it does not stop the device being lost. It stops the device loss taking the process with it. Recovery still means tearing the backend down and building a new one.

**What the apps do after the device is lost.** The failure comes back as `GGML_STATUS_FAILED` -> decode returns `-3`, which both frontends already handle:

- `llama-completion` / `llama-cli`: `common_prompt_batch_decode` logs `failed to eval` once and returns false, and `main` returns 1. Clean exit, one message.
- `llama-server`: `ret < -1` maps to `Compute error.`, so every processing slot gets an error response and is released, and `update_slots` breaks out of the batch loop. The server stays up; a later request fails the same way, one log line each. It does not spin - the retry-with-half-batch path only runs for the KV-space case (`ret == 1`), never for a compute error.

The sticky flag matters here: once set, `graph_compute` returns before touching the device at all, so nothing is submitted to a dead queue in a loop. Metal logs on that path per call too, and I kept it the same.

Related: #25664, #27076.

Two things I deliberately left out, happy to add either if you want them here rather than in a follow-up:

- Failing `ggml_backend_vk_buffer_*` fast once the device is lost. Bigger diff, and the flag is already in the right place to do it later.
- Wrapping `llama_encode` / `llama_decode` in try/catch so no backend can unwind across the C boundary. That one is a separate concern from the Vulkan bug; I will open it after this lands.

Builds clean with `GGML_VULKAN=ON`. I will post the result of re-running the reproducer against a patched build - expected outcome is a failed decode and a live process instead of an abort.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. I hit this crash on my own machine, did the debugging above myself, and decided on the fix. A coding assistant (Claude Code) helped me write the patch and this description under my direction. I have reviewed every line and I am responsible for all of it. The commit carries an `Assisted-by:` trailer.
