### PR TITLE
cli: honor -no-cnv by exiting after a predefined prompt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -269,6 +269,12 @@ llama_build_and_test(test-thread-safety.cpp ARGS -m "${MODEL_DEST}" -ngl 99 -p "
 set_tests_properties(test-thread-safety PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 llama_build_and_test(test-arg-parser.cpp)
+
+if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
+    llama_build_and_test(test-cli-no-cnv.cpp)
+    target_sources(test-cli-no-cnv PRIVATE ${PROJECT_SOURCE_DIR}/tools/cli/cli-params.cpp)
+    target_include_directories(test-cli-no-cnv PRIVATE ${PROJECT_SOURCE_DIR}/tools/cli)
+endif()
 llama_build_and_test(test-model-resolution.cpp)
 # the test serves its repos from an httplib server, and the library links it privately
 target_link_libraries(test-model-resolution PRIVATE cpp-httplib)

--- a/tests/test-cli-no-cnv.cpp
+++ b/tests/test-cli-no-cnv.cpp
@@ -1,0 +1,101 @@
+#include "arg.h"
+#include "cli-params.h"
+#include "common.h"
+
+#undef NDEBUG
+#include <cassert>
+
+static void test_cli_params_finalize(void) {
+    {
+        common_params params;
+        params.conversation_mode = COMMON_CONVERSATION_MODE_DISABLED;
+        params.prompt = "hello";
+        params.single_turn = false;
+
+        cli_params_finalize(params);
+
+        assert(params.single_turn);
+    }
+
+    {
+        common_params params;
+        params.conversation_mode = COMMON_CONVERSATION_MODE_DISABLED;
+        params.prompt.clear();
+        params.single_turn = false;
+
+        cli_params_finalize(params);
+
+        assert(!params.single_turn);
+    }
+
+    {
+        common_params params;
+        params.conversation_mode = COMMON_CONVERSATION_MODE_ENABLED;
+        params.prompt = "hello";
+        params.single_turn = false;
+
+        cli_params_finalize(params);
+
+        assert(!params.single_turn);
+    }
+
+    {
+        common_params params;
+        params.conversation_mode = COMMON_CONVERSATION_MODE_DISABLED;
+        params.prompt = "hello";
+        params.single_turn = true;
+
+        cli_params_finalize(params);
+
+        assert(params.single_turn);
+    }
+}
+
+static void test_cli_run_requires_prompt(void) {
+    {
+        common_params params;
+        params.conversation_mode = COMMON_CONVERSATION_MODE_DISABLED;
+        params.prompt.clear();
+
+        assert(cli_run_requires_prompt(params));
+    }
+
+    {
+        common_params params;
+        params.conversation_mode = COMMON_CONVERSATION_MODE_DISABLED;
+        params.prompt = "hello";
+
+        assert(!cli_run_requires_prompt(params));
+    }
+
+    {
+        common_params params;
+        params.conversation_mode = COMMON_CONVERSATION_MODE_ENABLED;
+        params.prompt.clear();
+
+        assert(!cli_run_requires_prompt(params));
+    }
+}
+
+static void test_cli_no_cnv_arg_parse(void) {
+    std::vector<std::string> argv = {"binary_name", "-m", "model.gguf", "-no-cnv", "-p", "hello"};
+    std::vector<char *> argv_ptr;
+    for (auto & arg : argv) {
+        argv_ptr.push_back(arg.data());
+    }
+
+    common_params params;
+    assert(common_params_parse(argv_ptr.size(), argv_ptr.data(), params, LLAMA_EXAMPLE_CLI));
+    assert(params.conversation_mode == COMMON_CONVERSATION_MODE_DISABLED);
+    assert(params.prompt == "hello");
+
+    cli_params_finalize(params);
+    assert(params.single_turn);
+}
+
+int main(void) {
+    test_cli_params_finalize();
+    test_cli_run_requires_prompt();
+    test_cli_no_cnv_arg_parse();
+    return 0;
+}

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -4,7 +4,8 @@ set(TARGET llama-cli-impl)
 
 add_library(${TARGET} cli.cpp
                       cli-client.cpp
-                      cli-context.cpp)
+                      cli-context.cpp
+                      cli-params.cpp)
 set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 target_include_directories(${TARGET} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ../server)

--- a/tools/cli/cli-context.cpp
+++ b/tools/cli/cli-context.cpp
@@ -412,6 +412,16 @@ bool cli_context::generate_completion(generated_content & content_out, cli_timin
 }
 
 int cli_context::run() {
+    const bool conversation = params.conversation_mode != COMMON_CONVERSATION_MODE_DISABLED;
+
+    if (!conversation && params.prompt.empty()) {
+        ui::show_error(
+            "non-conversation mode requires a prompt (-p)",
+            "omit -no-cnv/--no-conversation for interactive chat, or use llama-completion"
+        );
+        return 1;
+    }
+
     add_system_prompt();
 
     std::string modalities = "text";
@@ -438,23 +448,27 @@ int cli_context::run() {
     if (!params.system_prompt.empty()) {
         banner += "using custom system prompt\n";
     }
-    banner += "\n";
-    banner += "available commands:\n";
-    banner += "  /exit or Ctrl+C     stop or exit\n";
-    banner += "  /regen              regenerate the last response\n";
-    banner += "  /clear              clear the chat history\n";
-    banner += "  /read <file>        add a text file\n";
-    banner += "  /glob <pattern>     add text files using globbing pattern\n";
-    if (has_vision) {
-        banner += "  /image <file>       add an image file\n";
+    if (conversation) {
+        banner += "\n";
+        banner += "available commands:\n";
+        banner += "  /exit or Ctrl+C     stop or exit\n";
+        banner += "  /regen              regenerate the last response\n";
+        banner += "  /clear              clear the chat history\n";
+        banner += "  /read <file>        add a text file\n";
+        banner += "  /glob <pattern>     add text files using globbing pattern\n";
+        if (has_vision) {
+            banner += "  /image <file>       add an image file\n";
+        }
+        if (has_audio) {
+            banner += "  /audio <file>       add an audio file\n";
+        }
+        if (has_video) {
+            banner += "  /video <file>       add a video file\n";
+        }
+        banner += "\n";
+    } else {
+        banner += "\n";
     }
-    if (has_audio) {
-        banner += "  /audio <file>       add an audio file\n";
-    }
-    if (has_video) {
-        banner += "  /video <file>       add a video file\n";
-    }
-    banner += "\n";
 
     ui::show_message(banner);
 

--- a/tools/cli/cli-context.cpp
+++ b/tools/cli/cli-context.cpp
@@ -1,4 +1,5 @@
 #include "cli-context.h"
+#include "cli-params.h"
 #include "cli-ui.h"
 
 #include "arg.h"
@@ -414,7 +415,7 @@ bool cli_context::generate_completion(generated_content & content_out, cli_timin
 int cli_context::run() {
     const bool conversation = params.conversation_mode != COMMON_CONVERSATION_MODE_DISABLED;
 
-    if (!conversation && params.prompt.empty()) {
+    if (cli_run_requires_prompt(params)) {
         ui::show_error(
             "non-conversation mode requires a prompt (-p)",
             "omit -no-cnv/--no-conversation for interactive chat, or use llama-completion"

--- a/tools/cli/cli-params.cpp
+++ b/tools/cli/cli-params.cpp
@@ -1,0 +1,11 @@
+#include "cli-params.h"
+
+void cli_params_finalize(common_params & params) {
+    if (params.conversation_mode == COMMON_CONVERSATION_MODE_DISABLED && !params.prompt.empty()) {
+        params.single_turn = true;
+    }
+}
+
+bool cli_run_requires_prompt(const common_params & params) {
+    return params.conversation_mode == COMMON_CONVERSATION_MODE_DISABLED && params.prompt.empty();
+}

--- a/tools/cli/cli-params.h
+++ b/tools/cli/cli-params.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "common.h"
+
+// apply CLI-specific post-parse adjustments
+void cli_params_finalize(common_params & params);
+
+// non-conversation mode needs a predefined prompt
+bool cli_run_requires_prompt(const common_params & params);

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -3,6 +3,7 @@
 #include "log.h"
 
 #include "cli-context.h"
+#include "cli-params.h"
 
 #include <signal.h>
 
@@ -41,11 +42,7 @@ int llama_cli(int argc, char ** argv) {
         return 1;
     }
 
-    // -no-cnv disables interactive conversation mode (see tools/cli/README.md).
-    // Mirror llama-completion: with a predefined prompt, run one turn and exit.
-    if (params.conversation_mode == COMMON_CONVERSATION_MODE_DISABLED && !params.prompt.empty()) {
-        params.single_turn = true;
-    }
+    cli_params_finalize(params);
 
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
     struct sigaction sigint_action;

--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -41,6 +41,12 @@ int llama_cli(int argc, char ** argv) {
         return 1;
     }
 
+    // -no-cnv disables interactive conversation mode (see tools/cli/README.md).
+    // Mirror llama-completion: with a predefined prompt, run one turn and exit.
+    if (params.conversation_mode == COMMON_CONVERSATION_MODE_DISABLED && !params.prompt.empty()) {
+        params.single_turn = true;
+    }
+
 #if defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
     struct sigaction sigint_action;
     sigint_action.sa_handler = signal_handler;


### PR DESCRIPTION
## Overview

Fixes #27214

The new `llama-cli` accepted `-no-cnv` / `--no-conversation` but ignored `params.conversation_mode`, so scripted runs with `-p` generated once and then blocked at the interactive `>` prompt.

When `-no-cnv` is set and a prompt is provided, enable single-turn behavior and exit after generation (same as `-st`). When `-no-cnv` is used without a prompt, return a clear error instead of entering interactive chat. Hide the `/exit /regen /clear` banner in non-conversation mode.

## Additional information

Regression test: `tests/test-cli-no-cnv.cpp` (`ctest -R test-cli-no-cnv`)

Reproduced on Linux (CPU-only) with a small local GGUF:

```bash
llama-cli -m <tiny.gguf> -ngl 0 -no-cnv -p 'hello'
# exit 0, prints "Exiting..." (no hang)

llama-cli -m <tiny.gguf> -no-cnv
# exit 1: non-conversation mode requires a prompt (-p)
```

Issue repro (from #27214):

```bash
script -qec "llama-cli -hf ggml-org/Qwen3-0.6B-GGUF -ngl 0 -c 512 -n 8 --no-warmup -no-cnv -p '1+1='" /tmp/ts.txt
# before: blocks at >, killed by timeout
# after: exits cleanly
```

Changed files:
- `tools/cli/cli-params.cpp` - post-parse `-no-cnv` handling
- `tools/cli/cli-context.cpp` - error on `-no-cnv` without prompt; skip conversation banner
- `tests/test-cli-no-cnv.cpp` - regression test

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used AI for implementation, test, and local verification; I reviewed the changed lines and take responsibility for this PR.