### PR TITLE
common: set Muse Glimmer thinking tags in common_chat_params

### DIFF
--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -3331,6 +3331,9 @@ static common_chat_params common_chat_params_init_muse_glimmer(const common_chat
     data.format            = COMMON_CHAT_FORMAT_PEG_NATIVE;
     data.supports_thinking = true;
 
+    data.thinking_start_tag = " to=self<|message|>";
+    data.thinking_end_tags  = { "<|eom|>" };
+
     data.preserved_tokens = {
         "<|start|>", "<|message|>", "<|eom|>", "<|eot|>",
         // ATEM tool-call markup emitted on " to=<tool>" turns.


### PR DESCRIPTION
## Overview

Set thinking_start_tag and thinking_end_tags for muse glimmer.

Fixes thinking / reasoning budget not being applied properly.

## Additional information

```
   data.thinking_start_tag = " to=self<|message|>";
   data.thinking_end_tags  = { "<|eom|>" };
```

After the change, /v1/chat/completions with reasoning_budget_tokens: 32 and max_tokens: 384:

 - finish_reason=stop (not length)
 - reasoning contains the continuation message set in reasoning-budget-message

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
