### PR TITLE
llama: don't let exceptions escape llama_encode/llama_decode

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -4121,23 +4121,37 @@ size_t llama_state_seq_load_file(llama_context * ctx, const char * filepath, lla
 int32_t llama_encode(
         llama_context * ctx,
           llama_batch   batch) {
-    const int ret = ctx->encode(batch);
-    if (ret != 0) {
-        LLAMA_LOG_ERROR("%s: failed to encode, ret = %d\n", __func__, ret);
-    }
+    // llama_encode() is extern "C", so an exception must not escape it
+    try {
+        const int ret = ctx->encode(batch);
+        if (ret != 0) {
+            LLAMA_LOG_ERROR("%s: failed to encode, ret = %d\n", __func__, ret);
+        }
 
-    return ret;
+        return ret;
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: failed to encode: %s\n", __func__, err.what());
+
+        return -4;
+    }
 }
 
 int32_t llama_decode(
         llama_context * ctx,
           llama_batch   batch) {
-    const int ret = ctx->decode(batch);
-    if (ret != 0 && ret != 1) {
-        LLAMA_LOG_ERROR("%s: failed to decode, ret = %d\n", __func__, ret);
-    }
+    // llama_decode() is extern "C", so an exception must not escape it
+    try {
+        const int ret = ctx->decode(batch);
+        if (ret != 0 && ret != 1) {
+            LLAMA_LOG_ERROR("%s: failed to decode, ret = %d\n", __func__, ret);
+        }
 
-    return ret;
+        return ret;
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: failed to decode: %s\n", __func__, err.what());
+
+        return -4;
+    }
 }
 
 //


### PR DESCRIPTION
`llama_encode` and `llama_decode` are `extern "C"` and call straight into `ctx->encode` / `ctx->decode` with no handler. Anything thrown below them unwinds across a C boundary, which is undefined; in practice the process aborts and the caller never gets a chance to do anything about it.

This is not hypothetical - a Vulkan device loss does it today:

```
terminate called after throwing an instance of 'vk::DeviceLostError'
  what():  vk::Queue::submit: ErrorDeviceLost
```

I've sent a separate PR fixing that particular throw in the Vulkan backend (https://github.com/ggml-org/llama.cpp/pull/27183). This one is the belt-and-braces half: no exception should cross these two entry points regardless of which backend threw it, or which future one starts to.

The neighbouring public entry points in `llama-context.cpp` already do exactly this - `try` / `catch (const std::exception & err)`, log, return - so this just brings `llama_encode` and `llama_decode` in line with them. `-4` fits the documented "< -1 - fatal error" range for `llama_decode` and "< 0 - error" for `llama_encode`, and doesn't collide with the existing `-1` / `-2` / `-3`.

Kept separate from the Vulkan PR on purpose: that one is a backend bug fix, this one has a wider blast radius and you may want to weigh them apart.
