### PR TITLE
ggml-cpu : validate expert id in mul_mat_id

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -1562,8 +1562,8 @@ static void ggml_compute_forward_mul_mat_id(
     GGML_ASSERT(nb2 <= nb3);
 
     // row groups
-    const int n_ids = ids->ne[0]; // n_expert_used
-    const int n_as  = ne02;       // n_expert
+    const int64_t n_ids = ids->ne[0]; // n_expert_used
+    const int64_t n_as  = ne02;       // n_expert
 
     void * wdata_cur = params->wdata;
 
@@ -1628,7 +1628,7 @@ static void ggml_compute_forward_mul_mat_id(
             for (int id = 0; id < n_ids; ++id) {
                 const int32_t i02 = *(const int32_t *) ((const char *) ids->data + iid1*ids->nb[1] + id*ids->nb[0]);
 
-                assert(i02 >= 0 && i02 < n_as);
+                GGML_ASSERT(i02 >= 0 && i02 < n_as);
 
                 MMID_MATRIX_ROW(i02, matrix_row_counts[i02]) = (struct mmid_row_mapping) {id, iid1};
                 matrix_row_counts[i02] += 1;
@@ -2865,7 +2865,7 @@ struct ggml_cplan ggml_graph_plan(
                         const struct ggml_tensor * src1 = node->src[1];
                         const struct ggml_tensor * ids = node->src[2];
                         const enum ggml_type vec_dot_type = type_traits_cpu[src0->type].vec_dot_type;
-                        const int n_as = src0->ne[2];
+                        const int64_t n_as = src0->ne[2];
                         // src1
                         if (src1->type != vec_dot_type) {
                             cur += ggml_row_size(vec_dot_type, ggml_nelements(src1)) + sizeof(int64_t);


### PR DESCRIPTION
## Overview

`ggml_compute_forward_mul_mat_id` validates the expert index read from
the `ids` tensor with a debug-only `assert()`, which is compiled out in
release builds (`-DNDEBUG`). An out-of-range expert id causes a heap
out-of-bounds write into the `matrix_rows` and `matrix_row_counts` work
buffers.

The fix replaces `assert` with `GGML_ASSERT` (always active, matching
all sibling ops: `get_rows`, `set_rows`, `add_id`). Also widens `n_ids`
and `n_as` from `int` to `int64_t` to avoid truncation when
`n_expert` exceeds `INT_MAX`.

## Security note

This is a memory-safety fix. The expert index `i02` is read from the
`ids` tensor (type I32, model/routing-controlled) and used directly as
an array index without validation in release builds:

- `matrix_rows[i02 * ids->ne[0] * ids->ne[1] + ...]` — OOB write
- `matrix_row_counts[i02] += 1` — OOB write

Verified with ASan (release build with `-DNDEBUG`):
ERROR: AddressSanitizer: heap-buffer-overflow at ggml-cpu.c:1633
READ of size 8 ... located 488 bytes after 304-byte region

All sibling gather/scatter ops validate with `GGML_ASSERT`; `mul_mat_id`
was the only one using plain `assert`. In standard MoE routing, top-k
bounds the values, so not triggered in normal flow today, but the only
safety check is absent in release builds.

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES - AI-assisted (drafted code and description; reviewed and verified by me)