### PR TITLE
ci : create pre-release with change log and nightly link in make-release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -54,7 +54,6 @@ jobs:
         run: bash scripts/make-release-desc.sh "${{ steps.checks.outputs.version }}"
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          RELEASE_BRANCH: ${{ github.ref_name }}
 
       - name: Create release
         if: ${{ github.event.inputs.dry_run == 'false' }}

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -49,6 +49,34 @@ jobs:
           git push origin "${VERSION}"
           echo "Created and pushed tag ${VERSION}"
 
+      - name: Generate release description
+        id: desc
+        run: bash scripts/make-release-desc.sh "${{ steps.checks.outputs.version }}"
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_BRANCH: ${{ github.ref_name }}
+
+      - name: Create release
+        if: ${{ github.event.inputs.dry_run == 'false' }}
+        uses: ggml-org/action-create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ steps.checks.outputs.version }}
+          # TODO: remove the prerelease flag once the semantic versioning workflow is ready
+          # ref: https://github.com/ggml-org/ggml/discussions/1579
+          prerelease: true
+          body: |
+            > [!NOTE]
+            > Semantic versioning is still work in progress.
+            > More info can be found in https://github.com/ggml-org/ggml/discussions/1579
+
+            ${{ steps.desc.outputs.nightly }}
+
+            ## ${{ steps.desc.outputs.changelog_title }}
+
+            ${{ steps.desc.outputs.changelog }}
+
       - name: Dry run summary
         if: ${{ github.event.inputs.dry_run == 'true' }}
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ include(CheckIncludeFileCXX)
 ### llama.cpp version
 set(LLAMA_VERSION_MAJOR 0)
 set(LLAMA_VERSION_MINOR 1)
-set(LLAMA_VERSION_PATCH 1)
+set(LLAMA_VERSION_PATCH 2)
 set(LLAMA_VERSION_BASE "${LLAMA_VERSION_MAJOR}.${LLAMA_VERSION_MINOR}.${LLAMA_VERSION_PATCH}")
 
 # whether this is a development/nightly build

--- a/scripts/make-release-desc.sh
+++ b/scripts/make-release-desc.sh
@@ -7,10 +7,12 @@
 #
 # The previous version is the highest plain semver tag (v<maj>.<min>.<pat>)
 # strictly below <version>. The change log lists all commits between the
-# previous version tag and HEAD, one line per commit.
+# previous version tag and the release commit, one line per commit.
 #
-# The nightly release is the b* tag pointing to HEAD (release.yml tags the
-# same commit); the link is only generated when that tag exists.
+# The release commit is the commit <version> points at when the tag exists,
+# HEAD otherwise. The nightly release is the b* tag pointing at that commit
+# (release.yml tags the same commit); the link is only generated when that
+# tag exists.
 #
 # Env (when running in GitHub Actions):
 #   GITHUB_OUTPUT: previous_tag, changelog_title, changelog and nightly are written here
@@ -28,21 +30,29 @@ if ! git fetch --tags origin 2>/dev/null; then
     echo "Warning: could not fetch tags from origin (local run?)"
 fi
 
+# Release commit: the commit <version> points at when the tag exists, HEAD otherwise.
+# Resolve to a SHA: --points-at does not peel annotated tags.
+if ! RELEASE_COMMIT="$(git rev-parse -q --verify "refs/tags/${VERSION}^{commit}" 2>/dev/null)"; then
+    RELEASE_COMMIT="$(git rev-parse HEAD)"
+fi
+
+echo "Release commit: $(git rev-parse --short "${RELEASE_COMMIT}")"
+
 PREV="$( { git tag --list; echo "${VERSION}"; } \
     | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
     | sort -V \
     | awk -v cur="${VERSION}" '$0 == cur { exit } { prev = $0 } END { print prev }')"
 
 if [[ -n "${PREV}" ]]; then
-    CHANGELOG="$(git log --oneline "${PREV}..HEAD")"
+    CHANGELOG="$(git log --oneline "${PREV}..${RELEASE_COMMIT}")"
     CHANGELOG_TITLE="Change log since ${PREV}"
 else
     CHANGELOG="(no previous release tag found)"
     CHANGELOG_TITLE="Change log"
 fi
 
-# Nightly release: the b* tag pointing to HEAD (|| true: no match is not an error)
-NIGHTLY_TAG="$(git tag --points-at HEAD | grep -E '(^|-)b[0-9]+(-[0-9a-f]{7})?$' | head -n 1 || true)"
+# Nightly release: the b* tag pointing at the release commit (|| true: no match is not an error)
+NIGHTLY_TAG="$(git tag --points-at "${RELEASE_COMMIT}" | grep -E '(^|-)b[0-9]+(-[0-9a-f]{7})?$' | head -n 1 || true)"
 
 NIGHTLY=""
 if [[ -n "${NIGHTLY_TAG}" ]]; then
