### PR TITLE
server: add optional OTLP/HTTP tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ option(LLAMA_BUILD_SERVER    "llama: build server example"                      
 option(LLAMA_BUILD_APP       "llama: build the unified binary"                                                   ${LLAMA_STANDALONE})
 option(LLAMA_BUILD_UI        "llama: build the embedded Web UI for server"                                       ON)
 option(LLAMA_USE_PREBUILT_UI "llama: use prebuilt UI from HF Bucket when available (requires LLAMA_BUILD_UI=ON)" ON)
+option(LLAMA_SERVER_OPEN_TELEMETRY "llama-server: enable OpenTelemetry OTLP/HTTP tracing"                         OFF)
 
 option(LLAMA_TOOLS_INSTALL "llama: install tools" ${LLAMA_TOOLS_INSTALL_DEFAULT})
 option(LLAMA_TESTS_INSTALL "llama: install tests" ON)

--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3538,6 +3538,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_ENDPOINT_METRICS"));
     add_opt(common_arg(
+        {"--otel"},
+        string_format("enable OpenTelemetry tracing (default: %s)", params.endpoint_otel ? "enabled" : "disabled"),
+        [](common_params & params) {
+            params.endpoint_otel = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_OTEL"));
+    add_opt(common_arg(
         {"--props"},
         string_format("enable changing global properties via POST /props (default: %s)", params.endpoint_props ? "enabled" : "disabled"),
         [](common_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -653,6 +653,7 @@ struct common_params {
     bool endpoint_slots   = true;
     bool endpoint_props   = false; // only control POST requests, not GET
     bool endpoint_metrics = false;
+    bool endpoint_otel    = false;
 
     // enable built-in tools
     std::vector<std::string> server_tools;

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -43,12 +43,23 @@ add_library(${TARGET}
     server-http.h
     server-models.cpp
     server-models.h
+    server-telemetry.cpp
+    server-telemetry.h
 )
 set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(${TARGET} PRIVATE ../mtmd ${CMAKE_SOURCE_DIR})
 target_link_libraries(${TARGET} PUBLIC server-context llama-ui cpp-httplib ${CMAKE_THREAD_LIBS_INIT})
+
+if(LLAMA_SERVER_OPEN_TELEMETRY)
+    find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS exporters_otlp_http)
+    if(OPENTELEMETRY_VERSION VERSION_LESS 1.27.0)
+        message(FATAL_ERROR "LLAMA_SERVER_OPEN_TELEMETRY requires opentelemetry-cpp 1.27.0 or newer")
+    endif()
+    target_compile_definitions(${TARGET} PRIVATE LLAMA_SERVER_OPEN_TELEMETRY)
+    target_link_libraries(${TARGET} PRIVATE opentelemetry-cpp::otlp_http_exporter)
+endif()
 
 if(LLAMA_TOOLS_INSTALL)
     install(TARGETS ${TARGET} LIBRARY)

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1110,7 +1110,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 ./build/bin/llama-server --otel -m model.gguf
 ```
 
-`OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a base URL and `/v1/traces` is appended. To provide the complete traces URL instead, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. Exporter headers, TLS, timeout, batching, resource attributes, SDK disablement, and sampling use the standard `OTEL_EXPORTER_OTLP_*`, `OTEL_BSP_*`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SDK_DISABLED`, `OTEL_TRACES_SAMPLER`, and `OTEL_TRACES_SAMPLER_ARG` environment variables.
+`OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a base URL and `/v1/traces` is appended. To provide the complete traces URL instead, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. Completed spans are batched and pushed to that endpoint with HTTP POST; no collector scrape is required. Exporter headers, TLS, timeout, batching, resource attributes, SDK disablement, and sampling use the standard `OTEL_EXPORTER_OTLP_*`, `OTEL_BSP_*`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SDK_DISABLED`, `OTEL_TRACES_SAMPLER`, and `OTEL_TRACES_SAMPLER_ARG` environment variables.
 
 Each request reaching a registered API handler produces a server span using the stable OpenTelemetry HTTP semantic conventions. Router and CORS-proxy requests also produce client spans and propagate W3C `traceparent` context downstream. Streaming spans remain open until the stream completes or the client disconnects.
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -215,6 +215,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `--cache-prompt, --no-cache-prompt` | whether to enable prompt caching (default: enabled)<br/>(env: LLAMA_ARG_CACHE_PROMPT) |
 | `--cache-reuse N` | min chunk size to attempt reusing from the cache via KV shifting, requires prompt caching to be enabled (default: 0)<br/>[(card)](https://ggml.ai/f0.png)<br/>(env: LLAMA_ARG_CACHE_REUSE) |
 | `--metrics` | enable prometheus compatible metrics endpoint (default: disabled)<br/>(env: LLAMA_ARG_ENDPOINT_METRICS) |
+| `--otel` | enable OpenTelemetry tracing (default: disabled)<br/>(env: LLAMA_ARG_OTEL) |
 | `--props` | enable changing global properties via POST /props (default: disabled)<br/>(env: LLAMA_ARG_ENDPOINT_PROPS) |
 | `--slots, --no-slots` | expose slots monitoring endpoint (default: enabled)<br/>(env: LLAMA_ARG_ENDPOINT_SLOTS) |
 | `--slot-save-path PATH` | path to save slot kv cache (default: disabled) |
@@ -366,6 +367,19 @@ To use this feature, start the server with `--tools all`. You can also enable on
   cmake -B build -DLLAMA_OPENSSL=ON
   cmake --build build --config Release -t llama-server
   ```
+
+## Build with OpenTelemetry tracing
+
+OTLP tracing is optional and requires OpenTelemetry C++ 1.27 or newer, built with the OTLP HTTP exporter. Point CMake at its installation prefix when configuring:
+
+```bash
+cmake -B build \
+  -DLLAMA_SERVER_OPEN_TELEMETRY=ON \
+  -DCMAKE_PREFIX_PATH=/path/to/opentelemetry-cpp/install
+cmake --build build --config Release -t llama-server
+```
+
+The default build does not link OpenTelemetry. Starting that build with `--otel` reports how to enable the dependency.
 
 ## Quick Start
 
@@ -1085,6 +1099,22 @@ In *router mode* the query param `?model={model_id}` has to be set. This endpoin
 | `llamacpp:spec_decode_num_accepted_tokens_total` | Counter | Total draft tokens accepted by the target model (0 when spec-decode is off). |
 | `llamacpp:spec_decode_num_drafts_total` | Counter | Total speculative decoding verification steps (0 when spec-decode is off). |
 | `llamacpp:spec_decode_num_accepted_tokens_per_pos_total` | Counter | Accepted tokens per draft position (labeled `position="N"`; absent when spec-decode is off or before the first completed speculative request). |
+
+### OpenTelemetry tracing
+
+Start an OpenTelemetry-enabled build with `--otel` (or `LLAMA_ARG_OTEL=1`) to export server request spans over OTLP/HTTP with protobuf encoding:
+
+```bash
+OTEL_SERVICE_NAME=llama-server \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
+./build/bin/llama-server --otel -m model.gguf
+```
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a base URL and `/v1/traces` is appended. To provide the complete traces URL instead, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. Exporter headers, TLS, timeout, batching, resource attributes, SDK disablement, and sampling use the standard `OTEL_EXPORTER_OTLP_*`, `OTEL_BSP_*`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SDK_DISABLED`, `OTEL_TRACES_SAMPLER`, and `OTEL_TRACES_SAMPLER_ARG` environment variables.
+
+Each request reaching a registered API handler produces a server span using the stable OpenTelemetry HTTP semantic conventions. Router and CORS-proxy requests also produce client spans and propagate W3C `traceparent` context downstream. Streaming spans remain open until the stream completes or the client disconnects.
+
+Request and response bodies, prompts, completions, API keys, and arbitrary HTTP headers are never added to spans. Routes are recorded using their registered templates to avoid high-cardinality path parameters.
 
 ### POST `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.
 

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1118,6 +1118,26 @@ When `OTEL_SDK_DISABLED=true`, no spans are created or exported, but incoming W3
 
 Each request reaching a registered API handler produces a server span using the stable OpenTelemetry HTTP semantic conventions. Router and CORS-proxy requests also produce client spans and propagate W3C `traceparent` context downstream. Streaming spans remain open until the stream completes or the client disconnects.
 
+Completed text and chat inference spans include token usage and performance attributes. Standard `gen_ai.*` attributes describe the operation, model, total input and output tokens, and prompt-cache reads. The following llama.cpp-specific attributes provide the internal phase breakdown:
+
+| Attribute | Description |
+| --- | --- |
+| `llama.completion.count` | Number of completions represented by the request. |
+| `llama.completion.input_tokens.processed` | Input tokens evaluated rather than served from the prompt cache. |
+| `llama.completion.cache.hit_ratio` | Cached input tokens divided by total input tokens. |
+| `llama.completion.queue.duration_ms` | Time from entering the inference queue until prompt evaluation starts. |
+| `llama.completion.prompt.duration_ms` | Prompt evaluation duration. |
+| `llama.completion.generation.duration_ms` | Token generation duration. |
+| `llama.completion.time_to_first_token_ms` | Queue plus prompt evaluation duration. |
+| `llama.completion.inference.duration_ms` | Queue, prompt evaluation, and generation duration. |
+| `llama.completion.prompt.tokens_per_second` | Evaluated prompt-token throughput. |
+| `llama.completion.generation.tokens_per_second` | Generated-token throughput, excluding the first token produced by prompt evaluation. |
+| `llama.completion.speculative.draft_tokens` | Draft tokens proposed by speculative decoding. |
+| `llama.completion.speculative.accepted_tokens` | Draft tokens accepted by the target model. |
+| `llama.completion.speculative.acceptance_ratio` | Accepted draft tokens divided by proposed draft tokens. |
+
+For requests containing multiple completions, token counts are summed and duration attributes report the longest completion. These attributes contain no prompt or completion content.
+
 Request and response bodies, prompts, completions, API keys, and arbitrary HTTP headers are never added to spans. Routes are recorded using their registered templates to avoid high-cardinality path parameters.
 
 ### POST `/slots/{id_slot}?action=save`: Save the prompt cache of the specified slot to a file.

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1102,7 +1102,7 @@ In *router mode* the query param `?model={model_id}` has to be set. This endpoin
 
 ### OpenTelemetry tracing
 
-Start an OpenTelemetry-enabled build with `--otel` (or `LLAMA_ARG_OTEL=1`) to export server request spans over OTLP/HTTP with protobuf encoding:
+Start an OpenTelemetry-enabled build with `--otel` (or `LLAMA_ARG_OTEL=1`) to export server request spans over OTLP/HTTP. Protobuf is the default encoding:
 
 ```bash
 OTEL_SERVICE_NAME=llama-server \
@@ -1110,7 +1110,11 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 ./build/bin/llama-server --otel -m model.gguf
 ```
 
-`OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a base URL and `/v1/traces` is appended. To provide the complete traces URL instead, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. Completed spans are batched and pushed to that endpoint with HTTP POST; no collector scrape is required. Exporter headers, TLS, timeout, batching, resource attributes, SDK disablement, and sampling use the standard `OTEL_EXPORTER_OTLP_*`, `OTEL_BSP_*`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SDK_DISABLED`, `OTEL_TRACES_SAMPLER`, and `OTEL_TRACES_SAMPLER_ARG` environment variables.
+`OTEL_EXPORTER_OTLP_ENDPOINT` is treated as a base URL and `/v1/traces` is appended. To provide the complete traces URL instead, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. Completed spans are batched and pushed to that endpoint with HTTP POST; no collector scrape is required. Exporter headers, TLS, timeout, batching, resource attributes, and SDK disablement are handled by OpenTelemetry C++ through the standard `OTEL_EXPORTER_OTLP_*`, `OTEL_BSP_*`, `OTEL_RESOURCE_ATTRIBUTES`, `OTEL_SERVICE_NAME`, and `OTEL_SDK_DISABLED` environment variables. Set `OTEL_EXPORTER_OTLP_PROTOCOL` or `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` to `http/json` to use JSON instead of the default `http/protobuf` encoding.
+
+`OTEL_TRACES_SAMPLER` supports `always_on`, `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, and `parentbased_traceidratio`; ratio-based samplers read `OTEL_TRACES_SAMPLER_ARG`. These variables require a small llama.cpp adapter because OpenTelemetry C++ 1.27 does not apply the flat sampler environment variables when a tracer provider is assembled programmatically.
+
+When `OTEL_SDK_DISABLED=true`, no spans are created or exported, but incoming W3C trace context is still propagated to router and CORS-proxy requests as required by the OpenTelemetry environment-variable specification.
 
 Each request reaching a registered API handler produces a server span using the stable OpenTelemetry HTTP semantic conventions. Router and CORS-proxy requests also produce client spans and propagate W3C `traceparent` context downstream. Streaming spans remain open until the stream completes or the client disconnects.
 

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -356,10 +356,16 @@ struct server_slot_stats {
     int64_t t_prompt_last = 0;
     int64_t t_gen_last    = 0;
 
+    // duration from entering the task queue until prompt processing starts (in us)
+    int64_t t_queue = 0;
+
     // can only move one direction: start -> prompt -> gen
-    void update_prompt_start() {
+    void update_prompt_start(int64_t t_queued_us = 0) {
         GGML_ASSERT(t_start == 0);
         t_start = ggml_time_us();
+        if (t_queued_us > 0) {
+            t_queue = std::max<int64_t>(0, t_start - t_queued_us);
+        }
     }
     void set_prompt_last(int64_t t_us) {
         GGML_ASSERT(t_start > 0);
@@ -382,6 +388,9 @@ struct server_slot_stats {
             return 0.0; // the prompt is not processed yet
         }
         return (t_prompt_last - t_start) / 1000.0;
+    }
+    double t_queue_ms() const {
+        return t_queue / 1000.0;
     }
     int64_t t_gen_us() const {
         if (t_gen_last == 0) {

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3046,7 +3046,7 @@ private:
 
                     // TODO: maybe move branch to outside of this loop in the future
                     if (slot.state == SLOT_STATE_STARTED) {
-                        slot.stats.update_prompt_start();
+                        slot.stats.update_prompt_start(slot.task->t_queued_us);
 
                         slot.state = SLOT_STATE_PROCESSING_PROMPT;
 
@@ -4117,6 +4117,114 @@ server_context_meta server_context::get_meta() const {
     };
 }
 
+struct server_completion_trace_data {
+    uint64_t count                   = 0;
+    uint64_t input_tokens            = 0;
+    uint64_t input_tokens_cached     = 0;
+    uint64_t input_tokens_processed  = 0;
+    uint64_t output_tokens           = 0;
+    uint64_t generation_steps        = 0;
+    uint64_t draft_tokens            = 0;
+    uint64_t draft_tokens_accepted   = 0;
+    double   queue_ms                = 0.0;
+    double   prompt_ms               = 0.0;
+    double   generation_ms           = 0.0;
+    double   time_to_first_token_ms  = 0.0;
+    double   inference_ms            = 0.0;
+    std::string model;
+
+    void add(const server_task_result_cmpl_final & result) {
+        count++;
+        input_tokens           += result.n_prompt_tokens;
+        input_tokens_cached    += result.n_prompt_tokens_cache;
+        input_tokens_processed += result.stats.n_prompt_processed;
+        output_tokens          += result.n_decoded;
+        generation_steps       += result.stats.n_gen_steps();
+        draft_tokens           += result.stats.n_draft_tokens;
+        draft_tokens_accepted  += result.stats.n_draft_accepted;
+
+        const double result_queue_ms      = result.stats.t_queue_ms();
+        const double result_prompt_ms     = result.stats.t_prompt_ms();
+        const double result_generation_ms = result.stats.t_gen_ms();
+        queue_ms               = std::max(queue_ms, result_queue_ms);
+        prompt_ms              = std::max(prompt_ms, result_prompt_ms);
+        generation_ms          = std::max(generation_ms, result_generation_ms);
+        time_to_first_token_ms = std::max(time_to_first_token_ms, result_queue_ms + result_prompt_ms);
+        inference_ms           = std::max(inference_ms, result_queue_ms + result_prompt_ms + result_generation_ms);
+
+        if (model.empty()) {
+            model = result.oaicompat_model;
+        }
+    }
+
+    void apply(server_http_res & response, task_response_type res_type) const {
+        if (count == 0) {
+            return;
+        }
+
+        const char * operation = nullptr;
+        switch (res_type) {
+            case TASK_RESPONSE_TYPE_OAI_CHAT:
+            case TASK_RESPONSE_TYPE_ANTHROPIC:
+                operation = "chat";
+                break;
+            case TASK_RESPONSE_TYPE_NONE:
+            case TASK_RESPONSE_TYPE_OAI_CMPL:
+                operation = "text_completion";
+                break;
+            case TASK_RESPONSE_TYPE_OAI_RESP:
+                operation = "generate_content";
+                break;
+            default:
+                break;
+        }
+
+        if (operation != nullptr) {
+            response.set_trace_attribute("gen_ai.operation.name", std::string(operation));
+        }
+        response.set_trace_attribute("gen_ai.provider.name", std::string("llama.cpp"));
+        if (!model.empty()) {
+            response.set_trace_attribute("gen_ai.request.model", model);
+            response.set_trace_attribute("gen_ai.response.model", model);
+        }
+        response.set_trace_attribute("gen_ai.usage.input_tokens", static_cast<int64_t>(input_tokens));
+        response.set_trace_attribute("gen_ai.usage.output_tokens", static_cast<int64_t>(output_tokens));
+        response.set_trace_attribute(
+            "gen_ai.usage.cache_read.input_tokens", static_cast<int64_t>(input_tokens_cached));
+
+        response.set_trace_attribute("llama.completion.count", static_cast<int64_t>(count));
+        response.set_trace_attribute(
+            "llama.completion.input_tokens.processed", static_cast<int64_t>(input_tokens_processed));
+        response.set_trace_attribute("llama.completion.queue.duration_ms", queue_ms);
+        response.set_trace_attribute("llama.completion.prompt.duration_ms", prompt_ms);
+        response.set_trace_attribute("llama.completion.generation.duration_ms", generation_ms);
+        response.set_trace_attribute("llama.completion.time_to_first_token_ms", time_to_first_token_ms);
+        response.set_trace_attribute("llama.completion.inference.duration_ms", inference_ms);
+
+        if (input_tokens > 0) {
+            response.set_trace_attribute(
+                "llama.completion.cache.hit_ratio", static_cast<double>(input_tokens_cached) / input_tokens);
+        }
+        if (prompt_ms > 0.0) {
+            response.set_trace_attribute(
+                "llama.completion.prompt.tokens_per_second", input_tokens_processed * 1000.0 / prompt_ms);
+        }
+        if (generation_ms > 0.0) {
+            response.set_trace_attribute(
+                "llama.completion.generation.tokens_per_second", generation_steps * 1000.0 / generation_ms);
+        }
+        if (draft_tokens > 0) {
+            response.set_trace_attribute(
+                "llama.completion.speculative.draft_tokens", static_cast<int64_t>(draft_tokens));
+            response.set_trace_attribute(
+                "llama.completion.speculative.accepted_tokens", static_cast<int64_t>(draft_tokens_accepted));
+            response.set_trace_attribute(
+                "llama.completion.speculative.acceptance_ratio",
+                static_cast<double>(draft_tokens_accepted) / draft_tokens);
+        }
+    }
+};
+
 // generator-like API for HTTP response generation
 // may have bypass_sleep = true if the task does not use ctx_server
 struct server_res_generator : server_res_spipe {
@@ -4244,6 +4352,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
     }
 
     bool stream = json_value(data, "stream", false);
+    auto trace_data = std::make_shared<server_completion_trace_data>();
 
     if (!stream) {
         // non-stream, wait for the results
@@ -4255,9 +4364,11 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             return res;
         } else {
             json arr = json::array();
-            for (auto & res : all_results.results) {
-                GGML_ASSERT(dynamic_cast<server_task_result_cmpl_final*>(res.get()) != nullptr);
-                arr.push_back(res->to_json());
+            for (auto & result : all_results.results) {
+                auto * final_result = dynamic_cast<server_task_result_cmpl_final *>(result.get());
+                GGML_ASSERT(final_result != nullptr);
+                trace_data->add(*final_result);
+                arr.push_back(result->to_json());
             }
             GGML_ASSERT(!arr.empty() && "empty results");
             if (arr.size() == 1) {
@@ -4274,6 +4385,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                 // multi-results, non-OAI compat
                 res->ok(arr);
             }
+            trace_data->apply(*res, res_type);
         }
     } else {
         // in streaming mode, the first error must be treated as non-stream response
@@ -4294,6 +4406,9 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             dynamic_cast<server_task_result_cmpl_partial*>(first_result.get()) != nullptr ||
             dynamic_cast<server_task_result_cmpl_final*>  (first_result.get()) != nullptr
         );
+        if (auto * final_result = dynamic_cast<server_task_result_cmpl_final *>(first_result.get())) {
+            trace_data->add(*final_result);
+        }
 
         // next responses are streamed
         // to be sent immediately
@@ -4309,7 +4424,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
         }
         res->status = 200;
         res->content_type = "text/event-stream";
-        res->set_next([res_this = res.get(), res_type, sse_ping_interval](std::string & output) -> bool {
+        res->set_next([res_this = res.get(), res_type, sse_ping_interval, trace_data](std::string & output) -> bool {
             static auto format_error = [](task_response_type res_type, const json & res_json) {
                 if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
                     return format_anthropic_sse({
@@ -4342,6 +4457,7 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
 
                 // check if there is more data
                 if (!rd.has_next()) {
+                    trace_data->apply(*res_this, res_type);
                     switch (res_type) {
                         case TASK_RESPONSE_TYPE_NONE:
                         case TASK_RESPONSE_TYPE_OAI_RESP:
@@ -4394,6 +4510,9 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
                         dynamic_cast<server_task_result_cmpl_partial*>(result.get()) != nullptr
                         || dynamic_cast<server_task_result_cmpl_final*>(result.get()) != nullptr
                     );
+                    if (auto * final_result = dynamic_cast<server_task_result_cmpl_final *>(result.get())) {
+                        trace_data->add(*final_result);
+                    }
                     json res_json = result->to_json();
                     if (res_type == TASK_RESPONSE_TYPE_ANTHROPIC) {
                         output = format_anthropic_sse(res_json);

--- a/tools/server/server-cors-proxy.h
+++ b/tools/server/server-cors-proxy.h
@@ -68,7 +68,8 @@ static server_http_res_ptr proxy_request(const server_http_req & req, std::strin
             req.files,
             req.should_stop,
             600, // timeout_read (default to 10 minutes)
-            600  // timeout_write (default to 10 minutes)
+            600, // timeout_write (default to 10 minutes)
+            req.trace_span
             );
 
     return proxy;

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -571,7 +571,7 @@ static void process_handler_response(server_http_req_ptr && request, server_http
                 sink.done();
                 SRV_DBG("%s", "http: stream ended\n");
             }
-            return has_next;
+            return true;
         };
         const auto on_complete = [request = q_ptr, response = r_ptr](bool success) mutable {
             response->on_complete();

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -544,6 +544,21 @@ static std::string build_query_string(const httplib::Request & req) {
 // using unique_ptr for request to allow safe capturing in lambdas
 using server_http_req_ptr = std::unique_ptr<server_http_req>;
 
+static void apply_trace_attributes(const server_telemetry_span_ptr & span, const server_http_res & response) {
+    if (!span) {
+        return;
+    }
+    for (const auto & attribute : response.trace_string_attributes) {
+        span->set_attribute(attribute.first, attribute.second);
+    }
+    for (const auto & attribute : response.trace_int_attributes) {
+        span->set_attribute(attribute.first, attribute.second);
+    }
+    for (const auto & attribute : response.trace_double_attributes) {
+        span->set_attribute(attribute.first, attribute.second);
+    }
+}
+
 static void process_handler_response(server_http_req_ptr && request, server_http_res_ptr & response, httplib::Response & res) {
     if (request->trace_span) {
         request->trace_span->set_http_status(response->status);
@@ -576,6 +591,7 @@ static void process_handler_response(server_http_req_ptr && request, server_http
         const auto on_complete = [request = q_ptr, response = r_ptr](bool success) mutable {
             response->on_complete();
             if (request->trace_span) {
+                apply_trace_attributes(request->trace_span, *response);
                 if (!success) {
                     request->trace_span->set_error("client_disconnect");
                 }
@@ -591,6 +607,7 @@ static void process_handler_response(server_http_req_ptr && request, server_http
         res.set_content(response->data, response->content_type);
         response->on_complete();
         if (request->trace_span) {
+            apply_trace_attributes(request->trace_span, *response);
             request->trace_span->end();
         }
     }

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -545,6 +545,9 @@ static std::string build_query_string(const httplib::Request & req) {
 using server_http_req_ptr = std::unique_ptr<server_http_req>;
 
 static void process_handler_response(server_http_req_ptr && request, server_http_res_ptr & response, httplib::Response & res) {
+    if (request->trace_span) {
+        request->trace_span->set_http_status(response->status);
+    }
     if (response->is_stream()) {
         res.status = response->status;
         // Tell Nginx to not buffer any streamed response
@@ -570,8 +573,14 @@ static void process_handler_response(server_http_req_ptr && request, server_http
             }
             return has_next;
         };
-        const auto on_complete = [request = q_ptr, response = r_ptr](bool) mutable {
+        const auto on_complete = [request = q_ptr, response = r_ptr](bool success) mutable {
             response->on_complete();
+            if (request->trace_span) {
+                if (!success) {
+                    request->trace_span->set_error("client_disconnect");
+                }
+                request->trace_span->end();
+            }
             response.reset();
             request.reset();
         };
@@ -581,20 +590,26 @@ static void process_handler_response(server_http_req_ptr && request, server_http
         set_headers(res, response->headers);
         res.set_content(response->data, response->content_type);
         response->on_complete();
+        if (request->trace_span) {
+            request->trace_span->end();
+        }
     }
 }
 
 void server_http_context::get(const std::string & path, const server_http_context::handler_t & handler) const {
     handlers.emplace(path, handler);
-    pimpl->srv->Get(path_prefix + path, [handler](const httplib::Request & req, httplib::Response & res) {
+    pimpl->srv->Get(path_prefix + path, [this, handler, path](const httplib::Request & req, httplib::Response & res) {
+        auto headers = get_headers(req);
         server_http_req_ptr request = std::make_unique<server_http_req>(server_http_req{
             get_params(req),
-            get_headers(req),
+            headers,
             req.path,
             build_query_string(req),
             req.body,
             {},
-            req.is_connection_closed
+            req.is_connection_closed,
+            server_telemetry_start_server_span(
+                "GET", path_prefix + path, req.path, is_ssl ? "https" : "http", hostname, port, req.remote_addr, headers),
         });
         server_http_res_ptr response = handler(*request);
         process_handler_response(std::move(request), response, res);
@@ -603,9 +618,10 @@ void server_http_context::get(const std::string & path, const server_http_contex
 
 void server_http_context::post(const std::string & path, const server_http_context::handler_t & handler) const {
     handlers.emplace(path, handler);
-    pimpl->srv->Post(path_prefix + path, [handler](const httplib::Request & req, httplib::Response & res) {
+    pimpl->srv->Post(path_prefix + path, [this, handler, path](const httplib::Request & req, httplib::Response & res) {
         std::string body = req.body;
         std::map<std::string, uploaded_file> files;
+        auto headers = get_headers(req);
 
         if (req.is_multipart_form_data()) {
             // translate text fields to a JSON object and use it as the body
@@ -636,12 +652,14 @@ void server_http_context::post(const std::string & path, const server_http_conte
 
         server_http_req_ptr request = std::make_unique<server_http_req>(server_http_req{
             get_params(req),
-            get_headers(req),
+            headers,
             req.path,
             build_query_string(req),
             body,
             std::move(files),
-            req.is_connection_closed
+            req.is_connection_closed,
+            server_telemetry_start_server_span(
+                "POST", path_prefix + path, req.path, is_ssl ? "https" : "http", hostname, port, req.remote_addr, headers),
         });
         server_http_res_ptr response = handler(*request);
         process_handler_response(std::move(request), response, res);
@@ -650,15 +668,18 @@ void server_http_context::post(const std::string & path, const server_http_conte
 
 void server_http_context::del(const std::string & path, const server_http_context::handler_t & handler) const {
     handlers.emplace(path, handler);
-    pimpl->srv->Delete(path_prefix + path, [handler](const httplib::Request & req, httplib::Response & res) {
+    pimpl->srv->Delete(path_prefix + path, [this, handler, path](const httplib::Request & req, httplib::Response & res) {
+        auto headers = get_headers(req);
         server_http_req_ptr request = std::make_unique<server_http_req>(server_http_req{
             get_params(req),
-            get_headers(req),
+            headers,
             req.path,
             build_query_string(req),
             req.body,
             {},
-            req.is_connection_closed
+            req.is_connection_closed,
+            server_telemetry_start_server_span(
+                "DELETE", path_prefix + path, req.path, is_ssl ? "https" : "http", hostname, port, req.remote_addr, headers),
         });
         server_http_res_ptr response = handler(*request);
         process_handler_response(std::move(request), response, res);
@@ -814,6 +835,7 @@ void server_http_context::register_gcp_compat() const {
                         payload.dump(),
                         {},
                         req.should_stop,
+                        req.trace_span,
                     };
 
                     server_http_res_ptr internal_res = handlers.at(dispatch_path)(internal_req);

--- a/tools/server/server-http.h
+++ b/tools/server/server-http.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "server-telemetry.h"
+
 #include <atomic>
 #include <functional>
 #include <map>
@@ -54,6 +56,7 @@ struct server_http_req {
     std::string body;
     std::map<std::string, uploaded_file> files; // used for file uploads (form data)
     const std::function<bool()> & should_stop;
+    server_telemetry_span_ptr trace_span;
 
     std::string get_param(const std::string & key, const std::string & def = "") const {
         auto it = params.find(key);

--- a/tools/server/server-http.h
+++ b/tools/server/server-http.h
@@ -27,6 +27,26 @@ struct server_http_res {
     std::map<std::string, std::string> headers;
 
     std::function<bool(std::string &)> next = nullptr;
+
+    // Attributes collected by request handlers and applied to the HTTP server span
+    // when the response completes. Keeping these values transport-neutral avoids an
+    // OpenTelemetry dependency in server-context.
+    std::map<std::string, std::string> trace_string_attributes;
+    std::map<std::string, int64_t>     trace_int_attributes;
+    std::map<std::string, double>      trace_double_attributes;
+
+    void set_trace_attribute(const std::string & name, const std::string & value) {
+        trace_string_attributes[name] = value;
+    }
+
+    void set_trace_attribute(const std::string & name, int64_t value) {
+        trace_int_attributes[name] = value;
+    }
+
+    void set_trace_attribute(const std::string & name, double value) {
+        trace_double_attributes[name] = value;
+    }
+
     bool is_stream() const {
         return next != nullptr;
     }

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -2481,11 +2481,14 @@ server_http_proxy::server_http_proxy(
 
     // start the proxy thread
     SRV_DBG("start proxy thread %s %s\n", req.method.c_str(), req.path.c_str());
-    this->thread = std::thread([cli, pipe, req, headers_sent, make_header_msg]() {
+    this->thread = std::thread([cli, pipe, req, headers_sent, make_header_msg, trace_span = this->trace_span]() {
         auto result = cli->send(std::move(req));
         if (result.error() != httplib::Error::Success) {
             auto err_str = httplib::to_string(result.error());
             SRV_ERR("http client error: %s\n", err_str.c_str());
+            if (trace_span) {
+                trace_span->set_error("http_client_error");
+            }
             pipe->write({{}, 500, "", ""}); // header
             pipe->write({{}, 0, "proxy error: " + err_str, ""}); // body
         } else if (!headers_sent->load()) {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1481,7 +1481,8 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
                 ? std::function<bool()>([]() { return false; })
                 : req.should_stop,
             base_params.timeout_read,
-            base_params.timeout_write
+            base_params.timeout_write,
+            req.trace_span
             );
 
     proxy->cleanup = [this, name]() {
@@ -2130,7 +2131,8 @@ void server_models_routes::init_routes() {
                 req.files,
                 req.should_stop,
                 params.timeout_read,
-                params.timeout_write);
+                params.timeout_write,
+                req.trace_span);
         return std::unique_ptr<server_http_res>(std::move(proxy));
     };
 
@@ -2340,8 +2342,11 @@ server_http_proxy::server_http_proxy(
         const std::map<std::string, uploaded_file> & files,
         const std::function<bool()> should_stop,
         int32_t timeout_read,
-        int32_t timeout_write
+        int32_t timeout_write,
+        const server_telemetry_span_ptr & parent_span
         ) {
+    this->trace_span = server_telemetry_start_client_span(method, scheme, host, port, path, parent_span);
+
     // shared between reader and writer threads
     auto cli  = std::make_shared<httplib::ClientImpl>(host, port);
     auto pipe = std::make_shared<server_pipe<msg_t>>();
@@ -2428,9 +2433,11 @@ server_http_proxy::server_http_proxy(
     // prepare the request to destination server
     httplib::Request req;
     {
+        auto forwarded_headers = headers;
+        server_telemetry_inject(forwarded_headers, this->trace_span);
         req.method = method;
         req.path = path;
-        for (const auto & [key, value] : headers) {
+        for (const auto & [key, value] : forwarded_headers) {
             const auto lowered = to_lower_copy(key);
             if (lowered == "accept-encoding") {
                 // disable Accept-Encoding to avoid compressed responses
@@ -2500,8 +2507,14 @@ server_http_proxy::server_http_proxy(
             if (!header.content_type.empty()) {
                 this->content_type = std::move(header.content_type);
             }
+            if (this->trace_span) {
+                this->trace_span->set_http_status(this->status);
+            }
         } else {
             SRV_DBG("%s", "no response headers received (request cancelled?)\n");
+            if (this->trace_span) {
+                this->trace_span->set_error("request_cancelled");
+            }
         }
     }
 }

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -368,7 +368,8 @@ struct server_http_proxy : server_http_res {
                       const std::map<std::string, uploaded_file> & files,
                       const std::function<bool()> should_stop,
                       int32_t timeout_read,
-                      int32_t timeout_write
+                      int32_t timeout_write,
+                      const server_telemetry_span_ptr & parent_span
                       );
     ~server_http_proxy() {
         if (cleanup_pipes) {
@@ -377,9 +378,13 @@ struct server_http_proxy : server_http_res {
         if (cleanup) {
             cleanup();
         }
+        if (trace_span) {
+            trace_span->end();
+        }
     }
 private:
     std::function<void()> cleanup_pipes = nullptr;
+    server_telemetry_span_ptr trace_span;
     std::thread thread;
     struct msg_t {
         std::map<std::string, std::string> headers;

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -23,6 +23,9 @@
 int server_queue::post(server_task && task, bool front) {
     std::unique_lock<std::mutex> lock(mutex_tasks);
     GGML_ASSERT(task.id != -1);
+    if (task.t_queued_us == 0) {
+        task.t_queued_us = ggml_time_us();
+    }
     // if this is cancel task make sure to clean up pending tasks
     if (task.type == SERVER_TASK_TYPE_CANCEL) {
         cleanup_pending_task(task.id_target);
@@ -41,7 +44,16 @@ int server_queue::post(server_task && task, bool front) {
 
 int server_queue::post(std::vector<server_task> && tasks, bool front) {
     std::unique_lock<std::mutex> lock(mutex_tasks);
+    const int64_t t_queued_us = ggml_time_us();
     for (auto & task : tasks) {
+        if (task.t_queued_us == 0) {
+            task.t_queued_us = t_queued_us;
+        }
+        for (auto & child : task.child_tasks) {
+            if (child.t_queued_us == 0) {
+                child.t_queued_us = t_queued_us;
+            }
+        }
         if (task.id == -1) {
             task.id = id++;
         }

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -136,6 +136,10 @@ struct task_result_state {
 struct server_task {
     int id = -1; // to be filled by server_queue
 
+    // Monotonic timestamp set when the task enters server_queue. Used to
+    // distinguish queue latency from prompt evaluation and token generation.
+    int64_t t_queued_us = 0;
+
     // TODO @ngxson : remove this field and implement a mapping task_id -> idx in the response_reader
     size_t index = 0; // used when there are multiple prompts (batch request)
 

--- a/tools/server/server-telemetry.cpp
+++ b/tools/server/server-telemetry.cpp
@@ -272,8 +272,7 @@ bool server_telemetry_init(bool enabled, const std::string & service_version, st
         auto processor = otel_sdk::BatchSpanProcessorFactory::Create(std::move(exporter), processor_options);
 
         otel_res::ResourceAttributes attributes = {
-            { "service.name",    std::string("llama-server") },
-            { "service.version", service_version             },
+            { "service.version", service_version },
         };
         auto                                      resource = otel_res::Resource::Create(attributes);
         auto                                      sampler  = make_sampler();

--- a/tools/server/server-telemetry.cpp
+++ b/tools/server/server-telemetry.cpp
@@ -1,0 +1,414 @@
+#include "server-telemetry.h"
+
+#include "log.h"
+
+#include <atomic>
+#include <cctype>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
+#include <mutex>
+#include <utility>
+
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+#    include <opentelemetry/context/context.h>
+#    include <opentelemetry/context/propagation/global_propagator.h>
+#    include <opentelemetry/context/propagation/text_map_propagator.h>
+#    include <opentelemetry/exporters/otlp/otlp_http_exporter_factory.h>
+#    include <opentelemetry/exporters/otlp/otlp_http_exporter_options.h>
+#    include <opentelemetry/sdk/resource/resource.h>
+#    include <opentelemetry/sdk/trace/batch_span_processor_factory.h>
+#    include <opentelemetry/sdk/trace/batch_span_processor_options.h>
+#    include <opentelemetry/sdk/trace/sampler.h>
+#    include <opentelemetry/sdk/trace/samplers/always_off_factory.h>
+#    include <opentelemetry/sdk/trace/samplers/always_on_factory.h>
+#    include <opentelemetry/sdk/trace/samplers/parent_factory.h>
+#    include <opentelemetry/sdk/trace/samplers/trace_id_ratio_factory.h>
+#    include <opentelemetry/sdk/trace/tracer_provider.h>
+#    include <opentelemetry/sdk/trace/tracer_provider_factory.h>
+#    include <opentelemetry/trace/context.h>
+#    include <opentelemetry/trace/propagation/http_trace_context.h>
+#    include <opentelemetry/trace/span.h>
+#    include <opentelemetry/trace/span_startoptions.h>
+#    include <opentelemetry/trace/tracer.h>
+#endif
+
+namespace {
+
+bool string_iequals(const std::string & lhs, const std::string & rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        if (std::tolower(static_cast<unsigned char>(lhs[i])) != std::tolower(static_cast<unsigned char>(rhs[i]))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool env_is_true(const char * name) {
+    const char * value = std::getenv(name);
+    if (value == nullptr) {
+        return false;
+    }
+    const std::string text(value);
+    return string_iequals(text, "true") || text == "1" || string_iequals(text, "yes");
+}
+
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+
+namespace otel       = opentelemetry;
+namespace otel_ctx   = opentelemetry::context;
+namespace otel_otlp  = opentelemetry::exporter::otlp;
+namespace otel_res   = opentelemetry::sdk::resource;
+namespace otel_sdk   = opentelemetry::sdk::trace;
+namespace otel_trace = opentelemetry::trace;
+
+std::mutex                                g_telemetry_mutex;
+std::shared_ptr<otel_sdk::TracerProvider> g_provider;
+std::string                               g_service_version;
+bool                                      g_enabled = false;
+
+class header_carrier final : public otel_ctx::propagation::TextMapCarrier {
+  public:
+    explicit header_carrier(const std::map<std::string, std::string> & headers) :
+        read_headers(headers),
+        write_headers(nullptr) {}
+
+    explicit header_carrier(std::map<std::string, std::string> & headers) :
+        read_headers(headers),
+        write_headers(&headers) {}
+
+    otel::nostd::string_view Get(otel::nostd::string_view key) const noexcept override {
+        const std::string wanted(key.data(), key.size());
+        for (const auto & entry : read_headers) {
+            if (string_iequals(entry.first, wanted)) {
+                return entry.second;
+            }
+        }
+        return "";
+    }
+
+    void Set(otel::nostd::string_view key, otel::nostd::string_view value) noexcept override {
+        if (write_headers == nullptr) {
+            return;
+        }
+        const std::string name(key.data(), key.size());
+        for (auto it = write_headers->begin(); it != write_headers->end();) {
+            if (string_iequals(it->first, name)) {
+                it = write_headers->erase(it);
+            } else {
+                ++it;
+            }
+        }
+        write_headers->emplace(name, std::string(value.data(), value.size()));
+    }
+
+  private:
+    const std::map<std::string, std::string> & read_headers;
+    std::map<std::string, std::string> *       write_headers;
+};
+
+std::unique_ptr<otel_sdk::Sampler> make_sampler() {
+    const char *      sampler_env = std::getenv("OTEL_TRACES_SAMPLER");
+    const std::string sampler     = sampler_env == nullptr ? "parentbased_always_on" : sampler_env;
+
+    if (sampler == "always_on") {
+        return otel_sdk::AlwaysOnSamplerFactory::Create();
+    }
+    if (sampler == "always_off") {
+        return otel_sdk::AlwaysOffSamplerFactory::Create();
+    }
+
+    double ratio = 1.0;
+    if (sampler == "traceidratio" || sampler == "parentbased_traceidratio") {
+        const char * arg = std::getenv("OTEL_TRACES_SAMPLER_ARG");
+        try {
+            ratio = arg == nullptr ? 1.0 : std::stod(arg);
+        } catch (const std::exception &) {
+            LOG_WRN("invalid OTEL_TRACES_SAMPLER_ARG, using 1.0\n");
+            ratio = 1.0;
+        }
+        if (ratio < 0.0 || ratio > 1.0) {
+            LOG_WRN("OTEL_TRACES_SAMPLER_ARG must be between 0.0 and 1.0, using 1.0\n");
+            ratio = 1.0;
+        }
+    }
+
+    if (sampler == "traceidratio") {
+        return otel_sdk::TraceIdRatioBasedSamplerFactory::Create(ratio);
+    }
+
+    std::unique_ptr<otel_sdk::Sampler> root;
+    if (sampler == "parentbased_always_off") {
+        root = otel_sdk::AlwaysOffSamplerFactory::Create();
+    } else if (sampler == "parentbased_traceidratio") {
+        root = otel_sdk::TraceIdRatioBasedSamplerFactory::Create(ratio);
+    } else {
+        if (sampler != "parentbased_always_on") {
+            LOG_WRN("unsupported OTEL_TRACES_SAMPLER='%s', using parentbased_always_on\n", sampler.c_str());
+        }
+        root = otel_sdk::AlwaysOnSamplerFactory::Create();
+    }
+    return otel_sdk::ParentBasedSamplerFactory::Create(std::shared_ptr<otel_sdk::Sampler>(std::move(root)));
+}
+
+otel::nostd::shared_ptr<otel_trace::Tracer> get_tracer() {
+    std::shared_ptr<otel_sdk::TracerProvider> provider;
+    std::string                               version;
+    {
+        std::lock_guard<std::mutex> lock(g_telemetry_mutex);
+        if (!g_enabled || !g_provider) {
+            return {};
+        }
+        provider = g_provider;
+        version  = g_service_version;
+    }
+    return provider->GetTracer("llama.cpp.server", version);
+}
+
+#endif
+
+}  // namespace
+
+struct server_telemetry_span::Impl {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    otel::nostd::shared_ptr<otel_trace::Span> span;
+    bool                                      is_server = false;
+#endif
+    std::atomic<bool> ended{ false };
+};
+
+server_telemetry_span::server_telemetry_span(std::unique_ptr<Impl> impl) : pimpl(std::move(impl)) {}
+
+server_telemetry_span::~server_telemetry_span() {
+    end();
+}
+
+void server_telemetry_span::set_http_status(int status_code) {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    if (!pimpl || pimpl->ended.load() || !pimpl->span) {
+        return;
+    }
+    pimpl->span->SetAttribute("http.response.status_code", static_cast<int64_t>(status_code));
+    if ((pimpl->is_server && status_code >= 500) || (!pimpl->is_server && status_code >= 400)) {
+        pimpl->span->SetStatus(otel_trace::StatusCode::kError);
+        pimpl->span->SetAttribute("error.type", std::to_string(status_code));
+    }
+#else
+    (void) status_code;
+#endif
+}
+
+void server_telemetry_span::set_error(const std::string & error_type) {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    if (!pimpl || pimpl->ended.load() || !pimpl->span) {
+        return;
+    }
+    pimpl->span->SetStatus(otel_trace::StatusCode::kError);
+    pimpl->span->SetAttribute("error.type", error_type);
+#else
+    (void) error_type;
+#endif
+}
+
+void server_telemetry_span::end() {
+    if (!pimpl || pimpl->ended.exchange(true)) {
+        return;
+    }
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    if (pimpl->span) {
+        pimpl->span->End();
+    }
+#endif
+}
+
+bool server_telemetry_init(bool enabled, const std::string & service_version, std::string & error) {
+    if (!enabled) {
+        return true;
+    }
+
+#ifndef LLAMA_SERVER_OPEN_TELEMETRY
+    (void) service_version;
+    error = "OpenTelemetry support is not compiled in; rebuild with -DLLAMA_SERVER_OPEN_TELEMETRY=ON";
+    return false;
+#else
+    if (env_is_true("OTEL_SDK_DISABLED")) {
+        LOG_INF("OpenTelemetry SDK disabled by OTEL_SDK_DISABLED\n");
+        return true;
+    }
+
+    try {
+        auto exporter = otel_otlp::OtlpHttpExporterFactory::Create(otel_otlp::OtlpHttpExporterOptions{});
+        otel_sdk::BatchSpanProcessorOptions processor_options{};
+        auto processor = otel_sdk::BatchSpanProcessorFactory::Create(std::move(exporter), processor_options);
+
+        otel_res::ResourceAttributes attributes = {
+            { "service.version", service_version },
+        };
+        if (std::getenv("OTEL_SERVICE_NAME") == nullptr) {
+            attributes["service.name"] = std::string("llama-server");
+        }
+        auto                                      resource = otel_res::Resource::Create(attributes);
+        auto                                      sampler  = make_sampler();
+        std::shared_ptr<otel_sdk::TracerProvider> provider(
+            otel_sdk::TracerProviderFactory::Create(std::move(processor), resource, std::move(sampler)));
+
+        {
+            std::lock_guard<std::mutex> lock(g_telemetry_mutex);
+            g_provider        = provider;
+            g_service_version = service_version;
+            g_enabled         = true;
+        }
+
+        otel_ctx::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+            otel::nostd::shared_ptr<otel_ctx::propagation::TextMapPropagator>(
+                new otel_trace::propagation::HttpTraceContext()));
+
+        LOG_INF("OpenTelemetry OTLP/HTTP tracing enabled\n");
+        return true;
+    } catch (const std::exception & e) {
+        error = e.what();
+        return false;
+    }
+#endif
+}
+
+void server_telemetry_shutdown() {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    std::shared_ptr<otel_sdk::TracerProvider> provider;
+    {
+        std::lock_guard<std::mutex> lock(g_telemetry_mutex);
+        if (!g_enabled) {
+            return;
+        }
+        g_enabled = false;
+        provider  = std::move(g_provider);
+    }
+
+    constexpr auto timeout = std::chrono::seconds(5);
+    if (provider) {
+        if (!provider->ForceFlush(timeout)) {
+            LOG_WRN("OpenTelemetry trace flush timed out\n");
+        }
+        if (!provider->Shutdown(timeout)) {
+            LOG_WRN("OpenTelemetry trace shutdown timed out\n");
+        }
+    }
+#endif
+}
+
+server_telemetry_span_ptr server_telemetry_start_server_span(const std::string &                        method,
+                                                             const std::string &                        route,
+                                                             const std::string &                        path,
+                                                             const std::string &                        scheme,
+                                                             const std::string &                        server_address,
+                                                             int                                        server_port,
+                                                             const std::string &                        client_address,
+                                                             const std::map<std::string, std::string> & headers) {
+#ifndef LLAMA_SERVER_OPEN_TELEMETRY
+    (void) method;
+    (void) route;
+    (void) path;
+    (void) scheme;
+    (void) server_address;
+    (void) server_port;
+    (void) client_address;
+    (void) headers;
+    return nullptr;
+#else
+    auto tracer = get_tracer();
+    if (!tracer) {
+        return nullptr;
+    }
+
+    header_carrier    carrier(headers);
+    otel_ctx::Context empty_context;
+    auto              propagator     = otel_ctx::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    auto              parent_context = propagator->Extract(carrier, empty_context);
+
+    otel_trace::StartSpanOptions options;
+    options.kind   = otel_trace::SpanKind::kServer;
+    options.parent = parent_context;
+
+    auto span       = tracer->StartSpan(method + " " + route,
+                                        {
+                                      { "http.request.method", method                            },
+                                      { "http.route",          route                             },
+                                      { "url.path",            path                              },
+                                      { "url.scheme",          scheme                            },
+                                      { "server.address",      server_address                    },
+                                      { "server.port",         static_cast<int64_t>(server_port) },
+                                      { "client.address",      client_address                    },
+    },
+                                        options);
+    auto impl       = std::make_unique<server_telemetry_span::Impl>();
+    impl->span      = std::move(span);
+    impl->is_server = true;
+    return server_telemetry_span_ptr(new server_telemetry_span(std::move(impl)));
+#endif
+}
+
+server_telemetry_span_ptr server_telemetry_start_client_span(const std::string &               method,
+                                                             const std::string &               scheme,
+                                                             const std::string &               server_address,
+                                                             int                               server_port,
+                                                             const std::string &               path,
+                                                             const server_telemetry_span_ptr & parent) {
+#ifndef LLAMA_SERVER_OPEN_TELEMETRY
+    (void) method;
+    (void) scheme;
+    (void) server_address;
+    (void) server_port;
+    (void) path;
+    (void) parent;
+    return nullptr;
+#else
+    auto tracer = get_tracer();
+    if (!tracer) {
+        return nullptr;
+    }
+
+    otel_trace::StartSpanOptions options;
+    options.kind = otel_trace::SpanKind::kClient;
+    if (parent && parent->pimpl && parent->pimpl->span) {
+        options.parent = parent->pimpl->span->GetContext();
+    }
+
+    const size_t query_pos = path.find('?');
+    const std::string url_path = path.substr(0, query_pos);
+    auto span = tracer->StartSpan(
+            method,
+            {
+                {"http.request.method", method},
+                {"url.path", url_path},
+                {"url.scheme", scheme},
+                {"server.address", server_address},
+                {"server.port", static_cast<int64_t>(server_port)},
+            },
+            options);
+    auto              impl = std::make_unique<server_telemetry_span::Impl>();
+    impl->span             = std::move(span);
+    impl->is_server        = false;
+    return server_telemetry_span_ptr(new server_telemetry_span(std::move(impl)));
+#endif
+}
+
+void server_telemetry_inject(std::map<std::string, std::string> & headers, const server_telemetry_span_ptr & span) {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    if (!span || !span->pimpl || !span->pimpl->span || span->pimpl->ended.load()) {
+        return;
+    }
+
+    otel_ctx::Context context;
+    auto              span_context = otel_trace::SetSpan(context, span->pimpl->span);
+    header_carrier    carrier(headers);
+    auto              propagator = otel_ctx::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    propagator->Inject(carrier, span_context);
+#else
+    (void) headers;
+    (void) span;
+#endif
+}

--- a/tools/server/server-telemetry.cpp
+++ b/tools/server/server-telemetry.cpp
@@ -206,6 +206,42 @@ server_telemetry_span::~server_telemetry_span() {
     end();
 }
 
+void server_telemetry_span::set_attribute(const std::string & name, const std::string & value) {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    if (!pimpl || pimpl->ended.load() || !pimpl->span) {
+        return;
+    }
+    pimpl->span->SetAttribute(name, value);
+#else
+    (void) name;
+    (void) value;
+#endif
+}
+
+void server_telemetry_span::set_attribute(const std::string & name, int64_t value) {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    if (!pimpl || pimpl->ended.load() || !pimpl->span) {
+        return;
+    }
+    pimpl->span->SetAttribute(name, value);
+#else
+    (void) name;
+    (void) value;
+#endif
+}
+
+void server_telemetry_span::set_attribute(const std::string & name, double value) {
+#ifdef LLAMA_SERVER_OPEN_TELEMETRY
+    if (!pimpl || pimpl->ended.load() || !pimpl->span) {
+        return;
+    }
+    pimpl->span->SetAttribute(name, value);
+#else
+    (void) name;
+    (void) value;
+#endif
+}
+
 void server_telemetry_span::set_http_status(int status_code) {
 #ifdef LLAMA_SERVER_OPEN_TELEMETRY
     if (!pimpl || pimpl->ended.load() || !pimpl->span) {

--- a/tools/server/server-telemetry.cpp
+++ b/tools/server/server-telemetry.cpp
@@ -5,18 +5,20 @@
 #include <atomic>
 #include <cctype>
 #include <chrono>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
 #include <mutex>
+#include <stdexcept>
 #include <utility>
 
 #ifdef LLAMA_SERVER_OPEN_TELEMETRY
 #    include <opentelemetry/context/context.h>
-#    include <opentelemetry/context/propagation/global_propagator.h>
 #    include <opentelemetry/context/propagation/text_map_propagator.h>
 #    include <opentelemetry/exporters/otlp/otlp_http_exporter_factory.h>
 #    include <opentelemetry/exporters/otlp/otlp_http_exporter_options.h>
+#    include <opentelemetry/sdk/common/disabled.h>
 #    include <opentelemetry/sdk/resource/resource.h>
 #    include <opentelemetry/sdk/trace/batch_span_processor_factory.h>
 #    include <opentelemetry/sdk/trace/batch_span_processor_options.h>
@@ -48,28 +50,28 @@ bool string_iequals(const std::string & lhs, const std::string & rhs) {
     return true;
 }
 
-bool env_is_true(const char * name) {
-    const char * value = std::getenv(name);
-    if (value == nullptr) {
-        return false;
+std::string string_to_lower(std::string text) {
+    for (char & c : text) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
     }
-    const std::string text(value);
-    return string_iequals(text, "true") || text == "1" || string_iequals(text, "yes");
+    return text;
 }
 
 #ifdef LLAMA_SERVER_OPEN_TELEMETRY
 
-namespace otel       = opentelemetry;
-namespace otel_ctx   = opentelemetry::context;
-namespace otel_otlp  = opentelemetry::exporter::otlp;
-namespace otel_res   = opentelemetry::sdk::resource;
-namespace otel_sdk   = opentelemetry::sdk::trace;
-namespace otel_trace = opentelemetry::trace;
+namespace otel        = opentelemetry;
+namespace otel_ctx    = opentelemetry::context;
+namespace otel_otlp   = opentelemetry::exporter::otlp;
+namespace otel_common = opentelemetry::sdk::common;
+namespace otel_res    = opentelemetry::sdk::resource;
+namespace otel_sdk    = opentelemetry::sdk::trace;
+namespace otel_trace  = opentelemetry::trace;
 
-std::mutex                                g_telemetry_mutex;
-std::shared_ptr<otel_sdk::TracerProvider> g_provider;
-std::string                               g_service_version;
-bool                                      g_enabled = false;
+std::mutex                                                        g_telemetry_mutex;
+std::shared_ptr<otel_sdk::TracerProvider>                         g_provider;
+otel::nostd::shared_ptr<otel_ctx::propagation::TextMapPropagator> g_propagator;
+std::string                                                       g_service_version;
+bool                                                              g_enabled = false;
 
 class header_carrier final : public otel_ctx::propagation::TextMapCarrier {
   public:
@@ -113,7 +115,8 @@ class header_carrier final : public otel_ctx::propagation::TextMapCarrier {
 
 std::unique_ptr<otel_sdk::Sampler> make_sampler() {
     const char *      sampler_env = std::getenv("OTEL_TRACES_SAMPLER");
-    const std::string sampler     = sampler_env == nullptr ? "parentbased_always_on" : sampler_env;
+    const std::string sampler =
+        sampler_env == nullptr || sampler_env[0] == '\0' ? "parentbased_always_on" : string_to_lower(sampler_env);
 
     if (sampler == "always_on") {
         return otel_sdk::AlwaysOnSamplerFactory::Create();
@@ -125,15 +128,17 @@ std::unique_ptr<otel_sdk::Sampler> make_sampler() {
     double ratio = 1.0;
     if (sampler == "traceidratio" || sampler == "parentbased_traceidratio") {
         const char * arg = std::getenv("OTEL_TRACES_SAMPLER_ARG");
-        try {
-            ratio = arg == nullptr ? 1.0 : std::stod(arg);
-        } catch (const std::exception &) {
-            LOG_WRN("invalid OTEL_TRACES_SAMPLER_ARG, using 1.0\n");
-            ratio = 1.0;
-        }
-        if (ratio < 0.0 || ratio > 1.0) {
-            LOG_WRN("OTEL_TRACES_SAMPLER_ARG must be between 0.0 and 1.0, using 1.0\n");
-            ratio = 1.0;
+        if (arg != nullptr && arg[0] != '\0') {
+            try {
+                size_t parsed = 0;
+                ratio         = std::stod(arg, &parsed);
+                if (parsed != std::string(arg).size() || !std::isfinite(ratio) || ratio < 0.0 || ratio > 1.0) {
+                    throw std::invalid_argument("ratio must be a finite number between 0.0 and 1.0");
+                }
+            } catch (const std::exception &) {
+                LOG_WRN("invalid OTEL_TRACES_SAMPLER_ARG='%s', using 1.0\n", arg);
+                ratio = 1.0;
+            }
         }
     }
 
@@ -155,18 +160,30 @@ std::unique_ptr<otel_sdk::Sampler> make_sampler() {
     return otel_sdk::ParentBasedSamplerFactory::Create(std::shared_ptr<otel_sdk::Sampler>(std::move(root)));
 }
 
-otel::nostd::shared_ptr<otel_trace::Tracer> get_tracer() {
+struct telemetry_state {
+    bool                                                              enabled = false;
+    otel::nostd::shared_ptr<otel_trace::Tracer>                       tracer;
+    otel::nostd::shared_ptr<otel_ctx::propagation::TextMapPropagator> propagator;
+};
+
+telemetry_state get_telemetry_state() {
+    telemetry_state                           state;
     std::shared_ptr<otel_sdk::TracerProvider> provider;
     std::string                               version;
     {
         std::lock_guard<std::mutex> lock(g_telemetry_mutex);
-        if (!g_enabled || !g_provider) {
-            return {};
+        if (!g_enabled) {
+            return state;
         }
-        provider = g_provider;
-        version  = g_service_version;
+        state.enabled    = true;
+        state.propagator = g_propagator;
+        provider         = g_provider;
+        version          = g_service_version;
     }
-    return provider->GetTracer("llama.cpp.server", version);
+    if (provider) {
+        state.tracer = provider->GetTracer("llama.cpp.server", version);
+    }
+    return state;
 }
 
 #endif
@@ -175,8 +192,10 @@ otel::nostd::shared_ptr<otel_trace::Tracer> get_tracer() {
 
 struct server_telemetry_span::Impl {
 #ifdef LLAMA_SERVER_OPEN_TELEMETRY
-    otel::nostd::shared_ptr<otel_trace::Span> span;
-    bool                                      is_server = false;
+    otel::nostd::shared_ptr<otel_trace::Span>                         span;
+    otel::nostd::shared_ptr<otel_ctx::propagation::TextMapPropagator> propagator;
+    otel_ctx::Context                                                 context;
+    bool                                                              is_server = false;
 #endif
     std::atomic<bool> ended{ false };
 };
@@ -235,22 +254,27 @@ bool server_telemetry_init(bool enabled, const std::string & service_version, st
     error = "OpenTelemetry support is not compiled in; rebuild with -DLLAMA_SERVER_OPEN_TELEMETRY=ON";
     return false;
 #else
-    if (env_is_true("OTEL_SDK_DISABLED")) {
-        LOG_INF("OpenTelemetry SDK disabled by OTEL_SDK_DISABLED\n");
-        return true;
-    }
-
     try {
+        auto propagator = otel::nostd::shared_ptr<otel_ctx::propagation::TextMapPropagator>(
+            new otel_trace::propagation::HttpTraceContext());
+
+        if (otel_common::GetSdkDisabled()) {
+            std::lock_guard<std::mutex> lock(g_telemetry_mutex);
+            g_propagator      = std::move(propagator);
+            g_service_version = service_version;
+            g_enabled         = true;
+            LOG_INF("OpenTelemetry SDK disabled by OTEL_SDK_DISABLED; trace-context propagation remains enabled\n");
+            return true;
+        }
+
         auto exporter = otel_otlp::OtlpHttpExporterFactory::Create(otel_otlp::OtlpHttpExporterOptions{});
         otel_sdk::BatchSpanProcessorOptions processor_options{};
         auto processor = otel_sdk::BatchSpanProcessorFactory::Create(std::move(exporter), processor_options);
 
         otel_res::ResourceAttributes attributes = {
-            { "service.version", service_version },
+            { "service.name",    std::string("llama-server") },
+            { "service.version", service_version             },
         };
-        if (std::getenv("OTEL_SERVICE_NAME") == nullptr) {
-            attributes["service.name"] = std::string("llama-server");
-        }
         auto                                      resource = otel_res::Resource::Create(attributes);
         auto                                      sampler  = make_sampler();
         std::shared_ptr<otel_sdk::TracerProvider> provider(
@@ -259,13 +283,10 @@ bool server_telemetry_init(bool enabled, const std::string & service_version, st
         {
             std::lock_guard<std::mutex> lock(g_telemetry_mutex);
             g_provider        = provider;
+            g_propagator      = std::move(propagator);
             g_service_version = service_version;
             g_enabled         = true;
         }
-
-        otel_ctx::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
-            otel::nostd::shared_ptr<otel_ctx::propagation::TextMapPropagator>(
-                new otel_trace::propagation::HttpTraceContext()));
 
         LOG_INF("OpenTelemetry OTLP/HTTP tracing enabled\n");
         return true;
@@ -284,8 +305,10 @@ void server_telemetry_shutdown() {
         if (!g_enabled) {
             return;
         }
-        g_enabled = false;
-        provider  = std::move(g_provider);
+        g_enabled    = false;
+        provider     = std::move(g_provider);
+        g_propagator = {};
+        g_service_version.clear();
     }
 
     constexpr auto timeout = std::chrono::seconds(5);
@@ -319,34 +342,41 @@ server_telemetry_span_ptr server_telemetry_start_server_span(const std::string &
     (void) headers;
     return nullptr;
 #else
-    auto tracer = get_tracer();
-    if (!tracer) {
+    auto telemetry = get_telemetry_state();
+    if (!telemetry.enabled) {
         return nullptr;
     }
 
     header_carrier    carrier(headers);
     otel_ctx::Context empty_context;
-    auto              propagator     = otel_ctx::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
-    auto              parent_context = propagator->Extract(carrier, empty_context);
+    auto              parent_context = telemetry.propagator->Extract(carrier, empty_context);
+
+    auto impl        = std::make_unique<server_telemetry_span::Impl>();
+    impl->propagator = telemetry.propagator;
+    impl->context    = parent_context;
+    impl->is_server  = true;
+
+    if (!telemetry.tracer) {
+        return server_telemetry_span_ptr(new server_telemetry_span(std::move(impl)));
+    }
 
     otel_trace::StartSpanOptions options;
     options.kind   = otel_trace::SpanKind::kServer;
     options.parent = parent_context;
 
-    auto span       = tracer->StartSpan(method + " " + route,
-                                        {
-                                      { "http.request.method", method                            },
-                                      { "http.route",          route                             },
-                                      { "url.path",            path                              },
-                                      { "url.scheme",          scheme                            },
-                                      { "server.address",      server_address                    },
-                                      { "server.port",         static_cast<int64_t>(server_port) },
-                                      { "client.address",      client_address                    },
+    auto span     = telemetry.tracer->StartSpan(method + " " + route,
+                                                {
+                                                { "http.request.method", method                            },
+                                                { "http.route",          route                             },
+                                                { "url.path",            path                              },
+                                                { "url.scheme",          scheme                            },
+                                                { "server.address",      server_address                    },
+                                                { "server.port",         static_cast<int64_t>(server_port) },
+                                                { "client.address",      client_address                    },
     },
-                                        options);
-    auto impl       = std::make_unique<server_telemetry_span::Impl>();
-    impl->span      = std::move(span);
-    impl->is_server = true;
+                                                options);
+    impl->context = otel_trace::SetSpan(parent_context, span);
+    impl->span    = std::move(span);
     return server_telemetry_span_ptr(new server_telemetry_span(std::move(impl)));
 #endif
 }
@@ -366,47 +396,54 @@ server_telemetry_span_ptr server_telemetry_start_client_span(const std::string &
     (void) parent;
     return nullptr;
 #else
-    auto tracer = get_tracer();
-    if (!tracer) {
+    auto telemetry = get_telemetry_state();
+    if (!telemetry.enabled) {
         return nullptr;
     }
 
-    otel_trace::StartSpanOptions options;
-    options.kind = otel_trace::SpanKind::kClient;
-    if (parent && parent->pimpl && parent->pimpl->span) {
-        options.parent = parent->pimpl->span->GetContext();
+    otel_ctx::Context parent_context;
+    if (parent && parent->pimpl) {
+        parent_context = parent->pimpl->context;
     }
 
-    const size_t query_pos = path.find('?');
-    const std::string url_path = path.substr(0, query_pos);
-    auto span = tracer->StartSpan(
-            method,
-            {
-                {"http.request.method", method},
-                {"url.path", url_path},
-                {"url.scheme", scheme},
-                {"server.address", server_address},
-                {"server.port", static_cast<int64_t>(server_port)},
-            },
-            options);
-    auto              impl = std::make_unique<server_telemetry_span::Impl>();
-    impl->span             = std::move(span);
-    impl->is_server        = false;
+    auto impl        = std::make_unique<server_telemetry_span::Impl>();
+    impl->propagator = telemetry.propagator;
+    impl->context    = parent_context;
+    impl->is_server  = false;
+
+    if (!telemetry.tracer) {
+        return server_telemetry_span_ptr(new server_telemetry_span(std::move(impl)));
+    }
+
+    otel_trace::StartSpanOptions options;
+    options.kind   = otel_trace::SpanKind::kClient;
+    options.parent = parent_context;
+
+    const size_t      query_pos = path.find('?');
+    const std::string url_path  = path.substr(0, query_pos);
+    auto              span      = telemetry.tracer->StartSpan(method,
+                                                              {
+                                                { "http.request.method", method                            },
+                                                { "url.path",            url_path                          },
+                                                { "url.scheme",          scheme                            },
+                                                { "server.address",      server_address                    },
+                                                { "server.port",         static_cast<int64_t>(server_port) },
+    },
+                                                              options);
+    impl->context               = otel_trace::SetSpan(parent_context, span);
+    impl->span                  = std::move(span);
     return server_telemetry_span_ptr(new server_telemetry_span(std::move(impl)));
 #endif
 }
 
 void server_telemetry_inject(std::map<std::string, std::string> & headers, const server_telemetry_span_ptr & span) {
 #ifdef LLAMA_SERVER_OPEN_TELEMETRY
-    if (!span || !span->pimpl || !span->pimpl->span || span->pimpl->ended.load()) {
+    if (!span || !span->pimpl || !span->pimpl->propagator || span->pimpl->ended.load()) {
         return;
     }
 
-    otel_ctx::Context context;
-    auto              span_context = otel_trace::SetSpan(context, span->pimpl->span);
-    header_carrier    carrier(headers);
-    auto              propagator = otel_ctx::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
-    propagator->Inject(carrier, span_context);
+    header_carrier carrier(headers);
+    span->pimpl->propagator->Inject(carrier, span->pimpl->context);
 #else
     (void) headers;
     (void) span;

--- a/tools/server/server-telemetry.h
+++ b/tools/server/server-telemetry.h
@@ -11,6 +11,9 @@ class server_telemetry_span {
   public:
     ~server_telemetry_span();
 
+    void set_attribute(const std::string & name, const std::string & value);
+    void set_attribute(const std::string & name, int64_t value);
+    void set_attribute(const std::string & name, double value);
     void set_http_status(int status_code);
     void set_error(const std::string & error_type);
     void end();

--- a/tools/server/server-telemetry.h
+++ b/tools/server/server-telemetry.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+class server_telemetry_span;
+using server_telemetry_span_ptr = std::shared_ptr<server_telemetry_span>;
+
+class server_telemetry_span {
+  public:
+    ~server_telemetry_span();
+
+    void set_http_status(int status_code);
+    void set_error(const std::string & error_type);
+    void end();
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+
+    explicit server_telemetry_span(std::unique_ptr<Impl> impl);
+
+    friend server_telemetry_span_ptr server_telemetry_start_server_span(
+        const std::string &                        method,
+        const std::string &                        route,
+        const std::string &                        path,
+        const std::string &                        scheme,
+        const std::string &                        server_address,
+        int                                        server_port,
+        const std::string &                        client_address,
+        const std::map<std::string, std::string> & headers);
+    friend server_telemetry_span_ptr server_telemetry_start_client_span(const std::string & method,
+                                                                        const std::string & scheme,
+                                                                        const std::string & server_address,
+                                                                        int                 server_port,
+                                                                        const std::string & path,
+                                                                        const server_telemetry_span_ptr & parent);
+    friend void                      server_telemetry_inject(std::map<std::string, std::string> & headers,
+                                                             const server_telemetry_span_ptr &    span);
+};
+
+// Returns false only when tracing was requested but is unavailable in this build.
+bool server_telemetry_init(bool enabled, const std::string & service_version, std::string & error);
+void server_telemetry_shutdown();
+
+server_telemetry_span_ptr server_telemetry_start_server_span(const std::string &                        method,
+                                                             const std::string &                        route,
+                                                             const std::string &                        path,
+                                                             const std::string &                        scheme,
+                                                             const std::string &                        server_address,
+                                                             int                                        server_port,
+                                                             const std::string &                        client_address,
+                                                             const std::map<std::string, std::string> & headers);
+
+server_telemetry_span_ptr server_telemetry_start_client_span(const std::string &               method,
+                                                             const std::string &               scheme,
+                                                             const std::string &               server_address,
+                                                             int                               server_port,
+                                                             const std::string &               path,
+                                                             const server_telemetry_span_ptr & parent);
+
+void server_telemetry_inject(std::map<std::string, std::string> & headers, const server_telemetry_span_ptr & span);

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -3,6 +3,7 @@
 #include "server-models.h"
 #include "server-cors-proxy.h"
 #include "server-stream.h"
+#include "server-telemetry.h"
 #include "server-tools.h"
 
 #include "arg.h"
@@ -24,6 +25,12 @@
 
 static std::function<void(int)> shutdown_handler;
 static std::atomic_flag is_terminating = ATOMIC_FLAG_INIT;
+
+struct server_telemetry_guard {
+    ~server_telemetry_guard() {
+        server_telemetry_shutdown();
+    }
+};
 
 static inline void signal_handler(int signal) {
     if (is_terminating.test_and_set()) {
@@ -137,6 +144,13 @@ int llama_server(common_params & params, int argc, char ** argv) {
 
     // skip device enumeration so the CUDA primary context stays uncreated
     common_params_print_info(params, !is_router_server);
+
+    std::string telemetry_error;
+    if (!server_telemetry_init(params.endpoint_otel, llama_build_info(), telemetry_error)) {
+        SRV_ERR("failed to initialize OpenTelemetry: %s\n", telemetry_error.c_str());
+        return 1;
+    }
+    server_telemetry_guard telemetry_guard;
 
     if (!is_router_server) {
         // validate batch size for embeddings


### PR DESCRIPTION
## Overview

Adds OTel tracing to the server.

## Additional information

This is an optional compile time flag atm, but IMO, would be reasonable to make an auto-add, and then use the usual OTel env SDK to 

## Requirements


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes
- AI usage disclosure:  Yes

This was mainly generated using Codex 5.6 Sol High. Have self reviewed and running some tests locally, will take out of draft once I am happy.