### PR TITLE
vulkan: double the K-quant int-mmq large tile on RDNA3 iGPUs

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4287,6 +4287,7 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         s_warptile_mmqid_int_k = { mul_mat_subgroup_size_32, 32,  32, 32, s_warptile_wm,                32, 1, 2, 1, 1, mul_mat_subgroup_size_16 };
 
         // chip specific tuning
+        bool gfx1151_mmq_k_tile = false;
         if ((device->architecture == AMD_GCN) && (device->driver_id != vk::DriverId::eAmdProprietary)) {
             m_warptile_mmq = m_warptile_mmq_int = { 256, 64, 64, 32, 16, 16, 2, 2, 2, 1, 16 };
             m_warptile_mmqid = m_warptile_mmqid_int = { 256, 64, 64, 32, 16, 16, 2, 2, 2, 1, 16 };
@@ -4295,6 +4296,19 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
             l_warptile = { 256, 128, 128, 16, subgroup_size_8, 64, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq = l_warptile_mmq_int = { 256, 128, 128, 32, subgroup_size_8, 64, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
             l_warptile_mmq_int_k = { 256, 128, 128, 32, subgroup_size_16, 64, 1, 4, 2, 1, subgroup_size_16 };
+
+            // RDNA3 iGPU (gfx1151-class, e.g. Radeon 8060S): the stock 128x128 large
+            // tile at 256 threads underfills the shader cores at dense prefill shapes
+            // and re-reads the A weights once per 128-token slab. Doubling only BN and
+            // the thread count keeps the per-thread register tiling identical while
+            // halving the A re-reads per token: measured ~1.8x prompt processing on
+            // Qwen3.8-27B Q5_K_XL (pp4096, -ub 2048), tg128 unchanged, greedy outputs
+            // byte-identical. Decode and verify batches (n <= 64) select the small or
+            // medium tile and are unaffected.
+            gfx1151_mmq_k_tile = device->architecture == AMD_RDNA3 && device->uma;
+            if (gfx1151_mmq_k_tile) {
+                l_warptile_mmq_int_k = { 512, 128, 256, 32, subgroup_size_16, 64, 1, 4, 2, 1, subgroup_size_16 };
+            }
         } else if (device->vendor_id == VK_VENDOR_ID_INTEL && device->coopmat_support) {
             // Xe2/Xe3 with coopmat enabled - warptile performance tuning
             l_warptile = { 512, 128, 128, 16, subgroup_size_8, 32, 2, tm_m, tn_m, tk_m, subgroup_size_8 };
@@ -4304,6 +4318,10 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
         l_mmq_wg_denoms = l_wg_denoms = {128, 128, 1 };
         m_mmq_wg_denoms = m_wg_denoms = { 64,  64, 1 };
         s_mmq_wg_denoms = s_wg_denoms = { 32,  32, 1 };
+        // keep the dispatch grid in sync with the 128x256 gfx1151 tile above
+        if (gfx1151_mmq_k_tile) {
+            l_mmq_wg_denoms = { 128, 256, 1 };
+        }
         l_align = 128;
         m_align =  64;
         s_align =  32;


### PR DESCRIPTION
Implements #27553.

The integer-dot mmq path picks its large tile when both matmul dims exceed 64, which is every big GEMM in a dense-model prefill. On RDNA3 iGPUs (gfx1151-class, e.g. Radeon 8060S) the stock 128x128 tile at 256 threads underfills the shader cores at prefill shapes and re-reads the A weights once per 128-token slab; doubling only BN and the thread count keeps the per-thread register tiling identical while halving the A re-reads per token. No shader changes; `wg_denoms` kept in sync so dispatch and split-k see the real tile.

Qwen3.8-27B UD-Q5_K_XL-v2, RADV, `-fa 1 -b/-ub 2048`, same-binary stash A/B, r=5:

| test | stock | 128x256@512 | gain |
|---|---|---|---|
| pp512 | 294.5 ±6.4 | 517.0 ±3.4 | 1.76x |
| pp4096 | 249.6 ±0.2 | 436.7 ±0.8 | 1.75x |
| pp16384 | 216.1 ±0.4 | 333.2 ±1.7 | 1.54x |
| tg128 | 10.76 | 10.82 | unchanged |

Also measured (r=3, pp4096): Q4_K_XL 465.1 ±0.8, Q6_K_XL 411.8 ±1.3 with the new tile.

Correctness and scope:
- Greedy outputs byte-identical (temp 0, diffed, `-n 120`).
- Decode and speculative-verify batches (n ≤ 64) select the small/medium tile and are structurally unaffected — verified with an MTP/DFlash2 spec-decode serving config: 28.7 t/s average decode at 64% draft acceptance, no regression vs baseline.
- Gated to `AMD RDNA3 && device->uma`; discrete GPUs, other vendors, and all `mul_mat_id` (MoE) tile families untouched.
- Neutral probes on this hardware: BM=256, 1024 threads, TM/TN/WMITER reshapings, wave32. The coopmat dequant family (iq4_xs path) measurably dislikes the doubled tile and stays stock.