### PR TITLE
Escape regex special characters in quant tag matching

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -691,7 +691,7 @@ static hf_cache::hf_file find_best_model(const hf_cache::hf_files & files,
     }
 
     for (const auto & t : tags) {
-        std::regex pattern(t + "[.-]", std::regex::icase);
+        std::regex pattern(regex_escape(t) + "[.-]", std::regex::icase);
         for (const auto & f : files) {
             if (gguf_filename_is_model(f.path) &&
                 std::regex_search(f.path, pattern)) {


### PR DESCRIPTION
## Overview
Quant tags containing special regex characters (e.g. +, -, ()) were not matching correctly because the tag was inserted directly into a regex pattern so I just wrapped the tag in regex_escape() before building the pattern which got it matched literally.

## Additional information
Found this while testing #27231

Before (fails to match):
<img width="720" height="126" alt="Screenshot 2026-08-18 111323" src="https://github.com/user-attachments/assets/c048f1f7-b918-4409-a404-b533f5984433" />

After (matches correctly):
<img width="670" height="125" alt="Screenshot 2026-08-18 111544" src="https://github.com/user-attachments/assets/1360e9fe-8fff-4898-9f99-514853e7bab1" />

## Requirements
- I have read and agree with the contributing guidelines
- AI usage disclosure: YES, used AI to help debug the Windows/MSVC build setup and to verify the fix with local before/after tests. The description was written by me.