### PR TITLE
perplexity : support --parse-special

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3163,7 +3163,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params) {
             params.parse_special = true;
         }
-    ).set_examples({LLAMA_EXAMPLE_IMATRIX}));
+    ).set_examples({LLAMA_EXAMPLE_IMATRIX, LLAMA_EXAMPLE_PERPLEXITY}));
     add_opt(common_arg(
         {"--ids"},
         string_format("only print the token IDs, in a Python-parseable list form like [1, 2, 3] (default: %s)", params.tokenize_ids ? "true" : "false"),

--- a/common/common.h
+++ b/common/common.h
@@ -704,7 +704,7 @@ struct common_params {
     bool process_output  = false; // collect data for the output tensor
     bool compute_ppl     = true;  // whether to compute perplexity
     bool show_statistics = false; // show imatrix statistics per tensor
-    bool parse_special   = false; // whether to parse special tokens during imatrix tokenization
+    bool parse_special   = false; // whether to parse special tokens when tokenizing the input (imatrix, perplexity)
 
     // cvector-generator params
     int n_pca_batch = 100;

--- a/tools/perplexity/README.md
+++ b/tools/perplexity/README.md
@@ -10,6 +10,9 @@ The convention among contributors is to use the Wikitext-2 test set for testing 
 When numbers are listed all command line arguments and compilation options are left at their defaults unless noted otherwise.
 llama.cpp numbers are **not** directly comparable to those of other projects because the exact values depend strongly on the implementation details.
 
+By default the input text is tokenized as plain text: special tokens (e.g. `<|im_start|>`) that appear in the corpus are tokenized as literal text.
+Pass `--parse-special` to tokenize them as special tokens instead, e.g. when measuring perplexity over chat-formatted transcripts rendered with a model's chat template.
+
 By default only the mean perplexity value and the corresponding uncertainty is calculated.
 The uncertainty is determined empirically by assuming a Gaussian distribution of the "correct" logits per and then applying error propagation.
 

--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -307,7 +307,7 @@ static results_perplexity perplexity_v2(llama_context * ctx, const common_params
 
     LOG_INF("%s: tokenizing the input ..\n", __func__);
 
-    std::vector<llama_token> tokens = common_tokenize(ctx, params.prompt, true);
+    std::vector<llama_token> tokens = common_tokenize(ctx, params.prompt, true, params.parse_special);
 
     const int n_ctx = llama_n_ctx(ctx);
 
@@ -472,7 +472,7 @@ static results_perplexity perplexity(llama_context * ctx, const common_params & 
     auto tim1 = std::chrono::high_resolution_clock::now();
     LOG_INF("%s: tokenizing the input ..\n", __func__);
 
-    std::vector<llama_token> tokens = common_tokenize(ctx, params.prompt, true);
+    std::vector<llama_token> tokens = common_tokenize(ctx, params.prompt, true, params.parse_special);
 
     auto tim2 = std::chrono::high_resolution_clock::now();
     LOG_INF("%s: tokenization took %g ms\n",__func__,1e-3*std::chrono::duration_cast<std::chrono::microseconds>(tim2-tim1).count());


### PR DESCRIPTION
## Overview

`llama-perplexity` always tokenizes the input corpus as plain text, so special tokens (e.g. `<|im_start|>`) appearing in chat-formatted corpora rendered with a model's chat template are tokenized as literal text. The model never sees the special tokens it was trained on, which distorts perplexity measurements over such corpora.

This PR wires the existing `--parse-special` flag (already supported by `llama-imatrix` for the same reason) into `LLAMA_EXAMPLE_PERPLEXITY`, uses `params.parse_special` in both corpus tokenization paths (`perplexity()` and `perplexity_v2()`), and documents the flag in `tools/perplexity/README.md`. Default behavior is unchanged (`parse_special = false`).

## Additional information

Verification on a ChatML-formatted corpus with a Qwen3.8-27B IQ4_XS GGUF (`-c 2048 --chunks 2`):

| | tokenization | PPL |
|---|---|---|
| default | specials as literal text | 85.15 |
| `--parse-special` | specials parsed | 416.05 |

The numbers differ because the token streams differ; the flagged run matches the model's deployed tokenization. Plain-text corpora (wikitext) are unaffected: the token streams are identical with and without the flag.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - this change was developed with the assistance of an AI coding agent (Claude via the Oh My Pi harness): it performed the investigation that motivated the change, wrote the patch, and ran the verification commands above. I directed the work, reviewed every line, and take full responsibility for the submission.