### PR TITLE
cuda : prefer MMQ for IQ4_NL on CDNA2

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -335,7 +335,8 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         if (n_experts > 64 || ne11 <= 128) {
             return true;
         }
-        if (type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q4_1 || type == GGML_TYPE_Q5_0 || type == GGML_TYPE_Q5_1) {
+        if (type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q4_1 || type == GGML_TYPE_Q5_0 || type == GGML_TYPE_Q5_1 ||
+            type == GGML_TYPE_IQ4_NL) {
             return true;
         }
         if (ne11 <= 256 && (type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q5_K)) {


### PR DESCRIPTION
# cuda : prefer MMQ for IQ4_NL on CDNA2

One clause in `ggml_cuda_should_use_mmq`: add IQ4_NL to the CDNA2
unconditional-MMQ type list, alongside the Q4_0/Q4_1/Q5_0/Q5_1 it
structurally matches (same 4-bit non-linear codebook family; 32-value
blocks take the unconditional MMQ path, 256-value superblocks are gated —
IQ4_NL is a 32-value block type and was simply missing from the list).

## Measured (MI210, llama-bench, r=5, isolated whole-process arms)

| model | ne11=256 | ne11=512 | ne11=1024 | tg128 |
|---|---:|---:|---:|---:|
| DeepHat-7B IQ4_NL | **+26.8%** | +8.4% | +3.1% | +0.2% |
| Qwen3-1.7B IQ4_NL | **+74.5%** | +7.8% | +2.3% | +0.9% |

Routing confirmed by kernel trace: 648 dispatches move from
`dequantize_block_iq4_nl` + rocBLAS onto `mul_mat_q<IQ4_NL>`.
Perplexity unaffected (20.5983 -> 20.5942 vs run-to-run +-1.18).

Corroborated end-to-end: on a 35B-A3D MoE (256 experts), IQ4_NL beats every
K-quant at every prefill length with this clause (512/2048/8192 tok
prompts), which is what made IQ4_NL the recommended 4-bit format on this
hardware.

Dense matmuls only — >64-expert MoE tensors already take MMQ
unconditionally and are untouched by this clause.
