### PR TITLE
common: handle empty forced_tokens gracefully in reasoning-budget sampler

### DIFF
--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -83,9 +83,13 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
                 COM_TRC("activated, budget=%d tokens\n", ctx->budget);
 
                 if (ctx->remaining <= 0) {
-                    ctx->state = REASONING_BUDGET_FORCING;
-                    ctx->force_pos = 0;
-                    COM_TRC("%s", "budget=0, forcing immediately\n");
+                    if (ctx->forced_tokens.empty()) {
+                        ctx->state = REASONING_BUDGET_DONE;
+                    } else {
+                        ctx->state = REASONING_BUDGET_FORCING;
+                        ctx->force_pos = 0;
+                        COM_TRC("%s", "budget=0, forcing immediately\n");
+                    }
                 }
             }
             break;
@@ -109,19 +113,27 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
 
             if (ctx->state == REASONING_BUDGET_WAITING_UTF8) {
                 if (utf8_complete) {
-                    ctx->state = REASONING_BUDGET_FORCING;
-                    ctx->force_pos = 0;
-                    ctx->end_matcher.reset();
-                    COM_TRC("%s", "UTF-8 complete, now forcing end sequence\n");
+                    if (ctx->forced_tokens.empty()) {
+                        ctx->state = REASONING_BUDGET_DONE;
+                    } else {
+                        ctx->state = REASONING_BUDGET_FORCING;
+                        ctx->force_pos = 0;
+                        ctx->end_matcher.reset();
+                        COM_TRC("%s", "UTF-8 complete, now forcing end sequence\n");
+                    }
                 }
             } else if (ctx->state == REASONING_BUDGET_COUNTING) {
                 ctx->remaining--;
                 if (ctx->remaining <= 0) {
                     if (utf8_complete) {
-                        ctx->state = REASONING_BUDGET_FORCING;
-                        ctx->force_pos = 0;
-                        ctx->end_matcher.reset();
-                        COM_TRC("%s", "budget exhausted, forcing end sequence\n");
+                        if (ctx->forced_tokens.empty()) {
+                            ctx->state = REASONING_BUDGET_DONE;
+                        } else {
+                            ctx->state = REASONING_BUDGET_FORCING;
+                            ctx->force_pos = 0;
+                            ctx->end_matcher.reset();
+                            COM_TRC("%s", "budget exhausted, forcing end sequence\n");
+                        }
                     } else {
                         ctx->state = REASONING_BUDGET_WAITING_UTF8;
                         ctx->end_matcher.reset();
@@ -154,9 +166,13 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
                 COM_TRC("re-activated on new start tag, budget=%d tokens\n", ctx->budget);
 
                 if (ctx->remaining <= 0) {
-                    ctx->state = REASONING_BUDGET_FORCING;
-                    ctx->force_pos = 0;
-                    COM_TRC("%s", "budget=0, forcing immediately\n");
+                    if (ctx->forced_tokens.empty()) {
+                        ctx->state = REASONING_BUDGET_DONE;
+                    } else {
+                        ctx->state = REASONING_BUDGET_FORCING;
+                        ctx->force_pos = 0;
+                        COM_TRC("%s", "budget=0, forcing immediately\n");
+                    }
                 }
             }
             break;
@@ -299,6 +315,12 @@ bool common_reasoning_budget_force(struct llama_sampler * smpl) {
     // any other state (idle, already forcing/waiting, or done) is left untouched
     if (ctx->state != REASONING_BUDGET_COUNTING) {
         return false;
+    }
+
+    if (ctx->forced_tokens.empty()) {
+        ctx->state = REASONING_BUDGET_DONE;
+        ctx->end_matcher.reset();
+        return true;
     }
 
     ctx->state = REASONING_BUDGET_FORCING;

--- a/tests/test-reasoning-budget.cpp
+++ b/tests/test-reasoning-budget.cpp
@@ -490,12 +490,25 @@ int main(void) {
             SIZE_MAX, SIZE_MAX); // no forcing expected (natural end)
     }
 
+    // Test 9: Empty forced_tokens - when budget exhausts, smoothly transitions to DONE without forcing
+    {
+        const std::vector<llama_token> start = {100};
+        const std::vector<llama_token> end = {101};
+        const std::vector<llama_token> forced = {};
+        const std::vector<llama_token> sequence = {100, 50, 51, 52, 53};
+
+        test_reasoning_budget("empty forced_tokens smoothly transitions to DONE", sequence, {start}, {end}, forced,
+            2,      // budget of 2 tokens
+            REASONING_BUDGET_IDLE,
+            SIZE_MAX, SIZE_MAX); // no forcing expected since forced is empty
+    }
+
     test_reasoning_budget_clone_mid_counting();
     test_reasoning_budget_clone_mid_forcing();
     test_reasoning_budget_force_manual();
     test_reasoning_budget_end_match();
 
-    printf("OK (12 tests passed)\n");
+    printf("OK (13 tests passed)\n");
 
     printf("Testing UTF-8 boundary detection... ");
     test_utf8_boundary_detection();


### PR DESCRIPTION
## Motivation
When using `common_reasoning_budget_init` with an empty `forced_tokens` vector (or when budget expires in configurations without explicit forced end tokens), `common_reasoning_budget_accept` previously transitioned to `REASONING_BUDGET_FORCING` with `force_pos = 0`. Because `ctx->forced_tokens.empty()` is true, `common_reasoning_budget_apply` returns without applying any logits modification, and subsequent token acceptance increments `force_pos`, causing an unnecessary cycle in the forcing state.

## Description
- Transition directly to `REASONING_BUDGET_DONE` when `forced_tokens.empty()` upon budget exhaustion or budget=0 activation.
- Handle `forced_tokens.empty()` in `common_reasoning_budget_force`.
- Added unit test in `tests/test-reasoning-budget.cpp`. All 13 unit tests pass.