### PR TITLE
CUDA: Improve MXFP4 W4A4 activation quantization

### DIFF
--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -410,12 +410,12 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
                 const float err_diff = fabsf(xi) - 0.5f * fabsf(kvalues_fp4[q & 0x7]) * test_scale;
                 err[i] = err_diff*err_diff;
             }
+            float err_delta = err[1] - err[0];
 #pragma unroll
             for (int mask = 16; mask > 0; mask >>= 1) {
-                err[0] += __shfl_xor_sync(0xFFFFFFFF, err[0], mask, WARP_SIZE);
-                err[1] += __shfl_xor_sync(0xFFFFFFFF, err[1], mask, WARP_SIZE);
+                err_delta += __shfl_xor_sync(0xFFFFFFFF, err_delta, mask, WARP_SIZE);
             }
-            if (err[1] < err[0]) {
+            if (err_delta < 0.0f) {
                 e -= 1;
             }
         }

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -396,14 +396,15 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
         uint8_t e = compute_e8m0_scale(amax);
 
         if (amax > 0.0f && e > 0) {
+            static constexpr int test_offsets[2] = { 0, -1 };
             float err[2];
 #pragma unroll
-            for (int t = 0; t < 2; ++t) {
-                const float test_scale = ggml_cuda_e8m0_to_fp32(e - t);
+            for (int i = 0; i < 2; ++i) {
+                const float test_scale = ggml_cuda_e8m0_to_fp32(e + test_offsets[i]);
                 const float test_inv_scale = __frcp_rn(test_scale);
                 const uint8_t q = ggml_cuda_float_to_fp4_e2m1(xi, test_inv_scale);
                 const float err_diff = fabsf(xi) - 0.5f*fabsf((float) kvalues_fp4[q & 0x7])*test_scale;
-                err[t] = err_diff*err_diff;
+                err[i] = err_diff*err_diff;
             }
 #pragma unroll
             for (int mask = 16; mask > 0; mask >>= 1) {

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -403,7 +403,7 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
                 const float test_scale = ggml_cuda_e8m0_to_fp32(e + test_offsets[i]);
                 const float test_inv_scale = __frcp_rn(test_scale);
                 const uint8_t q = ggml_cuda_float_to_fp4_e2m1(xi, test_inv_scale);
-                const float err_diff = fabsf(xi) - 0.5f*fabsf((float) kvalues_fp4[q & 0x7])*test_scale;
+                const float err_diff = fabsf(xi) - 0.5f * fabsf(kvalues_fp4[q & 0x7]) * test_scale;
                 err[i] = err_diff*err_diff;
             }
 #pragma unroll

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -393,7 +393,28 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
             amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, mask, WARP_SIZE));
         }
 
-        const uint8_t e = compute_e8m0_scale(amax);
+        uint8_t e = compute_e8m0_scale(amax);
+
+        if (amax > 0.0f && e > 0) {
+            float err[2];
+#pragma unroll
+            for (int t = 0; t < 2; ++t) {
+                const float test_scale = ggml_cuda_e8m0_to_fp32(e - t);
+                const float test_inv_scale = __frcp_rn(test_scale);
+                const uint8_t q = ggml_cuda_float_to_fp4_e2m1(xi, test_inv_scale);
+                const float err_diff = fabsf(xi) - 0.5f*fabsf((float) kvalues_fp4[q & 0x7])*test_scale;
+                err[t] = err_diff*err_diff;
+            }
+#pragma unroll
+            for (int mask = 16; mask > 0; mask >>= 1) {
+                err[0] += __shfl_xor_sync(0xFFFFFFFF, err[0], mask, WARP_SIZE);
+                err[1] += __shfl_xor_sync(0xFFFFFFFF, err[1], mask, WARP_SIZE);
+            }
+            if (err[1] < err[0]) {
+                e -= 1;
+            }
+        }
+
         scales[b] = e;
         const float inv_s = (amax == 0.0f) ? 0.0f : __frcp_rn(ggml_cuda_e8m0_to_fp32(e));
 

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -394,14 +394,16 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
         }
 
         uint8_t e = compute_e8m0_scale(amax);
+        const float scale = ggml_cuda_e8m0_to_fp32(e);
+        float inv_s = amax == 0.0f ? 0.0f : __frcp_rn(scale);
 
         if (amax > 0.0f && e > 0) {
             static constexpr int test_offsets[2] = { 0, -1 };
             float err[2];
 #pragma unroll
             for (int i = 0; i < 2; ++i) {
-                const float test_scale = ggml_cuda_e8m0_to_fp32(e + test_offsets[i]);
-                const float test_inv_scale = __frcp_rn(test_scale);
+                const float test_scale = i == 0 ? scale : 0.5f * scale;
+                const float test_inv_scale = i == 0 ? inv_s : 2.0f * inv_s;
 #if CUDART_VERSION >= 12080
                 const uint8_t q = __nv_fp4_e2m1(xi * test_inv_scale).__x;
 #else
@@ -416,12 +418,12 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
                 err_delta += __shfl_xor_sync(0xFFFFFFFF, err_delta, mask, WARP_SIZE);
             }
             if (err_delta < 0.0f) {
-                e -= 1;
+                e += test_offsets[1];
+                inv_s *= 2.0f;
             }
         }
 
         scales[b] = e;