@@ -52,7 +62,7 @@ if [[ -n "${NIGHTLY_TAG}" ]]; then
         echo "Nightly release: ${NIGHTLY_URL}"
     fi
 else
-    echo "No nightly release found for HEAD"
+    echo "No nightly release found for commit $(git rev-parse --short "${RELEASE_COMMIT}")"
 fi
 
 echo "Previous version: ${PREV:-none}"

--- a/scripts/make-release-desc.sh
+++ b/scripts/make-release-desc.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Generate the description of a release: the previous release version, the
+# change log and the link to the nightly release corresponding to the commit being released.
+#
+# Usage: make-release-desc.sh <version>
+#   <version>: current release version (e.g. v0.1.1)
+#
+# The previous version is the highest plain semver tag (v<maj>.<min>.<pat>)
+# strictly below <version>. The change log lists all commits between the
+# previous version tag and HEAD, one line per commit.
+#
+# The nightly release is resolved the same way as the get-tag-name action in
+# release.yml (b<commit-count> on master, <branch>-b<commit-count>-<hash7>
+# otherwise); the link is only generated when that release tag exists.
+#
+# Env (when running in GitHub Actions):
+#   GITHUB_OUTPUT: previous_tag, changelog_title, changelog and nightly are written here
+#   GITHUB_REPOSITORY: owner/repo, used to build the nightly release URL (skipped when unset)
+#   RELEASE_BRANCH: branch the release commit belongs to (defaults to master)
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $(basename "$0") <version>"
+    exit 1
+fi
+VERSION="$1"
+
+# Make sure all remote tags are available locally (skipped on local runs without origin)
+if ! git fetch --tags origin 2>/dev/null; then
+    echo "Warning: could not fetch tags from origin (local run?)"
+fi
+
+PREV="$( { git tag --list; echo "${VERSION}"; } \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -V \
+    | awk -v cur="${VERSION}" '$0 == cur { exit } { prev = $0 } END { print prev }')"
+
+if [[ -n "${PREV}" ]]; then
+    CHANGELOG="$(git log --oneline "${PREV}..HEAD")"
+    CHANGELOG_TITLE="Change log since ${PREV}"
+else
+    CHANGELOG="(no previous release tag found)"
+    CHANGELOG_TITLE="Change log"
+fi
+
+# Nightly release corresponding to HEAD
+BRANCH="${RELEASE_BRANCH:-master}"
+BUILD_NUMBER="$(git rev-list --count HEAD)"
+SHORT_HASH="$(git rev-parse --short=7 HEAD)"
+if [[ "${BRANCH}" == "master" ]]; then
+    NIGHTLY_TAG="b${BUILD_NUMBER}"
+else
+    SAFE_NAME="$(echo "${BRANCH}" | tr '/' '-')"
+    NIGHTLY_TAG="${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}"
+fi
+
+NIGHTLY=""
+if [[ -n "${GITHUB_REPOSITORY:-}" ]] && git rev-parse -q --verify "refs/tags/${NIGHTLY_TAG}" >/dev/null 2>&1; then
+    NIGHTLY_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${NIGHTLY_TAG}"
+    NIGHTLY="**Nightly build:** [${NIGHTLY_TAG}](${NIGHTLY_URL})"
+    echo "Nightly release: ${NIGHTLY_URL}"
+else
+    echo "No nightly release found for tag ${NIGHTLY_TAG}"
+fi
+
+echo "Previous version: ${PREV:-none}"
+echo "${CHANGELOG}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+        echo "previous_tag=${PREV}"
+        echo "changelog_title=${CHANGELOG_TITLE}"
+        echo "nightly=${NIGHTLY}"
+        echo "changelog<<CHANGELOG_EOF"
+        echo "${CHANGELOG}"
+        echo "CHANGELOG_EOF"
+    } >> "${GITHUB_OUTPUT}"
+fi

--- a/scripts/make-release-desc.sh
+++ b/scripts/make-release-desc.sh
@@ -9,14 +9,12 @@
 # strictly below <version>. The change log lists all commits between the
 # previous version tag and HEAD, one line per commit.
 #
