### PR TITLE
metal : skinny-batch mul_mm tiles + deterministic split-K for small-batch decode

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -736,6 +736,112 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_ext(ggml_
     return res;
 }
 
+
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_sk(ggml_metal_library_t lib, const ggml_tensor * op) {
+    char base[256];
+    char name[256];
+
+    const ggml_type tsrc0 = op->src[0]->type;
+    const ggml_type tsrc1 = op->src[1]->type;
+
+    const bool bc_inp = op->src[0]->ne[0] % 32 != 0;
+    const bool bc_out = op->ne[0] % 32 != 0 || op->ne[1] % 16 != 0;
+
+    GGML_ASSERT(op->src[1]->ne[2] <= INT16_MAX && op->src[1]->ne[3] <= INT16_MAX);
+    const int16_t ne12 = (int16_t) op->src[1]->ne[2];
+    const int16_t ne13 = (int16_t) op->src[1]->ne[3];
+    const int16_t r2   = (int16_t) (ne12 / op->src[0]->ne[2]);
+    const int16_t r3   = (int16_t) (ne13 / op->src[0]->ne[3]);
+
+    snprintf(base, 256, "kernel_mul_mm_sk_%s_%s", ggml_type_name(tsrc0), ggml_type_name(tsrc1));
+    snprintf(name, 256, "%s_bci=%d_bco=%d_ne12=%d_ne13=%d_r2=%d_r3=%d",
+             base, bc_inp, bc_out, ne12, ne13, r2, r3);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        ggml_metal_cv_t cv = ggml_metal_cv_init();
+
+        ggml_metal_cv_set_bool(cv, bc_inp, FC_MUL_MM + 0);
+        ggml_metal_cv_set_bool(cv, bc_out, FC_MUL_MM + 1);
+        ggml_metal_cv_set_int16(cv, ne12,  FC_MUL_MM + 2);
+        ggml_metal_cv_set_int16(cv, ne13,  FC_MUL_MM + 3);
+        ggml_metal_cv_set_int16(cv, r2,    FC_MUL_MM + 4);
+        ggml_metal_cv_set_int16(cv, r3,    FC_MUL_MM + 5);
+
+        res = ggml_metal_library_compile_pipeline(lib, base, name, cv);
+
+        ggml_metal_cv_free(cv);
+    }
+
+    res.nr0  = 32;
+    res.nr1  = 16;
+    res.smem = 4096;
+    res.nsg  = 4;
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_sk_reduce(ggml_metal_library_t lib) {
+    const char * name = "kernel_mul_mm_sk_reduce";
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        ggml_metal_cv_t cv = ggml_metal_cv_init();
+        res = ggml_metal_library_compile_pipeline(lib, name, name, cv);
+        ggml_metal_cv_free(cv);
+    }
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_s(ggml_metal_library_t lib, const ggml_tensor * op) {
+    char base[256];
+    char name[256];
+
+    const ggml_type tsrc0 = op->src[0]->type;
+    const ggml_type tsrc1 = op->src[1]->type;
+
+    // tile family: 32x16 (default) or 16x16 via GGML_METAL_MM_SKINNY_TILE=16
+    static const int tile0 = getenv("GGML_METAL_MM_SKINNY_TILE") && atoi(getenv("GGML_METAL_MM_SKINNY_TILE")) == 16 ? 16 : 32;
+
+    const bool bc_inp = op->src[0]->ne[0] % 32 != 0;
+    const bool bc_out = op->ne[0] % tile0 != 0 || op->ne[1] % 16 != 0;
+
+    GGML_ASSERT(op->src[1]->ne[2] <= INT16_MAX && op->src[1]->ne[3] <= INT16_MAX);
+    const int16_t ne12 = (int16_t) op->src[1]->ne[2];
+    const int16_t ne13 = (int16_t) op->src[1]->ne[3];
+    const int16_t r2   = (int16_t) (ne12 / op->src[0]->ne[2]);
+    const int16_t r3   = (int16_t) (ne13 / op->src[0]->ne[3]);
+
+    snprintf(base, 256, "kernel_mul_mm_s%s_%s_%s", tile0 == 16 ? "2" : "", ggml_type_name(tsrc0), ggml_type_name(tsrc1));
+    snprintf(name, 256, "%s_bci=%d_bco=%d_ne12=%d_ne13=%d_r2=%d_r3=%d",
+             base, bc_inp, bc_out, ne12, ne13, r2, r3);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        ggml_metal_cv_t cv = ggml_metal_cv_init();
+
+        ggml_metal_cv_set_bool(cv, bc_inp, FC_MUL_MM + 0);
+        ggml_metal_cv_set_bool(cv, bc_out, FC_MUL_MM + 1);
+        ggml_metal_cv_set_int16(cv, ne12,  FC_MUL_MM + 2);
+        ggml_metal_cv_set_int16(cv, ne13,  FC_MUL_MM + 3);
+        ggml_metal_cv_set_int16(cv, r2,    FC_MUL_MM + 4);
+        ggml_metal_cv_set_int16(cv, r3,    FC_MUL_MM + 5);
+
+        res = ggml_metal_library_compile_pipeline(lib, base, name, cv);
+
+        ggml_metal_cv_free(cv);
+    }
+
+    res.nr0  = tile0;
+    res.nr1  = 16;
+    res.smem = 4096;
+    res.nsg  = 4;
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm(ggml_metal_library_t lib, const ggml_tensor * op) {
     char base[256];
     char name[256];

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -135,6 +135,9 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_gated_del
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_solve_tri         (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv_ext        (ggml_metal_library_t lib, const struct ggml_tensor * op, int nsg, int nxpsg, int r1ptg);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm            (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_s            (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_sk            (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_sk_reduce(ggml_metal_library_t lib);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mv            (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id_map0    (ggml_metal_library_t lib, int ne02, int ne20);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_mul_mm_id         (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -6,6 +6,12 @@
 // TODO: become function constants
 
 #define SZ_SIMDGROUP 16
+
+typedef struct {
+    uint64_t plane; // ne0*ne1 elements per (im, split) plane
+    uint64_t total; // ne0*ne1*ne12*ne13 output elements
+    int32_t  nsk;   // number of K splits
+} ggml_metal_kargs_mul_mm_sk_reduce;
 #define N_MM_NK 2
 #define N_MM_NK_TOTAL (SZ_SIMDGROUP * N_MM_NK)
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -2343,7 +2343,10 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
     const bool mv_ext_src0_float = op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_BF16;
     // measured crossover on M3 Max: skinny+split-K mm beats the ext kernels from ne11=4 (quants)
     // and ne11=6 (floats); ext keeps the remainder (2..mm_min)
-    const int  mm_min_default = mv_ext_src0_float ? 5 : 3;
+    // keep the stock mv-ext/mm break-even by default: on M4 Max the skinny mm tiles win the
+    // 8 < ne11 <= 32 range from the stock threshold, while the retuned (M3-measured) lower
+    // crossovers measured slightly worse; the envs below allow per-device tuning
+    const int  mm_min_default = 8;
     static const int ne11_mm_min_env = getenv("GGML_METAL_MM_MIN") ? atoi(getenv("GGML_METAL_MM_MIN")) : -1;
     const int ne11_mm_min = ne11_mm_min_env >= 0 ? ne11_mm_min_env : mm_min_default;
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -144,6 +144,11 @@ int ggml_metal_op_n_nodes(ggml_metal_op_t ctx) {
     return ctx->n_nodes();
 }
 
+// the split-K skinny matmul is instantiated with a fixed number of K splits
+static int mm_splitk_nsk() {
+    return 4;
+}
+
 static bool ggml_metal_op_concurrency_reset(ggml_metal_op_t ctx) {
     if (!ctx->mem_ranges) {
         return true;
@@ -2333,7 +2338,21 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
 
     // find the break-even point where the matrix-matrix kernel becomes more efficient compared
     // to the matrix-vector kernel
-    const int ne11_mm_min = 8;
+    // lower bound for the mat-mat branch; with the skinny+split-K kernels the mm path can win
+    // well below the upstream break-even of 8 (A/B via GGML_METAL_MM_MIN)
+    const bool mv_ext_src0_float = op->src[0]->type == GGML_TYPE_F32 || op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_BF16;
+    // measured crossover on M3 Max: skinny+split-K mm beats the ext kernels from ne11=4 (quants)
+    // and ne11=6 (floats); ext keeps the remainder (2..mm_min)
+    const int  mm_min_default = mv_ext_src0_float ? 5 : 3;
+    static const int ne11_mm_min_env = getenv("GGML_METAL_MM_MIN") ? atoi(getenv("GGML_METAL_MM_MIN")) : -1;
+    const int ne11_mm_min = ne11_mm_min_env >= 0 ? ne11_mm_min_env : mm_min_default;
+
+    // extended small-batch mat-vec window (skinny-batch / spec-decode optimization):
+    // floats stream weights once with r1ptg=16 up to ne11=16; quants tolerate re-reads up to ne11=32 with r1ptg=8.
+    // A/B overrides: GGML_METAL_MV_EXT_MAX (window; 8 = upstream behavior), GGML_METAL_MV_EXT_R1 (force r1ptg for ne11>8)
+    static const int mv_ext_max_env = getenv("GGML_METAL_MV_EXT_MAX") ? atoi(getenv("GGML_METAL_MV_EXT_MAX")) : -1;
+    static const int mv_ext_r1_env  = getenv("GGML_METAL_MV_EXT_R1")  ? atoi(getenv("GGML_METAL_MV_EXT_R1"))  : -1;
+    const int  mv_ext_max = mv_ext_max_env >= 0 ? mv_ext_max_env : mm_min_default;
 
     // first try to use small-batch mat-mv kernels
     // these should be efficient for BS [2, ~8]
@@ -2353,7 +2372,7 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
            op->src[0]->type == GGML_TYPE_Q8_0 ||
            op->src[0]->type == GGML_TYPE_MXFP4 ||
            op->src[0]->type == GGML_TYPE_IQ4_NL ||
-           false) && (ne11 >= 2 && ne11 <= 8)
+           false) && (ne11 >= 2 && ne11 <= mv_ext_max)
          ) ||
          (
           (
@@ -2404,7 +2423,10 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
             case 5:
                 r1ptg = 5; break;
             default:
-                GGML_ABORT("unsupported ne11");
+                // ne11 > 8: wide variants; floats prefer r1ptg=16 (weights streamed once)
+                r1ptg = (mv_ext_r1_env == 8 || mv_ext_r1_env == 16) ? (int16_t) mv_ext_r1_env
+                      : (mv_ext_src0_float && ne11 <= 16 ? 16 : 8);
+                break;
         };
 
         auto pipeline = ggml_metal_library_get_pipeline_mul_mv_ext(lib, op, nsg, nxpsg, r1ptg);
@@ -2454,7 +2476,19 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         //    default: break;
         //}
 
-        auto pipeline = ggml_metal_library_get_pipeline_mul_mm(lib, op);
+        // skinny-batch tiles (32x16) for small N: 4x threadgroups, no N-padding waste at N<=16
+        static const int mm_skinny_max = getenv("GGML_METAL_MM_SKINNY_MAX") ? atoi(getenv("GGML_METAL_MM_SKINNY_MAX")) : 32;
+        const bool use_mm_skinny = !props_dev->has_tensor && ne11 <= mm_skinny_max;
+
+        // split-K for occupancy-starved skinny shapes (few row-tiles): deterministic two-pass
+        static const int mm_splitk = getenv("GGML_METAL_MM_SPLITK") ? atoi(getenv("GGML_METAL_MM_SPLITK")) : 4;
+        const bool use_mm_sk = use_mm_skinny && mm_splitk > 1 &&
+            ne01 <= 5120 && ne00 >= 1024 &&
+            (uint64_t) ne0*ne1*ne12*ne13 <= UINT32_MAX;
+
+        auto pipeline = use_mm_sk     ? ggml_metal_library_get_pipeline_mul_mm_sk(lib, op)
+                      : use_mm_skinny ? ggml_metal_library_get_pipeline_mul_mm_s (lib, op)
+                                      : ggml_metal_library_get_pipeline_mul_mm  (lib, op);
 
         ggml_metal_kargs_mul_mm args = {
             /*.ne00 =*/ ne00,
@@ -2473,11 +2507,19 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
             /*.r3   =*/ r3,
         };
 
+        ggml_metal_buffer_id bid_dst = ggml_metal_get_buffer_id(op);
+
+        // split-K partials live in the scratch tail of the dst allocation
+        ggml_metal_buffer_id bid_out = bid_dst;
+        if (use_mm_sk) {
+            bid_out.offs += ggml_nbytes(op);
+        }
+
         ggml_metal_encoder_set_pipeline(enc, pipeline);
         ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
         ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
         ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
-        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
+        ggml_metal_encoder_set_buffer  (enc, bid_out,                              3);
 
         const size_t smem = pipeline.smem;
 
@@ -2487,7 +2529,29 @@ int ggml_metal_op_mul_mat(ggml_metal_op_t ctx, int idx) {
         const int nr1 = pipeline.nr1;
         const int nsg = pipeline.nsg;
 
-        ggml_metal_encoder_dispatch_threadgroups(enc, ((ne11 + nr1 - 1) / nr1), ((ne01 + nr0 - 1) / nr0), ne12 * ne13, 32, nsg, 1);
+        const int nz = use_mm_sk ? ne12 * ne13 * mm_splitk_nsk() : ne12 * ne13;
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, ((ne11 + nr1 - 1) / nr1), ((ne01 + nr0 - 1) / nr0), nz, 32, nsg, 1);
+
+        if (use_mm_sk) {
+            ggml_metal_op_concurrency_reset(ctx);
+
+            auto pipeline_red = ggml_metal_library_get_pipeline_mul_mm_sk_reduce(lib);
+
+            ggml_metal_kargs_mul_mm_sk_reduce args_red = {
+                /*.plane =*/ (uint64_t) ne0*ne1,
+                /*.total =*/ (uint64_t) ne0*ne1*ne12*ne13,
+                /*.nsk   =*/ mm_splitk_nsk(),
+            };
+
+            ggml_metal_encoder_set_pipeline(enc, pipeline_red);
+            ggml_metal_encoder_set_bytes   (enc, &args_red, sizeof(args_red), 0);
+            ggml_metal_encoder_set_buffer  (enc, bid_out, 1);
+            ggml_metal_encoder_set_buffer  (enc, bid_dst, 2);
+
+            const int64_t total = (int64_t) ne0*ne1*ne12*ne13;
+            ggml_metal_encoder_dispatch_threadgroups(enc, (int)((total + 255)/256), 1, 1, 256, 1, 1);
+        }
     } else {
         auto pipeline = ggml_metal_library_get_pipeline_mul_mv(lib, op);
 

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -215,6 +215,13 @@ static size_t ggml_backend_metal_buffer_type_get_alloc_size(ggml_backend_buffer_
 
     // some operations require additional memory for fleeting data:
     switch (tensor->op) {
+        case GGML_OP_MUL_MAT:
+            {
+                // split-K skinny matmul partials (must cover the runtime gate in ggml-metal-ops.cpp)
+                if (tensor->ne[1] <= 32 && tensor->src[0]->ne[1] <= 5120 && tensor->src[0]->ne[0] >= 1024) {
+                    res += 4*ggml_nbytes(tensor);
+                }
+            } break;
         case GGML_OP_MUL_MAT_ID:
             {
                 res += ggml_metal_op_mul_mat_id_extra_tpe(tensor);

--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -4223,23 +4223,31 @@ template [[host_name("kernel_mul_mv_ext_f32_f32_r1_2")]]    kernel mul_mv_ext_q4
 template [[host_name("kernel_mul_mv_ext_f32_f32_r1_3")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, float4,       4,  dequantize_f32_t4>;
 template [[host_name("kernel_mul_mv_ext_f32_f32_r1_4")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, float4,       4,  dequantize_f32_t4>;
 template [[host_name("kernel_mul_mv_ext_f32_f32_r1_5")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, float4,       4,  dequantize_f32_t4>;
+template [[host_name("kernel_mul_mv_ext_f32_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, float4,       4,  dequantize_f32_t4>;
+template [[host_name("kernel_mul_mv_ext_f32_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, float4,       4,  dequantize_f32_t4>;
 
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_2")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, half4,        4,  dequantize_f16_t4>;
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_3")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, half4,        4,  dequantize_f16_t4>;
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_4")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, half4,        4,  dequantize_f16_t4>;
 template [[host_name("kernel_mul_mv_ext_f16_f32_r1_5")]]    kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, half4,        4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, half4,        4,  dequantize_f16_t4>;
+template [[host_name("kernel_mul_mv_ext_f16_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, half4,        4,  dequantize_f16_t4>;
 
 #if defined(GGML_METAL_HAS_BF16)
 template [[host_name("kernel_mul_mv_ext_bf16_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, bfloat4,      4,  dequantize_bf16_t4>;
 template [[host_name("kernel_mul_mv_ext_bf16_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, bfloat4,      4,  dequantize_bf16_t4>;
 template [[host_name("kernel_mul_mv_ext_bf16_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, bfloat4,      4,  dequantize_bf16_t4>;
 template [[host_name("kernel_mul_mv_ext_bf16_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, bfloat4,      4,  dequantize_bf16_t4>;
+template [[host_name("kernel_mul_mv_ext_bf16_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, bfloat4,      4,  dequantize_bf16_t4>;
+template [[host_name("kernel_mul_mv_ext_bf16_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, bfloat4,      4,  dequantize_bf16_t4>;
 #endif
 
 template [[host_name("kernel_mul_mv_ext_q1_0_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q1_0,   128, dequantize_q1_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q1_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q1_0,   128, dequantize_q1_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q1_0_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q1_0,   128, dequantize_q1_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q1_0_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q1_0,   128, dequantize_q1_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q1_0_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q1_0,   128, dequantize_q1_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q1_0_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_q1_0,   128, dequantize_q1_0_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q2_0_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q2_0,    64, dequantize_q2_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q2_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q2_0,    64, dequantize_q2_0_t4>;
@@ -4250,36 +4258,50 @@ template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_2")]]   kernel mul_mv_ext_q4
 template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q4_0,   32, dequantize_q4_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q4_0,   32, dequantize_q4_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q4_0,   32, dequantize_q4_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q4_0,   32, dequantize_q4_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_0_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_q4_0,   32, dequantize_q4_0_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q4_1,   32, dequantize_q4_1_t4>;
 template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q4_1,   32, dequantize_q4_1_t4>;
 template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q4_1,   32, dequantize_q4_1_t4>;
 template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q4_1,   32, dequantize_q4_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q4_1,   32, dequantize_q4_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q4_1_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_q4_1,   32, dequantize_q4_1_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q5_0,   32, dequantize_q5_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q5_0,   32, dequantize_q5_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q5_0,   32, dequantize_q5_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q5_0,   32, dequantize_q5_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q5_0,   32, dequantize_q5_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_0_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_q5_0,   32, dequantize_q5_0_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q5_1,   32, dequantize_q5_1_t4>;
 template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q5_1,   32, dequantize_q5_1_t4>;
 template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q5_1,   32, dequantize_q5_1_t4>;
 template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q5_1,   32, dequantize_q5_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q5_1,   32, dequantize_q5_1_t4>;
+template [[host_name("kernel_mul_mv_ext_q5_1_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_q5_1,   32, dequantize_q5_1_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_2")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_q8_0,   32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_3")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_q8_0,   32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_4")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_q8_0,   32, dequantize_q8_0_t4>;
 template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_5")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_q8_0,   32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_q8_0,   32, dequantize_q8_0_t4>;
+template [[host_name("kernel_mul_mv_ext_q8_0_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_q8_0,   32, dequantize_q8_0_t4>;
 
 template [[host_name("kernel_mul_mv_ext_mxfp4_f32_r1_2")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_mxfp4,  32, dequantize_mxfp4_t4>;
 template [[host_name("kernel_mul_mv_ext_mxfp4_f32_r1_3")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_mxfp4,  32, dequantize_mxfp4_t4>;
 template [[host_name("kernel_mul_mv_ext_mxfp4_f32_r1_4")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_mxfp4,  32, dequantize_mxfp4_t4>;
 template [[host_name("kernel_mul_mv_ext_mxfp4_f32_r1_5")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_mxfp4,  32, dequantize_mxfp4_t4>;
+template [[host_name("kernel_mul_mv_ext_mxfp4_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_mxfp4,  32, dequantize_mxfp4_t4>;
+template [[host_name("kernel_mul_mv_ext_mxfp4_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_mxfp4,  32, dequantize_mxfp4_t4>;
 
 template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_2")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<2, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
 template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_3")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<3, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
 template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_4")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<4, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
 template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_5")]] kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<5, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
+template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_8")]]   kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<8, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
+template [[host_name("kernel_mul_mv_ext_iq4_nl_f32_r1_16")]]  kernel mul_mv_ext_q4_f32_t kernel_mul_mv_ext_q4_f32_disp<16, block_iq4_nl, 32, dequantize_iq4_nl_t4>;
 
 template [[host_name("kernel_mul_mv_ext_q4_K_f32_r1_2")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<2, block_q4_K, 256, dequantize_q4_K>;
 template [[host_name("kernel_mul_mv_ext_q4_K_f32_r1_3")]] kernel mul_mv_ext_q4x4_f32_t kernel_mul_mv_ext_q4x4_f32_disp<3, block_q4_K, 256, dequantize_q4_K>;
@@ -10652,6 +10674,264 @@ kernel void kernel_mul_mm(
     }
 }
 
+
+// skinny-batch matrix-matrix kernel, tile-size templated: NR0T x NR1T output tiles
+// (instantiated as 32x16 and 16x16; stock kernel_mul_mm is 64x32).
+// For small N (spec-decode verify/draft blocks, N in (8, 32]) the 64x32 kernel pads N to 32
+// and launches only ne01/64 threadgroups -> occupancy-starved and half the FLOPs wasted.
+// Same 128-thread / 4-simdgroup structure (2x2 sg grid over the tile); threads above the
+// reduced load work-item counts idle during load phases (loads are bandwidth-bound; harmless).
+template<
+    typename S0, typename S0_4x4, typename S0_8x8,
+    typename S1, typename S1_2x4, typename S1_8x8,
+    typename block_q, short nl, void (*dequantize_func)(device const block_q *, short, thread S0_4x4 &),
+    typename T0, typename T0_4x4, typename T1, typename T1_2x4,
+    short NR0T, short NR1T, short NSK>
+kernel void kernel_mul_mm_s(
+        constant ggml_metal_kargs_mul_mm & args,
+        device const char * src0,
+        device const char * src1,
+        device       char * dst,
+        threadgroup  char * shmem [[threadgroup(0)]],
+        uint3  tgpig[[threadgroup_position_in_grid]],
+        ushort tiitg[[thread_index_in_threadgroup]],
+        ushort sgitg[[simdgroup_index_in_threadgroup]]) {
+
+    constexpr int NR0 = NR0T;
+    constexpr int NR1 = NR1T;
+
+    constexpr int NK  = 32;
+    constexpr int NL0 = NK/16;
+    constexpr int NL1 = NK/8;
+
+    constexpr int RB0 = NR0/8;  // 8x8 row-blocks in the A tile
+    constexpr int CB1 = NR1/8;  // 8x8 col-blocks in the B tile
+    constexpr int MA  = RB0/2;  // row-blocks per simdgroup half
+    constexpr int MB  = CB1/2;  // col-blocks per simdgroup half
+
+    threadgroup S0 * sa = (threadgroup S0 *)(shmem);
+    threadgroup S1 * sb = (threadgroup S1 *)(shmem + NR0*NK*2);
+
+    const int imz = tgpig.z;                          // (im, split) plane index when NSK > 1
+    const int im  = (NSK > 1) ? imz / NSK : imz;
+    const int isk = (NSK > 1) ? imz % NSK : 0;
+    const int r0 = tgpig.y*NR0;
+    const int r1 = tgpig.x*NR1;
+
+    const short nr0 = (args.ne0 - r0 < NR0) ? (args.ne0 - r0) : NR0;
+    const short nr1 = (args.ne1 - r1 < NR1) ? (args.ne1 - r1) : NR1;
+
+    // load-phase guards: 128 threads, but only NR0*NL0 A work items and NR1*NL1 B work items
+    const bool loada = tiitg < NR0*NL0;
+    const bool loadb = tiitg < NR1*NL1;
+
+    const short lr0 = ((short)tiitg/NL0) < nr0 ? ((short)tiitg/NL0) : nr0 - 1;
+    const short lr1 = ((short)tiitg/NL1) < nr1 ? ((short)tiitg/NL1) : nr1 - 1;
+
+    const short il0 = (tiitg % NL0);
+
+    short il = il0;
+
+    const int i12 = im % FC_mul_mm_ne12;
+    const int i13 = im / FC_mul_mm_ne12;
+
+    const uint64_t offset0 = (i12/FC_mul_mm_r2)*args.nb02 + (i13/FC_mul_mm_r3)*args.nb03;
+    const short    offset1 = il0/nl;
+
+    device const block_q * x = (device const block_q *)(src0 + args.nb01*(r0 + lr0) + offset0) + offset1;
+
+    const short iy = 8*(tiitg % NL1);
+
+    device const T1 * y = (device const T1 *)(src1
+        + args.nb13*i13
+        + args.nb12*i12
+        + args.nb11*(r1 + lr1)
+        + args.nb10*iy);
+
+    S0_8x8 ma[MA];
+    S1_8x8 mb[MB];
+
+    simdgroup_float8x8 mc[MA*MB];
+
+    for (short i = 0; i < MA*MB; i++){
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    }
+
+    // split-K window: this split covers K in [k0, k1); walk x/il to the k0 state
+    int k0 = 0, k1 = args.ne00;
+    if (NSK > 1) {
+        const int kc = ((args.ne00/NSK + NK - 1)/NK)*NK;
+        k0 = isk*kc;
+        k1 = (args.ne00 < k0 + kc) ? args.ne00 : k0 + kc;
+        for (int t = 0; t < k0/NK; ++t) {
+            il = (il + 2 < nl) ? il + 2 : il % 2;
+            x  = (il < 2) ? x + (2 + nl - 1)/nl : x;
+        }
+        y += k0;
+    }
+
+    for (int loop_k = k0; loop_k < k1; loop_k += NK) {
+        // load data and store to threadgroup memory
+        if (is_same<T0_4x4, block_q>::value && FC_mul_mm_bc_inp) {
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            // no need for dequantization
+            if (loada) {
+                for (short i = 0; i < 16; i++) {
+                    const short sx = 2*il0 + i/8;
+                    const short sy = (tiitg/NL0)/8;
+
+                    const short lx = (tiitg/NL0)%8;
+                    const short ly = i%8;
+
+                    const short ib = RB0*sx + sy;
+
+                    *(sa + 64*ib + 8*ly + lx) = loop_k + 16*il + i < args.ne00 ? *((device T0 *) x + i) : 0;
+                }
+            }
+        } else {
+            S0_4x4 temp_a;
+            if (loada) {
+                dequantize_func(x, il, temp_a);
+            }
+
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            if (loada) {
+                FOR_UNROLL (short i = 0; i < 16; i++) {
+                    const short sx = 2*il0 + i/8;
+                    const short sy = (tiitg/NL0)/8;
+
+                    const short lx = (tiitg/NL0)%8;
+                    const short ly = i%8;
+
+                    const short ib = RB0*sx + sy;
+
+                    *(sa + 64*ib + 8*ly + lx) = temp_a[i/4][i%4];
+                }
+            }
+        }
+
+        if (FC_mul_mm_bc_inp) {
+            if (loadb) {
+                for (short i = 0; i < 8; ++i) {
+                    const short sx = (tiitg%NL1);
+                    const short sy = (tiitg/NL1)/8;
+
+                    const short lx = i;
+                    const short ly = (tiitg/NL1)%8;
+
+                    const short ib = CB1*sx + sy;
+
+                    *(sb + 64*ib + 8*ly + lx) = loop_k + iy + i < args.ne00 ? (S1) *((device T1 *) y + i) : 0;
+                }
+            }
+        } else {
+            if (loadb) {
+                const short sx = (tiitg%NL1);
+                const short sy = (tiitg/NL1)/8;
+
+                const short ly = (tiitg/NL1)%8;
+
+                const short ib = CB1*sx + sy;
+
+                *(threadgroup S1_2x4 *)(sb + 64*ib + 8*ly) = (S1_2x4)(*((device T1_2x4 *) y));
+            }
+        }
+
+        il = (il + 2 < nl) ? il + 2 : il % 2;
+        x  = (il < 2) ? x + (2 + nl - 1)/nl : x;
+
+        y += NK;
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // load matrices from threadgroup memory and conduct outer products
+        threadgroup const S0 * lsma = (sa + MA*64*(sgitg%2));
+        threadgroup const S1 * lsmb = (sb + MB*64*(sgitg/2));
+
+        FOR_UNROLL (short ik = 0; ik < NK/8; ik++) {
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < MA; i++) {
+                simdgroup_load(ma[i], lsma + 64*i, 8, 0, false);
+            }
+
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < MB; i++) {
+                simdgroup_load(mb[i], lsmb + 64*i, 8, 0, false);
+            }
+
+            simdgroup_barrier(mem_flags::mem_none);
+
+            FOR_UNROLL (short i = 0; i < MA*MB; i++){
+                simdgroup_multiply_accumulate(mc[i], mb[i/MA], ma[i%MA], mc[i]);
+            }
+
+            lsma += RB0*64;
+            lsmb += CB1*64;
+        }
+    }
+
+    if (!FC_mul_mm_bc_out || (r0 + NR0 <= args.ne0 && r1 + NR1 <= args.ne1)) {
+        device float * C = (device float *) dst +
+            (r0 + (NR0/2)*(sgitg &  1)) + \
+            (r1 + (NR1/2)*(sgitg >> 1)) * args.ne0 + (uint64_t) imz*args.ne1*args.ne0;
+
+        for (short i = 0; i < MA*MB; i++) {
+            simdgroup_store(mc[i], C + 8*(i%MA) + 8*args.ne0*(i/MA), args.ne0, 0, false);
+        }
+    } else {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        threadgroup float * temp_str = ((threadgroup float *) shmem) + (NR0/2)*(sgitg&1) + ((NR1/2)*(sgitg >> 1))*NR0;
+
+        for (short i = 0; i < MA*MB; i++) {
+            simdgroup_store(mc[i], temp_str + 8*(i%MA) + 8*NR0*(i/MA), NR0, 0, false);
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (sgitg == 0) {
+            for (int j = tiitg; j < nr1; j += NR1) {
+                device float  * D  = (device float  *) dst + r0 + (r1 + j)*args.ne0 + (uint64_t) imz*args.ne1*args.ne0;
+                device float4 * D4 = (device float4 *) D;
+
+                threadgroup float  * C  = temp_str + (j*NR0);
+                threadgroup float4 * C4 = (threadgroup float4 *) C;
+
+                int i = 0;
+                for (; i < nr0/4; i++) {
+                    *(D4 + i) = *(C4 + i);
+                }
+
+                i *= 4;
+                for (; i < nr0; i++) {
+                    *(D + i) = *(C + i);
+                }
+            }
+        }
+    }
+}
+
+
+// deterministic fixed-order reduce for the split-K skinny matmul partials
+kernel void kernel_mul_mm_sk_reduce(
+        constant ggml_metal_kargs_mul_mm_sk_reduce & args,
+        device const float * part,
+        device       float * dst,
+        uint gid [[thread_position_in_grid]]) {
+    if (gid >= args.total) return;
+    const uint64_t im = gid / args.plane;
+    const uint64_t i  = gid % args.plane;
+    float s = 0.0f;
+    for (int k = 0; k < args.nsk; ++k) {
+        s += part[(im*args.nsk + k)*args.plane + i];
+    }
+    dst[gid] = s;
+}
+
 #endif // GGML_METAL_HAS_TENSOR
 
 template<short ne20> // n_expert_used
@@ -11085,6 +11365,156 @@ template [[host_name("kernel_mul_mm_iq1_m_f16")]]   kernel mul_mm_t kernel_mul_m
 template [[host_name("kernel_mul_mm_iq4_nl_f16")]]  kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_nl,  2,     dequantize_iq4_nl,  float,  float4x4,  half, half2x4>;
 template [[host_name("kernel_mul_mm_iq4_xs_f16")]]  kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_xs,  QK_NL, dequantize_iq4_xs,  float,  float4x4,  half, half2x4>;
 template [[host_name("kernel_mul_mm_tq2_0_f16")]]   kernel mul_mm_t kernel_mul_mm<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_tq2_0,   QK_NL, dequantize_tq2_0,   float,  float4x4,  half, half2x4>;
+
+#ifndef GGML_METAL_HAS_TENSOR
+typedef decltype(kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  float, float2x4, 32, 16, 1>) mul_mm_s_t;
+typedef decltype(kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  float, float2x4, 16, 16, 1>) mul_mm_s2_t;
+typedef decltype(kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  float, float2x4, 32, 16, 4>) mul_mm_sk_t;
+
+template [[host_name("kernel_mul_mm_s_f32_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_f16_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   half4x4,       1,     dequantize_f16,     half,   half4x4,   float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_bf16_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<bfloat, bfloat4x4, simdgroup_bfloat8x8, bfloat, bfloat2x4, simdgroup_bfloat8x8, bfloat4x4,     1,     dequantize_bf16,    bfloat, bfloat4x4, float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q1_0_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q1_0,    8,     dequantize_q1_0,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q4_0_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_0,    2,     dequantize_q4_0,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q4_1_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_1,    2,     dequantize_q4_1,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q5_0_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_0,    2,     dequantize_q5_0,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q5_1_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_1,    2,     dequantize_q5_1,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q8_0_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q8_0,    2,     dequantize_q8_0,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_mxfp4_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_mxfp4,   2,     dequantize_mxfp4,   float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q2_K_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q2_K,    QK_NL, dequantize_q2_K,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q3_K_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q3_K,    QK_NL, dequantize_q3_K,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q4_K_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_K,    QK_NL, dequantize_q4_K,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q5_K_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_K,    QK_NL, dequantize_q5_K,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q6_K_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q6_K,    QK_NL, dequantize_q6_K,    float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq2_xxs_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq2_xs_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xs,  QK_NL, dequantize_iq2_xs,  float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq3_xxs_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_xxs, QK_NL, dequantize_iq3_xxs, float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq3_s_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_s,   QK_NL, dequantize_iq3_s,   float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq2_s_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_s,   QK_NL, dequantize_iq2_s,   float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq1_s_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_s,   QK_NL, dequantize_iq1_s,   float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq1_m_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_m,   QK_NL, dequantize_iq1_m,   float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq4_nl_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_nl,  2,     dequantize_iq4_nl,  float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq4_xs_f32")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_xs,  QK_NL, dequantize_iq4_xs,  float,  float4x4,  float, float2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_f32_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_f16_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   half4x4,       1,     dequantize_f16,     half,   half4x4,   half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q1_0_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q1_0,    8,     dequantize_q1_0,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q4_0_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_0,    2,     dequantize_q4_0,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q4_1_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_1,    2,     dequantize_q4_1,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q5_0_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_0,    2,     dequantize_q5_0,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q5_1_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_1,    2,     dequantize_q5_1,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q8_0_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q8_0,    2,     dequantize_q8_0,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_mxfp4_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_mxfp4,   2,     dequantize_mxfp4,   float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q2_K_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q2_K,    QK_NL, dequantize_q2_K,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q3_K_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q3_K,    QK_NL, dequantize_q3_K,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q4_K_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_K,    QK_NL, dequantize_q4_K,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q5_K_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_K,    QK_NL, dequantize_q5_K,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_q6_K_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q6_K,    QK_NL, dequantize_q6_K,    float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq2_xxs_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq2_xs_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xs,  QK_NL, dequantize_iq2_xs,  float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq3_xxs_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_xxs, QK_NL, dequantize_iq3_xxs, float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq3_s_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_s,   QK_NL, dequantize_iq3_s,   float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq2_s_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_s,   QK_NL, dequantize_iq2_s,   float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq1_s_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_s,   QK_NL, dequantize_iq1_s,   float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq1_m_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_m,   QK_NL, dequantize_iq1_m,   float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq4_nl_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_nl,  2,     dequantize_iq4_nl,  float,  float4x4,  half, half2x4, 32, 16, 1>;
+template [[host_name("kernel_mul_mm_s_iq4_xs_f16")]] kernel mul_mm_s_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_xs,  QK_NL, dequantize_iq4_xs,  float,  float4x4,  half, half2x4, 32, 16, 1>;
+
+template [[host_name("kernel_mul_mm_s2_f32_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_f16_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   half4x4,       1,     dequantize_f16,     half,   half4x4,   float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_bf16_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<bfloat, bfloat4x4, simdgroup_bfloat8x8, bfloat, bfloat2x4, simdgroup_bfloat8x8, bfloat4x4,     1,     dequantize_bf16,    bfloat, bfloat4x4, float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q1_0_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q1_0,    8,     dequantize_q1_0,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q4_0_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_0,    2,     dequantize_q4_0,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q4_1_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_1,    2,     dequantize_q4_1,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q5_0_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_0,    2,     dequantize_q5_0,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q5_1_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_1,    2,     dequantize_q5_1,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q8_0_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q8_0,    2,     dequantize_q8_0,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_mxfp4_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_mxfp4,   2,     dequantize_mxfp4,   float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q2_K_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q2_K,    QK_NL, dequantize_q2_K,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q3_K_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q3_K,    QK_NL, dequantize_q3_K,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q4_K_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_K,    QK_NL, dequantize_q4_K,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q5_K_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_K,    QK_NL, dequantize_q5_K,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q6_K_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q6_K,    QK_NL, dequantize_q6_K,    float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq2_xxs_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq2_xs_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xs,  QK_NL, dequantize_iq2_xs,  float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq3_xxs_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_xxs, QK_NL, dequantize_iq3_xxs, float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq3_s_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_s,   QK_NL, dequantize_iq3_s,   float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq2_s_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_s,   QK_NL, dequantize_iq2_s,   float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq1_s_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_s,   QK_NL, dequantize_iq1_s,   float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq1_m_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_m,   QK_NL, dequantize_iq1_m,   float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq4_nl_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_nl,  2,     dequantize_iq4_nl,  float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq4_xs_f32")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_xs,  QK_NL, dequantize_iq4_xs,  float,  float4x4,  float, float2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_f32_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_f16_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   half4x4,       1,     dequantize_f16,     half,   half4x4,   half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q1_0_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q1_0,    8,     dequantize_q1_0,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q4_0_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_0,    2,     dequantize_q4_0,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q4_1_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_1,    2,     dequantize_q4_1,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q5_0_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_0,    2,     dequantize_q5_0,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q5_1_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_1,    2,     dequantize_q5_1,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q8_0_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q8_0,    2,     dequantize_q8_0,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_mxfp4_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_mxfp4,   2,     dequantize_mxfp4,   float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q2_K_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q2_K,    QK_NL, dequantize_q2_K,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q3_K_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q3_K,    QK_NL, dequantize_q3_K,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q4_K_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_K,    QK_NL, dequantize_q4_K,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q5_K_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_K,    QK_NL, dequantize_q5_K,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_q6_K_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q6_K,    QK_NL, dequantize_q6_K,    float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq2_xxs_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq2_xs_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xs,  QK_NL, dequantize_iq2_xs,  float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq3_xxs_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_xxs, QK_NL, dequantize_iq3_xxs, float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq3_s_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_s,   QK_NL, dequantize_iq3_s,   float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq2_s_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_s,   QK_NL, dequantize_iq2_s,   float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq1_s_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_s,   QK_NL, dequantize_iq1_s,   float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq1_m_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_m,   QK_NL, dequantize_iq1_m,   float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq4_nl_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_nl,  2,     dequantize_iq4_nl,  float,  float4x4,  half, half2x4, 16, 16, 1>;
+template [[host_name("kernel_mul_mm_s2_iq4_xs_f16")]] kernel mul_mm_s2_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_xs,  QK_NL, dequantize_iq4_xs,  float,  float4x4,  half, half2x4, 16, 16, 1>;
+
+template [[host_name("kernel_mul_mm_sk_f32_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_f16_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   half4x4,       1,     dequantize_f16,     half,   half4x4,   float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_bf16_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<bfloat, bfloat4x4, simdgroup_bfloat8x8, bfloat, bfloat2x4, simdgroup_bfloat8x8, bfloat4x4,     1,     dequantize_bf16,    bfloat, bfloat4x4, float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q1_0_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q1_0,    8,     dequantize_q1_0,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q4_0_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_0,    2,     dequantize_q4_0,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q4_1_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_1,    2,     dequantize_q4_1,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q5_0_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_0,    2,     dequantize_q5_0,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q5_1_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_1,    2,     dequantize_q5_1,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q8_0_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q8_0,    2,     dequantize_q8_0,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_mxfp4_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_mxfp4,   2,     dequantize_mxfp4,   float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q2_K_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q2_K,    QK_NL, dequantize_q2_K,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q3_K_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q3_K,    QK_NL, dequantize_q3_K,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q4_K_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_K,    QK_NL, dequantize_q4_K,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q5_K_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_K,    QK_NL, dequantize_q5_K,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q6_K_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q6_K,    QK_NL, dequantize_q6_K,    float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq2_xxs_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq2_xs_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xs,  QK_NL, dequantize_iq2_xs,  float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq3_xxs_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_xxs, QK_NL, dequantize_iq3_xxs, float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq3_s_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_s,   QK_NL, dequantize_iq3_s,   float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq2_s_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_s,   QK_NL, dequantize_iq2_s,   float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq1_s_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_s,   QK_NL, dequantize_iq1_s,   float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq1_m_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_m,   QK_NL, dequantize_iq1_m,   float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq4_nl_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_nl,  2,     dequantize_iq4_nl,  float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq4_xs_f32")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_xs,  QK_NL, dequantize_iq4_xs,  float,  float4x4,  float, float2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_f32_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   float4x4,      1,     dequantize_f32,     float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_f16_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   half4x4,       1,     dequantize_f16,     half,   half4x4,   half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q1_0_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q1_0,    8,     dequantize_q1_0,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q4_0_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_0,    2,     dequantize_q4_0,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q4_1_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_1,    2,     dequantize_q4_1,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q5_0_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_0,    2,     dequantize_q5_0,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q5_1_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_1,    2,     dequantize_q5_1,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q8_0_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q8_0,    2,     dequantize_q8_0,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_mxfp4_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_mxfp4,   2,     dequantize_mxfp4,   float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q2_K_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q2_K,    QK_NL, dequantize_q2_K,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q3_K_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q3_K,    QK_NL, dequantize_q3_K,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q4_K_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q4_K,    QK_NL, dequantize_q4_K,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q5_K_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q5_K,    QK_NL, dequantize_q5_K,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_q6_K_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_q6_K,    QK_NL, dequantize_q6_K,    float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq2_xxs_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xxs, QK_NL, dequantize_iq2_xxs, float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq2_xs_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_xs,  QK_NL, dequantize_iq2_xs,  float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq3_xxs_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_xxs, QK_NL, dequantize_iq3_xxs, float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq3_s_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq3_s,   QK_NL, dequantize_iq3_s,   float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq2_s_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq2_s,   QK_NL, dequantize_iq2_s,   float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq1_s_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_s,   QK_NL, dequantize_iq1_s,   float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq1_m_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq1_m,   QK_NL, dequantize_iq1_m,   float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq4_nl_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_nl,  2,     dequantize_iq4_nl,  float,  float4x4,  half, half2x4, 32, 16, 4>;
+template [[host_name("kernel_mul_mm_sk_iq4_xs_f16")]] kernel mul_mm_sk_t kernel_mul_mm_s<half,   half4x4,   simdgroup_half8x8,   half,   half2x4,   simdgroup_half8x8,   block_iq4_xs,  QK_NL, dequantize_iq4_xs,  float,  float4x4,  half, half2x4, 32, 16, 4>;
+#endif // GGML_METAL_HAS_TENSOR
 
 //
 // indirect matrix-matrix multiplication


### PR DESCRIPTION
This is a draft that we will keep iterating on: the description and commit messages will be revised before marking ready for review.

Adds two Metal matmul kernels for small batches (8 < `ne11` <= 32) — the speculative-decoding verify/draft regime:

- `kernel_mul_mm_s`: `mul_mm` with 32x16 tiles instead of 64x32. The stock tile pads N to 32 and launches `ne01/64` threadgroups, which under-fills the GPU at these sizes (on M3/M4, `pp16 == pp32` in wall time).
- split-K variant (4 slices) for shapes with few row tiles. Partials are written to scratch at the tail of the dst allocation (same pattern as `mul_mat_id`) and summed by a fixed-order reduce, so results are deterministic.

Kernel selection is unchanged by default: mv-ext keeps `ne11` 2..8, the mm branch keeps its stock break-even and uses the new tiles for 8 < `ne11` <= 32. `ne11` > 32 and tensor-API devices (M5+) use the stock path. `GGML_METAL_MM_SKINNY_MAX=0` restores stock behavior; `GGML_METAL_MM_SPLITK`, `GGML_METAL_MM_MIN`, `GGML_METAL_MV_EXT_MAX/_R1` are available for tuning.

Companion to #27383 — DSpark verify/draft batches run at `ne11` ~ 8..16. The kernels themselves are model-independent.

Numbers so far (M4 Max, 36 GB): `llama-bench -p 10` on LFM2.5-2.6B F16 goes 334 -> 460 t/s; end-to-end speculative decoding on a 150-prompt suite at temp 0 goes 1.84x -> 2.27x mean speedup, accept length unchanged. tg and large-batch pp are unaffected. Split-K changes f16 summation order, so occasional greedy ties differ from the stock kernel; outputs are bit-reproducible run to run.

End-to-end speculative decoding, this branch + #27383 merged (LFM2.5-2.6B F16 target + block-9 DSpark drafter, M4 Max, temp 0, speedup vs the same server without spec flags; accept length identical between configs):

| dataset | accept | stock | this PR |
|---|---:|---:|---:|
| math500 (n=20) | 4.45 | 1.79x | 2.26x |
| humaneval (n=20) | 5.24 | 2.04x | 2.62x |
| mtbench (n=10) | 3.33 | 1.28x | 1.62x |

With the block-7 drafters linked from #27383 the verify batch is 8 tokens (`ne11` = 8, outside the changed range) and speedups are unchanged (1.85x vs 1.87x mean) — block-9 LFM2.5 drafter GGUFs are being published.

`test-backend-ops test -o MUL_MAT -b Metal` passes with the new paths enabled and disabled.

llama-bench on this branch, M4 Max 36GB (`-p 8,10,16,32 -n 16 -b 32 -ub 32 -fa 1 -r 3`), t/s stock (`GGML_METAL_MM_SKINNY_MAX=0`) → this PR:

| model | pp8 | pp10 | pp16 | pp32 | tg16 |
|---|---:|---:|---:|---:|---:|
| LFM2.5-2.6B-F16 | 291 → 292 | 353 → 478 | 563 → 804 | 1138 → 1316 | 64 → 64 |
| LFM2.5-1.2B-Instruct-F16 | 662 → 658 | 794 → 1107 | 1258 → 1768 | 2563 → 2946 | 142 → 142 |
| Qwen3-4B-Instruct-2507-F16 | 201 → 201 | 247 → 307 | 386 → 507 | 790 → 858 | 43 → 43 |
| Qwen3-4B-Instruct-2507-Q4_0 | 204 → 205 | 268 → 454 | 419 → 718 | 871 → 942 | 117 → 115 |

Kernels by @fernando-neto-ai, developed on Liquid AI's fork. This PR keeps the stock crossover thresholds; the fork's retuned (M3-measured) values were slightly slower on M4.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. The kernels were developed with Claude on Liquid AI's fork (AI-drafted, human-benchmarked and reviewed there and on this branch); the upstream adaptation (cherry-pick + defaults commit) was likewise AI-assisted, and this PR description was co-written with Claude.
