### PR TITLE
ggml : widen im2col offset stride to int64_t (CWE-680/787)

### DIFF
--- a/ggml/src/ggml-cpu/ops.cpp
+++ b/ggml/src/ggml-cpu/ops.cpp
@@ -6381,8 +6381,8 @@ static void ggml_compute_forward_im2col_f32(
     const int64_t OH = is_2D ? ne2 : 1;
     const int64_t OW = ne1;
 
-    int ofs0 = is_2D ? nb13 : nb12;
-    int ofs1 = is_2D ? nb12 : nb11;
+    int64_t ofs0 = is_2D ? nb13 : nb12;
+    int64_t ofs1 = is_2D ? nb12 : nb11;
 
     GGML_ASSERT(nb10 == sizeof(float));
 
@@ -6457,8 +6457,8 @@ static void ggml_compute_forward_im2col_f16(
     const int64_t OH = is_2D ? ne2 : 1;
     const int64_t OW = ne1;
 
-    int ofs0 = is_2D ? nb13 : nb12;
-    int ofs1 = is_2D ? nb12 : nb11;
+    int64_t ofs0 = is_2D ? nb13 : nb12;
+    int64_t ofs1 = is_2D ? nb12 : nb11;
 
     GGML_ASSERT(nb10 == ggml_type_size(src1->type));
 
@@ -6559,8 +6559,8 @@ void ggml_compute_forward_im2col_back_f32(
     const int64_t OH = is_2D ? ne02 : 1;
     const int64_t OW = ne01;
 
-    int ofs0 = is_2D ? nb3 : nb2;
-    int ofs1 = is_2D ? nb2 : nb1;
+    int64_t ofs0 = is_2D ? nb3 : nb2;
+    int64_t ofs1 = is_2D ? nb2 : nb1;
 
     GGML_ASSERT(nb0  == sizeof(float));
 


### PR DESCRIPTION
### Problem
`ggml_compute_forward_im2col_back_f32` (`ggml/src/ggml-cpu/ops.cpp`) -- the backward/gradient
pass of `GGML_OP_IM2COL`, reached automatically when backpropagating through a conv1d/conv2d
layer -- truncates the destination tensor's `size_t` byte-strides into a 32-bit `int`:

```c
int ofs0 = is_2D ? nb3 : nb2;
int ofs1 = is_2D ? nb2 : nb1;
...
float * dst_data = (float *)((char *) wdata + (in*ofs0 + iic*ofs1));
dst_data[iih*IW + iiw] = grad;   // write through the truncated offset
```

For a large enough destination tensor (byte-stride at or beyond 2^31, which forces an allocation
on the order of ~4GiB -- large but not impractical for real conv2d backward-pass workloads at
large batch/channel/spatial-size combinations), the truncation wraps to a large negative 32-bit
value, producing a wildly wrong write pointer. Two sibling forward functions in the same file
(`ggml_compute_forward_im2col_f32`/`_f16`) have the identical copy-pasted truncation on the read
side.

Reproduced with `IW=2^29+4096, IC=1, N=2` (`nb2 ~= 2.147e9 >= 2^31`, wrapping to
`-2147467264` on truncation): AddressSanitizer SEGV on a WRITE inside
`ggml_compute_forward_im2col_back_f32`, matching the predicted wrapped value exactly.

### Fix
Changed `ofs0`/`ofs1` from `int` to `int64_t` in all three sites sharing this pattern: the
write-side sink (`ggml_compute_forward_im2col_back_f32`) and both read-side siblings
(`ggml_compute_forward_im2col_f32`/`_f16`). The source values (`nb1`/`nb2`/`nb3`) are already
`size_t`; the truncation served no purpose.

### Testing
- Before: the large-tensor scenario produces an AddressSanitizer SEGV on write, matching the
  predicted truncated/wrapped stride.
- After: the same scenario completes with `status=0`, no crash.
- Regression: a small 1D im2col_back (`IW=6, KW=3`) produces the exact expected accumulation
  counts (`{1,2,3,3,2,1}`), unaffected by widening the offset type.
