### PR TITLE
ggml-cuda: hipBLAS 7.x compat — fix enum-type mismatch in cublasGemmEx

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1223,7 +1223,7 @@ static void ggml_cuda_op_mul_mat_cublas(
                     &alpha_f32,  src0_ptr,       CUDA_R_16BF, ne00,
                                  src1_ptr,       CUDA_R_16BF, ne10,
                     &beta_f32,   dst_bf16.get(), CUDA_R_16BF, ldc,
-                    CUBLAS_COMPUTE_32F,
+                    (cublasComputeType_t)(int)CUBLAS_COMPUTE_32F,
                     CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 
         const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_BF16);
@@ -1261,7 +1261,7 @@ static void ggml_cuda_op_mul_mat_cublas(
                         &alpha, src0_ptr,  CUDA_R_16F, ne00,
                                 src1_ptr,  CUDA_R_16F, ne10,
                         &beta,   dst_dd_i, CUDA_R_32F, ldc,
-                        CUBLAS_COMPUTE_32F,
+                        (cublasComputeType_t)(int)CUBLAS_COMPUTE_32F,
                         CUBLAS_GEMM_DEFAULT_TENSOR_OP));
         } else {
             ggml_cuda_pool_alloc<half> dst_f16(ctx.pool(id), row_diff*src1_ncols);
@@ -1275,7 +1275,7 @@ static void ggml_cuda_op_mul_mat_cublas(
                         &alpha_f16, src0_ptr,      CUDA_R_16F, ne00,
                                     src1_ptr,      CUDA_R_16F, ne10,
                         &beta_f16,  dst_f16.get(), CUDA_R_16F, ldc,
-                        CUBLAS_COMPUTE_16F,
+                        (cublasComputeType_t)(int)CUBLAS_COMPUTE_16F,
                         CUBLAS_GEMM_DEFAULT_TENSOR_OP));
 
             const to_fp32_cuda_t to_fp32_cuda = ggml_get_to_fp32_cuda(GGML_TYPE_F16);
