### PR TITLE
Thread swizzling in kernel_mul_mm (Metal) for better cache locality.

### DIFF
--- a/ggml/src/ggml-metal/kernels/mul_mm.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mm.metal
@@ -168,8 +168,33 @@ kernel void kernel_mul_mm(
     constexpr int NL1 = NK/8;
 
     const int im = tgpig.z;
-    const int r0 = tgpig.y*NR0;
-    const int r1 = tgpig.x*NR1;
+
+    int sy = tgpig.y;
+    int sx = tgpig.x;
+
+    // Threadgroup swizzle. Walking the grid in groups of SWZ row tiles, cutting src1
+    // DRAM traffic by ~SWZ. Only worth doing once src1 is large.
+    if ((size_t) args.ne1 * args.nb11 > (32u << 20)){
+        const uint tile_bytes = NR0*(uint) args.nb01;
+        const uint want = clamp((10u << 20)/max(tile_bytes, 1u), 1u, 8u);
+
+        const int SWZ = want >= 8 ? 8 : want >= 4 ? 4 : want >= 2 ? 2 : 1;
+
+        const int nbx = (args.ne1 + NR1 - 1)/NR1; // src1 (batch) tiles
+        const int nby = (args.ne0 + NR0 - 1)/NR0; // src0 (row)   tiles
+
+        const int lin = (int) tgpig.y*nbx + (int) tgpig.x;
+        const int tpg = SWZ*nbx;
+        const int y0  = (lin/tpg)*SWZ;
+        const int lid = lin%tpg;
+        const int gh  = (nby - y0) < SWZ ? (nby - y0) : SWZ;
+
+        sy = y0 + lid%gh;
+        sx = lid/gh;
+    }
+
+    const int r0 = sy*NR0;
+    const int r1 = sx*NR1;
 
     // if this block is of 64x32 shape or smaller
     const short nr0 = (args.ne0 - r0 < NR0) ? (args.ne0 - r0) : NR0;
@@ -453,13 +478,37 @@ kernel void kernel_mul_mm_id(
     constexpr int NL1 = NK/8;
 
     const int im = tgpig.z; // expert
-    const int r0 = tgpig.y*NR0;
-    const int r1 = tgpig.x*NR1;
 
     device const uint32_t * tpe_u32 = (device const uint32_t *) (htpe);
     device const int32_t  * ids_i32 = (device const int32_t  *) (hids);
 
     const int32_t neh1 = tpe_u32[im];
+
+    int sy = tgpig.y;
+    int sx = tgpig.x;
+
+    // Same threadgroup swizzle as kernel_mul_mm
+    if ((size_t) neh1 * args.nb11 > (32u << 20)) {
+        const uint tile_bytes = NR0*(uint) args.nb01;
+        const uint want = clamp((10u << 20)/max(tile_bytes, 1u), 1u, 8u);
+
+        const int SWZ = want >= 8 ? 8 : want >= 4 ? 4 : want >= 2 ? 2 : 1;
+
+        const int nbx = (args.ne21 + NR1 - 1)/NR1;
+        const int nby = (args.ne0  + NR0 - 1)/NR0;
+
+        const int lin = (int) tgpig.y*nbx + (int) tgpig.x;
+        const int tpg = SWZ*nbx;
+        const int y0  = (lin/tpg)*SWZ;
+        const int lid = lin%tpg;
+        const int gh  = (nby - y0) < SWZ ? (nby - y0) : SWZ;
+
+        sy = y0 + lid%gh;
+        sx = lid/gh;
+    }
+
+    const int r0 = sy*NR0;
+    const int r1 = sx*NR1;
 
     if (r1 >= neh1) {
         return;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9299,6 +9299,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 6, 4096, 5120, {1, 1}, {1, 1}));
 
+    // Threads swizzle path in Metal
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_Q8_0, GGML_TYPE_F32, 640, 1056,  8192, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16,  GGML_TYPE_F32, 320,  512, 17408, {1, 1}, {1, 1}));
+    test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q8_0, GGML_TYPE_F32, 2, 2, false, 128, 1056, 8192));
+
     // K not a multiple of 32
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 64, 32,  65, {1, 1}, {1, 1}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_F16, GGML_TYPE_F16, 64, 32,  80, {1, 1}, {1, 1}));


### PR DESCRIPTION
## Overview

This adds swizzling trick into the Metal backend's multiplication kernels to avoid hitting the cache size performance cliff on large inputs. Gains 5.5% - 22.5%  t/s for Qwen 3.8 27B on Apple M1 Max (depending on ubatch).

## Additional information

./llama-bench -m ~./models/qwen3.8-27b/Qwen3.8-27B-Q8_0.gguf -p 8980 -n 0 -ngl 99 -fa on -b 2048 -ub 512,1024,2048 -r 3
ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.014 sec
ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
ggml_metal_device_init: GPU name:   MTL0 (Apple M1 Max)
ggml_metal_device_init: GPU family: MTLGPUFamilyApple7  (1007)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal4  (5002)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = false
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 55662.79 MB

Before: 

| model                          |       size |     params | backend    | threads | n_ubatch |  fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | -------: | --: | --------------: | -------------------: |
| qwen35 27B Q8_0                |  27.11 GiB |    27.32 B | MTL,BLAS   |       8 |      512 |   1 |          pp8980 |        140.13 ± 0.10 |
| qwen35 27B Q8_0                |  27.11 GiB |    27.32 B | MTL,BLAS   |       8 |     1024 |   1 |          pp8980 |        126.28 ± 0.06 |
| qwen35 27B Q8_0                |  27.11 GiB |    27.32 B | MTL,BLAS   |       8 |     2048 |   1 |          pp8980 |        117.57 ± 0.11 |

After:

| model                          |       size |     params | backend    | threads | n_ubatch |  fa |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | -------: | --: | --------------: | -------------------: |
| qwen35 27B Q8_0                |  27.11 GiB |    27.32 B | MTL,BLAS   |       8 |      512 |   1 |          pp8980 |        147.78 ± 0.01 |
| qwen35 27B Q8_0                |  27.11 GiB |    27.32 B | MTL,BLAS   |       8 |     1024 |   1 |          pp8980 |        146.01 ± 0.02 |
| qwen35 27B Q8_0                |  27.11 GiB |    27.32 B | MTL,BLAS   |       8 |     2048 |   1 |          pp8980 |        143.98 ± 0.07 |


ctest --output-on-failure -R test-backend-ops
Test project /Users/sergeikulik/CODE/llama.cpp/build/swz
    Start 43: test-backend-ops
1/1 Test #43: test-backend-ops .................   Passed  165.43 sec

Perplexity byte-identical on wikitext-2-raw/wiki.test.raw
Final estimate: PPL = 6.7478 +/- 0.10325

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

YES
Used Claude Opus 5 to debug the inefficiency and suggest the patch.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
