### PR TITLE
reasoning-budget: opt-in soft wrap-up hint and bounded grace with hard termination cap

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3694,6 +3694,30 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET_MESSAGE"));
     add_opt(common_arg(
+        {"--reasoning-budget-soft-ratio"}, "N",
+        "fraction of the reasoning budget after which a one-time soft wrap-up hint may be injected, 0 < N <= 1 (default: -1 = disabled)",
+        [](common_params & params, const std::string & value) {
+            const float ratio = std::stof(value);
+            if (ratio != -1.0f && (ratio <= 0.0f || ratio > 1.0f)) { throw std::invalid_argument("invalid value"); }
+            params.sampling.reasoning_budget_soft_ratio = ratio;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET_SOFT_RATIO"));
+    add_opt(common_arg(
+        {"--reasoning-budget-soft-message"}, "MESSAGE",
+        "wrap-up hint injected once near a line boundary after the soft ratio of the reasoning budget is consumed (default: none)",
+        [](common_params & params, const std::string & value) {
+            params.sampling.reasoning_budget_soft_message = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET_SOFT_MESSAGE"));
+    add_opt(common_arg(
+        {"--reasoning-budget-grace-tokens"}, "N",
+        "extra tokens allowed past the reasoning budget before the end sequence is forced; natural ends and paragraph boundaries inside the grace region are respected (default: 0)",
+        [](common_params & params, int value) {
+            if (value < 0) { throw std::invalid_argument("invalid value"); }
+            params.sampling.reasoning_budget_grace_tokens = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET_GRACE_TOKENS"));
+    add_opt(common_arg(
         {"--reasoning-preserve"},
         {"--no-reasoning-preserve"},
         "preserve reasoning trace in the full history, not just the last assistant message (default: template default)\n"

--- a/common/common.h
+++ b/common/common.h
@@ -292,6 +292,11 @@ struct common_params_sampling {
     std::string               reasoning_budget_message;        // message injected before end tag when budget exhausted
     bool                      reasoning_control = false;       // create the budget sampler on demand so reasoning can be ended at runtime
 
+    // soft reasoning-budget guidance (local patch; no-op unless reasoning_budget_tokens > 0)
+    float       reasoning_budget_soft_ratio   = -1.0f; // fraction of the budget after which the soft message may be injected; < 0 or > 1 disables
+    std::string reasoning_budget_soft_message;         // wrap-up hint injected once near a line boundary after the soft threshold
+    int32_t     reasoning_budget_grace_tokens = 0;     // extra tokens allowed past the budget before the end sequence is forced
+
     bool backend_sampling = false;
 
     // print the parameters into a string

--- a/common/reasoning-budget.cpp
+++ b/common/reasoning-budget.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <climits>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -65,6 +66,14 @@ struct common_reasoning_budget_ctx {
     size_t force_pos;         // next position in forced_tokens to force
 
     int32_t end_match;        // index into end_matcher.seqs of the sequence that transitioned to DONE, -1 if none
+
+    // local soft-budget extension
+    int32_t    soft_threshold; // consumed-token count at which the soft message may fire; <= 0 disables
+    llama_tokens soft_tokens;  // tokenized soft wrap-up message
+    bool       soft_fired;     // the soft warning fires at most once per reasoning block
+    size_t     soft_force_pos; // next position in soft_tokens to force
+    int32_t    grace_total;    // grace tokens allowed past the budget; 0 disables grace
+    int32_t    grace_used;     // tokens consumed inside the grace region
 };
 
 static const char * common_reasoning_budget_name(const struct llama_sampler * /*smpl*/) {
@@ -80,6 +89,8 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
             if (ctx->start_matcher.advance(token) >= 0) {
                 ctx->state = REASONING_BUDGET_COUNTING;
                 ctx->remaining = ctx->budget;
+                ctx->soft_fired = false;
+                ctx->grace_used = 0;
                 COM_TRC("activated, budget=%d tokens\n", ctx->budget);
 
                 if (ctx->remaining <= 0) {
@@ -91,8 +102,12 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
             break;
         }
         case REASONING_BUDGET_COUNTING:
+        case REASONING_BUDGET_SOFT_PENDING:
+        case REASONING_BUDGET_HARD_PENDING:
         case REASONING_BUDGET_WAITING_UTF8:
         {
+            // a natural reasoning end always takes precedence over any
+            // soft/hard budget intervention
             const int32_t match = ctx->end_matcher.advance(token);
             if (match >= 0) {
                 ctx->state = REASONING_BUDGET_DONE;
@@ -102,8 +117,9 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
             }
 
             bool utf8_complete = true;
+            std::string piece;
             if (ctx->vocab != nullptr) {
-                const std::string piece = common_token_to_piece(ctx->vocab, token, false);
+                piece = common_token_to_piece(ctx->vocab, token, false);
                 utf8_complete = common_utf8_is_complete(piece);
             }
 
@@ -114,20 +130,97 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
                     ctx->end_matcher.reset();
                     COM_TRC("%s", "UTF-8 complete, now forcing end sequence\n");
                 }
-            } else if (ctx->state == REASONING_BUDGET_COUNTING) {
-                ctx->remaining--;
-                if (ctx->remaining <= 0) {
+                break;
+            }
+
+            if (ctx->state == REASONING_BUDGET_HARD_PENDING) {
+                // bounded grace region: accept a natural close (checked above),
+                // close safely at a paragraph boundary, or force once the
+                // grace tokens are exhausted; grace never grows unbounded
+                ctx->grace_used++;
+                const bool paragraph = piece.find("\n\n") != std::string::npos;
+                if (utf8_complete && paragraph) {
+                    ctx->state = REASONING_BUDGET_FORCING;
+                    ctx->force_pos = 0;
+                    ctx->end_matcher.reset();
+                    COM_TRC("grace paragraph boundary at token %d, forcing end sequence\n", ctx->grace_used);
+                } else if (ctx->grace_used >= ctx->grace_total) {
                     if (utf8_complete) {
                         ctx->state = REASONING_BUDGET_FORCING;
                         ctx->force_pos = 0;
                         ctx->end_matcher.reset();
-                        COM_TRC("%s", "budget exhausted, forcing end sequence\n");
+                        COM_TRC("%s", "grace exhausted, forcing end sequence\n");
                     } else {
                         ctx->state = REASONING_BUDGET_WAITING_UTF8;
                         ctx->end_matcher.reset();
-                        COM_TRC("%s", "budget exhausted, waiting for UTF-8 completion\n");
+                        COM_TRC("%s", "grace exhausted, waiting for UTF-8 completion\n");
                     }
                 }
+                break;
+            }
+
+            // COUNTING / SOFT_PENDING still consume the nominal budget
+            ctx->remaining--;
+            if (ctx->remaining <= 0) {
+                if (ctx->grace_total > 0) {
+                    ctx->state = REASONING_BUDGET_HARD_PENDING;
+                    ctx->grace_used = 0;
+                    COM_TRC("budget exhausted, entering bounded grace region (%d tokens)\n", ctx->grace_total);
+                } else if (utf8_complete) {
+                    ctx->state = REASONING_BUDGET_FORCING;
+                    ctx->force_pos = 0;
+                    ctx->end_matcher.reset();
+                    COM_TRC("%s", "budget exhausted, forcing end sequence\n");
+                } else {
+                    ctx->state = REASONING_BUDGET_WAITING_UTF8;
+                    ctx->end_matcher.reset();
+                    COM_TRC("%s", "budget exhausted, waiting for UTF-8 completion\n");
+                }
+                break;
+            }
+
+            // one-shot soft warning once the configured fraction of the
+            // budget has been consumed; injected at a line boundary so the
+            // message never splits an arbitrary token sequence
+            if (ctx->state == REASONING_BUDGET_COUNTING
+                    && !ctx->soft_fired
+                    && ctx->soft_threshold > 0
+                    && (ctx->budget - ctx->remaining) >= ctx->soft_threshold) {
+                ctx->soft_fired = true;
+                const bool boundary = (ctx->vocab == nullptr)
+                    || piece.find('\n') != std::string::npos;
+                if (!ctx->soft_tokens.empty() && boundary && utf8_complete) {
+                    ctx->state = REASONING_BUDGET_SOFT_FORCING;
+                    ctx->soft_force_pos = 0;
+                    COM_TRC("%s", "soft threshold reached at a line boundary, injecting wrap-up message\n");
+                } else if (!ctx->soft_tokens.empty()) {
+                    ctx->state = REASONING_BUDGET_SOFT_PENDING;
+                    COM_TRC("%s", "soft threshold reached, waiting for a line boundary\n");
+                } else {
+                    COM_TRC("%s", "soft threshold reached, no soft message configured\n");
+                }
+                break;
+            }
+
+            if (ctx->state == REASONING_BUDGET_SOFT_PENDING) {
+                const bool boundary = (ctx->vocab == nullptr)
+                    || piece.find('\n') != std::string::npos;
+                if (boundary && utf8_complete) {
+                    ctx->state = REASONING_BUDGET_SOFT_FORCING;
+                    ctx->soft_force_pos = 0;
+                    COM_TRC("%s", "line boundary after soft threshold, injecting wrap-up message\n");
+                }
+            }
+            break;
+        }
+        case REASONING_BUDGET_SOFT_FORCING:
+        {
+            // force the soft wrap-up message token-by-token, then resume
+            // normal counting; the natural end sequence stays armed
+            ctx->soft_force_pos++;
+            if (ctx->soft_force_pos >= ctx->soft_tokens.size()) {
+                ctx->state = REASONING_BUDGET_COUNTING;
+                COM_TRC("%s", "soft message complete, resuming counting\n");
             }
             break;
         }
@@ -149,6 +242,8 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
             if (ctx->start_matcher.advance(token) >= 0) {
                 ctx->state = REASONING_BUDGET_COUNTING;
                 ctx->remaining = ctx->budget;
+                ctx->soft_fired = false;
+                ctx->grace_used = 0;
                 ctx->end_matcher.reset();
                 ctx->end_match = -1;
                 COM_TRC("re-activated on new start tag, budget=%d tokens\n", ctx->budget);
@@ -165,6 +260,22 @@ static void common_reasoning_budget_accept(struct llama_sampler * smpl, llama_to
 
 static void common_reasoning_budget_apply(struct llama_sampler * smpl, llama_token_data_array * cur_p) {
     auto * ctx = (common_reasoning_budget_ctx *) smpl->ctx;
+
+    if (ctx->state == REASONING_BUDGET_SOFT_FORCING) {
+        if (ctx->soft_force_pos >= ctx->soft_tokens.size()) {
+            return;
+        }
+
+        const llama_token forced = ctx->soft_tokens[ctx->soft_force_pos];
+
+        // set all logits to -inf except the forced token
+        for (size_t i = 0; i < cur_p->size; i++) {
+            if (cur_p->data[i].id != forced) {
+                cur_p->data[i].logit = -INFINITY;
+            }
+        }
+        return;
+    }
 
     if (ctx->state != REASONING_BUDGET_FORCING) {
         // passthrough — don't modify logits
@@ -193,12 +304,15 @@ static void common_reasoning_budget_reset(struct llama_sampler * smpl) {
     ctx->end_matcher.reset();
     ctx->force_pos = 0;
     ctx->end_match = -1;
+    ctx->soft_fired = false;
+    ctx->grace_used = 0;
 }
 
 static struct llama_sampler * common_reasoning_budget_init_state(
         const struct llama_vocab * vocab, const std::vector<llama_tokens> & start_seqs,
         const std::vector<llama_tokens> & end_seqs, const llama_tokens & forced_tokens,
-        int32_t budget, common_reasoning_budget_state initial_state);
+        int32_t budget, common_reasoning_budget_state initial_state,
+        float soft_ratio, const llama_tokens & soft_tokens, int32_t grace_tokens);
 
 static struct llama_sampler * common_reasoning_budget_clone(const struct llama_sampler * smpl);
 
@@ -236,24 +350,44 @@ static struct llama_sampler * common_reasoning_budget_init_state(
         const std::vector<llama_tokens> & end_seqs,
         const llama_tokens              & forced_tokens,
         int32_t                           budget,
-        common_reasoning_budget_state     initial_state) {
+        common_reasoning_budget_state     initial_state,
+        float                             soft_ratio,
+        const llama_tokens              & soft_tokens,
+        int32_t                           grace_tokens) {
     // promote COUNTING with budget <= 0 to FORCING
     if (initial_state == REASONING_BUDGET_COUNTING && budget <= 0) {
         initial_state = REASONING_BUDGET_FORCING;
     }
 
+    // soft guidance only applies to a finite positive budget; invalid ratios
+    // disable the feature instead of producing surprising behavior
+    int32_t soft_threshold = 0;
+    if (budget > 0 && budget != INT_MAX
+            && soft_ratio > 0.0f && soft_ratio <= 1.0f) {
+        soft_threshold = (int32_t) std::ceil(budget * (double) soft_ratio);
+        if (soft_threshold >= budget) {
+            soft_threshold = 0; // would never fire before the hard budget
+        }
+    }
+
     return llama_sampler_init(
         /* .iface = */ &common_reasoning_budget_i,
         /* .ctx   = */ new common_reasoning_budget_ctx {
-            /* .vocab         = */ vocab,
-            /* .start_matcher = */ token_matcher(start_seqs),
-            /* .end_matcher   = */ token_matcher(end_seqs),
-            /* .forced_tokens = */ forced_tokens,
-            /* .budget        = */ budget,
-            /* .remaining     = */ budget,
-            /* .state         = */ initial_state,
-            /* .force_pos     = */ 0,
-            /* .end_match     = */ -1,
+            /* .vocab          = */ vocab,
+            /* .start_matcher  = */ token_matcher(start_seqs),
+            /* .end_matcher    = */ token_matcher(end_seqs),
+            /* .forced_tokens  = */ forced_tokens,
+            /* .budget         = */ budget,
+            /* .remaining      = */ budget,
+            /* .state          = */ initial_state,
+            /* .force_pos      = */ 0,
+            /* .end_match      = */ -1,
+            /* .soft_threshold = */ soft_threshold,
+            /* .soft_tokens    = */ soft_tokens,
+            /* .soft_fired     = */ false,
+            /* .soft_force_pos = */ 0,
+            /* .grace_total    = */ grace_tokens > 0 ? grace_tokens : 0,
+            /* .grace_used     = */ 0,
         }
     );
 }
@@ -264,8 +398,12 @@ struct llama_sampler * common_reasoning_budget_init(
         const std::vector<llama_tokens> & end_seqs,
         const llama_tokens              & forced_tokens,
         int32_t                           budget,
-        common_reasoning_budget_state     initial_state) {
-    return common_reasoning_budget_init_state(vocab, start_seqs, end_seqs, forced_tokens, budget, initial_state);
+        common_reasoning_budget_state     initial_state,
+        float                             soft_ratio,
+        const llama_tokens              & soft_tokens,
+        int32_t                           grace_tokens) {
+    return common_reasoning_budget_init_state(vocab, start_seqs, end_seqs, forced_tokens, budget, initial_state,
+            soft_ratio, soft_tokens, grace_tokens);
 }
 
 common_reasoning_budget_state common_reasoning_budget_get_state(const struct llama_sampler * smpl) {

--- a/common/reasoning-budget.h
+++ b/common/reasoning-budget.h
@@ -8,11 +8,15 @@
 #include <vector>
 
 enum common_reasoning_budget_state {
-    REASONING_BUDGET_IDLE,         // waiting for start sequence
-    REASONING_BUDGET_COUNTING,     // counting down tokens
-    REASONING_BUDGET_FORCING,      // forcing budget message + end sequence
-    REASONING_BUDGET_WAITING_UTF8, // budget exhausted, waiting for UTF-8 completion
-    REASONING_BUDGET_DONE,         // passthrough forever
+    REASONING_BUDGET_IDLE,          // waiting for start sequence
+    REASONING_BUDGET_COUNTING,      // counting down tokens
+    REASONING_BUDGET_FORCING,       // forcing budget message + end sequence
+    REASONING_BUDGET_WAITING_UTF8,  // budget exhausted, waiting for UTF-8 completion
+    REASONING_BUDGET_DONE,          // passthrough forever
+    // local soft-budget extension (only reachable when soft_ratio/grace are configured)
+    REASONING_BUDGET_SOFT_PENDING,  // soft threshold reached, waiting for a line boundary
+    REASONING_BUDGET_SOFT_FORCING,  // forcing the soft wrap-up message, then back to COUNTING
+    REASONING_BUDGET_HARD_PENDING,  // budget exhausted, bounded grace region before forced end
 };
 
 // Creates a reasoning budget sampler that limits token generation inside a
@@ -39,7 +43,11 @@ struct llama_sampler * common_reasoning_budget_init(
         const std::vector<llama_tokens> & end_seqs,
         const llama_tokens              & forced_tokens,
         int32_t                           budget,
-        common_reasoning_budget_state     initial_state = REASONING_BUDGET_IDLE);
+        common_reasoning_budget_state     initial_state = REASONING_BUDGET_IDLE,
+        // local soft-budget extension: defaults keep exact upstream behavior
+        float                             soft_ratio   = -1.0f, // fraction of budget for the soft warning; <= 0 or > 1 disables
+        const llama_tokens              & soft_tokens  = {},    // tokenized soft wrap-up message (injected once, near a line boundary)
+        int32_t                           grace_tokens = 0);    // extra tokens allowed past the budget before forced termination
 
 common_reasoning_budget_state common_reasoning_budget_get_state(const struct llama_sampler * smpl);
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -309,12 +309,23 @@ struct common_sampler * common_sampler_init(
 
     // reasoning budget sampler (skip when budget is unlimited unless a lazy grammar is active, which needs rbudget for thinking-block suppression)
     if (!params.reasoning_budget_start.empty() && !params.reasoning_budget_end.empty() && (params.grammar_lazy || params.reasoning_budget_tokens >= 0 || params.reasoning_control)) {
+        // local soft-budget extension: tokenize the wrap-up hint once up front
+        llama_tokens soft_tokens;
+        if (params.reasoning_budget_tokens > 0
+                && params.reasoning_budget_soft_ratio > 0.0f && params.reasoning_budget_soft_ratio <= 1.0f
+                && !params.reasoning_budget_soft_message.empty()) {
+            soft_tokens = common_tokenize(vocab, params.reasoning_budget_soft_message, false, true);
+        }
         rbudget = common_reasoning_budget_init(
             vocab,
             {params.reasoning_budget_start},
             params.reasoning_budget_end,
             params.reasoning_budget_forced,
-            params.reasoning_budget_tokens < 0 ? INT_MAX : params.reasoning_budget_tokens);
+            params.reasoning_budget_tokens < 0 ? INT_MAX : params.reasoning_budget_tokens,
+            REASONING_BUDGET_IDLE,
+            params.reasoning_budget_soft_ratio,
+            soft_tokens,
+            params.reasoning_budget_grace_tokens);
 
         for (const auto & token : prefill_tokens) {
             llama_sampler_accept(rbudget, token);

--- a/tests/test-reasoning-budget.cpp
+++ b/tests/test-reasoning-budget.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -333,6 +334,215 @@ static void test_reasoning_budget_end_match() {
     fprintf(stderr, "  Test 'matched end sequence' passed\n");
 }
 
+// ---------------------------------------------------------------------------
+// Local soft-budget extension tests
+//
+// These tests run with vocab == nullptr, where the sampler treats every token
+// as UTF-8-complete and as a line boundary (the soft message injects at the
+// first opportunity after the threshold), while a paragraph boundary requires
+// a real "\n\n" piece and therefore never matches; grace regions consequently
+// run to exhaustion, which is exactly the safety path worth unit testing.
+// ---------------------------------------------------------------------------
+
+struct soft_budget_step {
+    bool        forcing = false;
+    llama_token forced  = -1;
+};
+
+static std::vector<soft_budget_step> run_soft_sequence(
+    const std::vector<llama_token>   & sequence,
+    const std::vector<llama_tokens>  & start_seqs,
+    const std::vector<llama_tokens>  & end_seqs,
+    const std::vector<llama_token>   & forced_tokens,
+    int32_t                            budget,
+    float                              soft_ratio,
+    const std::vector<llama_token>   & soft_tokens,
+    int32_t                            grace_tokens,
+    common_reasoning_budget_state    * final_state_out = nullptr
+) {
+    llama_token max_token = 0;
+    for (auto t : sequence) max_token = std::max(max_token, t);
+    for (const auto & seq : start_seqs) for (auto t : seq) max_token = std::max(max_token, t);
+    for (const auto & seq : end_seqs)   for (auto t : seq) max_token = std::max(max_token, t);
+    for (auto t : forced_tokens) max_token = std::max(max_token, t);
+    for (auto t : soft_tokens)   max_token = std::max(max_token, t);
+
+    auto * sampler = common_reasoning_budget_init(
+        nullptr, start_seqs, end_seqs, forced_tokens, budget,
+        REASONING_BUDGET_IDLE, soft_ratio, soft_tokens, grace_tokens);
+
+    std::vector<llama_token_data> cur;
+    for (size_t i = 0; i <= (size_t) max_token; i++) {
+        cur.emplace_back(llama_token_data{(llama_token)i, logf((float)(i+1)), 0.0f});
+    }
+    llama_token_data_array cur_p = { cur.data(), cur.size(), -1, false };
+
+    std::vector<soft_budget_step> steps;
+    for (size_t i = 0; i < sequence.size(); i++) {
+        for (size_t j = 0; j < cur.size(); j++) {
+            cur[j].logit = logf((float)(j+1));
+        }
+        llama_sampler_apply(sampler, &cur_p);
+
+        soft_budget_step step;
+        size_t finite_count = 0;
+        for (size_t j = 0; j < cur.size(); j++) {
+            if (std::isfinite(cur[j].logit)) {
+                finite_count++;
+                step.forced = cur[j].id;
+            }
+        }
+        step.forcing = finite_count == 1;
+        steps.push_back(step);
+
+        llama_sampler_accept(sampler, sequence[i]);
+    }
+
+    if (final_state_out) {
+        *final_state_out = common_reasoning_budget_get_state(sampler);
+    }
+    llama_sampler_free(sampler);
+    return steps;
+}
+
+static void expect_only_forced(const char * test_name, const std::vector<soft_budget_step> & steps,
+                               const std::map<size_t, llama_token> & expected) {
+    for (size_t i = 0; i < steps.size(); i++) {
+        const auto it = expected.find(i);
+        if (it != expected.end()) {
+            if (!steps[i].forcing || steps[i].forced != it->second) {
+                fprintf(stderr, "%s: expected forcing of token %d at index %zu, got forcing=%d token=%d\n",
+                        test_name, it->second, i, (int) steps[i].forcing, steps[i].forced);
+                exit(1);
+            }
+        } else if (steps[i].forcing) {
+            fprintf(stderr, "%s: unexpected forcing of token %d at index %zu\n",
+                    test_name, steps[i].forced, i);
+            exit(1);
+        }
+    }
+}
+
+// Soft warning fires once at the configured threshold and the natural end
+// after the warning is accepted normally.
+static void test_soft_fires_once_at_threshold() {
+    common_reasoning_budget_state final_state = REASONING_BUDGET_IDLE;
+    const auto steps = run_soft_sequence(
+        /* sequence    */ {100, 50, 51, 52, 53, 101},
+        /* start_seqs  */ {{100}},
+        /* end_seqs    */ {{101}},
+        /* forced      */ {},
+        /* budget      */ 4,
+        /* soft_ratio  */ 0.5f,   // threshold = ceil(4 * 0.5) = 2 consumed tokens
+        /* soft_tokens */ {200, 201},
+        /* grace       */ 0,
+        &final_state);
+
+    expect_only_forced("soft fires once at threshold", steps, {{3, 200}, {4, 201}});
+    if (final_state != REASONING_BUDGET_DONE) {
+        fprintf(stderr, "soft fires once at threshold: expected DONE, got %d\n", (int) final_state);
+        exit(1);
+    }
+}
+
+// No soft injection before the threshold; a natural end before the threshold
+// prevents any soft injection entirely.
+static void test_soft_does_not_fire_before_threshold() {
+    const auto steps = run_soft_sequence(
+        {100, 50, 51, 101}, {{100}}, {{101}}, {}, 10, 0.5f, {200}, 0);
+
+    expect_only_forced("soft does not fire before threshold", steps, {});
+}
+
+// With an invalid ratio (> 1) the soft feature is fully disabled and the
+// hard-budget path keeps upstream behavior.
+static void test_soft_disabled_on_invalid_ratio() {
+    const auto steps = run_soft_sequence(
+        {100, 50, 51, 52, 101}, {{100}}, {{101}}, {}, 2, 1.5f, {200}, 0);
+
+    expect_only_forced("soft disabled on invalid ratio", steps, {});
+}
+
+// Hard-budget exhaustion enters the bounded grace region; without a paragraph
+// boundary the grace region runs to exhaustion and then forces the end
+// sequence, so total reasoning stays within budget + grace.
+static void test_grace_exhaustion_forces_end() {
+    common_reasoning_budget_state final_state = REASONING_BUDGET_IDLE;
+    const auto steps = run_soft_sequence(
+        {100, 50, 51, 52, 53, 54, 55, 101},
+        {{100}}, {{101}}, {102, 101},
+        2,      // budget
+        -1.0f,  // soft disabled
+        {},
+        2,      // grace tokens
+        &final_state);
+
+    // budget exhausts after i2; grace runs i3-i4; forcing begins at i5
+    expect_only_forced("grace exhaustion forces end", steps, {{5, 102}, {6, 101}});
+    if (final_state != REASONING_BUDGET_DONE) {
+        fprintf(stderr, "grace exhaustion forces end: expected DONE, got %d\n", (int) final_state);
+        exit(1);
+    }
+}
+
+// A natural reasoning close inside the grace region wins over forced
+// termination.
+static void test_grace_natural_close_wins() {
+    const auto steps = run_soft_sequence(
+        {100, 50, 51, 101, 52, 53},
+        {{100}}, {{101}}, {102, 101},
+        2, -1.0f, {}, 5);
+
+    expect_only_forced("grace natural close wins", steps, {});
+}
+
+// Reasoning cannot grow unbounded: with budget B and grace G, forcing must
+// begin no later than B + G generated tokens after the start tag.
+static void test_grace_bounds_total_reasoning() {
+    std::vector<llama_token> sequence = {100};
+    for (int i = 0; i < 30; i++) {
+        sequence.push_back(60 + (i % 20));
+    }
+    sequence.push_back(101);
+
+    const auto steps = run_soft_sequence(
+        sequence, {{100}}, {{101}}, {102, 101},
+        3, -1.0f, {}, 3);
+
+    size_t first_forcing = SIZE_MAX;
+    for (size_t i = 0; i < steps.size(); i++) {
+        if (steps[i].forcing) {
+            first_forcing = i;
+            break;
+        }
+    }
+    // start tag at i0; budget 3 + grace 3 consumed by i6; forcing at i7
+    if (first_forcing != 7) {
+        fprintf(stderr, "grace bounds total reasoning: expected first forcing at index 7, got %zu\n",
+                first_forcing == SIZE_MAX ? (size_t)-1 : first_forcing);
+        exit(1);
+    }
+}
+
+// Multiple reasoning blocks re-arm correctly: the soft warning and the grace
+// region both reset per block.
+static void test_soft_and_grace_rearm_per_block() {
+    common_reasoning_budget_state final_state = REASONING_BUDGET_IDLE;
+    const auto steps = run_soft_sequence(
+        {100, 50, 51, 52, 101,      // block 1: soft fires, natural close
+         100, 60, 61, 62, 63, 64, 101, 65}, // block 2: soft fires, grace exhausts
+        {{100}}, {{101}}, {102, 101},
+        2, 0.5f, {200}, 2,
+        &final_state);
+
+    expect_only_forced("soft and grace re-arm per block", steps,
+                       {{2, 200}, {7, 200}, {11, 102}, {12, 101}});
+    if (final_state != REASONING_BUDGET_DONE) {
+        fprintf(stderr, "soft and grace re-arm per block: expected DONE, got %d\n", (int) final_state);
+        exit(1);
+    }
+}
+
 // UTF-8 boundary detection unit test
 // Tests common_utf8_is_complete() from reasoning-budget.h
 static void test_utf8_boundary_detection() {
@@ -495,7 +705,16 @@ int main(void) {
     test_reasoning_budget_force_manual();
     test_reasoning_budget_end_match();
 
-    printf("OK (12 tests passed)\n");
+    // local soft-budget extension
+    test_soft_fires_once_at_threshold();
+    test_soft_does_not_fire_before_threshold();
+    test_soft_disabled_on_invalid_ratio();
+    test_grace_exhaustion_forces_end();
+    test_grace_natural_close_wins();
+    test_grace_bounds_total_reasoning();
+    test_soft_and_grace_rearm_per_block();
+
+    printf("OK (19 tests passed)\n");
 
     printf("Testing UTF-8 boundary detection... ");
     test_utf8_boundary_detection();


### PR DESCRIPTION
## Overview

This is based on the work in draft PR [ggml-org/llama.cpp#25961 (`reasoning-budget: Implementing thinking-budget mechanism to control thought process`)](https://github.com/ggml-org/llama.cpp/pull/25961) by @laurencehardman, updated for the current tree and with a slightly different approach to what happens near the end of the reasoning budget.

It adds two optional behaviors to the existing `reasoning-budget` sampler:

1. **Soft wrap-up hint** — when reasoning reaches a configurable fraction of the budget (`--reasoning-budget-soft-ratio N`), a hint is injected at the next newline boundary. It fires at most once per reasoning block and re-arms for later blocks. The text can be changed with `--reasoning-budget-soft-message MESSAGE`.

2. **Grace tokens** — once the reasoning budget is exhausted, the model gets up to `--reasoning-budget-grace-tokens N` additional tokens to finish naturally. If it still has not ended reasoning by then, the end sequence is forced.

The result is still bounded at `budget + grace_tokens`, but avoids cutting the model off immediately when it reaches the configured budget.

I did not carry over the intro-budget message from #25961. That PR can inject a message at the start of reasoning telling the model how much budget it has. This version only injects the wrap-up hint near the end.

### Differences from #25961

| Behavior | #25961 | This PR |
|---|---|---|
| Intro message at reasoning start | Yes | No |
| Soft warning | Configurable fraction of budget | Configurable fraction, fired once at a newline boundary |
| After budget is reached | Hard cutoff | Bounded grace period, then forced end |
| Natural reasoning end | — | Always takes precedence over forcing |
| Multiple reasoning blocks | — | Soft hint and grace state re-arm per block |
| Default behavior | Opt-in | Opt-in; unchanged when the new options are not used |

I left out the intro message because it is not necessary to enforce the limit, and injecting text at the beginning of every reasoning block can influence the model before it has started working on the problem. The soft hint and grace window are enough for the intended behavior while keeping the default path close to upstream.

## Files changed

- `common/arg.cpp` — CLI options and environment-variable handling.
- `common/common.h` — new `common_params_sampling` fields.
- `common/reasoning-budget.h` — adds `SOFT_PENDING`, `SOFT_FORCING`, and `HARD_PENDING`; extends the init signature while preserving existing defaults.
- `common/reasoning-budget.cpp` — soft threshold handling, grace window, natural-end precedence, and per-block reset.
- `common/sampling.cpp` — tokenizes the optional soft message with `common_tokenize(..., false, true)` and passes it into the sampler.
- `tests/test-reasoning-budget.cpp` — 7 additional unit tests.

## CLI / environment variables

```text
--reasoning-budget-soft-ratio N         LLAMA_ARG_THINK_BUDGET_SOFT_RATIO
--reasoning-budget-soft-message MESSAGE LLAMA_ARG_THINK_BUDGET_SOFT_MESSAGE
--reasoning-budget-grace-tokens N       LLAMA_ARG_THINK_BUDGET_GRACE_TOKENS
```

These only have an effect when reasoning is enabled and a `reasoning-budget` is active.

Invalid values disable the corresponding behavior. For example, a soft ratio outside `(0, 1]` disables the soft hint.

## Tests

Added 7 tests to `tests/test-reasoning-budget.cpp`:

- `test_soft_fires_once_at_threshold` — fires the soft hint once after the threshold is crossed and a newline is reached.
- `test_soft_does_not_fire_before_threshold` — does not fire early.
- `test_soft_disabled_on_invalid_ratio` — ratios `<= 0` or `> 1` disable the feature.
- `test_grace_exhaustion_forces_end` — forces the end sequence once grace tokens are exhausted.
- `test_grace_natural_close_wins` — a normal reasoning close during grace is allowed through.
- `test_grace_bounds_total_reasoning` — reasoning cannot exceed `budget + grace_tokens`.
- `test_soft_and_grace_rearm_per_block` — both mechanisms reset correctly for later reasoning blocks.

## Validation

On base `a298422da` (`b10548`):

- `tests/test-reasoning-budget.cpp`: **19/19 passing** (12 existing + 7 new)
- GNU 14.2.0 / Linux x86_64
- CUDA `llama-server` built from this branch using `.devops/cuda.Dockerfile`

I also ran a live server smoke test with:

```text
--reasoning on
--reasoning-budget 8192
--reasoning-budget-soft-ratio 0.65
--reasoning-budget-grace-tokens 1536
```

The server accepted the new settings and streamed normal `reasoning_content`.

There was no intro text at the start of reasoning, as intended. The test generation also ended before reaching the 65% soft threshold, and no soft message was injected.

With the new options omitted, the existing reasoning-budget behavior is unchanged.

## Motivation

The main use case is reasoning models that sometimes get stuck in repetitive or increasingly unproductive thought loops, particularly at lower temperatures.

A hard token cutoff solves the upper-bound problem, but it can also stop the model in the middle of a useful thought. The soft hint gives it a chance to start wrapping up before the limit, and the small grace window lets it finish naturally without turning the reasoning budget into an unbounded suggestion.

Based on: [#25961](https://github.com/ggml-org/llama.cpp/pull/25961).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md).
- AI usage disclosure: Yes. An AI coding agent assisted with the sampler state-machine implementation, unit tests, build work, and validation.