### PR TITLE
metal: fix flash-attention unroll heuristic at DK=512

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.metal
+++ b/ggml/src/ggml-metal/ggml-metal.metal
@@ -6820,7 +6820,10 @@ void kernel_flash_attn_ext_impl(
                         q8x8_t mq[2];
 
                         // note: too much unroll can tank the performance for large heads
-                        #pragma unroll (MIN(DK8/2, 4*NSG))
+                        // the original guard was `#pragma unroll (MIN(DK8/2, 4*NSG))`, but NSG is a
+                        // template parameter and the host picks nsg=8 for DK=512, so the MIN folds to
+                        // 32 - a 32x unroll of the DK loop. Cap it at 4.
+                        #pragma unroll (DK8/2 > 8 ? 4 : DK8/2)
                         for (short i = 0; i < DK8/2; ++i) {
                             simdgroup_barrier(mem_flags::mem_none);
 


### PR DESCRIPTION
The tiled flash-attention kernel guarded its DK loop with

    #pragma unroll (MIN(DK8/2, 4*NSG))

NSG is a template parameter, so the expression folds at compile time. For a DK=512 MLA model the host picks nsg=8, giving MIN(32, 32) = 32 - the loop is unrolled 32x. The resulting kernel spills and costs 3.97x.

Cap the unroll at 4. Affects any model with head_dim 512 on Metal, which is every DeepSeek MLA checkpoint.

Measured prefill: +20% at 4.3k, +60% at 16k, +90% at 32k context. Decode is unaffected (it uses the vec kernel). 3883 test-backend-ops cases pass and generated output is identical.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
