### PR TITLE
server: return prompt-token logprobs when echo=true (#27174)

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -561,6 +561,7 @@ extern "C" {
     LLAMA_API uint32_t llama_n_ubatch   (const struct llama_context * ctx);
     LLAMA_API uint32_t llama_n_seq_max  (const struct llama_context * ctx);
     LLAMA_API uint32_t llama_n_rs_seq   (const struct llama_context * ctx);
+    LLAMA_API uint32_t llama_n_outputs_max(const struct llama_context * ctx);
 
     DEPRECATED(LLAMA_API int32_t llama_n_ctx_train(const struct llama_model * model), "use llama_model_n_ctx_train instead");
     DEPRECATED(LLAMA_API int32_t llama_n_embd     (const struct llama_model * model), "use llama_model_n_embd instead");

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3685,6 +3685,10 @@ uint32_t llama_n_rs_seq(const llama_context * ctx) {
     return ctx->get_cparams().n_rs_seq;
 }
 
+uint32_t llama_n_outputs_max(const llama_context * ctx) {
+    return ctx->get_cparams().n_outputs_max;
+}
+
 const llama_model * llama_get_model(const llama_context * ctx) {
     return &ctx->get_model();
 }

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1026,8 +1026,8 @@ json oaicompat_completion_params_parse(const json & body) {
     }
 
     // Handle "echo" field
-    if (json_value(body, "echo", false)) {
-        throw std::runtime_error("Only no echo is supported");
+    if (body.contains("echo")) {
+        llama_params["echo"] = body.at("echo");
     }
 
     // Params supported by OAI but unsupported by llama.cpp

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1973,6 +1973,11 @@ private:
         }
     }
 
+    bool accept_special_token(const server_slot & slot, llama_token token) const {
+        return params_base.special ||
+            slot.task->params.sampling.preserved_tokens.find(token) != slot.task->params.sampling.preserved_tokens.end();
+    }
+
     void send_error(const server_task & task, const std::string & error, const enum error_type type = ERROR_TYPE_SERVER) {
         send_error(task.id, error, type);
     }
@@ -3464,8 +3469,14 @@ private:
                     const auto & spans = slot.task->params.message_spans;
                     const auto last_user_pos = spans.last_user_message_pos();
 
+                    const int32_t n_tokens_prev_slot = batch.size();
+                    const int32_t max_prompt_batch_slot = slot.need_prompt_logits() ?
+                        std::max<int32_t>(1, llama_n_outputs_max(ctx_tgt)) : n_batch;
+
                     // add prompt tokens for processing in the current batch
-                    while (slot.prompt.n_tokens() < slot.task->n_tokens() && batch.size() < n_batch) {
+                    while (slot.prompt.n_tokens() < slot.task->n_tokens() &&
+                           batch.size() < n_batch &&
+                           (batch.size() - n_tokens_prev_slot) < max_prompt_batch_slot) {
                         // get next token to process
                         llama_token cur_tok = input_tokens[slot.prompt.n_tokens()];
                         if (cur_tok == LLAMA_TOKEN_NULL) {
@@ -3745,28 +3756,38 @@ private:
             }
         });
 
-        auto accept_special_token = [&](server_slot & slot, llama_token token) {
-            return params_base.special ||
-                slot.task->params.sampling.preserved_tokens.find(token) != slot.task->params.sampling.preserved_tokens.end();
-        };
-
         iterate(slots, [&](server_slot & slot) {
-            // optionally send prompt processing progress
             if (slot.state == SLOT_STATE_PROCESSING_PROMPT || slot.state == SLOT_STATE_DONE_PROMPT) {
                 if (slot.task->params.stream && slot.task->params.return_progress) {
                     send_partial_response(slot, {}, true);
                 }
                 if (!slot.i_batch_prompt.empty()) {
-                    for (auto & [tok_idx, id] : slot.i_batch_prompt) {
+                    if (slot.prompt_probs_output.empty() && !slot.prompt.tokens.empty()) {
+                        completion_token_output res0;
+                        res0.tok = slot.prompt.tokens[0];
+                        res0.text_to_send = common_token_to_piece(slot.ctx_tgt, res0.tok, accept_special_token(slot, res0.tok));
+                        res0.prob = 1.0f;
+                        slot.prompt_probs_output.push_back(res0);
+                    }
+
+                    const size_t chunk_start = slot.prompt.n_tokens() - slot.i_batch_prompt.size();
+
+                    for (size_t k = 0; k < slot.i_batch_prompt.size(); ++k) {
+                        const auto & [tok_idx, id] = slot.i_batch_prompt[k];
                         if (!is_inside_view(tok_idx)) {
                             continue;
                         }
-                        completion_token_output result;
-                        result.tok          = id;
-                        result.text_to_send = common_token_to_piece(slot.ctx_tgt, result.tok, accept_special_token(slot, result.tok));
-                        result.prob         = 1.0f;
-                        populate_token_probs(slot, result, slot.task->params.post_sampling_probs, params_base.special, tok_idx - off);
-                        slot.prompt_probs_output.push_back(result);
+
+                        const size_t target_token_idx = chunk_start + k + 1;
+                        if (target_token_idx < (size_t) slot.task->n_tokens()) {
+                            llama_token target_tok = slot.task->tokens[target_token_idx];
+                            completion_token_output result;
+                            result.tok          = target_tok;
+                            result.text_to_send = common_token_to_piece(slot.ctx_tgt, result.tok, accept_special_token(slot, result.tok));
+                            result.prob         = 1.0f;
+                            populate_token_probs(slot, result, slot.task->params.post_sampling_probs, params_base.special, tok_idx - off);
+                            slot.prompt_probs_output.push_back(result);
+                        }
                     }
                     slot.i_batch_prompt.clear();
                 }

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -238,6 +238,13 @@ struct server_slot {
     size_t n_sent_text = 0; // number of sent text character (i.e. handle partial UTF-8 on streaming)
 
     std::vector<completion_token_output> generated_token_probs;
+    std::vector<std::pair<int32_t, llama_token>> i_batch_prompt;
+    std::vector<completion_token_output> prompt_probs_output;
+
+    bool need_prompt_logits() const {
+        GGML_ASSERT(task);
+        return task->params.echo && task->params.sampling.n_probs > 0;
+    }
 
     bool has_next_token = true;
     bool has_new_line   = false;
@@ -342,6 +349,8 @@ struct server_slot {
         }
         generated_tokens.clear();
         generated_token_probs.clear();
+        i_batch_prompt.clear();
+        prompt_probs_output.clear();
         json_schema = json();
 
         task_prev = std::move(task);
@@ -2076,6 +2085,9 @@ private:
 
         // populate res.probs_output
         if (slot.task->params.sampling.n_probs > 0) {
+            if (slot.task->params.echo) {
+                res->prompt_probs_output = slot.prompt_probs_output;
+            }
             if (!slot.task->params.stream && slot.stop == STOP_TYPE_WORD) {
                 const llama_tokens stop_word_toks = common_tokenize(ctx_tgt, slot.stopping_word, false);
 
@@ -3073,6 +3085,8 @@ private:
                         slot.stats.update_prompt_start();
 
                         slot.state = SLOT_STATE_PROCESSING_PROMPT;
+                        slot.i_batch_prompt.clear();
+                        slot.prompt_probs_output.clear();
 
                         SLT_TRC(slot, "new prompt, n_ctx_slot = %d, n_keep = %d, task.n_tokens = %d\n",
                                 slot.n_ctx, slot.task->params.n_keep, slot.task->n_tokens());
@@ -3469,11 +3483,15 @@ private:
                         // embedding requires all tokens in the batch to be output;
                         // MTP also wants logits at every prompt position so the
                         // streaming hook can mirror t_h_nextn into ctx_dft.
+                        const bool need_logits = slot.need_embd() || slot.need_prompt_logits();
                         add_ok &= batch.add(slot.id,
                             cur_tok,
                             /* pos       = */ slot.prompt.tokens.pos_next(),
-                            /* output    = */ slot.need_embd(),
+                            /* output    = */ need_logits,
                             /* is_prompt = */ true);
+                        if (slot.need_prompt_logits()) {
+                            slot.i_batch_prompt.push_back({(int32_t)(batch.size() - 1), cur_tok});
+                        }
                         slot.prompt.tokens.push_back(cur_tok);
 
                         // break at the last user message, or at user messages at least min step past the last checkpoint
@@ -3737,6 +3755,20 @@ private:
             if (slot.state == SLOT_STATE_PROCESSING_PROMPT || slot.state == SLOT_STATE_DONE_PROMPT) {
                 if (slot.task->params.stream && slot.task->params.return_progress) {
                     send_partial_response(slot, {}, true);
+                }
+                if (!slot.i_batch_prompt.empty()) {
+                    for (auto & [tok_idx, id] : slot.i_batch_prompt) {
+                        if (!is_inside_view(tok_idx)) {
+                            continue;
+                        }
+                        completion_token_output result;
+                        result.tok          = id;
+                        result.text_to_send = common_token_to_piece(slot.ctx_tgt, result.tok, accept_special_token(slot, result.tok));
+                        result.prob         = 1.0f;
+                        populate_token_probs(slot, result, slot.task->params.post_sampling_probs, params_base.special, tok_idx - off);
+                        slot.prompt_probs_output.push_back(result);
+                    }
+                    slot.i_batch_prompt.clear();
                 }
             }
 

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -327,7 +327,7 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
             ctx.params.chat_parser_params.is_continuation = continuation != COMMON_CHAT_CONTINUATION_NONE;
         }));
 
-    add((new field_bool("echo", params.chat_parser_params.echo))
+    add((new field_bool("echo", params.echo))
         ->set_desc("Whether to echo the input tokens in the output"));
 
     //

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -73,6 +73,7 @@ json task_params::to_json(bool only_metrics) const {
             {"n_discard",                 n_discard},
             {"ignore_eos",                sampling.ignore_eos},
             {"stream",                    stream},
+            {"echo",                      echo},
             {"n_probs",                   sampling.n_probs},
             {"min_keep",                  sampling.min_keep},
             {"chat_format",               common_chat_format_name(chat_parser_params.format)},
@@ -127,6 +128,7 @@ json task_params::to_json(bool only_metrics) const {
         {"n_discard",                 n_discard},
         {"ignore_eos",                sampling.ignore_eos},
         {"stream",                    stream},
+        {"echo",                      echo},
         {"logit_bias",                format_logit_bias(sampling.logit_bias)},
         {"n_probs",                   sampling.n_probs},
         {"min_keep",                  sampling.min_keep},
@@ -376,19 +378,67 @@ json server_task_result_cmpl_final::usage_json_oaicompat() {
 json server_task_result_cmpl_final::to_json_oaicompat() {
     std::time_t t = std::time(0);
     json logprobs = json(nullptr); // OAI default to null
-    if (!stream && probs_output.size() > 0) {
-        logprobs = json{
-            {"content", completion_token_output::probs_vector_to_json(probs_output, post_sampling_probs)},
+    if (!stream && (probs_output.size() > 0 || prompt_probs_output.size() > 0)) {
+        json tokens = json::array();
+        json token_logprobs = json::array();
+        json top_logprobs = json::array();
+        json text_offset = json::array();
+
+        size_t cur_offset = 0;
+
+        for (size_t i = 0; i < prompt_probs_output.size(); i++) {
+            const auto & ptok = prompt_probs_output[i];
+            tokens.push_back(ptok.text_to_send);
+            text_offset.push_back(cur_offset);
+            cur_offset += ptok.text_to_send.size();
+
+            if (i == 0) {
+                token_logprobs.push_back(json(nullptr));
+                top_logprobs.push_back(json(nullptr));
+            } else {
+                token_logprobs.push_back(post_sampling_probs ? ptok.prob : completion_token_output::logarithm(ptok.prob));
+                json top = json::object();
+                for (const auto & top_p : ptok.probs) {
+                    std::string txt(top_p.txt);
+                    txt.resize(validate_utf8(txt));
+                    top[txt] = post_sampling_probs ? top_p.prob : completion_token_output::logarithm(top_p.prob);
+                }
+                top_logprobs.push_back(top);
+            }
+        }
+
+        for (size_t i = 0; i < probs_output.size(); i++) {
+            const auto & gtok = probs_output[i];
+            tokens.push_back(gtok.text_to_send);
+            text_offset.push_back(cur_offset);
+            cur_offset += gtok.text_to_send.size();
+
+            token_logprobs.push_back(post_sampling_probs ? gtok.prob : completion_token_output::logarithm(gtok.prob));
+            json top = json::object();
+            for (const auto & top_p : gtok.probs) {
+                std::string txt(top_p.txt);
+                txt.resize(validate_utf8(txt));
+                top[txt] = post_sampling_probs ? top_p.prob : completion_token_output::logarithm(top_p.prob);
+            }
+            top_logprobs.push_back(top);
+        }
+
+        logprobs = json {
+            {"tokens",         tokens},
+            {"token_logprobs", token_logprobs},
+            {"top_logprobs",   top_logprobs},
+            {"text_offset",    text_offset},
         };
     }
     json finish_reason = "length";
     if (stop == STOP_TYPE_WORD || stop == STOP_TYPE_EOS) {
         finish_reason = "stop";
     }
+    std::string text_out = generation_params.echo ? (prompt + content) : content;
     json res = json {
         {"choices",            json::array({
             json{
-                {"text",          content},
+                {"text",          text_out},
                 {"index",         index},
                 {"logprobs",      logprobs},
                 {"finish_reason", finish_reason},

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -50,6 +50,7 @@ enum stop_type {
 
 struct task_params {
     bool stream          = false;
+    bool echo            = false;
     bool include_usage   = false;
     bool cache_prompt    = true; // remember the prompt to avoid reprocessing all prompt
     bool return_tokens   = false;
@@ -337,6 +338,7 @@ struct server_task_result_cmpl_final : server_task_result {
     stop_type stop = STOP_TYPE_NONE;
 
     bool post_sampling_probs;
+    std::vector<completion_token_output> prompt_probs_output;
     std::vector<completion_token_output> probs_output;
     std::vector<std::string>  response_fields;
 

--- a/tools/server/tests/unit/test_completion.py
+++ b/tools/server/tests/unit/test_completion.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 import time
 import random
+import math
 
 from openai import OpenAI
 from utils import *
@@ -661,3 +662,69 @@ def test_completion_prompt_cache():
         assert "prompt_n" in timings and timings["prompt_n"] + timings["cache_n"] == n_prompt
         assert "predicted_n" in timings and timings["predicted_n"] == n_predict
         assert "tokens" in res.body and isinstance(res.body["tokens"], list)
+
+
+def test_oai_completions_echo_logprobs():
+    global server
+    server.start()
+    prompt = "The capital of France is"
+    res = server.make_request("POST", "/v1/completions", data={
+        "prompt": prompt,
+        "echo": True,
+        "logprobs": 3,
+        "max_tokens": 1,
+        "temperature": 0.0,
+    })
+    assert res.status_code == 200
+    assert "choices" in res.body
+    assert len(res.body["choices"]) == 1
+    choice = res.body["choices"][0]
+    assert prompt in choice["text"]
+    assert "logprobs" in choice and choice["logprobs"] is not None
+    lp = choice["logprobs"]
+    assert "tokens" in lp and "token_logprobs" in lp and "top_logprobs" in lp and "text_offset" in lp
+
+    tokens = lp["tokens"]
+    token_logprobs = lp["token_logprobs"]
+    top_logprobs = lp["top_logprobs"]
+    text_offset = lp["text_offset"]
+
+    assert len(tokens) > 1  # prompt tokens + 1 generated token
+    assert len(token_logprobs) == len(tokens)
+    assert len(top_logprobs) == len(tokens)
+    assert len(text_offset) == len(tokens)
+
+    # First prompt token must explicitly have null logprob and null top_logprobs
+    assert token_logprobs[0] is None
+    assert top_logprobs[0] is None
+    assert text_offset[0] == 0
+
+    # Subsequent prompt tokens and generated tokens must have finite negative logprobs
+    for i in range(1, len(tokens)):
+        assert token_logprobs[i] is not None
+        assert math.isfinite(token_logprobs[i])
+        assert token_logprobs[i] <= 0.0
+        assert top_logprobs[i] is not None
+        assert isinstance(top_logprobs[i], dict)
+        assert len(top_logprobs[i]) <= 3
+        for k, v in top_logprobs[i].items():
+            assert isinstance(k, str)
+            assert math.isfinite(v)
+            assert v <= 0.0
+
+
+def test_oai_completions_echo_logprobs_stream():
+    global server
+    server.start()
+    prompt = "The capital of France is"
+    res = server.make_stream_request("POST", "/v1/completions", data={
+        "prompt": prompt,
+        "echo": True,
+        "logprobs": 3,
+        "max_tokens": 1,
+        "temperature": 0.0,
+        "stream": True,
+    })
+    chunks = list(res)
+    assert len(chunks) > 0
+


### PR DESCRIPTION
## Overview

Fixes #27174.

This PR enables support for `echo=true` combined with `logprobs=N` in the `/v1/completions` endpoint without triggering memory assertions or KV cache errors. Previously, the server ignored the `echo` setting for logprobs, returning an empty list for prompt tokens and breaking downstream evaluation frameworks like `lm-eval`.

## Additional information

### Motivation
Evaluation frameworks like `lm-eval` grade a model by feeding it a specific correct answer as a prompt and adding up the logprobs for those prompt tokens to calculate a total score[cite: 1]. Because prompt scores were missing, `lm-eval` received blanks and assumed the model was randomly guessing[cite: 1]. Furthermore, naive attempts to fix this caused a `GGML_ASSERT(n_outputs_max <= cparams.n_outputs_max)` hard abort on large prompts due to buffer overflow.

### Changes
* **Dynamic Capacity Query**: Expose `llama_n_outputs_max` in the core API (`include/llama.h` and `src/llama-context.cpp`) to safely query runtime output capacity.
* **Main Loop Chunking**: Integrate chunked prompt logprob extraction directly into the main prompt processing loop in `tools/server/server-context.cpp`.
* **Memory and Cache Safety**: Bound prompt token ingestion per iteration by `llama_n_outputs_max(ctx_tgt)` when `need_prompt_logits()` is true. This prevents output buffer overflow (fixing the hard abort) and ensures the KV cache timeline advances consecutively (fixing sequence inconsistency errors).
* **Zero VRAM Bloat**: Extract logprobs within existing memory limits without requiring extra startup VRAM allocation.
* **OAI JSON Formatting**: Correctly populate `token_logprobs` and `top_logprobs` for the echoed prompt tokens, ensuring the first prompt token explicitly returns `null`.

## Requirements

- [x] I have read and agree with the contributing guidelines (https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used AI to understand the code structure and data flow but wrote and fully understand the submitted logic myself.

**Co-author:** @simongonzalezdc