-# The nightly release is resolved the same way as the get-tag-name action in
-# release.yml (b<commit-count> on master, <branch>-b<commit-count>-<hash7>
-# otherwise); the link is only generated when that release tag exists.
+# The nightly release is the b* tag pointing to HEAD (release.yml tags the
+# same commit); the link is only generated when that tag exists.
 #
 # Env (when running in GitHub Actions):
 #   GITHUB_OUTPUT: previous_tag, changelog_title, changelog and nightly are written here
 #   GITHUB_REPOSITORY: owner/repo, used to build the nightly release URL (skipped when unset)
-#   RELEASE_BRANCH: branch the release commit belongs to (defaults to master)
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
@@ -43,24 +41,18 @@ else
     CHANGELOG_TITLE="Change log"
 fi
 
-# Nightly release corresponding to HEAD
-BRANCH="${RELEASE_BRANCH:-master}"
-BUILD_NUMBER="$(git rev-list --count HEAD)"
-SHORT_HASH="$(git rev-parse --short=7 HEAD)"
-if [[ "${BRANCH}" == "master" ]]; then
-    NIGHTLY_TAG="b${BUILD_NUMBER}"
-else
-    SAFE_NAME="$(echo "${BRANCH}" | tr '/' '-')"
-    NIGHTLY_TAG="${SAFE_NAME}-b${BUILD_NUMBER}-${SHORT_HASH}"
-fi
+# Nightly release: the b* tag pointing to HEAD (|| true: no match is not an error)
+NIGHTLY_TAG="$(git tag --points-at HEAD | grep -E '(^|-)b[0-9]+(-[0-9a-f]{7})?$' | head -n 1 || true)"
 
 NIGHTLY=""
-if [[ -n "${GITHUB_REPOSITORY:-}" ]] && git rev-parse -q --verify "refs/tags/${NIGHTLY_TAG}" >/dev/null 2>&1; then
-    NIGHTLY_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${NIGHTLY_TAG}"
-    NIGHTLY="**Nightly build:** [${NIGHTLY_TAG}](${NIGHTLY_URL})"
-    echo "Nightly release: ${NIGHTLY_URL}"
+if [[ -n "${NIGHTLY_TAG}" ]]; then
+    if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+        NIGHTLY_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${NIGHTLY_TAG}"
+        NIGHTLY="**Nightly build:** [${NIGHTLY_TAG}](${NIGHTLY_URL})"
+        echo "Nightly release: ${NIGHTLY_URL}"
+    fi
 else
-    echo "No nightly release found for tag ${NIGHTLY_TAG}"
+    echo "No nightly release found for HEAD"
 fi
 
 echo "Previous version: ${PREV:-none}"

--- a/scripts/make-release-desc.sh
+++ b/scripts/make-release-desc.sh
@@ -39,7 +39,6 @@ if ! git fetch --tags origin 2>/dev/null; then
 fi
 
 # Release commit: the commit <version> points at when the tag exists, HEAD otherwise.
-# Resolve to a SHA: --points-at does not peel annotated tags.
 if ! RELEASE_COMMIT="$(git rev-parse -q --verify "refs/tags/${VERSION}^{commit}" 2>/dev/null)"; then
     RELEASE_COMMIT="$(git rev-parse HEAD)"
 fi

--- a/scripts/make-release-desc.sh
+++ b/scripts/make-release-desc.sh
@@ -3,7 +3,7 @@
 # change log and the link to the nightly release corresponding to the commit being released.
 #
 # Usage: make-release-desc.sh <version>
-#   <version>: current release version (e.g. v0.1.1)
+#   <version>: current release version (v<maj>.<min>.<pat>, the leading v is optional)
 #
 # The previous version is the highest plain semver tag (v<maj>.<min>.<pat>)
 # strictly below <version>. The change log lists all commits between the
@@ -24,6 +24,14 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 VERSION="$1"
+
+# Accept the version with or without the leading v, reject anything else
+if [[ "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    VERSION="v${VERSION}"
+elif [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Error: invalid version '${VERSION}' (expected v<maj>.<min>.<pat>)"
+    exit 1
+fi
 
 # Make sure all remote tags are available locally (skipped on local runs without origin)
 if ! git fetch --tags origin 2>/dev/null; then


### PR DESCRIPTION
## Overview

Extends the `make-release` workflow to create a GitHub release after pushing the tag:

- Creates a **pre-release** using `ggml-org/action-create-release` (TODO to drop the prerelease flag once semantic versioning is ready)
- New `scripts/make-release-desc.sh` generates the release description: previous release version (highest semver tag below the current one), change log between the two versions (one line per commit), and a link to the corresponding nightly build when it exists
- Bumps the version to 0.1.2

## Additional information

- Semantic versioning is still work in progress: https://github.com/ggml-org/ggml/discussions/1579
- The release description is also printed on `dry_run`, so it can be inspected before the tag/release are created

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.8-27B
