### PR TITLE
ggml-cpu : fix dup_bytes row size for block-quantized types

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -372,7 +372,7 @@ static void ggml_compute_forward_dup_bytes(
     if (ggml_is_contiguous(dst)) {
         size_t id = 0;
         char * dst_ptr = (char *) dst->data;
-        const size_t rs = ne00 * type_size;
+        const size_t rs = ggml_row_size(src0->type, ne00);
 
         if (nb00 == type_size) {
             // src0 is contiguous on first dimension, copy by rows
@@ -390,12 +390,15 @@ static void ggml_compute_forward_dup_bytes(
         } else {
             //printf("%s: this is not optimal - fix me\n", __func__);
 
+            // number of blocks in a row
+            const int64_t nk00 = ne00 / ggml_blck_size(src0->type);
+
             for (int64_t i03 = 0; i03 < ne03; i03++) {
                 for (int64_t i02 = 0; i02 < ne02; i02++) {
                     id += rs * ir0;
                     for (int64_t i01 = ir0; i01 < ir1; i01++) {
-                        for (int64_t i00 = 0; i00 < ne00; i00++) {
-                            const char * src0_ptr = (char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03;
+                        for (int64_t k00 = 0; k00 < nk00; k00++) {
+                            const char * src0_ptr = (char *) src0->data + k00*nb00 + i01*nb01 + i02*nb02 + i03*nb03;
                             memcpy(dst_ptr + id, src0_ptr, type_size);
 
                             id += type_size;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -8880,6 +8880,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // permuted block-quantized src into a contiguous dst, hitting both copy paths of
+    // ggml_compute_forward_dup_bytes: nb00 == type_size (first) and nb00 != type_size (second)
+    test_cases.emplace_back(new test_cpy(GGML_TYPE_Q4_0, GGML_TYPE_Q4_0, {32, 1, 3, 5},  {32, 5, 3, 1},  {0, 1, 3, 2}));
+    test_cases.emplace_back(new test_cpy(GGML_TYPE_Q4_0, GGML_TYPE_Q4_0, {64, 32, 1, 3}, {32, 3, 64, 1}, {3, 0, 1, 2}));
+
     for (ggml_type type_dst : { GGML_TYPE_F32, GGML_TYPE_I32, GGML_TYPE_F16, GGML_TYPE_BF16 }) {
         for (bool use_view_slice : { true, false }) {
             for (std::array<int64_t, 4> ne : std::initializer_list<std::array<int64_t, 4>>{ {2, 1, 1, 1}, {2, 1, 3, 5},


### PR DESCRIPTION
## Overview

Refs #27053. `ggml_compute_forward_dup_bytes` computes the contiguous-`dst` row stride as `rs = ne00 * type_size` (ops.cpp:375). `ne00` counts elements while `type_size` measures a whole block, so for q4_0 `rs` is 32x too large and the copy runs past the end of `dst`. The per-element loop below repeats the error in its trip count.

`ggml_row_size()` at :358 and `nk00` at :419 already do this in the same function; using them makes the two paths agree byte for byte.

This removes the out-of-bounds write. It does not make `ggml_cont` transpose a block-quantized tensor *correctly* - that needs requantization, and the generic path below has the same limitation. Happy to assert `ggml_blck_size(src0->type) == 1` in this branch instead if you prefer that contract.

## Additional information

Root-caused by @MLuc24 in #27048, who leaned towards the assert.

Two q4_0 CPY cases added; upstream's suite reaches neither contiguous-`dst` sub-branch with a quantized type (same-type q4_0 copies short-circuit via `dup_same_cont`; CUDA, Vulkan, Metal and OpenCL skip them in `supports_op`). SYCL accepts them and its `cpy_q_q` already indexes blocks by `nb00`. Both cases have `nk00 == 1`, so they pin `rs` but not the `k00*nb00` stride.

```
# base adb55e514, Release, no sanitizer, 5/5 runs
sentinel mismatch: sent_0 sent_1 sent_2 sent_3
0/1 tests passed
# with the fix: 17989/17989 tests passed, -b CPU
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the fix, the two test cases and the reproduction were produced with AI assistance. I have reviewed every line and can explain it.
