### PR TITLE
llama : fix K/V and recurrent state cleanup after failed restores

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2664,6 +2664,10 @@ public:
         buf_size -= size;
     }
 
+    void discard() override {
+        rinfos.clear();
+    }
+
     size_t n_bytes() override {
         return size_read;
     }
@@ -2870,6 +2874,10 @@ public:
     }
 
     ~llama_io_read_device() {
+        if (discarded) {
+            return;
+        }
+
         llama_memory_buffers mbufs_new;
 
         for (const auto & rinfo : rinfos) {
@@ -3014,6 +3022,10 @@ public:
         rinfos.push_back({tensor, ptr, size, offset});
     }
 
+    void discard() override {
+        discarded = true;
+    }
+
     size_t n_bytes() override {
         return size_read;
     }
@@ -3022,6 +3034,8 @@ private:
     const uint8_t * ptr;
     size_t buf_size = 0;
     size_t size_read = 0;
+
+    bool discarded = false;
 
     struct read_info {
         ggml_tensor * tensor;
@@ -3060,6 +3074,7 @@ size_t llama_context::state_set_data(const uint8_t * src, size_t size) {
         return state_read_data(io);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: error loading state: %s\n", __func__, err.what());
+        io.discard();
         return 0;
     }
 }
@@ -3133,6 +3148,7 @@ size_t llama_context::state_seq_set_data(llama_seq_id seq_id, const uint8_t * sr
         return state_seq_read_data(*io, seq_id, flags);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: error loading state: %s\n", __func__, err.what());
+        io->discard();
         return 0;
     }
 }

--- a/src/llama-impl.cpp
+++ b/src/llama-impl.cpp
@@ -1,8 +1,10 @@
 #include "llama-impl.h"
 
+#include "ggml-backend.h"
 #include "gguf.h"
 #include "llama.h"
 
+#include <algorithm>
 #include <cinttypes>
 #include <climits>
 #include <cstdarg>
@@ -64,6 +66,15 @@ void llama_log_callback_default(ggml_log_level level, const char * text, void * 
     (void) user_data;
     fputs(text, stderr);
     fflush(stderr);
+}
+
+void llama_clear_tensor_data(ggml_tensor * t, size_t offset, size_t size) {
+    static const std::vector<uint8_t> zeros(1024*1024, 0);
+
+    // not all backend buffers implement ggml_backend_tensor_memset(), so write zeros instead
+    for (size_t ofs = 0; ofs < size; ofs += zeros.size()) {
+        ggml_backend_tensor_set(t, zeros.data(), offset + ofs, std::min(size - ofs, zeros.size()));
+    }
 }
 
 void replace_all(std::string & s, const std::string & search, const std::string & replace) {

--- a/src/llama-impl.h
+++ b/src/llama-impl.h
@@ -93,6 +93,8 @@ struct buffer_view {
     }
 };
 
+void llama_clear_tensor_data(ggml_tensor * t, size_t offset, size_t size);
+
 void replace_all(std::string & s, const std::string & search, const std::string & replace);
 
 // TODO: rename to llama_format ?

--- a/src/llama-io.h
+++ b/src/llama-io.h
@@ -28,6 +28,9 @@ public:
     virtual void read(void * dst, size_t size) = 0;
     virtual void read_tensor(ggml_tensor * tensor, size_t offset, size_t size) = 0;
 
+    // drop tensor data that has been read but not yet applied (e.g. when a restore fails)
+    virtual void discard() {}
+
     // bytes read so far
     virtual size_t n_bytes() = 0;
 

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -2189,6 +2189,9 @@ const slot_info_vec_t *   sinfos_in) {
             if (seq_id == -1) {
                 clear(true);
             } else {
+                // zero the K/V data of the failed restore attempt - the attention can still read the data of free cells
+                clear_cells_data(strm, sinfo);
+
                 seq_rm(seq_id, -1, -1);
             }
             throw std::runtime_error("failed to restore kv cache");
@@ -2659,6 +2662,76 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
     }
 
     return true;
