### PR TITLE
server : reflect matching origin when --cors-origins is a list

### DIFF
--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -57,6 +57,19 @@ static bool origin_is_localhost(const std::string & origin) {
     }
 }
 
+// returns true if the Origin header value is one of the allowed origins
+static bool origin_is_allowed(const std::vector<std::string> & allowed, const std::string & origin) {
+    if (origin.empty()) {
+        return false;
+    }
+    for (const std::string & o : allowed) {
+        if (o == origin) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // For Google Cloud Platform deployment compatibility
 struct gcp_params {
     bool enabled;
@@ -289,7 +302,17 @@ bool server_http_context::init(const common_params & params) {
                 SRV_WRN("(CORS) skip non-localhost origin: %s\n", origin.c_str());
             }
         } else {
-            res.set_header("Access-Control-Allow-Origin", params.cors_origins);
+            // Access-Control-Allow-Origin holds a single origin, so send back the one that matches
+            // ref: https://github.com/ggml-org/llama.cpp/issues/26988
+            const std::vector<std::string> allowed = string_split<std::string>(params.cors_origins, ',');
+            const std::string origin = req.get_header_value("Origin");
+            if (allowed.size() == 1) {
+                res.set_header("Access-Control-Allow-Origin", allowed[0]);
+            } else if (origin_is_allowed(allowed, origin)) {
+                res.set_header("Access-Control-Allow-Origin", origin);
+            } else if (!origin.empty()) {
+                SRV_WRN("(CORS) skip origin not in --cors-origins: %s\n", origin.c_str());
+            }
         }
         // If this is OPTIONS request, skip validation because browsers don't include Authorization header
         if (req.method == "OPTIONS") {

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -149,6 +149,61 @@ def test_cors_origins_localhost_rejects(origin: str):
     assert "Access-Control-Allow-Origin" not in res.headers
 
 
+CORS_ORIGINS_LIST = "http://web.mydomain.fr,http://localhost:8042,moz-extension://f745c4ad-86bf-4062-b715-e26739741e4d"
+
+
+@pytest.mark.parametrize("origin", [
+    "http://web.mydomain.fr",
+    "http://localhost:8042",
+    "moz-extension://f745c4ad-86bf-4062-b715-e26739741e4d",
+])
+def test_cors_origins_list_reflects(origin: str):
+    global server
+    server = ServerPreset.router()
+    server.cors_origins = CORS_ORIGINS_LIST
+    server.start()
+    res = server.make_request("OPTIONS", "/completions", headers={
+        "Origin": origin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Authorization",
+    })
+    assert res.status_code == 200
+    assert res.headers["Access-Control-Allow-Origin"] == origin
+
+
+@pytest.mark.parametrize("origin", [
+    "http://evil.com",
+    "http://web.mydomain.fr.evil.com",
+    "http://localhost:8080",
+])
+def test_cors_origins_list_rejects(origin: str):
+    global server
+    server = ServerPreset.router()
+    server.cors_origins = CORS_ORIGINS_LIST
+    server.start()
+    res = server.make_request("OPTIONS", "/completions", headers={
+        "Origin": origin,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Authorization",
+    })
+    assert res.status_code == 200
+    assert "Access-Control-Allow-Origin" not in res.headers
+
+
+def test_cors_origins_single_is_sent_as_is():
+    global server
+    server = ServerPreset.router()
+    server.cors_origins = "http://web.mydomain.fr"
+    server.start()
+    res = server.make_request("OPTIONS", "/completions", headers={
+        "Origin": "http://web.mydomain.fr",
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Authorization",
+    })
+    assert res.status_code == 200
+    assert res.headers["Access-Control-Allow-Origin"] == "http://web.mydomain.fr"
+
+
 def test_cors_origins_defaults_to_localhost_with_tools_enabled():
     global server
     server = ServerPreset.router()

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -149,7 +149,7 @@ def test_cors_origins_localhost_rejects(origin: str):
     assert "Access-Control-Allow-Origin" not in res.headers
 
 
-CORS_ORIGINS_LIST = "http://web.mydomain.fr,http://localhost:8042,moz-extension://f745c4ad-86bf-4062-b715-e26739741e4d"
+CORS_ORIGINS_LIST = "http://web.mydomain.fr, http://localhost:8042, moz-extension://f745c4ad-86bf-4062-b715-e26739741e4d"
 
 
 @pytest.mark.parametrize("origin", [


### PR DESCRIPTION
Assisted-by: Claude Opus 5

## Overview

The docs say --cors-origins takes a comma-separated list, but the code never actually split it. Whatever you typed went straight into Access-Control-Allow-Origin, and that header only holds one value, either * or a single origin. So configuring two origins produced a header like:
```
Access-Control-Allow-Origin: http://a.example.com,http://b.example.com
```
which no browser will ever match. Every cross-origin request just got blocked, with no error at startup and nothing in the logs. 

This splits the value on commas, checks the request's Origin against the list, and sends back only the one that matched. If it's not on the list, no header goes out and the browser blocks it, which is what should have been happening all along. Configuring a single origin works the same as before.




Fixes #26988 
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) -YES
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
YES - AI Agent was used to run tests, draft code, and find bugs. I was in the loop the entire way through, and understand all code written. 
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
