### PR TITLE
vulkan: handle larger batch sizes (>4) efficiently for IQ3_S mat-vec …

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_iq3_s.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec_iq3_s.comp
@@ -7,7 +7,14 @@ layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
 FLOAT_TYPE temp[NUM_COLS][NUM_ROWS];
 
-void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, const uint i, const uint num_blocks_per_row, const uint first_row, const uint num_rows) {
+// invocations per superblock. with many columns, 8 invocations need too many
+// registers and spill, so use 16 to halve the per-invocation B working set
+const uint TPB = NUM_COLS <= 4 ? 8 : 16;
+const uint NL  = 32 / TPB; // l steps per invocation
+
+void calc_superblock(const uint a_offset, const uint b_offset, const uint itid, const uint i, const uint num_blocks_per_row, const uint first_row, const uint num_rows) {
+    const uint ib32 = itid / (TPB / 8);
+    const uint l0   = (itid % (TPB / 8)) * NL;
     const uint y_idx = i * QUANT_K + 32 * ib32;
 
     uint ibi = a_offset + first_row * num_blocks_per_row + i;
@@ -16,11 +23,8 @@ void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, 
         const uint scale = (data_a[ibi].scales[ib32/2] >> (4 * (ib32 & 1))) & 0xF;
         const float dscale = d * (1 + 2 * scale);
         const uint qh = data_a[ibi].qh[ib32];
-        FLOAT_TYPE sum[NUM_COLS];
-        [[unroll]] for (uint j = 0; j < NUM_COLS; ++j) {
-            sum[j] = 0.0;
-        }
-        [[unroll]] for (uint l = 0; l < 4; ++l) {
+        [[unroll]] for (uint ll = 0; ll < NL; ++ll) {
+            const uint l = l0 + ll;
             const u8vec2 qs = unpack8(uint32_t(data_a_packed16[ibi].qs[4 * ib32 + l])).xy; // vec4 used due to #12147
             const uint sign = data_a[ibi].signs[4 * ib32 + l];
             const vec4 grid0 = vec4(unpack8(iq3s_grid[qs.x | ((qh << (8 - 2*l)) & 0x100)]));
@@ -30,7 +34,7 @@ void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, 
                 const vec4 b0 = vec4(data_b_v4[(j*p.batch_stride_b + b_offset + y_idx) / 4 + 2*l + 0]);
                 const vec4 b4 = vec4(data_b_v4[(j*p.batch_stride_b + b_offset + y_idx) / 4 + 2*l + 1]);
 
-                sum[j] =
+                const FLOAT_TYPE sum =
                       fma(FLOAT_TYPE(b0.x), FLOAT_TYPE((sign &   1) != 0 ? -grid0.x : grid0.x),
                       fma(FLOAT_TYPE(b0.y), FLOAT_TYPE((sign &   2) != 0 ? -grid0.y : grid0.y),
                       fma(FLOAT_TYPE(b0.z), FLOAT_TYPE((sign &   4) != 0 ? -grid0.z : grid0.z),
@@ -39,11 +43,10 @@ void calc_superblock(const uint a_offset, const uint b_offset, const uint ib32, 
                       fma(FLOAT_TYPE(b4.y), FLOAT_TYPE((sign &  32) != 0 ? -grid1.y : grid1.y),
                       fma(FLOAT_TYPE(b4.z), FLOAT_TYPE((sign &  64) != 0 ? -grid1.z : grid1.z),
                       fma(FLOAT_TYPE(b4.w), FLOAT_TYPE((sign & 128) != 0 ? -grid1.w : grid1.w),
-                      sum[j]))))))));
+                      FLOAT_TYPE(0.0)))))))));
+
+                temp[j][n] = fma(dscale, sum, temp[j][n]);
             }
-        }
-        [[unroll]] for (uint j = 0; j < NUM_COLS; ++j) {
-            temp[j][n] = fma(dscale, sum[j], temp[j][n]);
         }
         ibi += num_blocks_per_row;
     }
@@ -55,11 +58,11 @@ void compute_outputs(const uint32_t first_row, const uint32_t num_rows) {
 
     const uint num_blocks_per_row = p.ncols / QUANT_K;
 
-    // 8 threads are used to process each block
-    const uint blocks_per_wg = gl_WorkGroupSize.x/8;
+    // TPB invocations are used to process each block
+    const uint blocks_per_wg = gl_WorkGroupSize.x/TPB;
     const uint tid = gl_LocalInvocationID.x;
-    const uint itid = tid % 8;  // 0...7
-    const uint ix = tid / 8;
+    const uint itid = tid % TPB;
+    const uint ix = tid / TPB;
 
     [[unroll]] for (uint j = 0; j < NUM_COLS; ++j) {
         [[unroll]] for (uint i = 0; i < NUM_ROWS; ++i) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9161,6 +9161,10 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             //test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 18,  i, 32*256, { 1,  1}, {8, 1}));
             //test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 19,  i, 33*256, { 1,  1}, {1, 1}));
         }
+        // mat-vec shaders split k across lanes and loop over the blocks in strides. k must be
+        // long enough that the loop wraps, else the stride is never exercised
+        test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 16,  1, 16*256, { 1,  1}, {1, 1}));
+        test_cases.emplace_back(new test_mul_mat(type_a,    GGML_TYPE_F32, 16,  8, 16*256, { 1,  1}, {1, 1}));
     }
 
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q4_0, GGML_TYPE_F32, 2880, 32, 2880, {1, 1}, {1, 1}));