+}
+
+// the cleared ranges mirror the write pattern of state_read_data() - keep both in sync
+void llama_kv_cache::clear_cells_data(uint32_t strm, const slot_info & sinfo) {
+    if (sinfo.empty() || sinfo.size() == 0) {
+        return;
+    }
+
+    const auto & cells = v_cells[strm];
+
+    const uint32_t cell_count = sinfo.size();
+
+    const bool is_contiguous = sinfo.is_contiguous();
+
+    for (const auto & layer : layers) {
+        const uint32_t il = layer.il;
+
+        const uint32_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
+
+        auto * k = layer.k_stream[strm];
+
+        const size_t k_size_row = ggml_row_size(k->type, n_embd_k_gqa);
+
+        if (is_contiguous) {
+            llama_clear_tensor_data(k, sinfo.head() * k_size_row, cell_count * k_size_row);
+        } else {
+            for (uint32_t i = 0; i < cell_count; ++i) {
+                llama_clear_tensor_data(k, sinfo.idxs[0][i] * k_size_row, k_size_row);
+            }
+        }
+    }
+
+    for (const auto & layer : layers) {
+        const uint32_t il = layer.il;
+
+        const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(il);
+
+        auto * v = layer.v_stream[strm];
+        if (!v) {
+            continue;
+        }
+
+        if (!v_trans) {
+            const size_t v_size_row = ggml_row_size(v->type, n_embd_v_gqa);
+
+            if (is_contiguous) {
+                llama_clear_tensor_data(v, sinfo.head() * v_size_row, cell_count * v_size_row);
+            } else {
+                for (uint32_t i = 0; i < cell_count; ++i) {
+                    llama_clear_tensor_data(v, sinfo.idxs[0][i] * v_size_row, v_size_row);
+                }
+            }
+        } else {
+            const size_t v_size_el = ggml_type_size(v->type);
+
+            if (is_contiguous) {
+                const uint32_t h = sinfo.head();
+
+                for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
+                    llama_clear_tensor_data(v, (h + j * cells.size()) * v_size_el, cell_count * v_size_el);
+                }
+            } else {
+                for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
+                    for (uint32_t i = 0; i < cell_count; ++i) {
+                        llama_clear_tensor_data(v, (sinfo.idxs[0][i] + j * cells.size()) * v_size_el, v_size_el);
+                    }
+                }
+            }
+        }
+    }
 }
 
 //

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -345,6 +345,8 @@ private:
     // sinfo_in, when set, replaces the find_slot call: the cells are given by the caller
     bool state_read_meta(llama_io_read_i & io, uint32_t strm, uint32_t cell_count,       slot_info & sinfo, llama_seq_id dest_seq_id = -1, const slot_info * sinfo_in = nullptr);
     bool state_read_data(llama_io_read_i & io, uint32_t strm, uint32_t cell_count, const slot_info & sinfo);
