### PR TITLE
llama: fix mul_mat assert when reserving graph

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2405,6 +2405,12 @@ ggml_cgraph * llama_context::graph_reserve(
         LLAMA_LOG_DEBUG("%s: making n_tokens a multiple of n_seqs - n_tokens = %u, n_seqs = %u, n_outputs = %u\n", __func__, n_tokens, n_seqs, n_outputs);
     }
 
+    // pooling needs an output for every token, so the graph must be built with n_outputs == n_tokens
+    // ref: https://github.com/ggml-org/llama.cpp/issues/27175
+    if (cparams.embeddings && cparams.pooling_type != LLAMA_POOLING_TYPE_NONE) {
+        n_outputs = n_tokens;
+    }
+
     ggml_backend_sched_reset(sched.get());
 
     // when the scheduler is reset, we cannot reuse the old graph, so we reset the previous graph result to prevent that

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -515,6 +515,36 @@ static int save_models(const llm_arch target_arch, const size_t seed, const ggml
     return 0;
 }
 
+// pooled embeddings with an n_ubatch that is not a multiple of n_seq_max
+// ref: https://github.com/ggml-org/llama.cpp/issues/27175
+static void test_ctx_pooling_mean(const size_t seed) {
+    const uint32_t n_seq_max = 5;
+    const uint32_t n_ubatch  = 64; // must not be a multiple of n_seq_max
+
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_LLAMA, /*moe =*/ false);
+
+    llama_model_params model_params = llama_model_default_params();
+
+    size_t tmp = seed;
+    llama_model_ptr model(llama_model_init_from_user(gguf_ctx.get(), set_tensor_data, &tmp, model_params));
+    if (!model) {
+        throw std::runtime_error("failed to create llama model");
+    }
+
+    llama_context_params ctx_params = llama_context_default_params();
+    ctx_params.n_ctx        = 0;
+    ctx_params.n_batch      = n_ubatch;
+    ctx_params.n_ubatch     = n_ubatch;
+    ctx_params.n_seq_max    = n_seq_max;
+    ctx_params.embeddings   = true;
+    ctx_params.pooling_type = LLAMA_POOLING_TYPE_MEAN;
+
+    llama_context_ptr lctx(llama_init_from_model(model.get(), ctx_params));
+    if (!lctx) {
+        throw std::runtime_error("failed to create llama context");
+    }
+}
+
 static int test_backends(const llm_arch target_arch, const size_t seed, const ggml_log_level log_level) {
     struct user_data_t {
         struct {
@@ -532,6 +562,8 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const gg
         const ggml_log_level level_eff = level >= ud->min_level ? level : GGML_LOG_LEVEL_DEBUG;
         ud->original_logger.callback(level_eff, text, ud->original_logger.user_data);
     }, &ud);
+
+    test_ctx_pooling_mean(seed);
 
     const std::vector<llama_token> tokens = get_tokens(128, 128, seed);
 


### PR DESCRIPTION
## Overview

When reserving a graph and n_ubatch is not a multiple of n_seq_max, `mul_mat` crashes on assert. This is because `graph_reserve` rounds `n_tokens` up to a multiple of `n_seqs`, but leaves n_outputs (rows) the same. 

The two meet in a `ggml_mul_mat` whose inner dimensions have to match, otherwise the assert is triggered. This happens when pooling with MEAN type (and possibly others).

## Additional information

- I found the error when I was testing pooling, more details in my issue here:
https://github.com/ggml-org/llama.cpp/issues/27175. (includes gdb concrete debug)

- The code where I found the initial workaround and trigger is here: https://codeberg.org/nita-andrei-cristian/change/src/commit/b78a5160ab3df4e7d804593127827eb91fdb460b/src/main.c around line 102-135

- Solving meant simply matching `n_outputs` to `n_tokens` for pooling types. Because the mechanism is not specific to MEAN.

- The test written follows a similar structure, sets `n_ubatch` to a non-multiple of `n_seq_max` and calls `llama_init_from_model`, without this change it would fail.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, traced root cause, drafted my fix into reserve logic and investigated patterns. I had carefully reviewed it before submitting and considered alternative fixes.
