### PR TITLE
server : document --poll 0 recipe for always-on deployments

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -327,6 +327,25 @@ services:
       LLAMA_ARG_PORT: 8080
 ```
 
+### Always-on / low-idle deployments
+
+By default the server waits for backend work with polling enabled at level 50
+(`--poll 50`; `0 - no polling, 100 - mostly polling` per the scale in
+`common.h`). At the default level the CPU threads busy-poll for a substantial
+fraction of their wait time, which on a host with the model fully offloaded to
+the GPU typically keeps about one core busy even while the server is idle. For
+always-on boxes that is wasted idle power, and on small chassis it keeps the
+fans spinning.
+
+For such deployments run with `--poll 0`. The poll flags cascade:
+`--poll-batch` and `--spec-draft-poll` default to the value of `--poll`, and
+`--spec-draft-poll-batch` defaults to `--spec-draft-poll` (see the tables
+above), so the single `--poll 0` covers all four flags and repeating it per
+flag is redundant. Observed on one always-on ROCm mini-PC serving a fully
+offloaded model: idle CPU use dropped from ~1.4 cores to under 0.1 core, with
+negligible latency impact (see discussion
+[#22238](https://github.com/ggml-org/llama.cpp/discussions/22238)).
+
 ### Multimodal support
 
 Multimodal support was added in [#12898](https://github.com/ggml-org/llama.cpp/pull/12898) and is currently an experimental feature.


### PR DESCRIPTION
## Overview

Documents a `--poll 0` recipe for always-on llama-server deployments: why continuous polling wastes cycles on servers that never pop a queue, what `--poll 0` changes, and the operational caveats we hit running 24/7 deployments on a small AMD box.

Docs-only change; no code paths touched.

## Additional information

Came out of running llama-server as a long-lived service in our setup. Happy to restructure the wording if a different section fits the docs better.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - debugging and doc-formatting were assisted by AI tooling I run; the recipe itself is from my own deployment and I have reviewed and take responsibility for every line here.
