### PR TITLE
devops: use GGML_NATIVE=OFF for OpenVINO

### DIFF
--- a/.devops/openvino.Dockerfile
+++ b/.devops/openvino.Dockerfile
@@ -90,6 +90,7 @@ RUN bash -c "source ${OpenVINO_DIR}/setupvars.sh && \
     cmake -B build/ReleaseOV -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLAMA_BUILD_TESTS=OFF \
+        -DGGML_NATIVE=OFF \
         -DGGML_OPENVINO=ON && \
     cmake --build build/ReleaseOV --parallel "
 

--- a/.devops/openvino.Dockerfile
+++ b/.devops/openvino.Dockerfile
@@ -91,6 +91,8 @@ RUN bash -c "source ${OpenVINO_DIR}/setupvars.sh && \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLAMA_BUILD_TESTS=OFF \
         -DGGML_NATIVE=OFF \
+        -DGGML_BACKEND_DL=ON \
+        -DGGML_CPU_ALL_VARIANTS=ON \
         -DGGML_OPENVINO=ON && \
     cmake --build build/ReleaseOV --parallel "
 


### PR DESCRIPTION
Same as in other Dockerfiles.

Should fix #23100

## Overview

Disables GGML_NATIVE flag for OpenVINO docker builds, otherwise gcc selects emitted instruction set based on specific build machine. This can result in faults when image is run, as was in my case: emitted AVX-512 instructions from server-openvino-b10481 image are not compatible with my Intel(R) Core(TM) Ultra 5 225H CPU

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for troubleshooting
