### PR TITLE
cuda : prefer MMQ for IQ4_XS on CDNA2

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -335,6 +335,17 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         if (n_experts > 64 || ne11 <= 128) {
             return true;
         }
+        // IQ4_XS is the superblock sibling of IQ4_NL: the same 4-bit non-linear
+        // codebook, packed 256 values per superblock behind 6-bit sub-scales.
+        // In MMQ it uses the same traits as IQ4_NL (ggml_cuda_mmq_load_tiles_iq4_xs
+        // feeding ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma with MMQ_Q8_1_DS_LAYOUT_D4),
+        // so the reason change set 14 prefers MMQ for IQ4_NL on CDNA2 applies
+        // unchanged. Placement note: every clause between here and the closing
+        // "return false" can only return true, so this block is order-independent
+        // with respect to them.
+        if (type == GGML_TYPE_IQ4_XS) {
+            return true;
+        }
         if (type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q4_1 || type == GGML_TYPE_Q5_0 || type == GGML_TYPE_Q5_1 ||
             type == GGML_TYPE_IQ4_NL) {
             return true;

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -335,7 +335,8 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         if (n_experts > 64 || ne11 <= 128) {
             return true;
         }
-        if (type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q4_1 || type == GGML_TYPE_Q5_0 || type == GGML_TYPE_Q5_1) {
+        if (type == GGML_TYPE_Q4_0 || type == GGML_TYPE_Q4_1 || type == GGML_TYPE_Q5_0 || type == GGML_TYPE_Q5_1 ||
+            type == GGML_TYPE_IQ4_NL) {
             return true;
         }
         if (ne11 <= 256 && (type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q5_K)) {


### PR DESCRIPTION
# cuda : prefer MMQ for IQ4_XS on CDNA2

Stacked on the IQ4_NL clause: IQ4_XS is the superblock sibling of IQ4_NL —
same 4-bit non-linear codebook, packed 256 values per superblock behind
6-bit sub-scales. In MMQ it uses the same traits as IQ4_NL
(`ggml_cuda_mmq_load_tiles_iq4_xs` feeding
`ggml_cuda_mmq_vec_dot_q8_0_q8_1_mma` with `MMQ_Q8_1_DS_LAYOUT_D4`), so the
same reasoning applies unchanged.

Notably this falsifies the block-geometry rule's prediction that superblock
types need the ne11<=256 gate: measured unconditional wins everywhere
tested.

## Measured (MI210, isolated arms, pp128 no-change control)

| model | pp256 | pp512-2048 | control |
|---|---:|---:|---:|
| DeepHat-7B IQ4_XS | **+38.0%** | +14% | -0.36% |
| Qwen3-1.7B IQ4_XS | **+84%** | +10-11% | |

`dequantize_block_iq4_xs` vanishes from the kernel trace. Perplexity
9.5619 vs 9.5529 (+-0.38). With its decode lead (160.5 t/s vs IQ4_NL's
138.3 at equal ppl), IQ4_XS becomes the best overall 4-bit for dense models
on this hardware.
