### PR TITLE
peg-parser: allow whitespace before the comma in python_array

### DIFF
--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -1306,7 +1306,7 @@ common_peg_parser common_peg_parser_builder::python_dict() {
 common_peg_parser common_peg_parser_builder::python_array() {
     return rule("python-array", [this]() {
         auto ws = space();
-        auto elements = sequence({python_value(), zero_or_more(sequence({literal(","), ws, python_value()}))});
+        auto elements = sequence({python_value(), zero_or_more(sequence({ws, literal(","), ws, python_value()}))});
         return sequence({
             literal("["),
             ws,


### PR DESCRIPTION
`json_array()` was changed in #24835 to accept `ws "," ws` between elements,
matching `json_object()` and `python_dict()`. `python_array()` was left with
`"," ws` — whitespace only after the separator. It is the same asymmetry, one
rule further down the file:

```cpp
// python_dict(),  master
auto members  = sequence({member, zero_or_more(sequence({ws, literal(","), ws, member}))});
// python_array(), master
auto elements = sequence({python_value(), zero_or_more(sequence({literal(","), ws, python_value()}))});
```

So `python_dict()` accepts `{1 : 2 , 3 : 4}` while `python_array()` rejects
`[1 , 2]`.

Why it matters beyond tidiness: every value rule emitted by
`json-schema-to-grammar` ends with `space`, so whitespace before a separator is
legal output for a grammar-constrained generation. A parser that rejects it
fails on output its own grammar just authorised. That is exactly the failure
#24835 fixed for the JSON side — I ran into it as a ~35% HTTP 500 rate on
`response_format: json_schema` (#27279) before finding #24835 had already
landed upstream.

Tested on this branch, on top of master:

```
test-peg-parser                  PASS
test-chat-peg-parser             PASS
test-chat-auto-parser            PASS
test-json-schema-to-grammar      PASS
test-grammar-integration         PASS
```

**AI disclosure**, per CONTRIBUTING.md: an AI coding agent working under my
direction found the asymmetry and wrote this description. The change is one
line and mirrors the rule directly above it; I have read it and can answer
questions on it. Flagging it rather than leaving it unstated — if that makes
the PR unacceptable, close it and I will not take it further.
