### PR TITLE
[SYCL] fix load model with mlock issue

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -1509,8 +1509,13 @@ static ggml_backend_buffer_t ggml_backend_sycl_host_buffer_type_alloc_buffer(ggm
 }
 
 static size_t ggml_backend_sycl_host_buffer_type_get_max_size(ggml_backend_buffer_type_t buft) {
-    ggml_backend_sycl_device_context * dev_ctx = (ggml_backend_sycl_device_context *) buft->device->context;
-    return dpct::dev_mgr::instance().get_device(dev_ctx->device).get_max_mem_alloc_size();
+
+    if (g_ggml_sycl_enable_host_pinned_mem) {
+        ggml_backend_sycl_device_context * dev_ctx = (ggml_backend_sycl_device_context *) buft->device->context;
+        return dpct::dev_mgr::instance().get_device(dev_ctx->device).get_max_mem_alloc_size();
+    } else {
+        return SIZE_MAX;
+    }
 }
 
 ggml_backend_buffer_type_t ggml_backend_sycl_host_buffer_type() {


### PR DESCRIPTION
## Overview

Fix the issue in: https://github.com/ggml-org/llama.cpp/commit/a97123e497968f3440264c0464a7adc7c999c027#commitcomment-196155079

breaks --load-mode mlock.

## Additional information

When enable the host-pinned memory, the get_max_size() for host will return max size for GPU.
It would impact the mlock.

This PR will restore it to return SIZE_MAX when disable host-pinned memory by `export GGML_SYCL_ENABLE_HOST_PINNED_MEM=0`.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO.

