### PR TITLE
ci: use shell script to check cmake pkg

### DIFF
--- a/.github/workflows/build-cmake-pkg.yml
+++ b/.github/workflows/build-cmake-pkg.yml
@@ -27,30 +27,26 @@ jobs:
           cmake --install build --prefix "$PREFIX" --config Release
 
           export LLAMA_CONFIG="$PREFIX"/lib/cmake/llama/llama-config.cmake
-          tclsh <<'EOF'
-          set build(commit)  [string trim [exec git rev-parse --short HEAD]]
-          set build(number)  [string trim [exec git rev-list  --count HEAD]]
+          build_commit=$(git rev-parse --short HEAD | xargs)
+          build_number=$(git rev-list --count HEAD | xargs)
 
-          set cmakelists [read [open "CMakeLists.txt" r]]
-          regexp {set\(LLAMA_VERSION_MAJOR\s+(\d+)\)} $cmakelists -> major
-          regexp {set\(LLAMA_VERSION_MINOR\s+(\d+)\)} $cmakelists -> minor
-          regexp {set\(LLAMA_VERSION_PATCH\s+(\d+)\)} $cmakelists -> patch
-          set build(version) "$major.$minor.$patch"
+          major=$(grep -oP 'set\(LLAMA_VERSION_MAJOR\s+\K\d+' CMakeLists.txt)
+          minor=$(grep -oP 'set\(LLAMA_VERSION_MINOR\s+\K\d+' CMakeLists.txt)
+          patch=$(grep -oP 'set\(LLAMA_VERSION_PATCH\s+\K\d+' CMakeLists.txt)
+          build_version="$major.$minor.$patch"
 
-          set llamaconfig [read [open "$env(LLAMA_CONFIG)" r]]
-          set checks [list "set\\(LLAMA_VERSION     \\s+$build(version)\\)" \
-                           "set\\(LLAMA_BUILD_COMMIT\\s+$build(commit)\\)" \
-                           "set\\(LLAMA_BUILD_NUMBER\\s+$build(number)\\)"]
+          checks=("set\(LLAMA_VERSION     \s+$build_version\)"
+                  "set\(LLAMA_BUILD_COMMIT\s+$build_commit\)"
+                  "set\(LLAMA_BUILD_NUMBER\s+$build_number\)")
 
-          puts -nonewline "Checking llama-config.cmake version... "
-          foreach check $checks {
-              if {![regexp -expanded -- $check $llamaconfig]} {
-                  puts "\"$check\" failed!"
+          for check in "${checks[@]}"; do
+              if ! grep -qP "$check" "$LLAMA_CONFIG"; then
+                  echo "Checking llama-config.cmake version... \"$check\" failed!"
                   exit 1
-              }
-          }
-          puts "success."
-          EOF
+              fi
+          done
+
+          echo "Checking llama-config.cmake version... success."
 
           cd examples/simple-cmake-pkg
           cmake -S . -B build -DCMAKE_PREFIX_PATH="$PREFIX"/lib/cmake

--- a/.github/workflows/build-cmake-pkg.yml
+++ b/.github/workflows/build-cmake-pkg.yml
@@ -30,17 +30,17 @@ jobs:
           build_commit=$(git rev-parse --short HEAD | xargs)
           build_number=$(git rev-list --count HEAD | xargs)
 
-          major=$(grep -oP 'set\(LLAMA_VERSION_MAJOR\s+\K\d+' CMakeLists.txt)
-          minor=$(grep -oP 'set\(LLAMA_VERSION_MINOR\s+\K\d+' CMakeLists.txt)
-          patch=$(grep -oP 'set\(LLAMA_VERSION_PATCH\s+\K\d+' CMakeLists.txt)
+          major=$(grep -oE "set\(LLAMA_VERSION_MAJOR[[:space:]]+[0-9]+" CMakeLists.txt | grep -oE "[0-9]+$")
+          minor=$(grep -oE "set\(LLAMA_VERSION_MINOR[[:space:]]+[0-9]+" CMakeLists.txt | grep -oE "[0-9]+$")
+          patch=$(grep -oE "set\(LLAMA_VERSION_PATCH[[:space:]]+[0-9]+" CMakeLists.txt | grep -oE "[0-9]+$")
           build_version="$major.$minor.$patch"
 
-          checks=("set\(LLAMA_VERSION     \s+$build_version\)"
-                  "set\(LLAMA_BUILD_COMMIT\s+$build_commit\)"
-                  "set\(LLAMA_BUILD_NUMBER\s+$build_number\)")
+          checks=("set\(LLAMA_VERSION[[:space:]]+$build_version\)"
+                  "set\(LLAMA_BUILD_COMMIT[[:space:]]+$build_commit\)"
+                  "set\(LLAMA_BUILD_NUMBER[[:space:]]+$build_number\)")
 
           for check in "${checks[@]}"; do
-              if ! grep -qP "$check" "$LLAMA_CONFIG"; then
+              if ! grep -qE "$check" "$LLAMA_CONFIG"; then
                   echo "Checking llama-config.cmake version... \"$check\" failed!"
                   exit 1
               fi


### PR DESCRIPTION
Turns out [some of our machines don't have tclsh](https://github.com/ggml-org/llama.cpp/actions/runs/31881677025/job/95005045699), my bad! See https://github.com/ggml-org/llama.cpp/pull/26927.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
