### PR TITLE
CUDA/HIP: do not classify gfx909 and gfx90c APUs as CDNA

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -68,6 +68,8 @@
 #define GGML_CUDA_CC_GCN4       (GGML_CUDA_CC_OFFSET_AMD + 0x803)  // Tonga, Fiji, Polaris, minimum for fast fp16
 #define GGML_CUDA_CC_VEGA       (GGML_CUDA_CC_OFFSET_AMD + 0x900)  // Vega56/64, minimum for fp16 dual issue
 #define GGML_CUDA_CC_VEGA20     (GGML_CUDA_CC_OFFSET_AMD + 0x906)  // MI50/Radeon VII, minimum for dp4a
+#define GGML_CUDA_CC_RAVEN2     (GGML_CUDA_CC_OFFSET_AMD + 0x909)  // Raven2 APU, Vega-class, no MFMA
+#define GGML_CUDA_CC_RENOIR     (GGML_CUDA_CC_OFFSET_AMD + 0x90c)  // Renoir/Cezanne/Barcelo APU, Vega-class, no MFMA
 #define GGML_CUDA_CC_CDNA1      (GGML_CUDA_CC_OFFSET_AMD + 0x908)  // MI100, minimum for MFMA, acc registers
 #define GGML_CUDA_CC_CDNA2      (GGML_CUDA_CC_OFFSET_AMD + 0x90a)  // MI210 (gfx90a), minimum acc register renaming
 #define GGML_CUDA_CC_CDNA3      (GGML_CUDA_CC_OFFSET_AMD + 0x942)  // MI300
@@ -88,10 +90,17 @@
 #define GGML_CUDA_CC_IS_RDNA3_5(cc) (cc >= GGML_CUDA_CC_RDNA3_5 && cc < GGML_CUDA_CC_RDNA4)
 #define GGML_CUDA_CC_IS_RDNA3(cc)   (GGML_CUDA_CC_IS_RDNA3_0(cc) || GGML_CUDA_CC_IS_RDNA3_5(cc))
 #define GGML_CUDA_CC_IS_RDNA4(cc)   (cc >= GGML_CUDA_CC_RDNA4)
-#define GGML_CUDA_CC_IS_GCN(cc)     (cc > GGML_CUDA_CC_OFFSET_AMD && cc < GGML_CUDA_CC_CDNA1)
-#define GGML_CUDA_CC_IS_CDNA(cc)    (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_RDNA1)
-#define GGML_CUDA_CC_IS_CDNA1(cc)   (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_CDNA2)
-#define GGML_CUDA_CC_IS_CDNA2(cc)   (cc >= GGML_CUDA_CC_CDNA2 && cc < GGML_CUDA_CC_CDNA3)
+// gfx909 (Raven2) and gfx90c (Renoir/Cezanne/Barcelo) are Vega-class integrated GPUs, but their
+// architecture numbers fall inside the range spanned by CDNA1..CDNA4, so a plain numeric comparison
+// misdetects them as MI100/MI210. The host would then select MFMA configs while the device code,
+// gated on the __gfx908__/__gfx90a__/__gfx942__/__gfx950__ macros, compiles the non-MFMA variant.
+// The resulting host/device disagreement makes kernel launches fail on __launch_bounds__.
+#define GGML_CUDA_CC_IS_GFX9_APU(cc) (cc == GGML_CUDA_CC_RAVEN2 || cc == GGML_CUDA_CC_RENOIR)
+
+#define GGML_CUDA_CC_IS_GCN(cc)     ((cc > GGML_CUDA_CC_OFFSET_AMD && cc < GGML_CUDA_CC_CDNA1) || GGML_CUDA_CC_IS_GFX9_APU(cc))
+#define GGML_CUDA_CC_IS_CDNA(cc)    (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_RDNA1 && !GGML_CUDA_CC_IS_GFX9_APU(cc))
+#define GGML_CUDA_CC_IS_CDNA1(cc)   (cc >= GGML_CUDA_CC_CDNA1 && cc < GGML_CUDA_CC_CDNA2 && !GGML_CUDA_CC_IS_GFX9_APU(cc))
+#define GGML_CUDA_CC_IS_CDNA2(cc)   (cc >= GGML_CUDA_CC_CDNA2 && cc < GGML_CUDA_CC_CDNA3 && !GGML_CUDA_CC_IS_GFX9_APU(cc))
 #define GGML_CUDA_CC_IS_CDNA3(cc)   (cc >= GGML_CUDA_CC_CDNA3 && cc < GGML_CUDA_CC_CDNA4)
 #define GGML_CUDA_CC_IS_CDNA4(cc)   (cc >= GGML_CUDA_CC_CDNA4 && cc < GGML_CUDA_CC_RDNA1)
 


### PR DESCRIPTION
## Overview

gfx909 (Raven2) and gfx90c (Renoir/Cezanne/Barcelo) are Vega-class integrated
GPUs without MFMA, but their architecture numbers land inside the numeric range
spanned by the CDNA constants:

```
arch                value
GGML_CUDA_CC_CDNA1  0x908  MI100
gfx909              0x909  Raven2 APU
GGML_CUDA_CC_CDNA2  0x90a  MI210
gfx90c              0x90c  Renoir/Cezanne/Barcelo APU
GGML_CUDA_CC_CDNA3  0x942  MI300
```

Because GGML_CUDA_CC_IS_CDNA, ..._CDNA1 and ..._CDNA2 are plain numeric range
checks, these two APUs are misdetected as MI100/MI210.

Host code then picks MFMA configurations, while the device code is gated on the
__gfx908__/__gfx90a__/__gfx942__/__gfx950__ macros and compiles the non-MFMA
variant. They disagree on the block size and the kernel launch fails on
__launch_bounds__.

This PR adds a GGML_CUDA_CC_IS_GFX9_APU() predicate, excludes it from the CDNA
checks and includes it in GGML_CUDA_CC_IS_GCN(). Detection only - 0x909 and
0x90c are the only values that change classification, discrete CDNA parts are
unaffected.

## Additional information

Found on a Ryzen 5000 (Cezanne, gfx90c) integrated GPU. I do not have Raven2
hardware; gfx909 is included because it sits in the same range with the same
Vega-class, non-MFMA characteristics. Can drop it if you prefer gfx90c only.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. The bug was diagnosed on my own hardware and I
  verified the fix there. AI was used to help write the code change and to
  draft this description and the commit message.
