### PR TITLE
ggml : bound-check row index in get_rows_back (CWE-125/787)

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -5222,6 +5222,8 @@ static void ggml_compute_forward_get_rows_back_f32_f16(
     for (int i = 0; i < nr; ++i) {
         const int r = ((int32_t *) src1->data)[i];
 
+        GGML_ASSERT(r >= 0 && r < dst->ne[1]);
+
         for (int j = 0; j < nc; ++j) {
             ggml_fp16_t v = ((ggml_fp16_t *) ((char *) src0->data + i*src0->nb[1]))[j];
             ((float *) ((char *) dst->data + r*dst->nb[1]))[j] += GGML_CPU_FP16_TO_FP32(v);
@@ -5254,6 +5256,8 @@ static void ggml_compute_forward_get_rows_back_f32(
 
     for (int i = 0; i < nr; ++i) {
         const int r = ((int32_t *) src1->data)[i];
+
+        GGML_ASSERT(r >= 0 && r < dst->ne[1]);
 
         ggml_vec_add_f32(nc,
                 (float *) ((char *)  dst->data + r*dst->nb[1]),


### PR DESCRIPTION
## Overview

`ggml_compute_forward_get_rows_back_f32` and `_f32_f16` (`ggml/src/ggml-cpu/ops.cpp`) read a row index straight from the `GET_ROWS_BACK` op's index-tensor operand and use it to address `dst` without checking it's in range:

```c
const int r = ((int32_t *) src1->data)[i];
...
(float *) ((char *) dst->data + r*dst->nb[1])
```

The sibling *forward* `get_rows` ops in the same file already assert the identical index is in range before the analogous access; the backward variant is missing that check. This PR adds it.

## Additional information

Tested with an out-of-range index:
- `r = 999999` (far out of range) crashes with an AddressSanitizer SEGV inside `ggml_vec_add_f32`, called from `ggml_compute_forward_get_rows_back_f32`.
- `r = 20` (moderately out of range, still past the valid bound) does **not** crash - the write lands inside some other tensor's memory in the same context pool instead of escaping the allocation. That's silent corruption with no fault, arguably a worse outcome than the clean crash the larger offset produces.

Fix: `GGML_ASSERT(r >= 0 && r < dst->ne[1])` before the accumulate in both functions, mirroring what the sibling forward ops already do for the identical index.

Verified after the fix:
- Both `r = 999999` and `r = 20` now assert cleanly instead of crashing or silently corrupting memory.
- Valid in-range indices, including a repeated index that must accumulate across two rows, compute the same byte-exact results as before the change.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, our automated vulnerability detection tool SAILOR uses an AI coding agent to write the harnesses, however, the verdict is independent of AI usage.  I reviewed, tested, and am responsible for the submitted change.