-        const float inv_s = (amax == 0.0f) ? 0.0f : __frcp_rn(ggml_cuda_e8m0_to_fp32(e));
 
 #if CUDART_VERSION >= 12080
         const float scaled_val = xi * inv_s;

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -399,10 +399,11 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
             float err[2];
 #pragma unroll
             for (int t = 0; t < 2; ++t) {
-                const float   s_t  = ggml_cuda_e8m0_to_fp32(e - t);
-                const uint8_t q    = ggml_cuda_float_to_fp4_e2m1(xi, __frcp_rn(s_t));
-                const float   diff = fabsf(xi) - 0.5f*fabsf((float) kvalues_fp4[q & 0x7])*s_t;
-                err[t] = diff*diff;
+                const float test_scale = ggml_cuda_e8m0_to_fp32(e - t);
+                const float test_inv_scale = __frcp_rn(test_scale);
+                const uint8_t q = ggml_cuda_float_to_fp4_e2m1(xi, test_inv_scale);
+                const float err_diff = fabsf(xi) - 0.5f*fabsf((float) kvalues_fp4[q & 0x7])*test_scale;
+                err[t] = err_diff*err_diff;
             }
 #pragma unroll
             for (int mask = 16; mask > 0; mask >>= 1) {

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -393,7 +393,27 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
             amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, mask, WARP_SIZE));
         }
 
-        const uint8_t e = compute_e8m0_scale(amax);
+        uint8_t e = compute_e8m0_scale(amax);
+
+        if (amax > 0.0f && e > 0) {
+            float err[2];
+#pragma unroll
+            for (int t = 0; t < 2; ++t) {
+                const float   s_t  = ggml_cuda_e8m0_to_fp32(e - t);
+                const uint8_t q    = ggml_cuda_float_to_fp4_e2m1(xi, __frcp_rn(s_t));
+                const float   diff = fabsf(xi) - 0.5f*fabsf((float) kvalues_fp4[q & 0x7])*s_t;
+                err[t] = diff*diff;
+            }
+#pragma unroll
+            for (int mask = 16; mask > 0; mask >>= 1) {
+                err[0] += __shfl_xor_sync(0xFFFFFFFF, err[0], mask, WARP_SIZE);
+                err[1] += __shfl_xor_sync(0xFFFFFFFF, err[1], mask, WARP_SIZE);
+            }
+            if (err[1] < err[0]) {
+                e -= 1;
+            }
+        }
+
         scales[b] = e;
         const float inv_s = (amax == 0.0f) ? 0.0f : __frcp_rn(ggml_cuda_e8m0_to_fp32(e));
 

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -393,28 +393,7 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
             amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFF, amax, mask, WARP_SIZE));
         }
 
-        uint8_t e = compute_e8m0_scale(amax);
-
-        if (amax > 0.0f && e > 0) {
-            float err[2];
-#pragma unroll
-            for (int t = 0; t < 2; ++t) {
-                const float test_scale = ggml_cuda_e8m0_to_fp32(e - t);
-                const float test_inv_scale = __frcp_rn(test_scale);
-                const uint8_t q = ggml_cuda_float_to_fp4_e2m1(xi, test_inv_scale);
-                const float err_diff = fabsf(xi) - 0.5f*fabsf((float) kvalues_fp4[q & 0x7])*test_scale;
-                err[t] = err_diff*err_diff;
-            }
-#pragma unroll
-            for (int mask = 16; mask > 0; mask >>= 1) {
-                err[0] += __shfl_xor_sync(0xFFFFFFFF, err[0], mask, WARP_SIZE);
-                err[1] += __shfl_xor_sync(0xFFFFFFFF, err[1], mask, WARP_SIZE);
-            }
-            if (err[1] < err[0]) {
-                e -= 1;
-            }
-        }
-
+        const uint8_t e = compute_e8m0_scale(amax);
         scales[b] = e;
         const float inv_s = (amax == 0.0f) ? 0.0f : __frcp_rn(ggml_cuda_e8m0_to_fp32(e));
 

--- a/ggml/src/ggml-cuda/quantize.cu
+++ b/ggml/src/ggml-cuda/quantize.cu
@@ -402,7 +402,11 @@ static __global__ void quantize_mmq_mxfp4(const float * __restrict__ x,
             for (int i = 0; i < 2; ++i) {
                 const float test_scale = ggml_cuda_e8m0_to_fp32(e + test_offsets[i]);
                 const float test_inv_scale = __frcp_rn(test_scale);
+#if CUDART_VERSION >= 12080
+                const uint8_t q = __nv_fp4_e2m1(xi * test_inv_scale).__x;
+#else
                 const uint8_t q = ggml_cuda_float_to_fp4_e2m1(xi, test_inv_scale);
+#endif // CUDART_VERSION >= 12080
                 const float err_diff = fabsf(xi) - 0.5f * fabsf(kvalues_fp4[q & 0x7]) * test_scale;
                 err[i] = err_diff*err_diff;
             }


### PR DESCRIPTION
## Overview

This PR improves MXFP4 W4A4 activation quantization primarily in quality. It replicates the same approach we use in `quantize_row_mxfp4_ref` but simplified given we only consider one other exponent.

Qwen3.8 27B quantized as MXFP4, shows slighly improved same top P while pp2048 went down even after various optimizations.

|    |    pp2048 t/s  | mean KLD | Same top P |
| ---  | ---  | --- | --- |
|no search | 5196 |  0.1316 | 84.24
| w/search | 5124 (-1.4%) | 0.1268 | 84.48
| W4A16 | no MMQ |  0.0567 | 89.99 | 


## Additional information


Tested with
```
./build/bin/test-backend-ops test -b CUDA0 -o MUL_MAT -p mxfp4
```


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I used Claude to make the initial port of this change from the CPU implementation, and made it run various benchmarks to validate it