### PR DESCRIPTION
## Overview

Vulkan fix: At larger batch sizes, as happens when using speculation (dflash2 in this case) the IQ3_S  mat_mul becomes highly inefficient by overflowing the VGPR budget. 

The shader spills 442 registers into 17 KB of scratch per wave, making it ~9x slower
than at `NUM_COLS = 4` while doing only 2x the work. iq3_s is the only quant type that does this

## Additional information

8 floats per l step  x  4 l steps  x  NUM_COLS

At `NUM_COLS = 8` that is 256 floats. A VGPR holds one 32-bit value per lane and RDNA gives a
wave at most 256 VGPRs, so B alone wants the whole register file, before `temp[8][4]` (32 more),
the grid values and the addresses.

The compiler batches those loads into VMEM clauses to hide memory latency, which is normally
correct. Here it means all 64 vec4 loads want to be live at once.

`RADV_DEBUG=shaderstats,nocache`, m=4096 k=14336:

| NUM_COLS | VGPRs | Spilled VGPRs | Scratch | Subgroups per SIMD |
|---|---|---|---|---|
| 1 | 84 | 0 | 0 | 18 |
| 4 | 192 | 0 | 0 | 8 |
| 5 | 252 | 0 | 0 | 6 |
| 8 | 256 | 442 | 17408 B | 4 |

After the fix, `NUM_COLS = 8` reports 252 VGPRs, 0 spilled, 0 scratch, 6 subgroups per SIMD.


Only iq3_s is affected. Same shape, n=4 -> n=8, microseconds/run:

| type | n=1 | n=4 | n=8 |
|---|---|---|---|
| iq3_s (before) | 77.9 | 172.5 | 1589.0 |
| iq3_xxs | 92.3 | 160.0 | 275.4 |
| iq2_s | 89.7 | 158.5 | 264.8 |
| iq2_xs | 84.9 | 156.3 | 264.3 |
| iq2_xxs | 84.7 | 154.4 | 267.8 |
| iq1_s | 34.3 | 61.3 | 120.5 |
| iq4_xs | 143.4 | 223.7 | 328.9 |
| iq4_nl | 100.0 | 167.8 | 279.6 |
| q4_K | 75.3 | 145.3 | 250.7 |
| q6_K | 210.7 | 274.4 | 504.7 |

Every other type scales smoothly (~1.6-1.8x from n=4 to n=8). iq3_s goes 9.2x.

Measured on Radeon 8060S Graphics (RADV STRIX_HALO)

Verified perplexity  and updated tests to catch this


### Model level

Qwen3.8-27B, unsloth UD-Q4_K_M, which carries 4 IQ3_S tensors
(`blk.11.ffn_gate`, `blk.14/15/17.ffn_down`) out of 866:

| metric | before | after |
|---|---|---|
| llama-bench pp8 | 67.6 t/s | 77.0 t/s |
| llama-bench tg32 | 12.4 t/s | 12.6 t/s |
| DFlash2 spec decode, n_max=7 | 31.3 / 31.8 / 34.9 t/s | 34.5 / 35.2 / 35.3 t/s |

UD-Q4_K_XL has 1 IQ3_S tensor: pp8 goes 69.3 -> 70.3 t/s. UD-Q5_K_M and UD-Q6_K_XL contain no
IQ3_S and are unaffected.

The end-to-end speculative numbers carry run-to-run variance because acceptance rate varied
(65.9% - 80.6% for the same request at temperature 0). pp8 is the controlled measurement: it is
the 8-token verify graph in isolation and it is deterministic.

### Perplexity

`unsloth/Qwen3.8-27B-GGUF:UD-IQ3_S`, which carries 127 IQ3_S tensors out of 866. wikitext-2 raw,
`-c 512 --chunks 30 -ngl 99 --seed 1234`:

| | PPL | wall | s per pass |
|---|---|---|---|
| before | 5.7100 +/- 0.15536 | 714.3 s | 23.20 |
| after | 5.7089 +/- 0.15531 | 283.2 s | 8.86 |


- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Assisted-by: Claude Opus 5, it found and fixed the bug when I found performance issues 
