### PR TITLE
HIP: bundle librocdxg.so when present

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -151,3 +151,30 @@ if (GGML_HIP_RCCL)
 endif()
 
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
+
+# librocdxg is dlopen'd by libhsa-runtime64, so link-time dependency scanning misses it.
+# it is optional - skip it when the ROCm install does not have it.
+# hip_DIR points at <rocm>/lib/cmake/hip, so the lib dir is two levels up
+get_filename_component(GGML_HIP_LIB_DIR "${hip_DIR}/../.." ABSOLUTE)
+file(GLOB GGML_HIP_ROCDXG "${GGML_HIP_LIB_DIR}/librocdxg.so*")
+
+if (GGML_HIP_ROCDXG)
+    message(STATUS "HIP: bundling ${GGML_HIP_ROCDXG}")
+
+    foreach (GGML_HIP_ROCDXG_FILE IN LISTS GGML_HIP_ROCDXG)
+        get_filename_component(GGML_HIP_ROCDXG_NAME "${GGML_HIP_ROCDXG_FILE}" NAME)
+        if (IS_SYMLINK "${GGML_HIP_ROCDXG_FILE}")
+            file(READ_SYMLINK "${GGML_HIP_ROCDXG_FILE}" GGML_HIP_ROCDXG_LINK)
+            get_filename_component(GGML_HIP_ROCDXG_LINK "${GGML_HIP_ROCDXG_LINK}" NAME)
+            add_custom_command(TARGET ggml-hip POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E create_symlink "${GGML_HIP_ROCDXG_LINK}" "$<TARGET_FILE_DIR:ggml-hip>/${GGML_HIP_ROCDXG_NAME}")
+        else()
+            add_custom_command(TARGET ggml-hip POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different "${GGML_HIP_ROCDXG_FILE}" "$<TARGET_FILE_DIR:ggml-hip>/${GGML_HIP_ROCDXG_NAME}")
+        endif()
+    endforeach()
+
+    # install(DIRECTORY) keeps the symlinks, install(FILES) would resolve them
+    install(DIRECTORY "${GGML_HIP_LIB_DIR}/" DESTINATION ${CMAKE_INSTALL_BINDIR}
+            FILES_MATCHING PATTERN "librocdxg.so*")
+endif()


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
`librocdxg.so` is a ROCm backend library for WSL. `libhsa-runtime64.so` loads it at runtime via `dlopen()`, so it never appears in libhsa-runtime64's `DT_NEEDED` entries. Tools or packaging processes that collect libraries solely from ELF link dependencies cannot discover it.
If a compatible copy is not present in the bundled library directory, the dynamic loader may resolve `librocdxg.so` from the system library search paths. That system-wide copy may not match the bundled version of `libhsa-runtime64.so`, causing runtime compatibility failures.
`librocdxg.so` is treated as an optional runtime library. If it is not present in the resolved ROCm installation, the bundling step is skipped without failing the build or installation. This preserves compatibility with ROCm environments that do not provide `librocdxg.so`.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES. AI helped locate the relevant ROCm packaging and CMake paths in the repository. <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
