### PR TITLE
server : add option to exit sleeping router workers

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3758,6 +3758,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--sleep-exit-worker"},
+        {"--no-sleep-exit-worker"},
+        string_format("in router mode, whether to exit workers when they enter sleep (default: %s)", params.sleep_exit_worker ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.sleep_exit_worker = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SLEEP_EXIT_WORKER"));
+    add_opt(common_arg(
         {"--simple-io"},
         "use basic IO for better compatibility in subprocesses and limited consoles",
         [](common_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -633,6 +633,7 @@ struct common_params {
     int enable_reasoning = -1; // -1 = auto, 0 = disable, 1 = enable
     bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
     int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
+    bool sleep_exit_worker = false; // if true, router workers will exit when entering sleep
 
     std::vector<std::string> api_keys;
 

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -186,6 +186,17 @@ static void test(void) {
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.verbosity > 1);
 
+    {
+        common_params server_params;
+        argv = {"binary_name", "--sleep-exit-worker"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), server_params, LLAMA_EXAMPLE_SERVER));
+        assert(server_params.sleep_exit_worker);
+
+        argv = {"binary_name", "--no-sleep-exit-worker"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), server_params, LLAMA_EXAMPLE_SERVER));
+        assert(!server_params.sleep_exit_worker);
+    }
+
     argv = {"binary_name", "-m", "abc.gguf", "--predict", "6789", "--batch-size", "9090"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.model.path == "abc.gguf");
@@ -242,6 +253,12 @@ static void test(void) {
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.model.path == "blah.gguf");
     assert(params.cpuparams.n_threads == 1010);
+
+    setenv("LLAMA_ARG_SLEEP_EXIT_WORKER", "1", true);
+    common_params server_params;
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), server_params, LLAMA_EXAMPLE_SERVER));
+    assert(server_params.sleep_exit_worker);
+    unsetenv("LLAMA_ARG_SLEEP_EXIT_WORKER");
 
     setenv("LLAMA_ARG_LOAD_MODE", "blah", true);
     argv = {"binary_name"};

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -237,6 +237,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-sps, --slot-prompt-similarity SIMILARITY` | how much the prompt of a request must match the prompt of a slot in order to use that slot (default: 0.10, 0.0 = disabled) |
 | `--lora-init-without-apply` | load LoRA adapters without applying them (apply later via POST /lora-adapters) (default: disabled) |
 | `--sleep-idle-seconds SECONDS` | number of seconds of idleness after which the server will sleep (default: -1; -1 = disabled) |
+| `--sleep-exit-worker, --no-sleep-exit-worker` | in router mode, whether to exit workers when they enter sleep (default: disabled)<br/>(env: LLAMA_ARG_SLEEP_EXIT_WORKER) |
 | `--log-prompts-dir PATH` | Log prompts to directory (auto-created if not present; only used for debugging, default: disabled) |
 | `--spec-draft-hf, -hfd, -hfrd, --hf-repo-draft <user>/<model>[:quant]` | Same as --hf-repo, but for the draft model (default: unused)<br/>(env: LLAMA_ARG_SPEC_DRAFT_HF_REPO) |
 | `--spec-draft-threads, -td, --threads-draft N` | number of threads to use during generation (default: same as --threads) |
@@ -1857,6 +1858,13 @@ The `status` object can be:
 }
 ```
 
