### PR TITLE
fix(server): reject router load when preset has no model source

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -297,6 +297,23 @@ static std::filesystem::path get_server_exec_path() {
 #endif
 }
 
+static bool preset_has_model_source(const common_preset & preset) {
+    std::string val;
+    if (preset.get_option("LLAMA_ARG_MODEL", val) && !val.empty()) {
+        return true;
+    }
+    if (preset.get_option("LLAMA_ARG_MODEL_URL", val) && !val.empty()) {
+        return true;
+    }
+    if (preset.get_option("LLAMA_ARG_HF_REPO", val) && !val.empty()) {
+        return true;
+    }
+    if (preset.get_option("LLAMA_ARG_DOCKER_REPO", val) && !val.empty()) {
+        return true;
+    }
+    return false;
+}
+
 static void unset_reserved_args(common_preset & preset, bool unset_model_args) {
     preset.unset_option("LLAMA_ARG_SSL_KEY_FILE");
     preset.unset_option("LLAMA_ARG_SSL_CERT_FILE");
@@ -1015,6 +1032,11 @@ void server_models::load(const std::string & name, const load_options & opts) {
 
     if (inst.meta.port <= 0) {
         throw std::runtime_error("failed to get a port number");
+    }
+
+    if (opts.mode != SERVER_CHILD_MODE_DOWNLOAD && !preset_has_model_source(inst.meta.preset)) {
+        throw std::invalid_argument(
+            "model '" + name + "' has no model source (model, model-url, hf-repo, or docker-repo)");
     }
 
     inst.subproc = std::make_shared<server_subproc>();

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -366,6 +366,38 @@ def test_router_api_key_required():
     assert "error" not in authed.body
 
 
+def test_router_load_preset_without_model_source():
+    """POST /models/load rejects presets that do not specify a model source."""
+    global server
+
+    preset_path = os.path.join(TMP_DIR, "test_no_model_source.ini")
+
+    with open(preset_path, "w") as f:
+        f.write(
+            "[broken-model]\n"
+            "ctx-size = 512\n"
+        )
+
+    server.models_preset = preset_path
+    server.no_models_autoload = True
+    server.start()
+
+    try:
+        ids = _get_model_ids(is_reload=False)
+        assert "broken-model" in ids
+
+        load_res = server.make_request(
+            "POST", "/models/load", data={"model": "broken-model"}
+        )
+        assert load_res.status_code == 400
+        assert "error" in load_res.body
+        assert "no model source" in load_res.body["error"]["message"].lower()
+
+        _wait_for_model_status("broken-model", {"unloaded"}, timeout=5)
+    finally:
+        os.remove(preset_path)
+
+
 def test_router_reload_models():
     """POST /models/reload re-reads the INI preset and updates the model list."""
     global server


### PR DESCRIPTION
## Summary

- Validate router model presets before spawning a child `llama-server` process
- Return HTTP 400 with a clear error when a preset lacks `model`, `model-url`, `hf-repo`, or `docker-repo`
- Skip validation for download mode (repo is supplied via `LLAMA_ARG_HF_REPO` env)

Fixes #27351

## Problem

Loading a preset without a model source returned `{"success": true}` and spawned a child in router mode with no model, leaving the model stuck in `loading` state.

## Test plan

- [x] Manual repro: `POST /models/load` on a preset without model source returns 400
- [x] Added `test_router_load_preset_without_model_source` in `tools/server/tests/unit/test_router.py`
- [x] Verified download mode path is unchanged (validation skipped when `SERVER_CHILD_MODE_DOWNLOAD`)