+
+    void clear_cells_data(uint32_t strm, const slot_info & sinfo);
 };
 
 class llama_kv_cache_context : public llama_memory_context_i {

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -852,7 +852,12 @@ void llama_memory_recurrent::state_read(llama_io_read_i & io, llama_seq_id seq_i
 
     bool res = true;
 
-    res = res && state_read_meta(io, cell_count, seq_id);
+    // save the head of the restored cells - the seq_rm() below can move it
+    // the head is valid only when state_read_meta() succeeded
+    const bool meta_read = state_read_meta(io, cell_count, seq_id);
+    const uint32_t cell_head = head;
+
+    res = res && meta_read;
 
     try {
         res = res && state_read_data(io, cell_count);
@@ -865,6 +870,9 @@ void llama_memory_recurrent::state_read(llama_io_read_i & io, llama_seq_id seq_i
         if (seq_id == -1) {
             clear(true);
         } else {
+            if (meta_read) {
+                clear_cells_data(cell_head, cell_count);
+            }
             seq_rm(seq_id, -1, -1);
         }
         throw std::runtime_error("failed to restore kv cache");
@@ -1221,6 +1229,33 @@ bool llama_memory_recurrent::state_read_data(llama_io_read_i & io, uint32_t cell
     }
 
     return true;
+}
+
+// the cleared ranges mirror the write pattern of state_read_data() - keep both in sync
+// the transposed s layout is not handled - state_read_data() rejects it before any write
+void llama_memory_recurrent::clear_cells_data(uint32_t cell_head, uint32_t cell_count) {
+    if (cell_count == 0) {
+        return;
+    }
+
+    const uint32_t n_layer = hparams.n_layer();
+
+    for (uint32_t il = 0; il < n_layer; ++il) {
+        if (r_l[il] != nullptr) {
+            const size_t r_size_row = ggml_row_size(r_l[il]->type, hparams.n_embd_r());
+            llama_clear_tensor_data(r_l[il], cell_head * r_size_row, cell_count * r_size_row);
+        }
+
+        if (s_l[il] != nullptr) {
+            const size_t s_size_row = ggml_row_size(s_l[il]->type, hparams.n_embd_s());
+            llama_clear_tensor_data(s_l[il], cell_head * s_size_row, cell_count * s_size_row);
+        }
+
+        if (p_l[il] != nullptr) {
+            const size_t p_size_row = ggml_row_size(p_l[il]->type, hparams.ple_conv_state());
+            llama_clear_tensor_data(p_l[il], cell_head * p_size_row, cell_count * p_size_row);
+        }
+    }
 }
 
 //

--- a/src/llama-memory-recurrent.h
+++ b/src/llama-memory-recurrent.h
@@ -134,6 +134,8 @@ private:
 
     bool state_read_meta(llama_io_read_i & io, uint32_t cell_count, llama_seq_id dest_seq_id = -1);
     bool state_read_data(llama_io_read_i & io, uint32_t cell_count);
+
+    void clear_cells_data(uint32_t cell_head, uint32_t cell_count);
 };
 
 class llama_memory_recurrent_context : public llama_memory_context_i {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -253,6 +253,13 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     set_tests_properties(test-save-load-state PROPERTIES FIXTURES_REQUIRED generate-models)
 
     llama_build(test-fusion.cpp)
+
+    # llama-dense covers llama_kv_cache, mamba-dense covers llama_memory_recurrent
+    llama_build(test-state-restore-failure.cpp)
+    llama_test(test-state-restore-failure LABEL main ARGS -m "${MODEL_DIR}/llama-dense.gguf")
+    set_tests_properties(test-state-restore-failure PROPERTIES FIXTURES_REQUIRED generate-models)
+    llama_test(test-state-restore-failure NAME test-state-restore-failure-mamba LABEL main ARGS -m "${MODEL_DIR}/mamba-dense.gguf")
+    set_tests_properties(test-state-restore-failure-mamba PROPERTIES FIXTURES_REQUIRED generate-models)
 endif()
 
 llama_build_and_test(test-chat-peg-parser.cpp peg-parser/simple-tokenize.cpp)

--- a/tests/test-state-restore-failure.cpp
+++ b/tests/test-state-restore-failure.cpp
@@ -1,0 +1,190 @@
+// a failed state restore must not leave data behind that a later decode can read
+// each case corrupts a saved state, checks that the restore fails, and compares a decode on another sequence against a clean run
+
+#include "arg.h"
+#include "common.h"
+#include "llama.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+static std::vector<llama_token> make_tokens(size_t n, int base) {
+    std::vector<llama_token> tokens(n);
+    for (size_t i = 0; i < n; ++i) {
+        tokens[i] = base + (int) ((i*37) % 100);
+    }
+    return tokens;
+}
+
+static bool decode(llama_context * ctx, const std::vector<llama_token> & tokens, llama_seq_id seq_id, std::vector<float> * logits_out) {
+    llama_batch batch = llama_batch_init(tokens.size(), 0, 1);
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        common_batch_add(batch, tokens[i], (llama_pos) i, {seq_id}, false);
+    }
+    batch.logits[batch.n_tokens - 1] = true;
+
+    const int ret = llama_decode(ctx, batch);
+    llama_batch_free(batch);
+    if (ret != 0) {
+        fprintf(stderr, "%s : llama_decode failed (%d)\n", __func__, ret);
+        return false;
+    }
+
+    if (logits_out) {
+        const int n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(llama_get_model(ctx)));
+        const float * logits = llama_get_logits_ith(ctx, -1);
+        logits_out->assign(logits, logits + n_vocab);
+    }
+
+    return true;
+}
+
+// overwrite the tensor data with 0xff bytes (NaN when read as f16/f32)
+// the tail is kept so that the restore fails after the corrupted data has been read
+static void corrupt_state(std::vector<uint8_t> & data) {
+    GGML_ASSERT(data.size() >= 3*4096);
+    std::fill(data.begin() + 4096, data.end() - data.size()/4, 0xff);
+}
+
+int main(int argc, char ** argv) {
+    common_params params;
+
+    params.kv_unified = true;
+    params.n_parallel = 4;
+    params.n_ctx = 256;
+
+    // without flash attention, NaN values in masked cells propagate to the logits and make leftover data detectable
+    params.flash_attn_type = LLAMA_FLASH_ATTN_TYPE_DISABLED;
+
+    common_init();
+
+    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_COMMON)) {
+        return 1;
+    }
+
+    ggml_backend_load_all();
+
+    common_init_result_ptr llama_init = common_init_from_params(params);
+
+    llama_context * ctx = llama_init->context();
+    if (ctx == nullptr) {
+        fprintf(stderr, "%s : failed to init\n", __func__);
+        return 1;
+    }
+
+    llama_memory_t mem = llama_get_memory(ctx);
+
+    // the registered tests share a working directory, so the state file is named after the model
+    const std::string path = "test-state-restore-failure." + params.model.path.substr(params.model.path.find_last_of("/\\") + 1) + ".tmp.bin";
+
+    const std::vector<llama_token> tokens_save   = make_tokens(24, 5);
+    const std::vector<llama_token> tokens_verify = make_tokens( 8, 7);
+
+    llama_memory_clear(mem, true);
+
+    std::vector<float> baseline;
+    if (!decode(ctx, tokens_verify, 1, &baseline)) {
+        return 1;
+    }
+
+    // each case restores a corrupted copy of the state of seq 0 and returns true if the restore failed
+    const std::vector<std::pair<const char *, std::function<bool()>>> cases = {
+        { "buffer", [&]() {
+            std::vector<uint8_t> state(llama_state_seq_get_size(ctx, 0));
+            GGML_ASSERT(llama_state_seq_get_data(ctx, state.data(), state.size(), 0) == state.size());
+            llama_memory_seq_rm(mem, 0, -1, -1);
+
+            corrupt_state(state);
+            return llama_state_seq_set_data(ctx, state.data(), state.size(), 0) == 0;
+        }},
+        { "file", [&]() {
+            GGML_ASSERT(llama_state_seq_save_file(ctx, path.c_str(), 0, tokens_save.data(), tokens_save.size()) > 0);
+            llama_memory_seq_rm(mem, 0, -1, -1);
+
+            std::vector<uint8_t> data;
+            {
+                std::ifstream f(path, std::ios::binary);
+                data.assign(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
+            }
+            corrupt_state(data);
+            {
+                std::ofstream f(path, std::ios::binary);
+                f.write((const char *) data.data(), data.size());
+            }
+
+            std::vector<llama_token> tokens_out(tokens_save.size());
+            size_t n_token_count = 0;
+            const size_t nread = llama_state_seq_load_file(ctx, path.c_str(), 0, tokens_out.data(), tokens_out.size(), &n_token_count);
+            std::remove(path.c_str());
+            return nread == 0;
+        }},
+        { "on device", [&]() {
+            const llama_state_seq_flags flags = LLAMA_STATE_SEQ_FLAGS_ON_DEVICE;
+
+            std::vector<uint8_t> state(llama_state_seq_get_size_ext(ctx, 0, flags));
+            GGML_ASSERT(llama_state_seq_get_data_ext(ctx, state.data(), state.size(), 0, flags) == state.size());
+            llama_memory_seq_rm(mem, 0, -1, -1);
+
+            // the tensor data of an on-device state stays in the memory buffers, so only the metadata can be corrupted
+            std::fill(state.end() - state.size()/4, state.end(), 0xff);
+            return llama_state_seq_set_data_ext(ctx, state.data(), state.size(), 0, flags) == 0;
+        }},
+        { "whole context", [&]() {
+            std::vector<uint8_t> state(llama_state_get_size(ctx));
+            GGML_ASSERT(llama_state_get_data(ctx, state.data(), state.size()) == state.size());
+            llama_memory_clear(mem, true);
+
+            corrupt_state(state);
+            return llama_state_set_data(ctx, state.data(), state.size()) == 0;
+        }},
+    };
+
+    for (const auto & [name, restore_failed] : cases) {
+        llama_memory_clear(mem, true);
+
+        if (!decode(ctx, tokens_save, 0, nullptr)) {
+            return 1;
+        }
+
+        if (!restore_failed()) {
+            fprintf(stderr, "%s : %s: restoring a corrupted state did not fail\n", __func__, name);
+            return 1;
+        }
+
+        if (llama_memory_seq_pos_max(mem, 0) != -1) {
+            fprintf(stderr, "%s : %s: sequence not empty after failed restore\n", __func__, name);
+            return 1;
+        }
+
+        std::vector<float> logits;
+        if (!decode(ctx, tokens_verify, 1, &logits)) {
+            return 1;
+        }
+
+        float diff_max = 0.0f;
+        size_t n_nan = 0;
+        for (size_t i = 0; i < logits.size(); ++i) {
+            if (std::isnan(logits[i]) || std::isnan(baseline[i])) {
+                n_nan++;
+            } else {
+                diff_max = std::max(diff_max, std::fabs(logits[i] - baseline[i]));
+            }
+        }
+
+        if (n_nan > 0 || diff_max > 1e-6f) {
+            fprintf(stderr, "%s : %s: FAILED - logits changed after failed restore (max diff = %g, nan = %zu)\n", __func__, name, diff_max, n_nan);
+            return 1;
+        }
+
+        fprintf(stderr, "%s : %s: logits match (max diff = %g)\n", __func__, name, diff_max);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Overview

A failed per-sequence state restore can remove sequence metadata while leaving K/V or recurrent-state tensor data written by the failed restore.

Buffer-backed restores can also leave deferred writes pending, allowing them to be applied after cleanup.

This PR contains failed restores by:

* clearing affected K/V or recurrent-state tensor data;
* discarding deferred writes after cleanup and before the reader is destroyed;
* applying the same deferred-write cleanup to whole-context buffer restores;
* validating restored `cell_count` values before they are used for allocation or target-range setup;
* cleaning up an already-restored attention state when a later recurrent-memory restore fails in `llama_memory_hybrid`.

Failures before modifying the target sequence leave it unchanged. After modification, the affected state is removed rather than attempting transactional rollback. For `llama_memory_hybrid`, if the attention component has already been restored and the recurrent component then fails, the restored attention state is also cleared.

Fixes #27068.

## Additional information

The original issue was observed in the K/V cache, but the same failure-cleanup behavior is needed for recurrent memory.

Tensor cleanup is only performed after a valid target range has been established, so failures during metadata parsing do not clear unrelated cells.

Per-sequence restore now also validates `cell_count` against the available cache or recurrent-memory capacity before using it.

For `llama_memory_hybrid`, restore is sequential across the attention and recurrent components. If the recurrent restore throws after the attention restore has succeeded, the attention state restored for that sequence is cleared before the exception is rethrown.

The cleanup runs only on restore failure and does not affect successful restore or normal decoding.

### Tests

Added failed-restore regression coverage to `test-save-load-state`. Test 9 exercises corrupted buffer and file restores and runs through the existing architecture coverage, including hybrid models.

The test verifies that a failed restore leaves the affected sequence empty and does not leave tensor data that changes the logits of another sequence.

Local validation:

* `ctest`: 62/62 passed.
* Sequential run across 127 generated models: Test 9 PASS 123 / SKIP 4 / FAIL 0. The four skipped models (`dream`, `llada`, `llada-moe`, and `rnd1`) do not have memory.

CUDA validation and server-level fault injection with K/V and hybrid recurrent memory were also performed on an earlier base.

### Non-goal

This does not provide transactional restore. If a failed restore has already modified the target sequence, its previous contents are not reconstructed.

Cross-component cleanup is handled for `llama_memory_hybrid`, where attention restore can precede a failing recurrent restore. Equivalent cleanup for the other composite memory implementations (`llama_kv_cache_iswa`, `llama_memory_hybrid_iswa`, `llama_kv_cache_dsa_iswa`, and `llama_kv_cache_msa`) is not addressed by this PR.

The separate ON_DEVICE pre-validation issue is tracked in #27439.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

* I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES

  * **Motivation & Design:** I found the failure through slot save / restore fault injection, reported it in #27068, and defined the scope as failure containment rather than transactional restore.
  * **Investigation & Code Review (Fable 5 / Opus 5 / GPT-5.6 Sol):** AI agents assisted investigation and code review under my instructions.
  * **Implementation (Opus 5 / GPT-5.6 Sol):** AI assistance was used to draft parts of the implementation and tests.
  * **Draft Translation (Opus 5):** AI assisted with English translation of my Japanese draft.
  * **Validation & Responsibility:** I manually reviewed the changes, ran local tests, mutation tests, CUDA validation, and server-level fault injection, and take responsibility for the submitted changes.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->