### PR TITLE
server : join model threads in destructor

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -427,7 +427,10 @@ server_models::server_models(
     debug_fake_timing = !common_get_env("LLAMA_SERVER_DEBUG_FAKE_TIMING").empty();
 }
 
-server_models::~server_models() = default;
+server_models::~server_models() {
+    // join monitor threads before the map destroys them
+    unload_all();
+}
 
 void server_models::add_model(server_model_meta && meta) {
     if (mapping.find(meta.name) != mapping.end()) {

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -594,3 +594,28 @@ def test_router_delete_model():
     # Model should no longer appear in GET /models
     ids = _get_model_ids(is_reload=False)
     assert MODEL_DOWNLOAD_ID not in ids, f"{MODEL_DOWNLOAD_ID} still present after deletion"
+
+def test_router_unknown_tool_load_on_startup_does_not_abort():
+    """unknown --tools plus load-on-startup must not abort the parent (issue 27384)"""
+    global server
+    preset_path = os.path.join(TMP_DIR, "test_unknown_tool_startup.ini")
+    with open(preset_path, "w") as f:
+        f.write(
+            "[tiny]\n"
+            "load-on-startup = true\n"
+            "hf-repo = ggml-org/test-model-stories260K\n"
+        )
+    server.models_preset = preset_path
+    server.server_tools = "get_datetime"
+    try:
+        try:
+            server.start(timeout_seconds=30)
+            assert server.process is not None
+            assert server.process.poll() is None
+        except Exception:
+            if server.process is not None:
+                rc = server.process.returncode
+                assert rc not in (-6, 134), f"parent aborted with {rc}"
+    finally:
+        if os.path.exists(preset_path):
+            os.remove(preset_path)


### PR DESCRIPTION
## Overview

fixes #27384

if you pass a unknown `--tools` and also have load-on-startup the whole llama-server just aborts. child dies with unknown tool, thats fine. then parent blows up because `~server_models()` is default so it destroys a thread thats still joinable. we hit std::terminate.

reload already joins those threads. `unload_all()` does too. destructor just wasnt calling it.

so i made `~server_models()` call `unload_all()`. added a router test for this

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used AI to help write the patch. i read it myself and tweaked it a bit