### PR TITLE
llama-mmap: fix numa path hint inconsistency.

### DIFF
--- a/src/llama-mmap.cpp
+++ b/src/llama-mmap.cpp
@@ -448,7 +448,12 @@ struct llama_mmap::impl {
         int flags = MAP_SHARED;
         if (numa) { prefetch = 0; }
 #ifdef __linux__
-        if (posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL)) {
+        if (numa) {
+            if (posix_fadvise(fd, 0, 0, POSIX_FADV_RANDOM)) {
+                LLAMA_LOG_WARN("warning: posix_fadvise(.., POSIX_FADV_RANDOM) failed: %s\n",
+                        strerror(errno));
+            }
+        } else if (posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL)) {
             LLAMA_LOG_WARN("warning: posix_fadvise(.., POSIX_FADV_SEQUENTIAL) failed: %s\n",
                     strerror(errno));
         }


### PR DESCRIPTION
## Overview

Hint when numa path used was setting SEQ as fadvise, but RAND on madvise . Doing so does makse it unclear what is applied in the end, while the intent of the existing code is to set RAND. 

## Additional information

numa sets RANDOM on the file memory map hint, but earlier the code sets SEQUENTIAL as file descriptor hint, contradicting what the numa path sets for mapping. This changes so the hint is RANDOM if numa is selected in both the call to posix_madvise and posix_fadvise.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
  Using AI to inspect and analyze code in the llama.cpp project. 
  In this instance also using AI with strict guidance on how to do the actual code update. 

## Test
CI passes
no regression in my quick testing
the numa path itself is untested because this hardware reports a single NUMA node.

