### PR TITLE
server : share checkpoint state and harden prompt cache OOM handling

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2265,9 +2265,9 @@ void common_prompt_checkpoint::update_tgt(
 
     const size_t ckpt_size = llama_state_seq_get_size_ext(ctx, seq_id, flags);
 
-    data_tgt.resize(ckpt_size);
+    uint8_t * data = data_tgt.reset(ckpt_size);
 
-    const size_t n = llama_state_seq_get_data_ext(ctx, data_tgt.data(), ckpt_size, seq_id, flags);
+    const size_t n = llama_state_seq_get_data_ext(ctx, data, ckpt_size, seq_id, flags);
     if (n != ckpt_size) {
         GGML_ABORT("checkpoint size mismatch: expected %zu, got %zu\n", ckpt_size, n);
     }
@@ -2283,9 +2283,9 @@ void common_prompt_checkpoint::update_dft(
 
     const size_t ckpt_size = llama_state_seq_get_size_ext(ctx, seq_id, flags);
 
-    data_dft.resize(ckpt_size);
+    uint8_t * data = data_dft.reset(ckpt_size);
 
-    const size_t n = llama_state_seq_get_data_ext(ctx, data_dft.data(), ckpt_size, seq_id, flags);
+    const size_t n = llama_state_seq_get_data_ext(ctx, data, ckpt_size, seq_id, flags);
     if (n != ckpt_size) {
         GGML_ABORT("checkpoint size mismatch: expected %zu, got %zu\n", ckpt_size, n);
     }

--- a/common/common.h
+++ b/common/common.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <algorithm>
 #include <fstream>
+#include <memory>
 
 #if defined(_WIN32) && !defined(_WIN32_WINNT)
 #define _WIN32_WINNT 0x0A00
@@ -1134,6 +1135,37 @@ enum ggml_opt_optimizer_type common_opt_get_optimizer(const char *);
 // prompt utils
 //
 
+class common_shared_state_buffer {
+public:
+    size_t size() const {
+        return storage ? storage->size() : 0;
+    }
+
+    bool empty() const {
+        return !storage || storage->empty();
+    }
+
+    const uint8_t * data() const {
+        return storage ? storage->data() : nullptr;
+    }
+
+    // Allocate fresh storage for a complete state snapshot. Copies of this
+    // object keep referencing the previous immutable snapshot; they are never
+    // modified in place. Only the newly allocated, uniquely owned buffer is
+    // exposed as mutable while the caller captures the replacement snapshot.
+    uint8_t * reset(size_t n) {
+        storage = std::make_shared<std::vector<uint8_t>>(n);
+        return storage->data();
+    }
+
+    void clear() {
+        storage.reset();
+    }
+
+private:
+    std::shared_ptr<std::vector<uint8_t>> storage;
+};
+
 struct common_prompt_checkpoint {
     int64_t n_tokens;
 
@@ -1143,8 +1175,11 @@ struct common_prompt_checkpoint {
     llama_pos pos_min;
     llama_pos pos_max;
 
-    std::vector<uint8_t> data_tgt;
-    std::vector<uint8_t> data_dft;
+    // Snapshot payloads are immutable after capture and can be shared safely
+    // between a live slot and host-memory prompt-cache entries. Copying a
+    // checkpoint therefore copies only the ref-counted handles, not the bytes.
+    common_shared_state_buffer data_tgt;
+    common_shared_state_buffer data_dft;
 
     // (optional) speculative-decoding implementation state stashed with the checkpoint
     // (e.g. eagle3's deferred-boundary g_embd row)

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1762,10 +1762,24 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
     std::vector<uint8_t> state_data_tgt;
     std::vector<uint8_t> state_data_dft;
 
-    // check if we can allocate enough memory for the new state
+    // Keep every allocation involved in creating the cache entry under the
+    // same bad_alloc guard. In particular, prompt.tokens.clone(), copying the
+    // checkpoint list (cheap shared snapshot handles) and states.push_back()
+    // can allocate too. A failure must skip caching, not terminate the server.
     try {
         state_data_tgt.resize(state_size_tgt);
         state_data_dft.resize(state_size_dft);
+
+        states.push_back({
+            /*.prompt =*/ {
+                /*.tokens      =*/ prompt.tokens.clone(),
+                /*.checkpoints =*/ prompt.checkpoints,
+            },
+            /*.data   =*/ {
+                /*.main =*/ std::move(state_data_tgt),
+                /*.drft =*/ std::move(state_data_dft),
+            },
+        });
     } catch (const std::bad_alloc & e) {
         SRV_ERR("failed to allocate memory for prompt cache state: %s\n", e.what());
 
@@ -1777,17 +1791,6 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
 
         return nullptr;
     }
-
-    states.push_back({
-        /*.prompt =*/ {
-            /*.tokens      =*/ prompt.tokens.clone(),
-            /*.checkpoints =*/ prompt.checkpoints,
-        },
-        /*.data   =*/ {
-            /*.main =*/ std::move(state_data_tgt),
-            /*.drft =*/ std::move(state_data_dft),
-        },
-    });
 
     return &states.back();
 }


### PR DESCRIPTION
Share target and draft checkpoint backing storage to avoid large deep copies when saving prompts to the in-memory cache.

Also handle `std::bad_alloc` during complete cache entry construction, including `states.push_back()`.

Assisted-by: Qwen3.8-27B


## Summary

This PR prevents excessive transient host-memory usage when `llama-server`
saves prompts containing large context checkpoints into the in-memory
prompt cache.

The current implementation deep-copies the complete checkpoint payload
when a prompt is inserted into the cache. For long-context
hybrid/recurrent workloads, checkpoint state can become large enough for
this temporary duplication to cause significant memory pressure or
allocation failure even when the resulting cache entry itself satisfies
the configured `--cache-ram` limit.

This PR:

* shares the large target and draft checkpoint state buffers using
  reference-counted backing storage;
* preserves checkpoint metadata and rollback semantics;
* keeps checkpoints available for hybrid/recurrent prompt reuse;
* avoids deep-copying checkpoint payloads during `server_prompt` copies;
* extends `std::bad_alloc` handling to cover complete prompt-cache entry
  construction, including `states.push_back(...)`.

## Problem

`server_prompt` stores checkpoints by value:

```cpp
struct server_prompt {
    server_tokens tokens;
    std::list<common_prompt_checkpoint> checkpoints;
};
```

Each checkpoint contains serialized state buffers such as:

```cpp
std::vector<uint8_t> data_tgt;
std::vector<uint8_t> data_dft;
```

When a prompt is saved to the in-memory prompt cache,
`server_prompt_cache::alloc()` constructs a new cache entry using the
equivalent of:

```cpp
states.push_back({
    {
        prompt.tokens.clone(),
        prompt.checkpoints,
    },
    ...
});
```

Copying `prompt.checkpoints` therefore performs a deep copy of every
`data_tgt` and `data_dft` buffer.

For long contexts or models requiring substantial recurrent checkpoint
state, this can make prompt-cache insertion temporarily require close to
an additional copy of the complete checkpoint payload.

## Why `--cache-ram` does not prevent the transient allocation

The cache admission logic includes checkpoint sizes when calculating the
logical size of a new cache entry:

```cpp
size_t checkpoints_size = 0;

for (const auto & ckpt : prompt.checkpoints) {
    checkpoints_size += ckpt.size();
}

const size_t state_size_new =
    state_size_tgt +
    state_size_dft +
    checkpoints_size;
```

This correctly limits the logical residency of the resulting cache entry.

However, during cache-entry construction the active prompt still owns its
original checkpoint buffers while the cache creates another copy.

The transient memory requirement is therefore approximately:

```text
existing checkpoint payload
+ newly allocated target/draft prompt state
+ duplicated checkpoint payload
```

As a result, satisfying the logical cache-size limit does not guarantee
that enough host memory is available for the temporary deep copy required
to construct the cache entry.

## Why checkpoints should not simply be removed

Clearing checkpoints before saving the prompt would avoid the duplication,
but would change behavior for hybrid/recurrent models.

These models may require captured checkpoints to restore recurrent state
when a later prompt shares only part of a cached prefix.

Discarding those checkpoints can prevent efficient partial-prefix reuse
and require substantially more prompt reprocessing.

This PR therefore preserves the checkpoints and removes only the
unnecessary duplication of their large serialized backing storage.

## Implementation

### Shared checkpoint payload

The large serialized target and draft checkpoint buffers now use
reference-counted backing storage.

Conceptually, instead of:

```text
active prompt ───> checkpoint payload A

cached prompt ───> duplicated checkpoint payload A
```

copies now behave as:

```text
active prompt ─┐
               ├──> checkpoint payload A
cached prompt ─┘
```

Only the lightweight ownership handle is copied.

### Snapshot semantics are preserved

Checkpoint payloads are treated as immutable after capture.

When a checkpoint is updated, a new backing buffer is allocated and the
new serialized state is written into that buffer rather than modifying an
existing shared snapshot.

Conceptually:

```text
before update:

slot  ─┐
       ├──> snapshot A
cache ─┘

after slot update:

cache ───> snapshot A
slot  ───> snapshot B
```

This preserves independent checkpoint snapshot semantics while avoiding
unnecessary deep copies.

### Target and draft state

Both large serialized state buffers use shared backing storage:

```text
data_tgt
data_dft
```

This preserves the behavior required for target and draft model state,
including speculative/MTP workloads.

The smaller speculative checkpoint state remains value-owned to keep the
change focused and avoid unnecessary modifications outside the primary
memory-pressure path.

## OOM handling

The existing implementation catches `std::bad_alloc` around:

```cpp
state_data_tgt.resize(state_size_tgt);
state_data_dft.resize(state_size_dft);
```

However, subsequent operations may allocate memory as well:

```cpp
prompt.tokens.clone()
prompt.checkpoints
states.push_back(...)
```

These operations were previously outside the protected section.

This PR extends the `try` block to cover the complete cache-entry
construction:

```cpp
try {
    state_data_tgt.resize(state_size_tgt);
    state_data_dft.resize(state_size_dft);

    states.push_back({
        {
            prompt.tokens.clone(),
            prompt.checkpoints,
        },
        ...
    });
} catch (const std::bad_alloc & e) {
    ...
}
```

If any allocation involved in constructing the cache entry fails, the
existing cache-recovery path is used and the function returns without
leaving a partially constructed entry.

Temporary allocations are released automatically during stack unwinding.

## Cache accounting

This PR intentionally does not change the existing logical cache-size
accounting.

Checkpoint payload sizes continue to count toward `--cache-ram` even when
their physical backing storage is shared.

This can make cache accounting conservative when multiple prompts refer
to the same backing allocation, potentially causing earlier eviction than
strict physical-byte accounting would require.

Keeping the existing accounting is intentional because it:

* preserves current `--cache-ram` semantics;
* avoids introducing under-counting;
* keeps the fix focused on eliminating unnecessary duplication;
* avoids coupling this change to a broader cache-accounting redesign.

Unique physical backing-store accounting or a global checkpoint pool can
be considered separately.

## Expected memory behavior

Before this change, prompt-cache insertion may temporarily require:

```text
checkpoint payload
+ target/draft prompt state
+ second copy of checkpoint payload
```

With shared checkpoint backing storage, the same operation requires
approximately:

```text
checkpoint payload
+ target/draft prompt state
+ lightweight checkpoint references
```

The large checkpoint payload is therefore retained only once instead of
being duplicated during cache insertion.

This does not make `--cache-ram` a total process-memory limit. Overall
memory usage still depends on active slots, model state, compute buffers,
allocator behavior and other process allocations.

## Scope

The patch is deliberately limited to:

* checkpoint backing-storage ownership;
* checkpoint update and clear handling required for shared snapshots;
* prompt-cache allocation exception handling.

It does not change:

* checkpoint selection;
* checkpoint creation policy;
* rollback logic;
* prompt-cache matching;
* cache eviction policy;
* speculative decoding behavior;
* recurrent-state algorithms;
* logical `--cache-ram` accounting.

## Validation

The patch has been applied and checked against the target source tree.

The affected translation units compile successfully:

```text
common/common.cpp
tools/server/server-task.cpp
tools/server/server-context.cpp
```

The recurrent-state rollback test build also proceeds through the affected
code without errors.

Additional runtime validation is appropriate for:

* transformer-only models;
* hybrid/recurrent models;
* prompt-cache hit and miss paths;
* partial-prefix reuse after cache restore;
* repeated checkpoint replacement;
* cache eviction while checkpoint backing storage is shared;
* speculative/MTP target and draft checkpoint restoration;
* large-context workloads;
* forced allocation failure to verify graceful `std::bad_alloc` handling;
* ownership and lifetime testing under sanitizers where available.

## Motivation

The goal is to eliminate excessive transient checkpoint duplication
without sacrificing the state required for correct and efficient
hybrid/recurrent prompt reuse.

The core ownership model becomes:

```text
checkpoint metadata:
    value semantics

serialized checkpoint payload:
    immutable shared backing storage

checkpoint update:
    allocate a new snapshot

checkpoint destruction / cache eviction:
    release one reference

prompt-cache copy:
    copy references rather than serialized state
```

This removes the problematic deep copy while retaining checkpoint
information needed for recurrent-state restoration and prompt reuse.


<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used for bug finding and fixing

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
