### PR TITLE
server : fix --docker-repo being treated as router mode

### DIFF
--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -133,7 +133,8 @@ int llama_server(common_params & params, int argc, char ** argv) {
 
     // router server never loads a model and must not touch the GPU
     const bool is_router_server = params.model.path.empty()
-                               && params.model.hf_repo.empty();
+                               && params.model.hf_repo.empty()
+                               && params.model.docker_repo.empty();
 
     // skip device enumeration so the CUDA primary context stays uncreated
     common_params_print_info(params, !is_router_server);


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
This PR fixes the docker repo being silently ignored when starting the server with no local path. Previously, router mode detection only checked model.path and model.hf_repo , as a result starting the server with only docker-repo caused it to incorrectly enter router mode, skip model loading and start with Available models(0) without error or warning. 
This change include model.docker_repo in the router mode check so common_models_handler_apply() is called , allowing the docker repositories to be resolved and the model to be downloaded as expected

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

Fixes #27159

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

-  I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)  
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->Yes , to help me replicate and reach to the root cause , the edit made is self made.
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
