### PR TITLE
spec : fuse the encoder into the KV injection decode

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -938,9 +938,6 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     const int32_t * target_layer_ids   = nullptr; // model_dft's extract layer indices
     uint32_t        target_layer_ids_n = 0;
 
-    // scratch buffer for concatenated target features [n_tokens, n_embd_enc]
-    std::vector<float> features_buf;
-
     common_speculative_impl_draft_dflash(const common_params_speculative & params, uint32_t n_seq,
             common_speculative_type type = COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH)
         : common_speculative_impl(type, n_seq, params.draft.n_max)
@@ -995,7 +992,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         this->n_max = this->params.n_max;
 
         batch        = llama_batch_init(llama_n_batch(ctx_dft), 0,          n_seq);
-        batch_inject = llama_batch_init(llama_n_batch(ctx_dft), n_embd_dec, n_seq);
+        batch_inject = llama_batch_init(llama_n_ubatch(ctx_dft), n_embd_enc, n_seq);
 
         // embd batches on an M-RoPE draft need 4 position rows per token
         is_mrope = llama_model_rope_type(model_dft) == LLAMA_ROPE_TYPE_MROPE;
@@ -1121,57 +1118,20 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             for (int32_t offset = 0; offset < n_rows; offset += n_ubatch) {
                 const int32_t n_chunk = std::min(n_ubatch, n_rows - offset);
 
-                // gather this chunk's target features, interleaved by extract layer
-                features_buf.resize((size_t) n_chunk * n_embd_enc);
+                // gather target features per extract layer; the fused decode encodes and
+                // injects them into the K/V cache at the target positions
+                batch_inject.n_tokens = n_chunk;
                 for (uint32_t k = 0; k < target_layer_ids_n; ++k) {
                     const float * layer = llama_get_embeddings_layer_inp(ctx_tgt, (uint32_t) target_layer_ids[k]);
                     if (!layer) {
                         GGML_ABORT("DFlash: target layer %d input not extracted.", target_layer_ids[k]);
                     }
                     for (int32_t i = 0; i < n_chunk; ++i) {
-                        float       * dst = features_buf.data() + (size_t) i * n_embd_enc + k * (size_t) n_embd_tgt;
+                        float       * dst = batch_inject.embd + (size_t) i * n_embd_enc + k * (size_t) n_embd_tgt;
                         const float * src = layer + (size_t) (i_batch_beg[seq_id] + offset + i) * n_embd_tgt;
                         std::memcpy(dst, src, (size_t) n_embd_tgt * sizeof(float));
                     }
                 }
-
-                // fuse extracted features through DFlash encoder
-                // M-RoPE drafts read 4 position rows per token from embd batches, so pass them explicitly
-                std::vector<llama_pos> enc_pos;
-                if (is_mrope) {
-                    enc_pos.resize((size_t) 4 * n_chunk);
-                    for (int32_t i = 0; i < n_chunk; ++i) {
-                        const llama_pos p = batch_in.pos[i_batch_beg[seq_id] + offset + i];
-                        enc_pos[0 * n_chunk + i] = p;
-                        enc_pos[1 * n_chunk + i] = p;
-                        enc_pos[2 * n_chunk + i] = p;
-                        enc_pos[3 * n_chunk + i] = 0;
-                    }
-                }
-
-                llama_batch enc_batch = {
-                    /*.n_tokens =*/ n_chunk,
-                    /*.token    =*/ nullptr,
-                    /*.embd     =*/ features_buf.data(),
-                    /*.pos      =*/ is_mrope ? enc_pos.data() : nullptr,
-                    /*.n_seq_id =*/ nullptr,
-                    /*.seq_id   =*/ nullptr,
-                    /*.logits   =*/ nullptr,
-                };
-
-                int32_t rc = llama_encode(ctx_dft, enc_batch);
-                if (rc != 0) {
-                    LOG_ERR("%s: llama_encode(ctx_dft) failed rc=%d (n_tokens=%d, offset=%d)\n",
-                            __func__, rc, (int) n_chunk, (int) offset);
-                    return false;
-                }
-
-                const float * inp_g = llama_get_embeddings_nextn(ctx_dft);
-                GGML_ASSERT(inp_g && "DFlash encoder produced no output.");
-
-                // inject the DFlash decoder K/V cache at the tokens' target positions
-                batch_inject.n_tokens = n_chunk;
-                std::memcpy(batch_inject.embd, inp_g, (size_t) n_chunk * n_embd_dec * sizeof(float));
 
                 for (int32_t i = 0; i < n_chunk; ++i) {
                     const llama_pos p = batch_in.pos[i_batch_beg[seq_id] + offset + i];
@@ -1185,7 +1145,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
                     batch_inject.seq_id[i][0] = seq_id;
                     batch_inject.logits[i]    = false;
                 }
-                rc = llama_decode(ctx_dft, batch_inject);
+                const int32_t rc = llama_decode(ctx_dft, batch_inject);
                 if (rc != 0) {
                     LOG_ERR("%s: llama_decode(ctx_dft) failed rc=%d (n_tokens=%d, offset=%d)\n",
                             __func__, rc, (int) n_chunk, (int) offset);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1652,7 +1652,9 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     const int64_t n_vocab = vocab.n_tokens();
     const bool    mtp_embd = cparams.ctx_type == LLAMA_CONTEXT_TYPE_MTP && batch_inp.embd;
-    const int64_t n_embd  = mtp_embd ? hparams.n_embd_out() : hparams.n_embd_inp();
+    // DFlash embd batches carry the fused target features at the encoder input width
+    const bool    dflash_embd = model.arch == LLM_ARCH_DFLASH && batch_inp.embd;
+    const int64_t n_embd  = mtp_embd ? hparams.n_embd_out() : dflash_embd ? hparams.n_embd_inp_enc() : hparams.n_embd_inp();
 
     // when computing embeddings, all tokens are output
     const bool output_all   = cparams.embeddings;

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -253,9 +253,10 @@ std::unique_ptr<llm_graph_context> llama_model_dflash::build_arch_graph(const ll
 
 template <>
 ggml_tensor * llama_model_dflash::graph<true>::build_inp_embd_enc() const {
-    auto inp_target = std::make_unique<llm_graph_input_embd>(hparams.n_embd_inp_enc());
+    const int64_t n_embd_inp = hparams.n_embd_inp_enc();
+    auto inp_target = std::make_unique<llm_graph_input_embd>(n_embd_inp);
 
-    inp_target->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd_inp_enc(), n_tokens);
+    inp_target->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd_inp, n_tokens);
     ggml_set_input(inp_target->embd);
 
     ggml_tensor * cur = inp_target->embd;
@@ -557,6 +558,7 @@ static void build_dflash2_selector(llm_graph_context & g, const llama_model & mo
 //   * token batch -> noise-block diffusion: attend over [committed, MASK...] to generate draft tokens
 template <>
 llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_graph_params & params) : llm_graph_context(params) {
+    const int64_t n_embd_inp = hparams.n_embd_inp_enc();
     const int64_t n_embd_head = hparams.n_embd_head_v();
 
     GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
@@ -592,9 +594,9 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 
     // KV cache injection
     if (ubatch.embd) {
-        auto inp = std::make_unique<llm_graph_input_embd>(hparams.n_embd_inp_enc());
+        auto inp = std::make_unique<llm_graph_input_embd>(n_embd_inp);
 
-        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd_inp_enc(), n_tokens);
+        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd_inp, n_tokens);
         ggml_set_input(inp->embd);
 
         ggml_tensor * inp_feat = inp->embd;
@@ -818,6 +820,7 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 //   * token batch -> noise block through 3 full DSV4 stages (hc + MLA + MoE), markov + confidence heads
 llama_model_dflash::graph_dsv4::graph_dsv4(const llama_model & model, const llm_graph_params & params) :
     llama_model_deepseek4::graph(params) {
+    const int64_t n_embd_inp       = hparams.n_embd_inp_enc();
     const int64_t n_embd_head      = hparams.n_embd_head_k();
     const int64_t n_embd_head_rope = hparams.n_rot();
     const int64_t n_embd_head_nope = n_embd_head - n_embd_head_rope;
@@ -828,9 +831,9 @@ llama_model_dflash::graph_dsv4::graph_dsv4(const llama_model & model, const llm_
 
     // KV cache injection: fused target features from the encoder
     if (ubatch.embd) {
-        auto inp = std::make_unique<llm_graph_input_embd>(hparams.n_embd_inp_enc());
+        auto inp = std::make_unique<llm_graph_input_embd>(n_embd_inp);
 
-        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd_inp_enc(), n_tokens);
+        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd_inp, n_tokens);
         ggml_set_input(inp->embd);
 
         ggml_tensor * inp_feat = inp->embd;

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -599,7 +599,7 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
         inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd_inp, n_tokens);
         ggml_set_input(inp->embd);
 
-        ggml_tensor * inp_feat = inp->embd;
+        ggml_tensor * inp_target = inp->embd;
         cb(inp_feat, "inp_target_features", -1);
 
         res->add_input(std::move(inp));
@@ -836,7 +836,7 @@ llama_model_dflash::graph_dsv4::graph_dsv4(const llama_model & model, const llm_
         inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd_inp, n_tokens);
         ggml_set_input(inp->embd);
 
-        ggml_tensor * inp_feat = inp->embd;
+        ggml_tensor * inp_target = inp->embd;
         cb(inp_feat, "inp_target_features", -1);
 
         res->add_input(std::move(inp));

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -600,12 +600,12 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
         ggml_set_input(inp->embd);
 
         ggml_tensor * inp_target = inp->embd;
-        cb(inp_feat, "inp_target_features", -1);
+        cb(inp_target, "inp_target_features", -1);
 
         res->add_input(std::move(inp));
 
         // fuse the target features through the encoder
-        ggml_tensor * inp_g = build_lora_mm(model.fc, inp_feat, model.fc_s);
+        ggml_tensor * inp_g = build_lora_mm(model.fc, inp_target, model.fc_s);
         inp_g = build_norm(inp_g, model.output_norm_enc, NULL, LLM_NORM_RMS, -1);
         cb(inp_g, "inp_g_embeddings", -1);
 
@@ -837,12 +837,12 @@ llama_model_dflash::graph_dsv4::graph_dsv4(const llama_model & model, const llm_
         ggml_set_input(inp->embd);
 
         ggml_tensor * inp_target = inp->embd;
-        cb(inp_feat, "inp_target_features", -1);
+        cb(inp_target, "inp_target_features", -1);
 
         res->add_input(std::move(inp));
 
         // fuse the target features through the encoder
-        ggml_tensor * inp_g = build_lora_mm(model.fc, inp_feat, model.fc_s);
+        ggml_tensor * inp_g = build_lora_mm(model.fc, inp_target, model.fc_s);
         inp_g = build_norm(inp_g, model.output_norm_enc, nullptr, LLM_NORM_RMS, -1);
         cb(inp_g, "inp_g_embeddings", -1);
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -592,15 +592,20 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 
     // KV cache injection
     if (ubatch.embd) {
-        auto inp = std::make_unique<llm_graph_input_embd>(n_embd);
+        auto inp = std::make_unique<llm_graph_input_embd>(hparams.n_embd_inp_enc());
 
-        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd, n_tokens);
+        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd_inp_enc(), n_tokens);
         ggml_set_input(inp->embd);
 
-        ggml_tensor * inp_g = inp->embd;
-        cb(inp_g, "inp_g_embeddings", -1);
+        ggml_tensor * inp_feat = inp->embd;
+        cb(inp_feat, "inp_target_features", -1);
 
         res->add_input(std::move(inp));
+
+        // fuse the target features through the encoder
+        ggml_tensor * inp_g = build_lora_mm(model.fc, inp_feat, model.fc_s);
+        inp_g = build_norm(inp_g, model.output_norm_enc, NULL, LLM_NORM_RMS, -1);
+        cb(inp_g, "inp_g_embeddings", -1);
 
         for (int il = 0; il < n_layer; ++il) {
             const auto & layer = model.layers[il];
@@ -823,15 +828,20 @@ llama_model_dflash::graph_dsv4::graph_dsv4(const llama_model & model, const llm_
 
     // KV cache injection: fused target features from the encoder
     if (ubatch.embd) {
-        auto inp = std::make_unique<llm_graph_input_embd>(n_embd);
+        auto inp = std::make_unique<llm_graph_input_embd>(hparams.n_embd_inp_enc());
 
-        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, n_embd, n_tokens);
+        inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd_inp_enc(), n_tokens);
         ggml_set_input(inp->embd);
 
-        ggml_tensor * inp_g = inp->embd;
-        cb(inp_g, "inp_g_embeddings", -1);
+        ggml_tensor * inp_feat = inp->embd;
+        cb(inp_feat, "inp_target_features", -1);
 
         res->add_input(std::move(inp));
+
+        // fuse the target features through the encoder
+        ggml_tensor * inp_g = build_lora_mm(model.fc, inp_feat, model.fc_s);
+        inp_g = build_norm(inp_g, model.output_norm_enc, nullptr, LLM_NORM_RMS, -1);
+        cb(inp_g, "inp_g_embeddings", -1);
 
         for (int il = 0; il < n_layer; ++il) {
             const auto & layer = model.layers[il];


### PR DESCRIPTION
## Overview
The encoder is a single `fc` + `norm`, but running it as a separate llama_encode forced a device-to-host round trip of its output before the injection decode could re-upload it, plus a second graph build per round. 

Fold the encoder into the decoder's embd branch and feed the target features directly to one llama_decode.
<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information
### before:
<img width="2176" height="712" alt="微信图片_20260818014440_3286_853" src="https://github.com/user-attachments/assets/99ddc0b8-3a26-4a1a-ad1d-8a11569557b2" />

### now:
<img width="2188" height="718" alt="微信图片_20260818014440_3287_853" src="https://github.com/user-attachments/assets/218ef42b-2af7-42cb-a91e-1b0e0ff19edb" />



<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Correctness

DeepSeek-V4-Flash-DSpark
8x RTX 4090, target q8_0 + MXFP4 experts (--n-cpu-moe 4), draft q8_0 on one GPU, greedy, 12 GSM8K prompts x 256 tokens, warm pass:
| arm  | gen t/s | injection path per round |
|------|---------|--------------------------|
| base | 41.5    | 2.85 ms (gather 2.14 + encode 0.40 + decode 0.30) |
| fuse | 42.8    | 2.64 ms (gather 2.16 + decode 0.48) |
### Measured with speed-bench Qwen3-8B-Q8_0 target with f16 DFlash/DSpark drafts
#### dflash: before vs after this PR 
```
category       base_avg_pred_t/s  spec_avg_pred_t/s  decode_speedup  base_avg_latency  spec_avg_latency  latency_speedup  accept_rate
-------------  -----------------  -----------------  --------------  ----------------  ----------------  ---------------  -----------
coding         155.49             159.60             1.03x           7.501s            7.290s            1.03x            0.4556
humanities     138.15             142.80             1.03x           8.227s            7.954s            1.03x            0.3679
math           141.94             148.94             1.05x           8.680s            8.247s            1.05x            0.4155
qa             136.16             142.89             1.05x           6.674s            6.338s            1.05x            0.3700
rag            141.98             148.77             1.05x           6.440s            6.112s            1.05x            0.4061
reasoning      139.14             145.57             1.05x           9.416s            8.955s            1.05x            0.3892
stem           136.93             143.94             1.05x           8.090s            7.678s            1.05x            0.3761
writing        126.66             134.37             1.06x           8.648s            8.088s            1.07x            0.3338
multilingual   146.12             155.11             1.06x           6.030s            5.650s            1.07x            0.4444
summarization  130.84             136.93             1.05x           2.589s            2.467s            1.05x            0.3475
roleplay       122.77             130.40             1.06x           7.979s            7.431s            1.07x            0.3151
overall        137.83             144.48             1.05x           7.298s            6.928s            1.05x            0.3842
```

#### dspark: before vs after this PR

```
category       base_avg_pred_t/s  spec_avg_pred_t/s  decode_speedup  base_avg_latency  spec_avg_latency  latency_speedup  accept_rate
-------------  -----------------  -----------------  --------------  ----------------  ----------------  ---------------  -----------
coding         166.80             170.51             1.02x           6.992s            6.816s            1.03x            0.5397
humanities     160.62             162.33             1.01x           7.093s            7.007s            1.01x            0.4962
math           166.54             168.11             1.01x           7.398s            7.334s            1.01x            0.5457
qa             161.84             163.29             1.01x           5.610s            5.568s            1.01x            0.5029
rag            166.70             167.84             1.01x           5.495s            5.457s            1.01x            0.5341
reasoning      164.22             165.11             1.01x           7.948s            7.915s            1.00x            0.5211
stem           162.41             163.12             1.00x           6.811s            6.783s            1.00x            0.5057
writing        150.79             151.46             1.00x           7.221s            7.204s            1.00x            0.4515
multilingual   168.22             169.65             1.01x           5.217s            5.180s            1.01x            0.5499
summarization  151.72             153.03             1.01x           2.230s            2.213s            1.01x            0.4546
roleplay       147.05             148.30             1.01x           6.628s            6.590s            1.01x            0.4296
overall        160.63             162.07             1.01x           6.240s            6.188s            1.01x            0.5049
```
#### dflash2: before vs after this PR Qwen3.8-27B

```
category       base_avg_pred_t/s  spec_avg_pred_t/s  decode_speedup  base_avg_latency  spec_avg_latency  latency_speedup  accept_rate
  -------------  -----------------  -----------------  --------------  ----------------  ----------------  ---------------  -----------
  coding         68.78              69.19              1.01x           18.621s           18.506s           1.01x            0.6615
  humanities     66.28              66.80              1.01x           10.953s           10.833s           1.01x            0.6379
  math           68.86              69.14              1.00x           7.886s            7.856s            1.00x            0.6670
  qa             63.06              63.42              1.01x           12.430s           12.375s           1.00x            0.5740
  rag            73.63              73.99              1.00x           8.899s            8.852s            1.01x            0.7346
  reasoning      66.37              66.91              1.01x           8.962s            8.902s            1.01x            0.6455
  stem           66.54              66.93              1.01x           8.573s            8.525s            1.01x            0.6491
  writing        62.13              62.51              1.01x           18.304s           18.199s           1.01x            0.5748
  multilingual   69.30              69.77              1.01x           11.951s           11.894s           1.00x            0.6700
  summarization  66.77              67.16              1.01x           3.249s            3.246s            1.00x            0.6625
  roleplay       63.90              64.20              1.00x           22.535s           22.466s           1.00x            0.5938
  overall        66.88              67.27              1.01x           12.033s           11.969s           1.01x            0.6317
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md --> 
