### PR TITLE
ggml-cuda: clamp bogus sharedMemPerBlockOptin on Blackwell (fixes #23385)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -346,7 +346,30 @@ static ggml_cuda_device_info ggml_cuda_init() {
                       id, prop.name, prop.major, prop.minor, device_vmm ? "yes" : "no",
                       device_vram_mib);
 #else
+        // On some Blackwell (SM120) cards/drivers, prop.sharedMemPerBlockOptin
+        // comes back as a bogus value -- observed in the wild as exactly
+        // 0x100000001 (4294967297) instead of a sane ~100KB figure (see
+        // issue #23385). The bogus value gets passed to cudaFuncSetAttribute
+        // via CUDA_SET_SHARED_MEMORY_LIMIT, which the driver correctly
+        // rejects with "invalid argument"; the next kernel launch that
+        // relies on the raised limit (e.g. ggml_cuda_launch_mm_ids_helper's
+        // MoE id-routing kernel) then fails the same way, and
+        // ggml_cuda_error() aborts the process. Confirmed via a debug print
+        // immediately before the crashing launch: smpbo was exactly
+        // 4294967297 on an RTX 5080, even though a standalone
+        // cudaGetDeviceProperties() call in isolation reported a sane
+        // value -- the bad read appears tied to this specific
+        // multi-device-aware init path, not a permanently broken driver.
+        // Sanity-clamp to prop.sharedMemPerBlock (the guaranteed-valid
+        // non-optin figure) whenever the optin value is zero or larger
+        // than any real GPU's physical limit (512KB, generous headroom).
         info.devices[id].smpbo = prop.sharedMemPerBlockOptin;
+        if (info.devices[id].smpbo == 0 || info.devices[id].smpbo > 512 * 1024) {
+            GGML_LOG_WARN("  Device %d: sharedMemPerBlockOptin reported as %zu -- bogus driver value, "
+                           "falling back to sharedMemPerBlock (%zu)\n",
+                           id, info.devices[id].smpbo, (size_t) prop.sharedMemPerBlock);
+            info.devices[id].smpbo = prop.sharedMemPerBlock;
+        }
         info.devices[id].cc = 100*prop.major + 10*prop.minor;
         GGML_LOG_INFO("  Device %d: %s, compute capability %d.%d, VMM: %s, VRAM: %zu MiB\n",
                       id, prop.name, prop.major, prop.minor, device_vmm ? "yes" : "no",


### PR DESCRIPTION
## Summary

On an RTX 5080 (SM120) with driver 595.84 / CUDA 13.3, `prop.sharedMemPerBlockOptin` was observed to come back as exactly `0x100000001` (4294967297) during `ggml_cuda_init()` instead of a sane ~100KB value — reproducing #23385.

The bogus value is stored in `devices[id].smpbo` and later passed to `cudaFuncSetAttribute(..., cudaFuncAttributeMaxDynamicSharedMemorySize, smpbo)` via the `CUDA_SET_SHARED_MEMORY_LIMIT` macro. The driver correctly rejects it with `invalid argument`; the next kernel launch that relies on the raised limit then fails the same way (observed here with `ggml_cuda_launch_mm_ids_helper`, the MoE expert id-routing kernel used by `mul_mat_id` — i.e. any MoE model), and `ggml_cuda_error()` aborts the whole process.

## Root cause detail

Confirmed with a debug print immediately before the crashing launch: `smpbo` printed as exactly `4294967297` on this card. A standalone, isolated `cudaGetDeviceProperties()` call in a separate minimal program reported a sane `sharedMemPerBlockOptin` (101376) on the same machine/driver, so the bad read appears tied to llama.cpp's specific multi-device-aware init path rather than a permanently broken driver value — consistent with this being intermittent/context-dependent rather than a fixed constant to special-case.

## Fix

Sanity-clamp `smpbo` to `prop.sharedMemPerBlock` (the guaranteed-valid non-optin figure) whenever the optin value is either zero or larger than any real GPU's physical shared-memory limit (512KB, generous headroom over current hardware's ~228KB ceiling). This is the same approach discussed (but not merged) in #23385.

## Testing

Verified on RTX 5080: three different quantized MoE GGUFs (a MXFP4_MOE full model requiring `--n-cpu-moe` partial CPU offload, a REAP-pruned MXFP4_MOE variant fitting fully in VRAM, and an unrelated dense-ish Q4_K_M model as a control) all previously crashed reliably on first real generation with this exact backtrace, and now run without crashing, including under repeated tool-calling workloads with multiple tool schemas declared.

Ruled out before finding this root cause:
- `--n-cpu-moe` specifically (control model crashes without any CPU offload too)
- Q8_0 KV-cache quantization (crash persists with plain fp16 KV cache)
- Q8_0-typed model weights specifically (excluding `GGML_TYPE_Q8_0` from `ggml_cuda_should_use_mmq()` does not fix it)
- nvcc optimization level (`-O3`/`-O2`/`-O0` all crash identically)

`-DGGML_CUDA_FORCE_CUBLAS=ON` does mask the crash (confirmed), but at the cost of disabling the native MMQ kernel for every quant type, including MXFP4/NVFP4 — this fix avoids that tradeoff by addressing the actual bad value instead.

## Test plan

- [x] Confirmed crash reproduces on unpatched build across 3 different models/configs
- [x] Confirmed no crash on patched build across the same 3 models/configs
- [x] Confirmed `-O3`/`-O2`/`-O0` all reproduce the crash identically (ruling out a codegen/optimization cause)
- [ ] Not tested on other Blackwell SKUs (5090, datacenter Blackwell) or other driver versions — only verified on this RTX 5080 / driver 595.84 combination
