### PR TITLE
ci : add nightly-tag.txt to make-release

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -55,6 +55,20 @@ jobs:
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
+      - name: Create nightly-tag.txt
+        id: nightly_tag_file
+        run: |
+          NIGHTLY_TAG="${{ steps.desc.outputs.nightly_tag }}"
+          if [[ -z "${NIGHTLY_TAG}" ]]; then
+            echo "Warning: no nightly tag found for the release commit - nightly-tag.txt will not be created"
+            echo "create=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "${NIGHTLY_TAG}" > nightly-tag.txt
+          echo "create=true" >> "$GITHUB_OUTPUT"
+          echo "nightly-tag.txt:"
+          cat nightly-tag.txt
+
       - name: Create release
         if: ${{ github.event.inputs.dry_run == 'false' }}
         uses: ggml-org/action-create-release@v1
@@ -70,11 +84,31 @@ jobs:
             New version has been released.
 
             ${{ steps.desc.outputs.nightly }}
+
+            **Web UI:** the `nightly-tag.txt` asset contains the tag of the corresponding nightly release
+
             **More info:** [dist : releases and versioning of ggml-org projects](https://github.com/ggml-org/ggml/discussions/1579)
 
             ## ${{ steps.desc.outputs.changelog_title }}
 
             ${{ steps.desc.outputs.changelog }}
+
+      - name: Upload nightly-tag.txt
+        if: ${{ github.event.inputs.dry_run == 'false' && steps.nightly_tag_file.outputs.create == 'true' }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs');
+            const release_id = '${{ steps.create_release.outputs.id }}';
+            console.log('uploadReleaseAsset', 'nightly-tag.txt');
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release_id,
+              name: 'nightly-tag.txt',
+              data: await fs.readFileSync('./nightly-tag.txt')
+            });
 
       - name: Dry run summary
         if: ${{ github.event.inputs.dry_run == 'true' }}
@@ -82,6 +116,9 @@ jobs:
           if [[ "${{ steps.checks.outputs.checks_passed }}" == "true" ]]; then
             echo "Dry run complete - all checks passed."
             echo "Would have created tag: ${{ steps.checks.outputs.version }}"
+            if [[ -n "${{ steps.desc.outputs.nightly_tag }}" ]]; then
+              echo "Would have uploaded nightly-tag.txt: ${{ steps.desc.outputs.nightly_tag }}"
+            fi
           else
             echo "::error::Dry run found release check failures. A release tag would not be created."
             exit 1

--- a/scripts/make-release-desc.sh
+++ b/scripts/make-release-desc.sh
@@ -15,7 +15,8 @@
 # tag exists.
 #
 # Env (when running in GitHub Actions):
-#   GITHUB_OUTPUT: previous_tag, changelog_title, changelog and nightly are written here
+#   GITHUB_OUTPUT: previous_tag, changelog_title, changelog, nightly and nightly_tag
+#     are written here
 #   GITHUB_REPOSITORY: owner/repo, used to build the nightly release URL (skipped when unset)
 set -euo pipefail
 
@@ -80,6 +81,7 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
         echo "previous_tag=${PREV}"
         echo "changelog_title=${CHANGELOG_TITLE}"
         echo "nightly=${NIGHTLY}"
+        echo "nightly_tag=${NIGHTLY_TAG}"
         echo "changelog<<CHANGELOG_EOF"
         echo "${CHANGELOG}"
         echo "CHANGELOG_EOF"


### PR DESCRIPTION
## Overview

Add a `nightly-tag.txt` asset to the official semver releases (created by `make-release.yml`), containing the tag of the corresponding nightly release (e.g. `b10485`). This makes the Web UI assets discoverable for each official release (e.g. to feed `LLAMA_BUILD_NUMBER`).

## Additional information

As agreed in [ggml discussion #1579](https://github.com/ggml-org/ggml/discussions/1579#discussioncomment-18097212).

- `scripts/make-release-desc.sh`: expose the resolved nightly tag as a `nightly_tag` output
- `.github/workflows/make-release.yml`: create `nightly-tag.txt` from that tag, upload it as a release asset (skipped on dry-run), mention it in the release body and in the dry-run summary

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.8-27B
