### PR TITLE
cuda : shrink the ubatch adaptively, gated on pipeline parallel

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1735,8 +1735,35 @@ int llama_context::decode(const llama_batch & batch_inp) {
 
     llama_memory_context_ptr mctx;
 
+    // MI210_ADAPTIVE_UBATCH: with a pipelined device split, one micro-batch means
+    // the devices run strictly sequentially -- GPU1 idles while GPU0 works. Only
+    // two or more micro-batches in a call overlap them. Measured aggregate
+    // utilisation on 2x MI210: 62% at 2 ubatches, 85.6% at 8.
+    //
+    // Note this keys on the size of THIS call, not the prompt length: llama.cpp
+    // already caps a call at n_batch, so a long prompt arrives as several full
+    // calls that each want the large ubatch for kernel efficiency. Keying on
+    // prompt length instead regressed 16k prompts by 10%.
+    //
+    // Only ever shrinks cparams.n_ubatch, so the compute buffers sized at
+    // context creation stay valid.
+    //
+    // Gated on cparams.pipeline_parallel: the entire benefit is device overlap,
+    // which only exists when the scheduler is actually pipelining across >1
+    // device. Without it the shrink is pure cost -- more, smaller micro-batches
+    // for nothing.
+    uint32_t n_ubatch_eff = cparams.n_ubatch;
+    if (cparams.pipeline_parallel && cparams.causal_attn && n_tokens_all >= 2) {
+        uint32_t want = 1;
+        while (want * 2 <= n_tokens_all / 2) {
+            want *= 2;
+        }
+        want = std::max<uint32_t>(want, 256);
+        n_ubatch_eff = std::min(n_ubatch_eff, want);
+    }
+
     while (true) {
-        mctx = memory->init_batch(*balloc, cparams.n_ubatch, output_all);
+        mctx = memory->init_batch(*balloc, n_ubatch_eff, output_all);
         if (!mctx) {
             return -2;
         }


### PR DESCRIPTION
# cuda : shrink the ubatch adaptively, gated on pipeline parallel

## Why

The adaptive-ubatch shrink's entire benefit is **device overlap** (62% ->
85.6% aggregate GPU utilisation on 2x MI210) — which only exists when the
scheduler pipelines across >1 device. Single-device and -cmoe deployments
paid the cost of splitting for overlap nothing could recover, and the split
itself changes effective micro-batch size, which is a numerics parameter.

## What

The shrink now runs only when `cparams.pipeline_parallel` is set. The new
condition is the old condition AND that flag, so pipelined deployments are
bit-identical by construction; single-device deployments return to
upstream-default behaviour and upstream-default numerics.

## Measured (single-device MI210 serve, DeepHat-7B Q4_K_M — the case the
gate restores)

**+10.02% pp512**, 49/49 patched samples above every control sample (worst
patched +9.35% over best control); tg128 moved 0.22% on bit-identical
kernel profiles, calibrating the noise floor at ~1/46 of the effect.

## Numerics disclosure

An unmodified binary at -ub 256 vs -ub 512 moves ~0.8% of greedy-argmax
tokens; this patch's before/after reproduces that movement digit-for-digit
(i.e. the movement is entirely the batch-width effect, no new numerical
content).
