### PR TITLE
ci : fix empty release_id in make-release upload step

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -70,6 +70,7 @@ jobs:
           cat nightly-tag.txt
 
       - name: Create release
+        id: create_release
         if: ${{ github.event.inputs.dry_run == 'false' }}
         uses: ggml-org/action-create-release@v1
         env:


### PR DESCRIPTION
## Overview

Fixes the `Upload nightly-tag.txt` failure in `make-release.yml`: the `Create release` step had no `id`, so `steps.create_release.outputs.id` resolved to an empty string and the asset upload request hit `https://uploads.github.com/repos/ggml-org/llama.cpp/releases//assets` → HTTP 404 (`Unhandled error: HttpError`), see run https://github.com/ggml-org/llama.cpp/actions/runs/32513839499/job/96870873377.

Adds `id: create_release` to the step. The action (`ggml-org/action-create-release@v1`) already exposes the `id` output, so this is the only missing piece.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.8-27B