### PR TITLE
ci : push release tag explicitly in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1662,6 +1662,16 @@ jobs:
         run: |
           tar -czvf release/llama-${{ steps.tag.outputs.name }}-ui.tar.gz --transform "s,^\.,llama-${{ steps.tag.outputs.name }}," -C ./ui-dist .
 
+      - name: Create and push git tag
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists, skipping creation"
+          else
+            git tag "${TAG}"
+            git push origin "${TAG}"
+          fi
+
       - name: Create release
         id: create_release
         uses: ggml-org/action-create-release@v1


### PR DESCRIPTION
## Overview

The `release` job in `release.yml` currently creates the `b<number>` tag implicitly — as a side effect of `ggml-org/action-create-release` calling the "Create a Release" REST API (which creates the tag at `target_commitish` if it does not exist).

This PR makes it explicit: a new **Create and push git tag** step in the `release` job (right before **Create release**) creates the tag with `git tag` and pushes it using the `DEPLOY_KEY_RELEASE` deploy key already configured by the Clone step. When the release action runs, the tag already exists, so the API only attaches the release to it.

Behavior change to note: tag and release are no longer created atomically by the API. If the release-creation step fails, the tag will remain on the repo without a release (a re-run skips tag creation and retries the release).

Should fix: https://github.com/ggml-org/llama.cpp/actions/runs/32026925108/job/95389714411#step:8:158

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.8-27B