### PR TITLE
server: do not re-reserve sched on lora scale changes

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -86,6 +86,7 @@ llama_context::llama_context(
     model(model),
     cvec(std::make_unique<llama_adapter_cvec>()),
     loras(std::make_unique<llama_adapter_loras>()),
+    loras_reserve(std::make_unique<llama_adapter_loras>()),
     balloc(std::make_unique<llama_batch_allocr>(model.hparams.n_pos_per_embd())) {
     // TODO warning when creating llama_context with awkward ctx size that is not a power of 2,
     //     may need to be backend-dependent
@@ -591,6 +592,10 @@ void llama_context::sched_reserve() {
 
     const int64_t t_start_us = ggml_time_us();
 
+    // reserve with all adapters at full scale so the buffers cover any combination of scales
+    auto loras_cur = std::move(loras);
+    loras = std::make_unique<llama_adapter_loras>(*loras_reserve);
+
     const uint32_t n_seqs = cparams.n_seq_max;
     const uint32_t n_tokens = std::min(cparams.n_ctx, cparams.n_ubatch);
 
@@ -695,6 +700,8 @@ void llama_context::sched_reserve() {
     } else {
         LLAMA_LOG_INFO("%s: graph splits = %d (with bs=%d), %d (with bs=1)\n", __func__, n_splits_pp, n_tokens, n_splits_tg);
     }
+
+    loras = std::move(loras_cur);
 
     const int64_t t_end_us = ggml_time_us();
 
@@ -1266,7 +1273,12 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
 void llama_context::set_adapters_lora(llama_adapter_lora ** adapters, size_t n_adapters, float * scales) {
     LLAMA_LOG_DEBUG("%s: adapters = %p\n", __func__, (void *) adapters);
 
-    if (adapters_lora_are_same(adapters, n_adapters, scales)) {
+    bool covered = loras_reserve->size() == n_adapters;
+    for (size_t i = 0; covered && i < n_adapters; i ++) {
+        covered = loras_reserve->find(adapters[i]) != loras_reserve->end();
+    }
+
+    if (covered && adapters_lora_are_same(adapters, n_adapters, scales)) {
         return;
     }
 
@@ -1278,7 +1290,16 @@ void llama_context::set_adapters_lora(llama_adapter_lora ** adapters, size_t n_a
         }
     }
 
-    sched_need_reserve = true;
+    // graphs cover all loras, so only re-reserve if the set changed (not just the scales)
+    if (!covered) {
+        loras_reserve.reset(new llama_adapter_loras());
+
+        for (size_t i = 0; i < n_adapters; i ++) {
+            loras_reserve->insert({adapters[i], 1.0f});
+        }
+
+        sched_need_reserve = true;
+    }
 }
 
 bool llama_context::adapters_lora_are_same(llama_adapter_lora ** adapters, size_t n_adapters, float * scales) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -284,6 +284,10 @@ private:
     llama_adapter_cvec_ptr  cvec;
     llama_adapter_loras_ptr loras;
 
+    // all adapters from the last set_adapters_lora call, at full scale. reserved graphs
+    // cover all of these so changing LoRA scale does not need a new reserve call.
+    llama_adapter_loras_ptr loras_reserve;
+
     llama_cross cross; // TODO: tmp for handling cross-attention - need something better probably
 
     llama_memory_ptr memory;

--- a/tools/server/tests/unit/test_lora.py
+++ b/tools/server/tests/unit/test_lora.py
@@ -66,6 +66,36 @@ def test_lora_per_request():
         assert match_regex(re_test, res.body["content"])
 
 
+def test_lora_per_request_alternating_scales():
+    global server
+    server.start()
+
+    # alternating scales on the same slot must keep producing the same outputs
+    prompt = "Look in thy glass"
+    lora_config = [
+        ( [{"id": 0, "scale": 0.0}], "(bright|day|many|happy)+" ),
+        ( [{"id": 0, "scale": 1.0}], "(eye|love|glass|sun)+" ),
+        ( [{"id": 0, "scale": 0.0}], "(bright|day|many|happy)+" ),
+        ( [{"id": 0, "scale": 1.0}], "(eye|love|glass|sun)+" ),
+    ]
+
+    results = []
+    for lora, re_test in lora_config:
+        res = server.make_request("POST", "/completion", data={
+            "prompt": prompt,
+            "lora": lora,
+            "seed": 42,
+            "temperature": 0.0,
+            "cache_prompt": False, # TODO: remove this once test_cache_vs_nocache_prompt is fixed
+        })
+        assert res.status_code == 200
+        assert match_regex(re_test, res.body["content"])
+        results.append(res.body["content"])
+
+    assert results[0] == results[2]
+    assert results[1] == results[3]
+
+
 @pytest.mark.skipif(not is_slow_test_allowed(), reason="skipping slow test")
 def test_with_big_model():
     server = ServerProcess()


### PR DESCRIPTION
## Overview

- Graph re-reservation was introduced in [#18547](https://github.com/ggml-org/llama.cpp/pull/18547) to avoid reallocating graphs in the middle of processing.
- However, any change of LoRA scales will re-reserve all compute buffers, even for changes that shouldn't need more buffer space (like `0.5` -> `1.0`).
- This PR changes buffer reservation so that, during reservation, we reserve enough room that all LoRAs can be used with a non-zero scale. As long as the set of LoRAs does not change, we skip buffer re-reservation (graphs are still rebuilt).

## Additional information

- I observed this latency causing heightened prompt processing times: ~85ms extra per request that changes LoRA scales on `Gemma-4-12B-it` on a 5090, and even more extra latency on a slower CPU + a 4090 with the same model.
- Based on my testing, VRAM usage is unchanged.
- Outputs are byte-identical with this change and without. A new test `test_lora_per_request_alternating_scales` covers this.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, root causing and initial implementation. I reviewed, edited, and validated the changes myself.