### PR TITLE
mtmd : treat unmatched media markers as literal text

### DIFF
--- a/tests/test-mtmd-impl.cpp
+++ b/tests/test-mtmd-impl.cpp
@@ -1,6 +1,7 @@
 #include "testing.h"
 
 #include "mtmd-image.h"
+#include "mtmd-tokenize-impl.h"
 
 #include <iostream>
 #include <string>
@@ -65,6 +66,54 @@ MAKE_TEST(test_image_preprocessor_lfm2) {
             std::string(expected ? "tiled" : "single"),
             std::string(actual   ? "tiled" : "single"));
     }
+}
+
+static std::string dump_marker_parts(const std::vector<mtmd_marker_part> & parts) {
+    std::string s;
+    for (size_t i = 0; i < parts.size(); ++i) {
+        if (i != 0) {
+            s += "|";
+        }
+        if (parts[i].bitmap_i >= 0) {
+            s += "BM" + std::to_string(parts[i].bitmap_i);
+        } else {
+            s += parts[i].text;
+        }
+    }
+    return s;
+}
+
+MAKE_TEST(test_bind_media_markers_surplus_as_text) {
+    const std::string marker = "<__media_abc__>";
+    std::vector<mtmd_marker_part> parts;
+
+    // quoted marker with 0 images stays text (the /props leak case)
+    t.assert_true(mtmd_bind_media_markers("props said: " + marker + " ok?", marker, 0, parts));
+    t.assert_equal(
+        "0 bmp quoted marker",
+        std::string("props said: |<__media_abc__>| ok?"),
+        dump_marker_parts(parts));
+
+    // first marker binds the image; leftover quoted marker stays text
+    t.assert_true(mtmd_bind_media_markers(
+        "see " + marker + " then quote " + marker, marker, 1, parts));
+    t.assert_equal(
+        "1 bmp + extra marker",
+        std::string("see |BM0| then quote |<__media_abc__>"),
+        dump_marker_parts(parts));
+
+    // exact count still binds every marker
+    t.assert_true(mtmd_bind_media_markers(
+        "a " + marker + " b " + marker + " c", marker, 2, parts));
+    t.assert_equal(
+        "2 bmp exact",
+        std::string("a |BM0| b |BM1| c"),
+        dump_marker_parts(parts));
+
+    t.assert_true("too few markers", !mtmd_bind_media_markers("no marker here", marker, 1, parts));
+
+    t.assert_true(mtmd_bind_media_markers("plain text", marker, 0, parts));
+    t.assert_equal("plain", std::string("plain text"), dump_marker_parts(parts));
 }
 
 //

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(mtmd
             mtmd-helper.cpp
             mtmd-helper-gen.cpp
             mtmd-helper-common.h
+            mtmd-tokenize-impl.h
             mtmd-helper.h
             clip.cpp
             clip.h

--- a/tools/mtmd/mtmd-tokenize-impl.h
+++ b/tools/mtmd/mtmd-tokenize-impl.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <cstddef>
+
+// Internal tokenizer helpers. Not part of the public mtmd API.
+
+struct mtmd_marker_part {
+    std::string text;
+    int bitmap_i; // -1 = literal text
+};
+
+// Split on delimiter and keep the delimiter as its own part.
+// "a <m> b" + "<m>" -> {"a ", "<m>", " b"}
+inline std::vector<std::string> mtmd_split_text(const std::string & input, const std::string & delimiter) {
+    std::vector<std::string> result;
+    if (input.empty()) {
+        return result;
+    }
+    size_t start = 0;
+    size_t pos = 0;
+    while ((pos = input.find(delimiter, start)) != std::string::npos) {
+        if (pos > start) {
+            result.push_back(input.substr(start, pos - start));
+        }
+        result.push_back(delimiter);
+        start = pos + delimiter.length();
+    }
+    if (start < input.length()) {
+        result.push_back(input.substr(start));
+    }
+    return result;
+}
+
+// Bind the first n_bitmaps marker hits as media slots. Extra hits stay as text.
+// Returns false if the prompt has fewer markers than bitmaps.
+inline bool mtmd_bind_media_markers(
+        const std::string & input,
+        const std::string & marker,
+        size_t n_bitmaps,
+        std::vector<mtmd_marker_part> & out) {
+    out.clear();
+    size_t i_bm = 0;
+    for (auto & part : mtmd_split_text(input, marker)) {
+        if (part == marker && i_bm < n_bitmaps) {
+            out.push_back({"", (int) i_bm++});
+        } else {
+            out.push_back({std::move(part), -1});
+        }
+    }
+    return i_bm == n_bitmaps;
+}

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -3,6 +3,7 @@
 #include "mtmd.h"
 #include "mtmd-audio.h"
 #include "mtmd-image.h"
+#include "mtmd-tokenize-impl.h"
 #include "debug/mtmd-debug.h"
 
 #include "llama.h"
@@ -1114,27 +1115,18 @@ struct mtmd_tokenizer {
         input_text.assign(text->text, text->text_len);
 
         std::vector<const mtmd_bitmap *> bitmaps(bmps, bmps + n_bitmaps);
-        auto parts_str = split_text(input_text, ctx->media_marker);
-        size_t i_bm = 0;
-        for (const auto & part : parts_str) {
-            if (part == ctx->media_marker) {
-                if (i_bm >= bitmaps.size()) {
-                    throw std::runtime_error(string_format("number of media markers in text (%zu) exceeds number of bitmaps (%zu)", i_bm + 1, bitmaps.size()));
-                }
-                parts.push_back({"", bitmaps[i_bm++]});
+        std::vector<mtmd_marker_part> bound;
+        if (!mtmd_bind_media_markers(input_text, ctx->media_marker, bitmaps.size(), bound)) {
+            throw std::runtime_error(string_format(
+                "number of media markers in text does not match number of bitmaps (%zu)",
+                bitmaps.size()));
+        }
+        for (auto & b : bound) {
+            if (b.bitmap_i >= 0) {
+                parts.push_back({"", bitmaps[b.bitmap_i]});
             } else {
-                parts.push_back({std::move(part), nullptr});
+                parts.push_back({std::move(b.text), nullptr});
             }
-        }
-
-        size_t n_markers = 0;
-        for (const auto & part : parts) {
-            if (part.bitmap != nullptr) {
-                n_markers++;
-            }
-        }
-        if (n_markers != bitmaps.size()) {
-            throw std::runtime_error(string_format("number of media markers in text (%zu) does not match number of bitmaps (%zu)", n_markers, bitmaps.size()));
         }
 
         expand_lazy_bitmaps();
@@ -1641,27 +1633,6 @@ struct mtmd_tokenizer {
         }
 
         return chunks;
-    }
-
-    // for example: "a <__media__> b <__media__> c" --> "a", "<__media__>", "b", "<__media__>", "c"
-    static std::vector<std::string> split_text(const std::string & input, const std::string & delimiter) {
-        std::vector<std::string> result;
-        if (input.empty()) {
-            return result;
-        }
-        size_t start = 0;
-        size_t pos = 0;
-        while ((pos = input.find(delimiter, start)) != std::string::npos) {
-            if (pos > start) {
-                result.push_back(input.substr(start, pos - start));
-            }
-            result.push_back(delimiter);
-            start = pos + delimiter.length();
-        }
-        if (start < input.length()) {
-            result.push_back(input.substr(start));
-        }
-        return result;
     }
 
     // copied from common_tokenize


### PR DESCRIPTION
## Overview

`mtmd_tokenize` treated every `media_marker` hit as a bitmap slot. If `/props` (or logs, retrieval, tool output) leaked the randomized marker into later chat text with no image attached, tokenize failed:

```
number of media markers in text (1) exceeds number of bitmaps (0)
Failed to tokenize prompt
```

This binds only as many marker hits as there are bitmaps. Leftover marker strings stay ordinary text. Extra attached bitmaps still error.

Fixes #27249

## Additional information

Standalone check of the bind helper (0 bitmaps + quoted marker, 1 image + extra quoted marker, exact match, too few markers) passed. I did not run a full llama-server + mmproj integration here.

I did not hide `media_marker` from `/props`. Randomization still helps against accidental collisions; unmatched markers now degrade to text instead of 400.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used Cursor to locate `mtmd_tokenize` / `split_text` and to draft the helper + regression test. I reviewed the bind rule and the test cases.

Made with [Cursor](https://cursor.com)