### PR TITLE
server : check existence of sink callback before calling it

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -565,7 +565,9 @@ static void process_handler_response(server_http_req_ptr && request, server_http
                 SRV_DBG("http: streamed chunk: %s\n", chunk.c_str());
             }
             if (!has_next) {
-                sink.done();
+                if (sink.done) {
+                    sink.done();
+                }
                 SRV_DBG("%s", "http: stream ended\n");
             }
             return has_next;

--- a/tools/server/tests/unit/test_proxy.py
+++ b/tools/server/tests/unit/test_proxy.py
@@ -69,3 +69,36 @@ def test_mcp_proxy_no_content():
         target.shutdown()
         target.server_close()
 
+
+def test_mcp_proxy_not_found_does_not_crash():
+    # note: see issue #27187
+    class NotFoundHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, format, *args):
+            pass
+
+    target = ThreadingHTTPServer(("127.0.0.1", 0), NotFoundHandler)
+    target_thread = threading.Thread(target=target.serve_forever, daemon=True)
+    target_thread.start()
+
+    try:
+        global server
+        server.ui_mcp_proxy = True
+        server.start()
+
+        url = f"http://{server.server_host}:{server.server_port}/cors-proxy?url=http://127.0.0.1:{target.server_port}/"
+        try:
+            requests.get(url, timeout=DEFAULT_REQUEST_TIMEOUT)
+        except requests.exceptions.RequestException:
+            pass
+
+        res = server.make_request("GET", "/health")
+        assert res.status_code == 200
+    finally:
+        target.shutdown()
+        target.server_close()
+


### PR DESCRIPTION
## Overview
This PR fixed the calling of streaming sink callback to avoid hard fail because of std::bad_function_call when the sink callback--sink.done is empty, and update a new test which uses a bodyless 404 response ,and the same test fails without the guard and passes with the guard

## Additional information
 In some cases, such as some error responses (http code 404.It will be executed error_handler callback and then have a non-empty body) have content provider and non-empty body (according to issue 27187) ,  cpp-httplib will select another condition branch ,executing  ''write_content_with_progress()' which won't initialize 'sink.done()' rather than 'write_content_chunked()' , so that the lambda 'chunked_content_provider' will throw std::bad_function_call error and the server crashes.
## Requirements



- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES,I used AI Agent to help me read code to ensure calling chain, and AI also assisted with regression-test implementation and verification, running the proxy test suite

