### PR TITLE
fix(server): reject requests with excessive JSON nesting depth

### DIFF
--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -37,6 +37,51 @@ using json = nlohmann::ordered_json;
 
 using raw_buffer = std::vector<uint8_t>;
 
+// nlohmann::json's copy constructor and dump() recurse once per nesting level
+// with no depth limit, so deeply nested input can crash the process; keep this
+// well above realistic use and well below where that recursion turns dangerous
+static constexpr size_t JSON_MAX_NESTING_DEPTH = 64;
+
+// scans raw JSON text for nesting depth without parsing or recursing, so it's
+// safe to call on untrusted input before json::parse
+static bool json_body_exceeds_max_depth(const std::string & body, size_t max_depth) {
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaped = false;
+    for (const char c : body) {
+        if (in_string) {
+            if (escaped) {
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+        switch (c) {
+            case '"':
+                in_string = true;
+                break;
+            case '{':
+            case '[':
+                if (++depth > max_depth) {
+                    return true;
+                }
+                break;
+            case '}':
+            case ']':
+                if (depth > 0) {
+                    depth--;
+                }
+                break;
+            default:
+                break;
+        }
+    }
+    return false;
+}
+
 template <typename T>
 static T json_value(const json & body, const std::string & key, const T & default_value) {
     // Fallback null to default value

--- a/tools/server/server.cpp
+++ b/tools/server/server.cpp
@@ -56,6 +56,9 @@ static server_http_context::handler_t ex_wrapper(server_http_context::handler_t 
         std::string message;
         error_type error;
         try {
+            if (json_body_exceeds_max_depth(req.body, JSON_MAX_NESTING_DEPTH)) {
+                throw std::invalid_argument("request body exceeds maximum JSON nesting depth of " + std::to_string(JSON_MAX_NESTING_DEPTH));
+            }
             return func(req);
         } catch (const std::invalid_argument & e) {
             // treat invalid_argument as invalid request (400)

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -1,4 +1,5 @@
 import pytest
+import requests
 from openai import OpenAI
 from utils import *
 import threading
@@ -243,3 +244,23 @@ def test_local_media_file(media_path, image_url, success,):
         assert res.status_code == 200
     else:
         assert res.status_code == 400
+
+
+def test_rejects_excessive_json_nesting_depth():
+    """Deeply nested JSON must be rejected, not crash the server (CWE-674)"""
+    global server
+    server = ServerPreset.tinyllama2()
+    server.start()
+    base_url = f"http://{server.server_host}:{server.server_port}"
+
+    depth = 3000
+    body = '{"model":"test","tools":' + ('[' * depth) + (']' * depth) + '}'
+    res = requests.post(
+        f"{base_url}/v1/chat/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert res.status_code == 400
+
+    health = requests.get(f"{base_url}/health")
+    assert health.status_code == 200


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Flagging and fixing a denial of service, where a deeply nested array terminates the process, including any same-model work in-flight.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

- Build
```
cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_TOOLS=ON -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DGGML_METAL=OFF
cmake --build build --target llama-server -j 16
```

- Run
```
MODEL=(~/.docker/models/bundles/sha256/0f5d7ed70618e80ad42d74852ba780f21686bb1b6ab30e1c35186f72048b8f58/model/model.gguf)
./build/bin/llama-server -m "$MODEL" --jinja --port 18080 --host 127.0.0.1 -c 2048
```

- Test
```
python3 -c "
open_br='['*3000; close_br=']'*3000
print('{\"model\":\"llama-3.2-1b\",\"tools\":'+open_br+close_br+'}')
" > /tmp/deep_payload.json

curl -s -w '\nHTTP_STATUS:%{http_code}\n' -X POST http://127.0.0.1:18080/v1/chat/completions \
  -H "Content-Type: application/json" --data-binary @/tmp/deep_payload.json
```

- Check results

Before:
```
...
HTTP_STATUS:000

# and in the server logs:
[1]    29699 bus error  ./build/bin/llama-server -m "$MODEL" --jinja --port 18080 --host 127.0.0.1 -c
```

Now:
```
...
{"error":{"code":400,"message":"request body exceeds maximum JSON nesting depth of 64","type":"invalid_request_error"}}
HTTP_STATUS:400

$ curl -s http://127.0.0.1:18080/health
{"status":"ok"}
```


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, only to write the code.
The root cause wasn't identified by AI. I wrote the PR description myself.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
