### PR TITLE
HIP: Expand Q5_K and Q6_K tile widths for RDNA2

### DIFF
--- a/ggml/src/ggml-cuda/mmq-config-rdna2.cuh
+++ b/ggml/src/ggml-cuda/mmq-config-rdna2.cuh
@@ -125,6 +125,7 @@ static constexpr __host__ __device__ ggml_cuda_mmq_config ggml_cuda_mmq_get_conf
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  16, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  32, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  64, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, true);
+    CASE(GGML_TYPE_Q5_K, 256, 2, 128,  128, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,   8, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  16, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  24, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
@@ -132,11 +133,16 @@ static constexpr __host__ __device__ ggml_cuda_mmq_config ggml_cuda_mmq_get_conf
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  40, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  48, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q5_K, 256, 2, 128,  64, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q5_K, 256, 2, 128,  80, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q5_K, 256, 2, 128,  96, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q5_K, 256, 2, 128,  112, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q5_K, 256, 2, 128,  128, GGML_CUDA_MMQ_SRAM_LAYOUT_Q8_1, MMQ_ITER_K, false, false);
 
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,   8, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  16, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  32, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  64, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, true);
+    CASE(GGML_TYPE_Q6_K, 256, 2, 128,  128, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, true);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,   8, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  16, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  24, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
@@ -144,6 +150,10 @@ static constexpr __host__ __device__ ggml_cuda_mmq_config ggml_cuda_mmq_get_conf
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  40, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  48, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
     CASE(GGML_TYPE_Q6_K, 256, 2, 128,  64, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q6_K, 256, 2, 128,  80, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q6_K, 256, 2, 128,  96, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q6_K, 256, 2, 128,  112, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
+    CASE(GGML_TYPE_Q6_K, 256, 2, 128,  128, GGML_CUDA_MMQ_SRAM_LAYOUT_Q6_K, MMQ_ITER_K, false, false);
 
 // ---------------------------------------------------------------------------------------------
 

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1475,6 +1475,17 @@ void mul_mat_q_switch_J(ggml_backend_cuda_context & ctx, const mmq_args & args, 
     int J_best        = 0;
     int ntiles_J_best = INT_MAX;
 
+    // The grid's y-dimension tiles the columns of each z-slice. For dense GEMM
+    // every z-slice spans the full ncols_max columns, but for MoE (ids_dst) the
+    // columns are the per-expert routed slots, averaging ncols_dst/nchannels_y.
+    // Selecting J from ncols_max for MoE over-provisions the column tile and, once
+    // J exceeds the per-expert width, wastes a full J-wide compute per tile. Use
+    // the per-channel width for selection only; the launch grid still uses
+    // ncols_max, which is a safe upper bound on any single expert's slots.
+    const int64_t ncols_sel = (GGML_CUDA_CC_IS_RDNA2(cc) && args.ids_dst != nullptr)
+        ? std::max<int64_t>(1, args.ncols_dst / args.nchannels_y)
+        : args.ncols_max;
+
     for (int J = 8; J <= 128 && ntiles_J_best > 1; J += 8) {
         const ggml_cuda_mmq_config config = ggml_cuda_mmq_get_config(type, J, fallback, cc);
         if (config.type == GGML_TYPE_COUNT) {
@@ -1485,7 +1496,7 @@ void mul_mat_q_switch_J(ggml_backend_cuda_context & ctx, const mmq_args & args, 
             continue;
         }
 
-        const int ntiles_x = (args.ncols_max + config.J - 1) / config.J;
+        const int ntiles_x = (ncols_sel + config.J - 1) / config.J;
 
         if (ntiles_x < ntiles_J_best) {
             J_best = J;


### PR DESCRIPTION
## Overview

I recently performed a tile sweep of the RDNA2 config to see if there were any easy performance wins. Most of the config is optimal as is, however Q6_K and Q5_K see a noticeable performance increase by allowing J=128. The intermediate values do not seem to have an impact in benchmarks but were added for consistency.

## Additional information

Test results from my Radeon Pro V620 on ROCm 7.14. I'm seeing up to 11.5% increase for Q6_K and up to 7.5% for Q5_K for classic quants. In my test of Qwen 3.8 27B, which is a more realistic mixed quant, I still see up to 8% increase. All test ops pass. Will post perplexity if requested.

Note that the small classic quants experience regression at pp128, while the larger mixed qwen model does not. I think this is an acceptable trade off but subject to debate and possible fixes.

**Master**
<details>
<summary>llama 8B Q5_K</summary>

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |           pp128 |      1217.14 ± 58.55 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |           pp256 |      1394.38 ± 18.03 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |           pp512 |      1461.10 ± 10.38 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |          pp1024 |       1441.81 ± 1.81 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |          pp2048 |       1399.76 ± 1.66 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |   pp128 @ d8192 |       892.67 ± 19.68 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |   pp256 @ d8192 |       981.11 ± 11.19 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |   pp512 @ d8192 |       1014.52 ± 6.15 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |  pp1024 @ d8192 |       1003.50 ± 0.28 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |  pp2048 @ d8192 |        982.25 ± 0.14 |

</details>

<details>
<summary>llama 8B Q6_K</summary>

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |           pp128 |      1041.73 ± 42.84 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |           pp256 |      1185.40 ± 13.33 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |           pp512 |       1244.74 ± 7.40 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |          pp1024 |       1232.88 ± 0.70 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |          pp2048 |       1204.22 ± 0.54 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |   pp128 @ d8192 |       794.21 ± 15.83 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |   pp256 @ d8192 |        872.66 ± 8.86 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |   pp512 @ d8192 |        906.13 ± 4.86 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |  pp1024 @ d8192 |        898.25 ± 0.25 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |  pp2048 @ d8192 |        882.34 ± 0.24 |

</details>

<details>
<summary>qwen35 27B Q6_K</summary>

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |           pp128 |       316.77 ± 16.41 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |           pp256 |        361.67 ± 8.22 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |           pp512 |        384.91 ± 4.38 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |          pp1024 |        383.11 ± 0.58 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |          pp2048 |        379.06 ± 0.25 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |   pp128 @ d8192 |       294.31 ± 10.80 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |   pp256 @ d8192 |        330.28 ± 6.64 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |   pp512 @ d8192 |        350.67 ± 3.75 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |  pp1024 @ d8192 |        350.74 ± 0.06 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |  pp2048 @ d8192 |        348.68 ± 0.04 |

</details>

**Branch**
<details>
<summary>llama 8B Q5_K</summary>

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |           pp128 |      1072.40 ± 49.93 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |           pp256 |      1451.47 ± 20.40 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |           pp512 |      1572.89 ± 11.40 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |          pp1024 |       1548.65 ± 1.66 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |          pp2048 |       1498.85 ± 1.44 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |   pp128 @ d8192 |       802.70 ± 18.99 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |   pp256 @ d8192 |      1010.06 ± 11.85 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |   pp512 @ d8192 |       1067.26 ± 7.07 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |  pp1024 @ d8192 |       1053.09 ± 0.20 |
| llama 8B Q5_K - Small          |   5.21 GiB |     8.03 B | ROCm       |  -1 |  pp2048 @ d8192 |       1029.58 ± 0.63 |

</details>

<details>
<summary>llama 8B Q6_K</summary>

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |           pp128 |       961.02 ± 39.37 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |           pp256 |      1279.67 ± 15.06 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |           pp512 |       1393.37 ± 9.35 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |          pp1024 |       1378.50 ± 0.57 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |          pp2048 |       1341.89 ± 0.52 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |   pp128 @ d8192 |       746.54 ± 14.00 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |   pp256 @ d8192 |       924.78 ± 10.28 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |   pp512 @ d8192 |        983.12 ± 5.51 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |  pp1024 @ d8192 |        973.56 ± 0.17 |
| llama 8B Q6_K                  |   6.14 GiB |     8.03 B | ROCm       |  -1 |  pp2048 @ d8192 |        954.36 ± 0.44 |

</details>

<details>
<summary>qwen35 27B Q6_K</summary>

| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |           pp128 |       324.60 ± 16.70 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |           pp256 |        380.59 ± 9.04 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |           pp512 |        414.32 ± 5.16 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |          pp1024 |        413.37 ± 0.40 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |          pp2048 |        409.68 ± 0.30 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |   pp128 @ d8192 |       302.18 ± 11.44 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |   pp256 @ d8192 |        348.23 ± 7.55 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |   pp512 @ d8192 |        376.80 ± 4.44 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |  pp1024 @ d8192 |        376.86 ± 0.05 |
| qwen35 27B Q6_K                |  21.49 GiB |    27.32 B | ROCm       |  -1 |  pp2048 @ d8192 |        374.57 ± 0.07 |

</details>

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was use to understand the codebase and write the automated sweep script. Final code was written by me.