### PR TITLE
speculative: cap the draft context batch instead of inheriting the target's

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2396,6 +2396,21 @@ common_speculative_init_result::common_speculative_init_result(
     cparams.n_rs_seq  = 0;
     cparams.ctx_other = ctx_tgt;
 
+    // the draft context inherits the target's n_batch/n_ubatch, but a drafter only submits
+    // n_seq*(n_max+1) tokens when drafting, and chunks prompt processing by n_ubatch anyway.
+    // for a small drafter the oversized compute buffer does not matter, but a DFlash/DSpark
+    // drafter is an MoE model (3 blocks x 256 experts) where buffers sized for the target's
+    // batch cost GBs - memory the target's expert cache needs.
+    {
+        const uint32_t n_batch_dft = 512; // >= n_seq*(n_max+1) for any supported block size
+        if (cparams.n_batch > n_batch_dft) {
+            cparams.n_batch = n_batch_dft;
+        }
+        if (cparams.n_ubatch > n_batch_dft) {
+            cparams.n_ubatch = n_batch_dft;
+        }
+    }
+
     std::string model_path;
     if (has_draft) {
         model_path = params.speculative.draft.mparams.path;


### PR DESCRIPTION
common_base_params_to_speculative copies the target's n_batch/n_ubatch into the draft params and never reduces them. The draft context then sizes its compute buffers for the target's batch (4096 here) even though the same function computes that a block drafter emits only n_max + 1 tokens.

For a small drafter this waste is negligible, which is what the existing comment above assumes. A DFlash/DSpark drafter is an MoE model - 3 blocks of 256 experts - so the oversized buffers cost 4-6 GB: a 7.2 GB Q2_K drafter held 11-13 GB resident.

On a 64 GB M1 Max that memory comes out of the MoE expert cache. Before this, DeepSeek-V4-Flash at --moe-stream-cache 38 plus the drafter thrashed (1.2 GB swap, prefill timed out); after, prefill is 86.3 t/s and the config runs.

Safe because drafting submits n_seq*(n_max+1) tokens - at most 17 for any supported block size - and prompt processing already chunks by n_ubatch in common_speculative_impl_draft_dflash::process().

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
