### PR TITLE
common : avoid zero divisor in multi-device fit (#27169)

### DIFF
--- a/common/fit.cpp
+++ b/common/fit.cpp
@@ -323,8 +323,11 @@ static void common_params_fit_impl(
                         //   - for MoE models only whole tensors can be assigned to devices, which we estimate to be <= 1/3 of a layer
                         //   - on average we expect a waste of 0.5 layers/tensors per device
                         //   - use slightly more than the expected average for nd devices to be safe
-                        const int64_t model_per_layer = sum_projected_model / std::min(uint32_t(mparams->n_gpu_layers), hp_ngl);
-                        sum_used_target -= (nd + 1) * model_per_layer / (hp_nex == 0 ? 2 : 6);
+                        const uint32_t n_gpu_layers = std::min(uint32_t(mparams->n_gpu_layers), hp_ngl);
+                        if (n_gpu_layers > 0) {
+                            const int64_t model_per_layer = sum_projected_model / n_gpu_layers;
+                            sum_used_target -= (nd + 1) * model_per_layer / (hp_nex == 0 ? 2 : 6);
+                        }
                     }
 
                     int64_t sum_projected_used_min_ctx = 0;


### PR DESCRIPTION
## Overview

Fixes an integer divide-by-zero in `common_params_fit_impl()` when the multi-device fit path is used with `-ngl 0`.

When no model layers are assigned to the GPU, the effective GPU layer count is zero. The existing per-layer memory adjustment divided by this value, causing a `SIGFPE` before model loading. This change skips that adjustment when the GPU layer count is zero, since there is no GPU layer-placement overhead to account for. Behavior with one or more GPU layers is unchanged.

## Additional information

Fixes #27169.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to code review, and build test environment.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
