### PR TITLE
mtmd : check for missing optional tensors before deref

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -312,12 +312,13 @@ void clip_graph::cb(ggml_tensor * cur, const char * name, int il) const {
 // siglip2 naflex
 ggml_tensor * clip_graph::resize_position_embeddings(uint32_t interpolation_mode) {
     ggml_tensor * pos_embd = model.position_embeddings;
+    if (pos_embd == nullptr) {
+        throw std::runtime_error("position_embeddings tensor is missing");
+    }
     const int height       = img.ny() / patch_size;
     const int width        = img.nx() / patch_size;
     const uint32_t mode    = interpolation_mode;
     const int n_per_side   = (int)std::sqrt(pos_embd->ne[1]);
-
-    GGML_ASSERT(pos_embd);
 
     if (height == n_per_side && width == n_per_side) {
         return pos_embd;
@@ -569,6 +570,9 @@ ggml_tensor * clip_graph::build_vit(
 // build the input after conv2d (inp_raw --> patches)
 // returns tensor with shape [n_embd, n_patches]
 ggml_tensor * clip_graph::build_inp() {
+    if (model.patch_embeddings_0 == nullptr) {
+        throw std::runtime_error("patch_embeddings_0 tensor is missing");
+    }
     ggml_tensor * inp_raw = build_inp_raw();
     ggml_tensor * inp = ggml_conv_2d(ctx0, model.patch_embeddings_0, inp_raw, patch_size, patch_size, 0, 0, 1, 1);
     inp = ggml_reshape_3d(ctx0, inp, n_patches, n_embd, n_batch);
@@ -5780,6 +5784,7 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
         case PROJECTOR_TYPE_DEEPSEEKOCR2:
             return ctx->model.mm_fc_w->ne[1];
         case PROJECTOR_TYPE_LFM2A:
+            GGML_ASSERT(ctx->model.position_embeddings != nullptr);
             return ctx->model.position_embeddings->ne[0];
         case PROJECTOR_TYPE_GRANITE_SPEECH:
             return ctx->model.qf_proj_blocks[0].qf_proj_linear_w->ne[1];

--- a/tools/mtmd/models/conformer.cpp
+++ b/tools/mtmd/models/conformer.cpp
@@ -4,6 +4,9 @@ ggml_cgraph * clip_graph_conformer::build() {
     const int n_frames   = img.nx();
     const int n_pos      = n_frames / 2;
     const int n_pos_embd = (((((n_frames + 1) / 2) + 1) / 2 + 1) / 2) * 2 - 1;
+    if (model.position_embeddings == nullptr) {
+        throw std::runtime_error("position_embeddings tensor is missing");
+    }
     GGML_ASSERT(model.position_embeddings->ne[1] >= n_pos);
 
     ggml_tensor * pos_emb = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, 512, n_pos_embd);

--- a/tools/mtmd/models/gemma4uv.cpp
+++ b/tools/mtmd/models/gemma4uv.cpp
@@ -35,6 +35,9 @@ ggml_cgraph * clip_graph_gemma4uv::build() {
     ggml_set_input(pos_y);
 
     {
+        if (model.position_embeddings == nullptr) {
+            throw std::runtime_error("position_embeddings tensor is missing");
+        }
         const int64_t pos_size = model.position_embeddings->ne[1];
         const size_t  nb1      = ggml_row_size(model.position_embeddings->type, n_embd);
 

--- a/tools/mtmd/models/gemma4v.cpp
+++ b/tools/mtmd/models/gemma4v.cpp
@@ -24,6 +24,9 @@ ggml_cgraph * clip_graph_gemma4v::build() {
     ggml_set_input(pos_y);
 
     {
+        if (model.position_embeddings == nullptr) {
+            throw std::runtime_error("position_embeddings tensor is missing");
+        }
         const int64_t pos_size = model.position_embeddings->ne[1];
         const size_t  nb1      = ggml_row_size(model.position_embeddings->type, n_embd);
 

--- a/tools/mtmd/models/qwen3a.cpp
+++ b/tools/mtmd/models/qwen3a.cpp
@@ -60,6 +60,9 @@ ggml_cgraph * clip_graph_qwen3a::build() {
     // Per-chunk positional embeddings: repeat pos[0:13] for each chunk
     // (position indices reset 0..12 per chunk, not sequential across chunks)
     {
+        if (model.position_embeddings == nullptr) {
+            throw std::runtime_error("position_embeddings tensor is missing");
+        }
         const int64_t tokens_per_chunk = n_pos / n_chunks; // 13
         ggml_tensor * pos_tmp = ggml_view_2d(ctx0, model.position_embeddings,
             model.position_embeddings->ne[0], tokens_per_chunk,

--- a/tools/mtmd/models/whisper-enc.cpp
+++ b/tools/mtmd/models/whisper-enc.cpp
@@ -3,6 +3,9 @@
 ggml_cgraph * clip_graph_whisper_enc::build() {
     const int n_frames = img.nx();
     const int n_pos    = n_frames / 2;
+    if (model.position_embeddings == nullptr) {
+        throw std::runtime_error("position_embeddings tensor is missing");
+    }
     GGML_ASSERT(model.position_embeddings->ne[1] >= n_pos);
 
     ggml_tensor * inp = build_inp_raw(1);


### PR DESCRIPTION
## Overview

Three vision model graph builders dereferenced optional tensors before
checking for null, causing a NULL-page SIGSEGV when a crafted mmproj GGUF
omits the expected tensor:

- `clip.cpp:318` — `resize_position_embeddings` dereferences
  `pos_embd->ne[1]` before the `GGML_ASSERT(pos_embd)` null check
- `clip.cpp:573` — `build_inp` passes `model.patch_embeddings_0` to
  `ggml_conv_2d` without any null check
- `conformer.cpp:7`, `whisper-enc.cpp:6` — dereference
  `model.position_embeddings->ne[1]` inside a `GGML_ASSERT` condition

All three tensors are loaded with `required=false`, so a crafted mmproj
that omits them crashes the server at startup (warmup is on by default)
or on the first image-encode request.

## The fix

Move null checks before the dereferences and throw
`std::runtime_error` instead of aborting. `clip_init` already wraps
loading in a try/catch, so the throw produces a clean load failure.

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES - AI-assisted (drafted code and description; reviewed and verified by me)