### PR TITLE
ggml : fix integer overflow in block-quantized ggml_nbytes (heap OOB read)

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -1310,7 +1310,7 @@ size_t ggml_nbytes(const struct ggml_tensor * tensor) {
         }
     }
     else {
-        nbytes = tensor->ne[0]*tensor->nb[0]/blck_size;
+        nbytes = (tensor->ne[0]/blck_size)*tensor->nb[0];
         for (int i = 1; i < GGML_MAX_DIMS; ++i) {
             nbytes += (tensor->ne[i] - 1)*tensor->nb[i];
         }
@@ -1339,7 +1339,7 @@ size_t ggml_row_size(enum ggml_type type, int64_t ne) {
     assert(type >= 0);
     assert(type < GGML_TYPE_COUNT);
     assert(ne % ggml_blck_size(type) == 0);
-    return ggml_type_size(type)*ne/ggml_blck_size(type);
+    return (ne/ggml_blck_size(type))*ggml_type_size(type);
 }
 
 double ggml_type_sizef(enum ggml_type type) {


### PR DESCRIPTION
## Overview

For block-quantized tensors, llama.cpp calculates the required bytes like this:

```c
nbytes = tensor->ne[0] * tensor->nb[0] / blck_size;
```

For the malicious Q4_0 tensor:

```text
ne[0]      = 5124095576030431008
type size  = 18 bytes per block
block size = 32 elements
```

The multiplication happens first:

```text
5124095576030431008 × 18
= 92233720368547758144
```

That exceeds a 64-bit `size_t`, so unsigned arithmetic silently wraps modulo 2^64:

```text
92233720368547758144 mod 2^64 = 64
64 / 32 = 2
```

Thus `ggml_nbytes()` reports only 2 bytes, although the tensor actually requires:

```text
(5124095576030431008 / 32) × 18
= 2882303761517117442 bytes
```
POC- [gen_q4_0_nbytes_overflow.py](https://github.com/user-attachments/files/31122543/gen_q4_0_nbytes_overflow.py)


## Requirements


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
-  AI was used to verify and  write this bug report.

