### PR TITLE
metal : add i-quant support to mul_mv_ext (small-batch decode path)

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2362,6 +2362,14 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
            op->src[0]->type == GGML_TYPE_Q6_K ||
            op->src[0]->type == GGML_TYPE_Q2_K ||
            op->src[0]->type == GGML_TYPE_Q3_K ||
+           op->src[0]->type == GGML_TYPE_IQ2_XXS ||
+           op->src[0]->type == GGML_TYPE_IQ2_XS  ||
+           op->src[0]->type == GGML_TYPE_IQ2_S   ||
+           op->src[0]->type == GGML_TYPE_IQ3_XXS ||
+           op->src[0]->type == GGML_TYPE_IQ3_S   ||
+           op->src[0]->type == GGML_TYPE_IQ1_S   ||
+           op->src[0]->type == GGML_TYPE_IQ1_M   ||
+           op->src[0]->type == GGML_TYPE_IQ4_XS  ||
            false) && (ne11 >= 4 && ne11 <= 8)
          )
         )

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -4308,6 +4308,46 @@ template [[host_name("kernel_mul_mv_ext_q3_K_f32_r1_3")]] kernel mul_mv_ext_q4x4
 template [[host_name("kernel_mul_mv_ext_q3_K_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_q3_K, 256, dequantize_q3_K>;
 template [[host_name("kernel_mul_mv_ext_q3_K_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_q3_K, 256, dequantize_q3_K>;
 
+template [[host_name("kernel_mul_mv_ext_iq2_xxs_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq2_xxs, 256, dequantize_iq2_xxs>;
+template [[host_name("kernel_mul_mv_ext_iq2_xxs_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq2_xxs, 256, dequantize_iq2_xxs>;
+template [[host_name("kernel_mul_mv_ext_iq2_xxs_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq2_xxs, 256, dequantize_iq2_xxs>;
+template [[host_name("kernel_mul_mv_ext_iq2_xxs_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq2_xxs, 256, dequantize_iq2_xxs>;
+
+template [[host_name("kernel_mul_mv_ext_iq2_xs_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq2_xs, 256, dequantize_iq2_xs>;
+template [[host_name("kernel_mul_mv_ext_iq2_xs_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq2_xs, 256, dequantize_iq2_xs>;
+template [[host_name("kernel_mul_mv_ext_iq2_xs_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq2_xs, 256, dequantize_iq2_xs>;
+template [[host_name("kernel_mul_mv_ext_iq2_xs_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq2_xs, 256, dequantize_iq2_xs>;
+
+template [[host_name("kernel_mul_mv_ext_iq2_s_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq2_s, 256, dequantize_iq2_s>;
+template [[host_name("kernel_mul_mv_ext_iq2_s_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq2_s, 256, dequantize_iq2_s>;
+template [[host_name("kernel_mul_mv_ext_iq2_s_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq2_s, 256, dequantize_iq2_s>;
+template [[host_name("kernel_mul_mv_ext_iq2_s_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq2_s, 256, dequantize_iq2_s>;
+
+template [[host_name("kernel_mul_mv_ext_iq3_xxs_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq3_xxs, 256, dequantize_iq3_xxs>;
+template [[host_name("kernel_mul_mv_ext_iq3_xxs_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq3_xxs, 256, dequantize_iq3_xxs>;
+template [[host_name("kernel_mul_mv_ext_iq3_xxs_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq3_xxs, 256, dequantize_iq3_xxs>;
+template [[host_name("kernel_mul_mv_ext_iq3_xxs_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq3_xxs, 256, dequantize_iq3_xxs>;
+
+template [[host_name("kernel_mul_mv_ext_iq3_s_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq3_s, 256, dequantize_iq3_s>;
+template [[host_name("kernel_mul_mv_ext_iq3_s_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq3_s, 256, dequantize_iq3_s>;
+template [[host_name("kernel_mul_mv_ext_iq3_s_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq3_s, 256, dequantize_iq3_s>;
+template [[host_name("kernel_mul_mv_ext_iq3_s_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq3_s, 256, dequantize_iq3_s>;
+
+template [[host_name("kernel_mul_mv_ext_iq1_s_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq1_s, 256, dequantize_iq1_s>;
+template [[host_name("kernel_mul_mv_ext_iq1_s_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq1_s, 256, dequantize_iq1_s>;
+template [[host_name("kernel_mul_mv_ext_iq1_s_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq1_s, 256, dequantize_iq1_s>;
+template [[host_name("kernel_mul_mv_ext_iq1_s_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq1_s, 256, dequantize_iq1_s>;
+
+template [[host_name("kernel_mul_mv_ext_iq1_m_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq1_m, 256, dequantize_iq1_m>;
+template [[host_name("kernel_mul_mv_ext_iq1_m_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq1_m, 256, dequantize_iq1_m>;
+template [[host_name("kernel_mul_mv_ext_iq1_m_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq1_m, 256, dequantize_iq1_m>;
+template [[host_name("kernel_mul_mv_ext_iq1_m_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq1_m, 256, dequantize_iq1_m>;
+
+template [[host_name("kernel_mul_mv_ext_iq4_xs_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_iq4_xs, 256, dequantize_iq4_xs>;
+template [[host_name("kernel_mul_mv_ext_iq4_xs_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_iq4_xs, 256, dequantize_iq4_xs>;
+template [[host_name("kernel_mul_mv_ext_iq4_xs_f32_r1_4")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<4, block_iq4_xs, 256, dequantize_iq4_xs>;
+template [[host_name("kernel_mul_mv_ext_iq4_xs_f32_r1_5")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<5, block_iq4_xs, 256, dequantize_iq4_xs>;
+
 template<typename T0, typename T1, short NR0, typename args_t>
 void kernel_mul_mv_t_t_impl(
         args_t args,


### PR DESCRIPTION
## Summary

The `mul_mv_ext` kernels — the small-batch (BS 2–8) mat-vec path — admit Q4_0-family types at `ne11 >= 2` and K-quants at `ne11 >= 4`, but **no i-quants**. IQ1/IQ2/IQ3/IQ4_XS models therefore fall through to the generic mat-vec kernel at exactly the batch widths speculative-decoding verification produces (3–5 rows), which is a large part of why MTP/spec decode measures as a wash on Metal for these quants while gaining substantially on CUDA.

The `type4x4` dequant functions for every i-quant already exist in-tree (used by `mul_mm`). This PR only adds the missing `mul_mv_ext` template instantiations (`iq2_xxs, iq2_xs, iq2_s, iq3_xxs, iq3_s, iq1_s, iq1_m, iq4_xs` × `r1_2..5`) and admits those types in the existing `ne11 4..8` group alongside the K-quants. No defaults or existing-type behavior changed. +48 lines.

## Performance

Apple M5 Pro (24 GB), macOS 26.3, `llama-batched-bench -npp 128 -ntg 64 -fa 1 -ngl 99`, decode t/s, median-of-runs. A/B on the same machine (baseline = this branch's parent, where these types take the generic path):

**Qwen3-1.7B UD-IQ2_XXS** (tensor mix: iq2_s / iq1_m / iq3_xxs / iq2_xxs / iq2_xs / iq4_xs):

| BS | master | PR | delta |
|---:|---:|---:|---|
| 4 | 148.0 | 209.9 | +42% |
| 5 | 146.0 | 240.1 | +64% |
| 8 | 137.7 | 237.7 | +73% |

**Qwen3-1.7B IQ3_XXS**: BS4 137.4→201.9 (+47%), BS5 134.9→227.8 (+69%), BS8 138.7→236.6 (+71%).

Batch amortization (BS8 vs BS1 throughput ratio) for these quants goes from ~1.08× to ~1.86×, which materially changes the spec-decode verify economics on Apple Silicon for the quants that memory-constrained machines typically run.

## Correctness

`test-backend-ops -o MUL_MAT -b MTL0`: all i-quant cases pass (all 8 types, n = 1–8; 66 cases, 0 failures). The new pipelines are visibly compiled and dispatched during the run (`kernel_mul_mv_ext_iq2_s_f32_r1_*`).

## Notes

- BS1 is untouched (measured: routing BS1 through a padded r1_2 dispatch is 18–47% *slower* than the existing mat-vec kernel, so admission correctly starts at 4).
- I also measured the tensor-API mat-mat path at BS 2–8 on M5 (Neural Accelerators): 41–72% slower than `mul_mv_ext` there, so the existing `ne11_mm_min = 8` gate remains right on this hardware; `mul_mm` only catches up around BS ≥ 13.
- Happy to run additional sweeps (other quants, other shapes, M-series variants I can access) if useful.

Method/full tables: https://github.com/ColeLundstrom/specgate-metal