@@ -1790,8 +1790,8 @@ static void ggml_cuda_mul_mat_batched_cublas(ggml_backend_cuda_context & ctx, co
     ggml_cuda_pool_alloc<half> dst_f16(ctx.pool());
     char * dst_t;
 
-    cublasComputeType_t cu_compute_type = CUBLAS_COMPUTE_16F;
-    cudaDataType_t      cu_data_type    = CUDA_R_16F;
+    cublasComputeType_t cu_compute_type = (cublasComputeType_t)(int)CUBLAS_COMPUTE_16F;
+    cudaDataType_t      cu_data_type    = (cudaDataType_t)(int)CUDA_R_16F;
 
     // dst strides
     size_t nbd2 = dst->nb[2];
@@ -1814,8 +1814,8 @@ static void ggml_cuda_mul_mat_batched_cublas(ggml_backend_cuda_context & ctx, co
     } else {
         dst_t = (char *) dst_ddf;
 
-        cu_compute_type = CUBLAS_COMPUTE_32F;
-        cu_data_type    = CUDA_R_32F;
+        cu_compute_type = (cublasComputeType_t)(int)CUBLAS_COMPUTE_32F;
+        cu_data_type    = (cudaDataType_t)(int)CUDA_R_32F;
 
         alpha = &alpha_f32;
         beta  = &beta_f32;
@@ -1824,7 +1824,7 @@ static void ggml_cuda_mul_mat_batched_cublas(ggml_backend_cuda_context & ctx, co
     int id = ggml_cuda_get_device();
     const int cc = ggml_cuda_info().devices[id].cc;
     if (GGML_CUDA_CC_IS_CDNA(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
-        cu_compute_type = CUBLAS_COMPUTE_32F;
+        cu_compute_type = (cublasComputeType_t)(int)CUBLAS_COMPUTE_32F;
         alpha = &alpha_f32;
         beta  = &beta_f32;
     }

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -30,7 +30,7 @@
 #define CU_CHECK(fn) {hipError_t err = fn; if(err != hipSuccess) { GGML_ABORT("HipVMM Failure: %s\n", hipGetErrorString(err)); }}
 #define __shfl_sync(mask, var, laneMask, width) __shfl(var, laneMask, width)
 #define __shfl_xor_sync(mask, var, laneMask, width) __shfl_xor(var, laneMask, width)
-#define cublasComputeType_t hipblasDatatype_t //deprecated, new hipblasComputeType_t not in 5.6
+#define cublasComputeType_t hipblasComputeType_t
 #define cublasCreate hipblasCreate
 #define cublasDestroy hipblasDestroy
 #define cublasGemmEx hipblasGemmEx
@@ -42,7 +42,7 @@
 #define cublasSgemm hipblasSgemm
 #define cublasStatus_t hipblasStatus_t
 #define cublasOperation_t hipblasOperation_t
-#define cudaDataType_t hipblasDatatype_t //deprecated, new hipblasDatatype not in 5.6
+#define cudaDataType_t hipDataType
 #define cudaDeviceCanAccessPeer hipDeviceCanAccessPeer
 #define cudaDeviceDisablePeerAccess hipDeviceDisablePeerAccess
 #define cudaDeviceEnablePeerAccess hipDeviceEnablePeerAccess


### PR DESCRIPTION
## Problem

Building llama.cpp with `GGML_HIP=ON` on Ubuntu 26.04 / hipBLAS 7.1 fails with:

```
ggml-cuda.cu:1221: error: no matching function for call to 'hipblasGemmEx'
    note: candidate function not viable: no known conversion from
    'hipDataType' to 'hipblasComputeType_t' for 18th argument

ggml-cuda.cu:1793: error: cannot initialize a variable of type
    'hipblasDiagType_t' with an rvalue of type 'hipDataType'
ggml-cuda.cu:1817: error: assigning to 'hipblasDiagType_t' from
    incompatible type 'hipDataType'
```

## Root cause

`ggml-cuda/vendors/hip.h` maps `cublasComputeType_t` and
`cudaDataType_t` to `hipblasDatatype_t` via `#define`. **hipBLAS 7.x
removed `hipblasDatatype_t`** — it now has separate
`hipblasComputeType_t` (for `cublasComputeType_t`) and `hipDataType`
(for `cudaDataType_t`). The old comment in `hip.h` says "deprecated,
new hipblasDatatype_t not in 5.6" — which is now wrong (and `5.6` is
also stale).

The `cublasGemmEx` and `cublasGemmBatchedEx` macros expand to
`hipblasGemmEx` and `hipblasGemmBatchedEx`. In hipBLAS 7.x, those
take `hipblasComputeType_t computeType` (the alias name
`cublasComputeType_t` is preserved as the alias for
`hipblasComputeType_t`) and `hipDataType aType` / `hipDataType
bType` / `hipDataType cType`. The call site in `ggml-cuda.cu` passed
`CUBLAS_COMPUTE_32F` (which is `HIPBLAS_R_32F`, typed `hipDataType`)
where the function now wants `hipblasComputeType_t` — the
type-equivalence held in 5.x via a single combined enum, but
hipBLAS 7.x split them, and the old `#define` chain in `hip.h` no
longer round-trips.

## Fix

Two changes (10 lines total):

1. `ggml/src/ggml-cuda/vendors/hip.h` — update the broken aliases to
   point to the actual hipBLAS 7.x types:

```diff
-#define cublasComputeType_t hipblasDatatype_t //deprecated, new hipblasComputeType_t not in 5.6
+#define cublasComputeType_t hipblasComputeType_t
...
-#define cudaDataType_t hipblasDatatype_t //deprecated, new hipblasDatatype not in 5.6
+#define cudaDataType_t hipDataType
```

2. `ggml/src/ggml-cuda/ggml-cuda.cu` — add explicit type casts at
   the call-site assignments so the right enum is always passed:

```diff
-cu_compute_type = CUBLAS_COMPUTE_32F;
+cu_compute_type = (cublasComputeType_t)(int)CUBLAS_COMPUTE_32F;
...
-cu_compute_type = CUBLAS_COMPUTE_16F;
+cu_compute_type = (cublasComputeType_t)(int)CUBLAS_COMPUTE_16F;
...
-cu_data_type    = CUDA_R_32F;
+cu_data_type    = (cudaDataType_t)(int)CUDA_R_32F;
-cu_data_type    = CUDA_R_16F;
+cu_data_type    = (cudaDataType_t)(int)CUDA_R_16F;
```

The `(int)` cast is what makes this work: it forces the enum literal
to be evaluated as an integer before being re-cast to the target
type, which is what hipBLAS 7.x's strict enums expect.

## Verification

Tested on hardware: **Beelink SER5 MAX (Ryzen 7 7735HS, Radeon 680M,
gfx1032/gfx1035)** on **Ubuntu 26.04.2 LTS**, ROCm 7.1.1
apt-installed (`rocm-dev`, `rocm-smi`, `libhiprand-dev`,
`libhipblaslt-dev`), hipBLAS 7.1 from `/usr/lib/rocm`.

Build command:
```bash
cmake -DGGML_HIP=ON -DGGML_HIP_IMPL=0 \
      -DAMDGPU_TARGETS='gfx1032;gfx1035' \
      -DLLAMA_BUILD_SERVER=ON ...
```

Compiles clean. The only warning remaining is the upstream
`__AMDGCN_WAVEFRONT_SIZE` deprecation notice (out of scope for
this PR). The resulting `llama-server` loads Qwen 7B Q4_K_M with
`--n-gpu-layers 99` GPU offload without crashing.

## Where this came from

Reported from the MoBozed carputer build diary:
https://github.com/darren853/MoBozed-carputer
(docs/blog/2026-08-16-bench-reboot-survival-and-rocm.md)

Tested by: darren853 / SER5 MAX carputer build.
