### PR TITLE
CUDA: add q3_K as a KV cache type

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -312,6 +312,7 @@ const std::vector<ggml_type> kv_cache_types = {
     GGML_TYPE_IQ4_NL,
     GGML_TYPE_Q5_0,
     GGML_TYPE_Q5_1,
+    GGML_TYPE_Q3_K,   // q3 KV (per-channel/asym K-quant, ~3.4 bit) - VRAM taupymui
 };
 
 static ggml_type kv_cache_type_from_str(const std::string & s) {

--- a/ggml/src/ggml-cuda/convert.cu
+++ b/ggml/src/ggml-cuda/convert.cu
@@ -282,6 +282,39 @@ static void dequantize_row_q3_K_cuda(const void * vx, dst_t * y, const int64_t k
     dequantize_block_q3_K<<<nb, 64, 0, stream>>>(vx, y);
 }
 
+// q3_K non-contiguous dequant (KV cache view): super-block'ai contiguous eilutej, row-stride s0x (block-units)
+template<typename dst_t>
+static __global__ void dequantize_block_q3_K_nc(
+        const void * __restrict__ vx, dst_t * __restrict__ y,
+        const int64_t ne00, const int64_t ne01, const int64_t ne02, const int64_t ne0203,
+        const int64_t s01, const int64_t s02, const int64_t s03) {
+    const int64_t nblk_row = ne00 / QK_K;
+    const int64_t cb = blockIdx.x;
+    if (cb >= nblk_row) return;
+    for (int64_t i0203 = blockIdx.z; i0203 < ne0203; i0203 += gridDim.z) {
+        const int64_t i02 = i0203 % ne02;
+        const int64_t i03 = i0203 / ne02;
+        for (int64_t i01 = blockIdx.y; i01 < ne01; i01 += gridDim.y) {
+            const int64_t src_ib  = i03*s03 + i02*s02 + i01*s01 + cb;   // block index (ts-units)
+            const int64_t dst_off = (i0203*ne01 + i01)*ne00 + cb*QK_K;  // contiguous f16 offset
+            dequantize_q3_K(vx, src_ib, y + dst_off, threadIdx.x);
+        }
+    }
+}
+
+template<typename dst_t>
+static void dequantize_row_q3_K_nc_cuda(
+        const void * vx, dst_t * y,
+        const int64_t ne00, const int64_t ne01, const int64_t ne02, const int64_t ne03,
+        const int64_t s01, const int64_t s02, const int64_t s03, cudaStream_t stream) {
+    const int64_t ne0203 = ne02*ne03;
+    const int64_t nblk_row = ne00 / QK_K;
+    const dim3 grid((unsigned) nblk_row,
+                    (unsigned) std::min(ne01,   (int64_t) 65535),
+                    (unsigned) std::min(ne0203, (int64_t) 65535));
+    dequantize_block_q3_K_nc<<<grid, 64, 0, stream>>>(vx, y, ne00, ne01, ne02, ne0203, s01, s02, s03);
+}
+
 template<typename dst_t>
 static void dequantize_row_q4_0_cuda(const void * vx, dst_t * y, const int64_t k, cudaStream_t stream) {
     const int nb32 = k / 32;
@@ -647,6 +680,8 @@ to_fp16_nc_cuda_t ggml_get_to_fp16_nc_cuda(ggml_type type) {
             return dequantize_block_cuda<QK5_1, QR5_1, dequantize_q5_1>;
         case GGML_TYPE_Q8_0:
             return dequantize_block_cuda<QK8_0, QR8_0, dequantize_q8_0>;
+        case GGML_TYPE_Q3_K:
+            return dequantize_row_q3_K_nc_cuda;
         case GGML_TYPE_BF16:
             return convert_unary_cuda<nv_bfloat16>;
         default:

--- a/ggml/src/ggml-cuda/cpy-utils.cuh
+++ b/ggml/src/ggml-cuda/cpy-utils.cuh
@@ -43,6 +43,106 @@ static __device__ void quantize_f32_q4_0_block(const float * __restrict__ x, blo
     }
 }
 
+// ---- q3_K KV cache write: kvantuoja viena 256-super-block (verbatim quantize_row_q3_K_ref portas) ----
+static __device__ __forceinline__ int q3k_nearest_int(float fval) {
+    fval = fval + 12582912.0f;
+    int i = __float_as_int(fval);
+    return (i & 0x007fffff) - 0x00400000;
+}
+
+// make_q3_quants(16, 4, x, L, do_rmse=true): grazina scale, uzpildo L (continue-atvejui)
+static __device__ float q3k_make_scale16(const float * __restrict__ x, int8_t * __restrict__ L) {
+    const int n = 16, nmax = 4;
+    float maxv = 0.0f, amax = 0.0f;
+    for (int i = 0; i < n; ++i) { float ax = fabsf(x[i]); if (ax > amax) { amax = ax; maxv = x[i]; } }
+    if (amax < 1e-15f) { for (int i = 0; i < n; ++i) L[i] = 0; return 0.0f; }
+    float iscale = -(float)nmax / maxv;
+    float sumlx = 0.0f, suml2 = 0.0f;
+    for (int i = 0; i < n; ++i) {
+        int l = q3k_nearest_int(iscale * x[i]);
+        l = max(-nmax, min(nmax - 1, l));
+        L[i] = (int8_t) l;
+        float w = x[i]*x[i];
+        sumlx += w*x[i]*l;
+        suml2 += w*(float)l*l;
+    }
+    for (int itry = 0; itry < 5; ++itry) {
+        int n_changed = 0;
+        for (int i = 0; i < n; ++i) {
+            float w = x[i]*x[i];
+            float slx = sumlx - w*x[i]*L[i];
+            if (slx > 0.0f) {
+                float sl2 = suml2 - w*(float)L[i]*L[i];
+                int new_l = q3k_nearest_int(x[i] * sl2 / slx);
+                new_l = max(-nmax, min(nmax - 1, new_l));
+                if (new_l != L[i]) {
+                    slx += w*x[i]*new_l;
+                    sl2 += w*(float)new_l*new_l;
+                    if (sl2 > 0.0f && slx*slx*suml2 > sumlx*sumlx*sl2) {
+                        L[i] = (int8_t) new_l; sumlx = slx; suml2 = sl2; ++n_changed;
+                    }
+                }
+            }
+        }
+        if (!n_changed) break;
+    }
+    for (int i = 0; i < n; ++i) L[i] += nmax;
+    return suml2 > 0.0f ? sumlx / suml2 : 0.0f;
+}
+
+static __device__ void quantize_f32_q3_K_block(const float * __restrict__ x, block_q3_K * __restrict__ y) {
+    int8_t L[QK_K];
+    float scales[QK_K/16];
+
+    float max_scale = 0.0f, amax = 0.0f;
+    for (int j = 0; j < QK_K/16; ++j) {
+        scales[j] = q3k_make_scale16(x + 16*j, L + 16*j);
+        float sc = fabsf(scales[j]);
+        if (sc > amax) { amax = sc; max_scale = scales[j]; }
+    }
+
+    for (int t = 0; t < 12; ++t) y->scales[t] = 0;
+    if (max_scale != 0.0f) {
+        float iscale = -32.0f / max_scale;
+        for (int j = 0; j < QK_K/16; ++j) {
+            int l = q3k_nearest_int(iscale * scales[j]);
+            l = max(-32, min(31, l)) + 32;
+            if (j < 8) y->scales[j] = l & 0xF;
+            else y->scales[j-8] |= ((l & 0xF) << 4);
+            l >>= 4;
+            y->scales[j%4 + 8] |= (l << (2*(j/4)));
+        }
+        y->d = 1.0f / iscale;
+    } else {
+        y->d = 0.0f;
+    }
+
+    for (int j = 0; j < QK_K/16; ++j) {
+        int8_t sc = j < 8 ? (int8_t)(y->scales[j] & 0xF) : (int8_t)(y->scales[j-8] >> 4);
+        sc = (int8_t)((sc | (((y->scales[8 + j%4] >> (2*(j/4))) & 3) << 4)) - 32);
+        float d = (float) y->d * (float) sc;
+        if (d == 0.0f) continue;
+        for (int ii = 0; ii < 16; ++ii) {
+            int l = q3k_nearest_int(x[16*j + ii] / d);
+            l = max(-4, min(3, l));
+            L[16*j + ii] = (int8_t)(l + 4);
+        }
+    }
+
+    for (int t = 0; t < QK_K/8; ++t) y->hmask[t] = 0;
+    int m = 0;
+    uint8_t hm = 1;
+    for (int j = 0; j < QK_K; ++j) {
+        if (L[j] > 3) { y->hmask[m] |= hm; L[j] -= 4; }
+        if (++m == QK_K/8) { m = 0; hm <<= 1; }
+    }
+    for (int j = 0; j < QK_K; j += 128) {
+        for (int l = 0; l < 32; ++l) {
+            y->qs[j/4 + l] = L[j + l] | (L[j + l + 32] << 2) | (L[j + l + 64] << 4) | (L[j + l + 96] << 6);
+        }
+    }
+}
+
 static __device__ void quantize_f32_q4_1_block(const float * __restrict__ x, block_q4_1 * __restrict__ y) {
     float vmin = FLT_MAX;
     float vmax = -FLT_MAX;

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -348,6 +348,7 @@ static bool ggml_cuda_fattn_kv_type_supported(ggml_type type) {
 #endif // GGML_CUDA_FA_ALL_QUANTS
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q8_0:
+        case GGML_TYPE_Q3_K:   // q3 KV: dequant'inamas per f16 kelia (need_f16_K)
         case GGML_TYPE_BF16:
             return true;
         default:
@@ -554,8 +555,9 @@ size_t ggml_cuda_flash_attn_ext_get_alloc_size(int device, const ggml_tensor * d
             need_f16_V = true;
             break;
         case BEST_FATTN_KERNEL_VEC:
-            need_f16_K = K->type == GGML_TYPE_F32;
-            need_f16_V = V->type == GGML_TYPE_F32;
+            // q3_K neturi VEC kernel dequant - priverst f16 konversija (kaip F32)
+            need_f16_K = K->type == GGML_TYPE_F32 || K->type == GGML_TYPE_Q3_K;
+            need_f16_V = V->type == GGML_TYPE_F32 || V->type == GGML_TYPE_Q3_K;
             break;
         case BEST_FATTN_KERNEL_NONE:
             break;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5015,7 +5015,8 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
                            (
                                (op->type == GGML_TYPE_F32 || op->type == GGML_TYPE_F16 || op->type == GGML_TYPE_BF16 ||
                                op->type == GGML_TYPE_Q4_0 || op->type == GGML_TYPE_Q4_1 || op->type == GGML_TYPE_Q5_0 ||
-                               op->type == GGML_TYPE_Q5_1 || op->type == GGML_TYPE_Q8_0 || op->type == GGML_TYPE_IQ4_NL) &&
+                               op->type == GGML_TYPE_Q5_1 || op->type == GGML_TYPE_Q8_0 || op->type == GGML_TYPE_IQ4_NL ||
+                               op->type == GGML_TYPE_Q3_K) &&
                                op->src[0]->type == GGML_TYPE_F32
                            ) || (
                                op->type == GGML_TYPE_F16 && op->src[0]->type == GGML_TYPE_F16

--- a/ggml/src/ggml-cuda/set-rows.cu
+++ b/ggml/src/ggml-cuda/set-rows.cu
@@ -307,6 +307,16 @@ static void set_rows_cuda(ggml_backend_cuda_context & ctx, const ggml_tensor * s
             nb1, nb2, nb3,
             stream
         );
+    } else if (dst->type == GGML_TYPE_Q3_K) {
+        set_rows_cuda_quant<idx_t, block_q3_K, QK_K, quantize_f32_q3_K_block>(
+            src0_d, src1_d, (block_q3_K*)dst->data,
+            ne00, ne01, ne02, ne03,
+            ne10, ne11, ne12, ne13,
+            nb01, nb02, nb03,
+            nb10, nb11, nb12,
+            nb1, nb2, nb3,
+            stream
+        );
     } else if (dst->type == GGML_TYPE_IQ4_NL) {
         set_rows_cuda_quant<idx_t, block_iq4_nl, QK4_NL, quantize_f32_iq4_nl_block>(
             src0_d, src1_d, (block_iq4_nl*)dst->data,

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -485,6 +485,9 @@ static ggml_type ggml_type_from_name(const std::string & s) {
     if (s == "q8_0") {
         return GGML_TYPE_Q8_0;
     }
+    if (s == "q3_K") {
+        return GGML_TYPE_Q3_K;
+    }
     if (s == "q4_0") {
         return GGML_TYPE_Q4_0;
     }


### PR DESCRIPTION
## Overview

Adds `q3_K` (3.4375 bits/elem) as a KV cache type on the CUDA backend, for
users who want to squeeze more context out of limited VRAM:

    llama-server --flash-attn on --cache-type-k q3_K --cache-type-v q3_K

- ~24% smaller KV cache than `q4_0`, ~78% smaller than `f16`.
- Same prefill speed as `q4_0` (pp4096 on RTX 3090: q3_K 967 t/s vs q4_0 966 t/s).
- Reuses the existing `q3_K` K-quant machinery — no new ggml type.
- Requires `n_embd_k_gqa % 256 == 0` (K-quant super-block size).
- Prebuilt Windows / CUDA 13 binary for RTX 3090 (if you don't want to compile): https://github.com/Cybertiron/llama.cpp-rtx3090-prefill-fix/releases/tag/q3_K-kv-cache

## Quality (Qwen3 27B, RTX 3090)

- Perplexity within ~0.13% of f16 (q4_0 is lossless); penalty does not grow
  with context.
- Needle-in-haystack: 10/10 secrets recalled at 256K context, same as q4_0.

## Implementation

cache-type parsing (arg.cpp), SET_ROWS quantized write (cpy-utils / set-rows /
supports_op), flash-attn support gate + f16 conversion (fattn.cu), and a
non-contiguous q3_K->f16 dequant for the strided KV view (convert.cu).
`llama-bench` accepts `-ctk`/`-ctv q3_K`.

## Acknowledgements

The `q3_K` quantization format itself is @ikawrakow's k-quant work. This PR
only wires that existing quant into the KV-cache path — it does not add a new
quantization scheme.

## Requirements

- [x] I have read the contributing guidelines
- AI usage disclosure: the CUDA code was written with AI (Opus 4.8); I directed
  the design and tested/verified everything on my own RTX 3090.