+```json
+"status": {
+  "value": "unloading",
+  "args": ["llama-server", "-ctx", "4096"]
+}
+```
+
 Note: for "downloading" state, there can be multiple files be downloading in parallel
 
 ```json
@@ -2063,6 +2071,10 @@ Example of an error:
 The server supports an automatic sleep mode that activates after a specified period of inactivity (no incoming tasks). This feature, introduced in [PR #18228](https://github.com/ggml-org/llama.cpp/pull/18228), can be enabled using the `--sleep-idle-seconds` command-line argument. It works seamlessly in both single-model and multi-model configurations.
 
 When the server enters sleep mode, the model and its associated memory (including the KV cache) are unloaded from RAM to conserve resources. Any new incoming task will automatically trigger the model to reload.
+
+In router mode, `--sleep-exit-worker` also terminates the worker process after it enters sleep. This releases backend contexts held by the process. With model autoload enabled, the next request starts a new worker and reloads the model. With `--no-models-autoload`, the model must be loaded explicitly before it can serve another request.
+
+The option can also be set per model in a preset with `sleep-exit-worker = true`. The command-line and preset precedence rules described in [Model presets](#model-presets) apply.
 
 The sleeping status can be retrieved from the `GET /props` endpoint (or `/props?model=(model_name)` in router mode).
 

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1182,6 +1182,9 @@ void server_models::update_status(const std::string & name, const update_status_
     auto it = mapping.find(name);
     if (it != mapping.end()) {
         auto & meta = it->second.meta;
+        if (meta.status == SERVER_MODEL_STATUS_UNLOADING && args.status != SERVER_MODEL_STATUS_UNLOADED) {
+            return;
+        }
         meta.status      = args.status;
         meta.exit_code   = args.exit_code;
         if (!args.loaded_info.is_null()) {
@@ -1209,6 +1212,37 @@ void server_models::update_status(const std::string & name, const update_status_
         notify_sse("status_change", name, data);
     }
     cv.notify_all();
+}
+
+void server_models::update_sleeping_status(const std::string & name) {
+    server_model_status status = SERVER_MODEL_STATUS_SLEEPING;
+    bool stop_worker = false;
+    {
+        std::unique_lock<std::mutex> lk(mutex);
+        auto it = mapping.find(name);
+        if (it == mapping.end() || it->second.meta.status == SERVER_MODEL_STATUS_UNLOADING) {
+            return;
+        }
+
+        std::string value;
+        bool exit_worker = it->second.meta.preset.get_option("LLAMA_ARG_SLEEP_EXIT_WORKER", value)
+            && common_arg_utils::is_truthy(value);
+        if (exit_worker && it->second.req_count == 0) {
+            status = SERVER_MODEL_STATUS_UNLOADING;
+            stopping_models.insert(name);
+            stop_worker = true;
+        }
+        it->second.meta.status = status;
+        it->second.meta.exit_code = 0;
+    }
+
+    notify_sse("status_change", name, {
+        {"status", server_model_status_to_string(status)},
+    });
+    cv.notify_all();
+    if (stop_worker) {
+        cv_stop.notify_all();
+    }
 }
 
 void server_models::update_download_progress(const std::string & name, const common_download_progress & progress, bool done, bool ok) {
@@ -1333,6 +1367,21 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
     if (meta->status == SERVER_MODEL_STATUS_SLEEPING) {
         return false; // child is sleeping but still running; new request will wake it up
     }
+    if (meta->status == SERVER_MODEL_STATUS_UNLOADING) {
+        std::unique_lock<std::mutex> lk(mutex);
+        while (true) {
+            auto it = mapping.find(name);
+            if (it == mapping.end() || it->second.meta.status != SERVER_MODEL_STATUS_UNLOADING) {
+                break;
+            }
+            if (should_stop && should_stop()) {
+                throw std::runtime_error("request cancelled while waiting for model name=" + name);
+            }
+            cv.wait_for(lk, std::chrono::milliseconds(200));
+        }
+        lk.unlock();
+        return ensure_model_ready(name, should_stop);
+    }
 
     bool queued   = false;
     bool did_load = false;
@@ -1444,25 +1493,30 @@ bool server_models::ensure_model_ready(const std::string & name, const std::func
 }
 
 server_http_res_ptr server_models::proxy_request(const server_http_req & req, const std::string & method, const std::string & name, bool update_last_used, bool detached) {
-    auto meta = get_meta(name);
-    if (!meta.has_value()) {
-        throw std::runtime_error("model name=" + name + " is not found");
-    }
-    if (!meta->is_running()) {
-        throw std::invalid_argument("model name=" + name + " is not running");
-    }
+    server_model_meta meta;
     {
         std::unique_lock<std::mutex> lk(mutex);
-        if (update_last_used) {
-            mapping[name].meta.last_used = ggml_time_ms();
+        auto it = mapping.find(name);
+        if (it == mapping.end()) {
+            throw std::runtime_error("model name=" + name + " is not found");
         }
-        mapping[name].req_count++;
+        if (it->second.meta.status == SERVER_MODEL_STATUS_UNLOADING || it->second.meta.status == SERVER_MODEL_STATUS_UNLOADED) {
+            return nullptr;
+        }
+        if (!it->second.meta.is_ready_or_sleep()) {
+            throw std::invalid_argument("model name=" + name + " is not ready");
+        }
+        if (update_last_used) {
+            it->second.meta.last_used = ggml_time_ms();
+        }
+        it->second.req_count++;
+        meta = it->second.meta;
     }
     if (debug_fake_timing) {
         // sleep after req_count++, so the model counts as busy while we wait here
         std::this_thread::sleep_for(std::chrono::seconds(2));
     }
-    SRV_INF("proxying request to model %s on port %d\n", name.c_str(), meta->port);
+    SRV_INF("proxying request to model %s on port %d\n", name.c_str(), meta.port);
     std::string proxy_path = req.path;
     if (!req.query_string.empty()) {
         proxy_path += '?' + req.query_string;
@@ -1471,7 +1525,7 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
             method,
             "http",
             CHILD_ADDR,
-            meta->port,
+            meta.port,
             proxy_path,
             req.headers,
             req.body,
@@ -1562,7 +1616,7 @@ void server_models::handle_child_state(const std::string & name, const std::stri
             } break;
         case SERVER_STATE_SLEEPING:
             {
-                update_status(name, { SERVER_MODEL_STATUS_SLEEPING });
+                update_sleeping_status(name);
             } break;
         default:
             // should never happen, but just in case
@@ -1861,10 +1915,18 @@ void server_models_routes::init_routes() {
         if (!router_validate_model(name, models, autoload, error_res)) {
             return error_res;
         }
-        if (autoload) {
-            models.ensure_model_ready(name, req.should_stop);
+        while (true) {
+            if (autoload) {
+                models.ensure_model_ready(name, req.should_stop);
+            }
+            auto proxy = models.proxy_request(req, method, name, false);
+            if (proxy) {
+                return proxy;
+            }
+            if (!autoload) {
+                throw std::invalid_argument("model name=" + name + " is not ready");
+            }
         }
-        return models.proxy_request(req, method, name, false);
     };
 
     this->proxy_post = [this](const server_http_req & req) {
@@ -1884,18 +1946,27 @@ void server_models_routes::init_routes() {
         uint64_t ticket = models.conv_models.remember(conv_id, name);
         // a dead socket must not cancel a session request, only a stop does (checked right below)
         auto should_stop = ticket == 0 ? req.should_stop : nullptr;
-        bool waited = autoload && models.ensure_model_ready(name, should_stop);
-        if (ticket != 0 && !models.conv_models.alive(conv_id, ticket)) {
-            SRV_INF("request for conv_id=%s cancelled while model name=%s was loading\n",
-                    conv_id.c_str(), name.c_str());
-            res_err(error_res, format_error_response(
-                    "request cancelled by a stop while the model was loading", ERROR_TYPE_INVALID_REQUEST));
-            return error_res;
+        bool waited = false;
+        while (true) {
+            if (autoload) {
+                waited = models.ensure_model_ready(name, should_stop) || waited;
+            }
+            if (ticket != 0 && !models.conv_models.alive(conv_id, ticket)) {
+                SRV_INF("request for conv_id=%s cancelled while model name=%s was loading\n",
+                        conv_id.c_str(), name.c_str());
+                res_err(error_res, format_error_response(
+                        "request cancelled by a stop while the model was loading", ERROR_TYPE_INVALID_REQUEST));
+                return error_res;
+            }
+            // A session request that waited for a load must survive a client reconnect.
+            auto proxy = models.proxy_request(req, method, name, true, waited && ticket != 0);
+            if (proxy) {
+                return proxy;
+            }
+            if (!autoload) {
+                throw std::invalid_argument("model name=" + name + " is not ready");
+            }
         }
-        // a session request that waited for a load detaches from the client socket: the
-        // client may have dropped during the wait (page reload) and the session buffer must
-        // still receive the generation for a later resume
-        return models.proxy_request(req, method, name, true, waited && ticket != 0); // update last usage for POST request only
     };
 
     this->post_router_models_load = [this](const server_http_req & req) {
@@ -2104,7 +2175,8 @@ void server_models_routes::init_routes() {
             auto meta = tracked.has_value() ? models.get_meta(*tracked) : std::nullopt;
             bool transient = meta.has_value() && (meta->status == SERVER_MODEL_STATUS_LOADING ||
                                                   meta->status == SERVER_MODEL_STATUS_DOWNLOADING ||
-                                                  meta->status == SERVER_MODEL_STATUS_DOWNLOADED);
+                                                  meta->status == SERVER_MODEL_STATUS_DOWNLOADED ||
+                                                  meta->status == SERVER_MODEL_STATUS_UNLOADING);
             if (transient) {
                 res_err(res, format_error_response("Stream owner model is loading, retry later", ERROR_TYPE_UNAVAILABLE));
             } else {

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -19,13 +19,15 @@
 /**
  * state diagram:
  *
- * DOWNLOADING ──► DOWNLOADED ──► (replaced by new instance)
+ * DOWNLOADING --> DOWNLOADED --> (replaced by new instance)
  *
- * UNLOADED ──► LOADING ──► LOADED ◄──── SLEEPING
- *  ▲            │            │               ▲
- *  └───failed───┘            │               │
- *  ▲                         └──sleeping─────┘
- *  └────────unloaded─────────┘
+ * UNLOADED --> LOADING --> LOADED <---- SLEEPING
+ *  ^            |            |               ^
+ *  +---failed---+            |               |
+ *  ^                         +---sleeping-----+
+ *  +--------unloaded---------+
+ *  ^                         |               |
+ *  +------UNLOADING <--------+---------------+
  */
 enum server_model_status {
     // TODO: also add downloading state when the logic is added
@@ -34,7 +36,8 @@ enum server_model_status {
     SERVER_MODEL_STATUS_UNLOADED,
     SERVER_MODEL_STATUS_LOADING,
     SERVER_MODEL_STATUS_LOADED,
-    SERVER_MODEL_STATUS_SLEEPING
+    SERVER_MODEL_STATUS_SLEEPING,
+    SERVER_MODEL_STATUS_UNLOADING
 };
 
 enum server_model_source {
@@ -56,6 +59,7 @@ static std::string server_model_status_to_string(server_model_status status) {
         case SERVER_MODEL_STATUS_LOADING:     return "loading";
         case SERVER_MODEL_STATUS_LOADED:      return "loaded";
         case SERVER_MODEL_STATUS_SLEEPING:    return "sleeping";
+        case SERVER_MODEL_STATUS_UNLOADING:   return "unloading";
         default:                              return "unknown";
     }
 }
@@ -90,7 +94,7 @@ struct server_model_meta {
     }
 
     bool is_running() const {
-        return status == SERVER_MODEL_STATUS_LOADED || status == SERVER_MODEL_STATUS_LOADING || status == SERVER_MODEL_STATUS_SLEEPING;
+        return status == SERVER_MODEL_STATUS_LOADED || status == SERVER_MODEL_STATUS_LOADING || status == SERVER_MODEL_STATUS_SLEEPING || status == SERVER_MODEL_STATUS_UNLOADING;
     }
 
     bool is_ready_or_sleep() const {
@@ -213,6 +217,9 @@ private:
 
     // notify SSE clients
     void notify_sse(const std::string & event, const std::string & model_id, const json & data = nullptr);
+
+    // update sleeping status and optionally begin graceful worker shutdown
+    void update_sleeping_status(const std::string & name);
 
 public:
     // conv_id -> model tracker for the resumable stream routes, owns its lock

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -158,6 +158,96 @@ def _tokenize(model_id: str, timeout: float | None = DEFAULT_REQUEST_TIMEOUT) ->
     )
 
 
+def test_router_sleep_keeps_worker_by_default():
+    global server
+    server.sleep_idle_seconds = 1
+    server.start()
+
+    first = _tokenize(MODEL_A, timeout=120)
+    assert first.status_code == 200
+    _wait_for_model_status(MODEL_A, {"sleeping"}, timeout=30)
+
+    second = _tokenize(MODEL_A, timeout=120)
+    assert second.status_code == 200
+    _wait_for_model_status(MODEL_A, {"loaded"}, timeout=30)
+
+
+def test_router_sleep_exit_worker():
+    global server
+    server.sleep_idle_seconds = 1
+    server.sleep_exit_worker = True
+    server.start()
+
+    first = _tokenize(MODEL_A, timeout=120)
+    assert first.status_code == 200
+    _wait_for_model_status(MODEL_A, {"unloaded"}, timeout=30)
+
+    second = _tokenize(MODEL_A, timeout=120)
+    assert second.status_code == 200
+    _wait_for_model_status(MODEL_A, {"loaded"}, timeout=30)
+
+
+def test_router_request_during_sleep_unload():
+    global server
+    server.sleep_idle_seconds = 1
+    server.sleep_exit_worker = True
+    server.start()
+
+    first = _tokenize(MODEL_A, timeout=120)
+    assert first.status_code == 200
+    _wait_for_model_status(MODEL_A, {"unloading"}, timeout=30)
+
+    during_unload = _tokenize(MODEL_A, timeout=120)
+    assert during_unload.status_code == 200
+    _wait_for_model_status(MODEL_A, {"loaded"}, timeout=30)
+
+
+def test_router_sleep_exit_worker_without_autoload():
+    global server
+    server.no_models_autoload = True
+    server.sleep_idle_seconds = 1
+    server.sleep_exit_worker = True
+    server.start()
+
+    _load_model_and_wait(MODEL_A, timeout=120)
+    first = _tokenize(MODEL_A, timeout=120)
+    assert first.status_code == 200
+    _wait_for_model_status(MODEL_A, {"unloaded"}, timeout=30)
+
+    unloaded = _tokenize(MODEL_A)
+    assert unloaded.status_code == 400
+    _load_model_and_wait(MODEL_A, timeout=120)
+    loaded = _tokenize(MODEL_A)
+    assert loaded.status_code == 200
+
+
+def test_router_sleep_exit_worker_from_preset():
+    global server
+    model_id = "sleep-exit-model"
+    preset_path = os.path.join(TMP_DIR, "test_sleep_exit_worker.ini")
+    with open(preset_path, "w") as f:
+        f.write(
+            f"[{model_id}]\n"
+            "hf-repo = ggml-org/test-model-stories260K\n"
+            "sleep-idle-seconds = 1\n"
+            "sleep-exit-worker = true\n"
+        )
+
+    try:
+        server.models_preset = preset_path
+        server.start()
+
+        first = _tokenize(model_id, timeout=120)
+        assert first.status_code == 200
+        _wait_for_model_status(model_id, {"unloaded"}, timeout=30)
+
+        second = _tokenize(model_id, timeout=120)
+        assert second.status_code == 200
+        _wait_for_model_status(model_id, {"loaded"}, timeout=30)
+    finally:
+        os.remove(preset_path)
+
+
 class _Bg:
     """runs one request in a thread, keeps its result, error and finish time"""
 

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -110,6 +110,7 @@ class ServerProcess:
     no_mmproj: bool | None = None
     media_path: str | None = None
     sleep_idle_seconds: int | None = None
+    sleep_exit_worker: bool | None = None
     cache_ram: int | None = None
     no_cache_idle_slots: bool = False
     log_path: str | None = None
@@ -269,6 +270,8 @@ class ServerProcess:
             server_args.extend(["--media-path", self.media_path])
         if self.sleep_idle_seconds is not None:
             server_args.extend(["--sleep-idle-seconds", self.sleep_idle_seconds])
+        if self.sleep_exit_worker is not None:
+            server_args.append("--sleep-exit-worker" if self.sleep_exit_worker else "--no-sleep-exit-worker")
         if self.cache_ram is not None:
             server_args.extend(["--cache-ram", self.cache_ram])
         if self.no_cache_idle_slots:


### PR DESCRIPTION
## Overview

Adds an optional `--sleep-exit-worker` mode for router workers.

When enabled together with `--sleep-idle-seconds`, the worker process exits after entering the sleep state instead of remaining alive with its backend context allocated. This allows resources such as CUDA contexts to be fully released and can reduce idle GPU power consumption.

The existing behavior remains unchanged by default.

## Additional information

The option is also available through `LLAMA_ARG_SLEEP_EXIT_WORKER` and model presets via:

```ini
sleep-exit-worker = true
```

With model autoload enabled, a new worker is started automatically on the next request. The change also handles the worker `unloading` state and requests that arrive while a worker is being terminated.

Related issue: #25570

I'm also open to feedback on the naming of the new option. If anyone has a better suggestion than `--sleep-exit-worker`, or thinks this behavior would be better implemented differently, I'd be happy to hear your thoughts and discuss alternative approaches.

## Requirements

* I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES — Codex, ChatGPT 5.6 Sol high