### PR TITLE
vulkan: use density gate for MUL_MAT_VEC_ID path

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10629,11 +10629,24 @@ static void ggml_vk_mul_mat_vec_id_q_f16(ggml_backend_vk_context * ctx, vk_conte
     }
 }
 
-static bool ggml_vk_use_mul_mat_vec_id(const struct ggml_cgraph * cgraph, int node_idx) {
+static bool ggml_vk_use_mul_mat_vec_id(const ggml_backend_vk_context * ctx, const struct ggml_cgraph * cgraph, int node_idx) {
     ggml_tensor * dst = cgraph->nodes[node_idx];
     ggml_tensor * src0 = dst->src[0];
     ggml_tensor * src2 = dst->src[2];
-    return (src2->ne[1] <= 8) && (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type));
+
+    bool use_vec_id = src2->ne[1] <= 8;
+    if (!ctx->device->coopmat2) {
+        // The tiled path is slow at small batch without coopmat2 (e.g. the
+        // decode cliff at 9+ sequences on gfx1013/gfx1100/gfx1151 and NV
+        // coopmat1). Keep the vector path while the routed density is low.
+        // coopmat2 (Blackwell) handles small batches fine - keep the cutoff.
+        const int64_t n_tokens  = src2->ne[1];
+        const int64_t n_per_tok = src2->ne[0];
+        const int64_t n_experts = src0->ne[2];
+        use_vec_id = (n_tokens * n_per_tok <= 2 * n_experts) && (n_tokens <= 64);
+    }
+
+    return use_vec_id && (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || ggml_is_quantized(src0->type));
 }
 
 static void ggml_vk_mul_mat_id(ggml_backend_vk_context * ctx, vk_context& subctx, const struct ggml_cgraph * cgraph, int node_idx) {
@@ -10642,7 +10655,7 @@ static void ggml_vk_mul_mat_id(ggml_backend_vk_context * ctx, vk_context& subctx
     ggml_tensor * src1 = dst->src[1];
     ggml_tensor * src2 = dst->src[2];
     VK_LOG_DEBUG("ggml_vk_mul_mat_id(" << src0 << ", " << src1 << ", " << src2 << ", " << dst << ")");
-    if (ggml_vk_use_mul_mat_vec_id(cgraph, node_idx)) {
+    if (ggml_vk_use_mul_mat_vec_id(ctx, cgraph, node_idx)) {
         ggml_vk_mul_mat_vec_id_q_f16(ctx, subctx, cgraph, node_idx);
     } else {
         ggml_vk_mul_mat_id_q_f16(ctx, subctx, src0, src1, src2, dst);
@@ -16480,7 +16493,7 @@ static bool ggml_vk_can_fuse(const ggml_backend_vk_context * ctx, const struct g
             return false;
         }
         // mat-vec only
-        if (!ggml_vk_use_mul_mat_vec_id(cgraph, node_idx)) {
+        if (!ggml_vk_use_mul_mat_vec_id(ctx, cgraph, node_idx)) {
             return false;
         }
         // shaders assume the types match
@@ -16515,7 +16528,7 @@ static bool ggml_vk_can_fuse(const ggml_backend_vk_context * ctx, const struct g
             return false;
         }
         // mat-vec only
-        if (!ggml_vk_use_mul_mat_vec_id(cgraph, node_idx)) {
+        if (!ggml_vk_use_mul_mat_vec_id(ctx, cgraph, node_idx)) {
             return false;
         }
         // shaders assume the types match

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10636,10 +10636,8 @@ static bool ggml_vk_use_mul_mat_vec_id(const ggml_backend_vk_context * ctx, cons
 
     bool use_vec_id = src2->ne[1] <= 8;
     if (!ctx->device->coopmat2) {
-        // The tiled path is slow at small batch without coopmat2 (e.g. the
-        // decode cliff at 9+ sequences on gfx1013/gfx1100/gfx1151 and NV
-        // coopmat1). Keep the vector path while the routed density is low.
-        // coopmat2 (Blackwell) handles small batches fine - keep the cutoff.
+        // Tiled mul_mat_id is slow at low batch without coopmat2; keep the
+        // vector path while the routed density is low.
         const int64_t n_tokens  = src2->ne[1];
         const int64_t n_per_tok = src2->ne[0];
         const int64_t n_experts = src0->ne[2];


### PR DESCRIPTION
Replace the fixed 8-token cutoff with the #25356 density gate (`n_tokens * experts_per_token <= 2 * n_experts`, capped at 64 tokens). Avoids the batch-9 decode regression on AMD RADV; validated on gfx1151, RDNA3 and gfx1013 (BC-250): +36% at B=9, +27% at B=16, +21% at B=64, neutral at B<=8.

Assisted-by: DeepSeek V4 Flash

## Overview

Replace the hardcoded `batch <= 8` threshold for the Vulkan `GGML_OP_MUL_MAT_ID` MMV path with the routed-density heuristic proposed in #25356.

For MoE decode, the MMV kernel performs better for small routed workloads, while the tiled kernel wins at larger workloads. The fixed cutoff causes a sharp kernel-selection regression when going from 8 to 9 concurrent sequences on AMD RADV.

The new gate keeps MMV selected while:

```text
n_tokens * experts_per_token <= 2 * n_experts
```

and `n_tokens <= 64`.

The existing F32/F16/quantized type check is unchanged, and large-batch prefill remains on the tiled path.

## Additional information

On a BC-250 (`gfx1013`), the new gate produced:

* B=9: +36%
* B=16: +27%
* B=64: +21%
* B<=8: neutral
* PP512: neutral (303-304 t/s)

The same density heuristic has previously been validated on Strix Halo (`gfx1151`) and RDNA3 in the discussion of #25356.

Forcing the tiled path everywhere was also tested on `gfx1013` and performed substantially worse (-44% at tg64, about -50% at B=1), supporting kernel selection rather than removal of the MMV path.

The change is limited to `ggml_vk_use_mul_mat_vec_id()`: 9 insertions, 1 deletion, with no new configuration or environment knobs.

Correctness: `test-backend-ops -b Vulkan0 -o MUL_MAT_ID` passes `872/872`
on the patched build (gfx1013, RADV).

## Related work

- #25356: reports the same batch-9 performance cliff on Strix Halo and proposes the density-based heuristic used here.
- #25862: addresses Vulkan MoE behavior for 256-expert models and a RADV tiled-shader pipeline compilation stall. This has a different motivation and is complementary to this change.
- #24407 / #24408: Intel Xe group-GEMM MoE work; unrelated to this kernel-selection heuristic.
- #25918: merged ZenDNN grouped-GEMM work for mul_mat_id on CPU; unrelated to Vulkan selection.

## Repro 

Reproduction (llama-batched-bench, Qwen3.5-35B-A3B, 4-node RPC):
  stock:  B=8 52.6, B=9 35.9 t/s   (cliff)
  patched: B=8 51.5, B=9 48.2 t/s  (+36%)


## Requirements

* I have read and agree to the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES - DeepSeek V4 Flash was used to assist with analysis and drafting of the code change and PR description. The submitted change and validation were reviewed by the author.