### PR TITLE
server: fix completion_tokens/total_tokens undercount when n > 1

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -4257,9 +4257,12 @@ std::unique_ptr<server_res_generator> server_routes::handle_completions_impl(
             } else if (res_type == TASK_RESPONSE_TYPE_OAI_CHAT || res_type == TASK_RESPONSE_TYPE_OAI_CMPL) {
                 // if multiple results in OAI format, we need to re-format them
                 json & choices = arr[0]["choices"];
+                json & usage   = arr[0]["usage"];
                 for (size_t i = 1; i < arr.size(); i++) {
                     choices.push_back(std::move(arr[i]["choices"][0]));
+                    usage["completion_tokens"] = usage["completion_tokens"].get<int32_t>() + arr[i]["usage"]["completion_tokens"].get<int32_t>();
                 }
+                usage["total_tokens"] = usage["prompt_tokens"].get<int32_t>() + usage["completion_tokens"].get<int32_t>();
                 res->ok(arr[0]);
             } else {
                 // multi-results, non-OAI compat

--- a/tools/server/tests/unit/test_chat_completion.py
+++ b/tools/server/tests/unit/test_chat_completion.py
@@ -587,6 +587,9 @@ def test_chat_completions_multiple_choices():
         for choice in res.body["choices"]:
             assert "assistant" == choice["message"]["role"]
             assert choice["finish_reason"] == "length"
+        # usage must be summed across all choices, not just the first one
+        assert res.body["usage"]["completion_tokens"] == 16
+        assert res.body["usage"]["total_tokens"] == res.body["usage"]["prompt_tokens"] + 16
 
 
 def test_chat_completions_token_count():


### PR DESCRIPTION
## Overview
 it counted tokens wrong when asking for multiple answers

it now counts tokens from all the answers, not just one

 

## Additional information

asked for 3 answers, it only counted tokens for 1

asking for 2 answers with max_tokens=8, it should report 16 total tokens used

in the server's response-merging code

 

## Requirements

 

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  
YES - I used Claude (Claude Code) to help investigate the bug, find the root cause, and write the fix and test. I reviewed, built, and tested everything myself before submitting.
 
