### PR TITLE
chat: allow reasoning_effort to control enable_thinking

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3634,10 +3634,8 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, const std::string & value) {
             if (is_truthy(value)) {
                 params.enable_reasoning = 1;
-                params.default_template_kwargs["enable_thinking"] = "true";
             } else if (is_falsey(value)) {
                 params.enable_reasoning = 0;
-                params.default_template_kwargs["enable_thinking"] = "false";
             } else if (is_autoy(value)) {
                 params.enable_reasoning = -1;
             } else {

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1299,6 +1299,7 @@ json oaicompat_chat_params_parse(
             inputs.enable_thinking = false;
             inputs.chat_template_kwargs.erase("reasoning_effort");
         } else if (!reasoning_effort.empty()) {
+            inputs.enable_thinking = true;
             inputs.chat_template_kwargs["reasoning_effort"] = json(reasoning_effort).dump();
         }
     }


### PR DESCRIPTION
## Overview

`reasoning_effort` is currently unable to turn thinking off (or on) if the server is launched with `--reasoning on|off` as it also adds it to `template_kwargs` which is applied after the `enable_thinking` boolean that will be set when reasoning effort is sent.

## Additional information

I have only ran some manual tests with pi.dev. As far as I can tell `enable_thinking` is already set in `common_chat_template_direct_apply_impl` and does not need to be part of `template_kwargs`.

pi does not send a reasoning effort for `off` by default, you will need to adjust the `thinkingLevelMap` if you want to do so:

```json
...
    {
      "id": "qwen3.8-27b",
      "input": ["text", "image"],
      "contextWindow": 262144,
      "maxTokens": 131072,
      "reasoning": true,
      "thinkingLevelMap": { "off": "none", "minimal": null, "high": null, "xhigh": null, "max": "xhigh"},
      "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
    },
    {
      "id": "gemma4-31b",
      "input": ["text", "image"],
      "contextWindow": 262144,
      "maxTokens": 131072,
      "reasoning": true,
      "thinkingLevelMap": { "off": "none", "minimal": null, "low": null, "medium": null, "high": null, "xhigh": null, "max": "max"},
      "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
    },
...
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: None.
