### PR TITLE
Improve error message when requested quant is not found in repo

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -771,7 +771,11 @@ common_download_hf_plan common_download_get_hf_plan(const common_params_model & 
         primary = find_best_model(all, tag);
         // a requested sidecar can resolve on its own, without a full model of the same tag
         if (primary.path.empty() && !opts.download_mtp && !opts.download_dflash && !opts.download_eagle3 && !opts.download_dspark) {
-            LOG_ERR("%s: no GGUF files found in repository %s\n", __func__, repo.c_str());
+            if (!tag.empty()) {
+                LOG_ERR("%s: no file matching quant '%s' found in repository %s\n", __func__, tag.c_str(), repo.c_str());
+            } else {
+                LOG_ERR("%s: no GGUF files found in repository %s\n", __func__, repo.c_str());
+            }
             list_available_gguf_files(all);
             return plan;
         }


### PR DESCRIPTION
## Overview
I was trying to download a specific quant with the -hf flag and it wasn't finding it. The error message made it look like the repository had no GGUF files at all, when really the repo just didn't have that specific quant. I fixed it so that when the requested quant isn't found, it says exactly which quant was missing and lists the GGUF files that are actually available in the repo.

## Additional information
Related to #27201.

Before:
`E common_download_get_hf_plan: no GGUF files found in repository ggml-org/Qwen3-8B-GGUF`

After:
```
E common_download_get_hf_plan: no file matching quant 'Q4_K_M' found in repository ggml-org/Qwen3-8B-GGUF
Available GGUF files:
 - Qwen3-8B-BF16.gguf
 - Qwen3-8B-Q8_0.gguf
```


## Requirements
- I have read and agree with the contributing guidelines.
- AI usage disclosure: YES, used AI to help debug the build environment and verify the fix locally. Description written by me.