### PR TITLE
cuda : prefer MMQ for MXFP4 on CDNA2

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -341,6 +341,15 @@ bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t
         if (ne11 <= 256 && (type == GGML_TYPE_Q4_K || type == GGML_TYPE_Q5_K)) {
             return true;
         }
+        // MXFP4 looks like IQ4_NL to MMQ: 32 values per block, 4 bits each,
+        // decoded through a 16-entry lookup table, one scale per block (an e8m0
+        // exponent instead of an fp16 factor). Its MMQ traits differ from
+        // IQ4_NL's only in the load_tiles function, so change set 14's argument
+        // carries over. Placement note: the clauses above can only return true,
+        // so this block is order-independent with respect to them.
+        if (type == GGML_TYPE_MXFP4) {
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
# cuda : prefer MMQ for MXFP4 on CDNA2

Same clause family, for MXFP4. Expert tensors consult the same type list on
the `mul_mat_id` path, so the clause also applies to expert-parallel MoE
tensors — measured on gpt-oss-20b (32 experts).

## Measured (MI210, isolated arms)

| workload | pp256 | pp512-2048 | tg | ppl |
|---|---:|---:|---:|---|
| gpt-oss-20b MXFP4 | **+59.0%** | **+43%** | flat | 368.95+-18.2 vs 372.31+-18.4 (identical) |

Control (no-change rerun): -0.66%. Kernel trace confirms MMQ routing.

## Recorded negative results (not landed)

- stream-k `IS_NVIDIA` flip: null (+-0.4%) at standard shapes.
- raising the Q4_K/Q5_K ne11 threshold to 512: **-1.7/-2.0%** — the 256
  boundary is correctly placed. Note the MMQ<->rocBLAS flip at that boundary
  moves ~1.8% of argmax rows on synthetic matrices, so any threshold change
  is also a numerics change.
