### PR TITLE
graph : create V as a view of K in the k_iswa build_attn

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -3099,8 +3099,6 @@ ggml_tensor * llm_graph_context::build_attn(
             int       il) const {
     const bool is_swa = hparams.is_swa(il);
 
-    GGML_UNUSED(v_cur);
-
     auto * k_rot = is_swa ? inp->self_k_rot_swa : inp->self_k_rot;
 
     if (k_rot) {
@@ -3133,7 +3131,7 @@ ggml_tensor * llm_graph_context::build_attn(
     // MLA-style attention: the cached K is used as V
     ggml_tensor * q = q_cur;
     ggml_tensor * k = mctx_cur->get_k(ctx0, il);
-    ggml_tensor * v = k;
+    ggml_tensor * v = ggml_view_4d(ctx0, k, v_cur->ne[0], k->ne[1], k->ne[2], k->ne[3], k->nb[1], k->nb[2], k->nb[3], 0);
 
     ggml_tensor * cur = build_attn_mha(q, k, v, kq_b, kq_mask, sinks, v_mla, kq_scale, il);
     cb(cur, "kqv_out", il);

--- a/src/models/deepseek4.cpp
+++ b/src/models/deepseek4.cpp
@@ -1225,7 +1225,7 @@ ggml_tensor * llama_model_deepseek4::graph::build_attention_impl(
     if (inp_mtp) {
         out = build_attn(inp_mtp,
                 nullptr, nullptr, nullptr,
-                q, kv, nullptr,
+                q, kv, kv,
                 nullptr, layer.attn_sinks, nullptr,
                 1.0f/sqrtf(float(n_embd_head)), il);
         cb(out, "attn_raw", il);


### PR DESCRIPTION
## Overview

In `build_attn` for the `llm_graph_input_attn_k_iswa` input (MLA-style attention where the cached K is used as V), V was the cached K tensor itself. It is now created as a view of K (the first `v_cur->ne[0]` elements of each row), like the other K-only `build_attn` overloads (`llm_graph_input_attn_k`, `llm_graph_input_attn_k_dsa`).

All current callers (deepseek4 MTP block, dflash DSpark decoder) have equal K/V head sizes, so the view is full-size and the attention results are unchanged — V simply becomes a proper view of K, which lets backends detect the V-is-view-of-K pattern.

The deepseek4 MTP call site now passes the `kv` tensor as `v_cur` (it passed `nullptr` before).

## Additional information

Related: https://github.com/ggml-org/llama.cpp/pull/27390 (Metal FA: skip the redundant V dequant when V is a view of K)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.8-27B
