### PR TITLE
ggml-cpu: add TQ2_0 8x8 blocked GEMM with i8mm (SMMLA)

### DIFF
--- a/ggml/src/ggml-cpu/arch-fallback.h
+++ b/ggml/src/ggml-cpu/arch-fallback.h
@@ -71,6 +71,8 @@
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
+#define ggml_gemv_tq2_0_8x8_q8_K_generic ggml_gemv_tq2_0_8x8_q8_K
+#define ggml_gemm_tq2_0_8x8_q8_K_generic ggml_gemm_tq2_0_8x8_q8_K
 #elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64)
 // repack.cpp
 #define ggml_quantize_mat_q8_K_4x4_generic ggml_quantize_mat_q8_K_4x4
@@ -109,6 +111,8 @@
 #define ggml_gemm_mxfp4_4x4_q8_0_generic ggml_gemm_mxfp4_4x4_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
+#define ggml_gemv_tq2_0_8x8_q8_K_generic ggml_gemv_tq2_0_8x8_q8_K
+#define ggml_gemm_tq2_0_8x8_q8_K_generic ggml_gemm_tq2_0_8x8_q8_K
 #elif defined(__POWERPC__) || defined(__powerpc__)
 // ref: https://github.com/ggml-org/llama.cpp/pull/14146#issuecomment-2972561679
 // quants.c
@@ -156,6 +160,8 @@
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
+#define ggml_gemv_tq2_0_8x8_q8_K_generic ggml_gemv_tq2_0_8x8_q8_K
+#define ggml_gemm_tq2_0_8x8_q8_K_generic ggml_gemm_tq2_0_8x8_q8_K
 #elif defined(__loongarch64)
 // quants.c
 #define quantize_row_q8_K_generic quantize_row_q8_K
@@ -203,6 +209,8 @@
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
+#define ggml_gemv_tq2_0_8x8_q8_K_generic ggml_gemv_tq2_0_8x8_q8_K
+#define ggml_gemm_tq2_0_8x8_q8_K_generic ggml_gemm_tq2_0_8x8_q8_K
 #elif defined(__riscv)
 // quants.c
 #define ggml_vec_dot_nvfp4_q8_0_generic ggml_vec_dot_nvfp4_q8_0
@@ -243,6 +251,8 @@
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
+#define ggml_gemv_tq2_0_8x8_q8_K_generic ggml_gemv_tq2_0_8x8_q8_K
+#define ggml_gemm_tq2_0_8x8_q8_K_generic ggml_gemm_tq2_0_8x8_q8_K
 #elif defined(__s390x__)
 // quants.c
 #define quantize_row_q8_K_generic quantize_row_q8_K
@@ -296,6 +306,8 @@
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
+#define ggml_gemv_tq2_0_8x8_q8_K_generic ggml_gemv_tq2_0_8x8_q8_K
+#define ggml_gemm_tq2_0_8x8_q8_K_generic ggml_gemm_tq2_0_8x8_q8_K
 #elif defined(__wasm__)
 // quants.c
 #define ggml_vec_dot_tq1_0_q8_K_generic ggml_vec_dot_tq1_0_q8_K
@@ -350,4 +362,6 @@
 #define ggml_gemm_mxfp4_8x8_q8_0_generic ggml_gemm_mxfp4_8x8_q8_0
 #define ggml_gemm_q8_0_4x4_q8_0_generic ggml_gemm_q8_0_4x4_q8_0
 #define ggml_gemm_q8_0_4x8_q8_0_generic ggml_gemm_q8_0_4x8_q8_0
+#define ggml_gemv_tq2_0_8x8_q8_K_generic ggml_gemv_tq2_0_8x8_q8_K
+#define ggml_gemm_tq2_0_8x8_q8_K_generic ggml_gemm_tq2_0_8x8_q8_K
 #endif

--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -5154,3 +5154,159 @@ void ggml_gemm_q8_0_4x8_q8_0(int                        n,
 #endif  // defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
     ggml_gemm_q8_0_4x8_q8_0_generic(n, s, bs, vx, vy, nr, nc);
 }
+
+// TQ2_0 blocked kernels. The repacked layout (block_tq2_0x8) is built so that one
+// 16-byte weight load plus four shift/mask steps produces operands already shaped
+// for SMMLA, and the q8_Kx4 activation interleave already supplies [rows 0,1] in
+// bytes [kb*32 .. +15] and [rows 2,3] in [+16 .. +31] -- no runtime shuffles.
+// Unpacking to {-1,0,+1} with vsubq_s8 makes the products exact, so the bsums
+// correction used by ggml_vec_dot_tq2_0_q8_K is not needed here.
+void ggml_gemv_tq2_0_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK_K;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert (n % qk == 0);
+    assert (nc % ncols_interleaved == 0);
+
+    UNUSED(bs);
+    UNUSED(nr);
+
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+    const uint8x16_t m3  = vdupq_n_u8(3);
+    const int8x16_t  one = vdupq_n_s8(1);
+
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_tq2_0x8 * b_ptr = (const block_tq2_0x8 *) vx + (x * nb);
+        const block_q8_K    * a_ptr = (const block_q8_K *) vy;
+
+        float sumf[8];
+        for (int j = 0; j < ncols_interleaved; j++) sumf[j] = 0.0f;
+
+        for (int l = 0; l < nb; l++) {
+            int32x4_t acc[4];
+            for (int p = 0; p < 4; p++) acc[p] = vdupq_n_s32(0);
+
+            const uint8_t * W = b_ptr[l].qs;
+            const int8_t  * A = a_ptr[l].qs;
+
+            for (int g = 0; g < 8; g++) {
+                // one activation octet per 2-bit field, duplicated into both halves
+                const int8x8_t  y0 = vld1_s8(A + (4 * g + 0) * 8);
+                const int8x8_t  y1 = vld1_s8(A + (4 * g + 1) * 8);
+                const int8x8_t  y2 = vld1_s8(A + (4 * g + 2) * 8);
+                const int8x8_t  y3 = vld1_s8(A + (4 * g + 3) * 8);
+                const int8x16_t a0 = vcombine_s8(y0, y0);
+                const int8x16_t a1 = vcombine_s8(y1, y1);
+                const int8x16_t a2 = vcombine_s8(y2, y2);
+                const int8x16_t a3 = vcombine_s8(y3, y3);
+
+                for (int p = 0; p < 4; p++) {
+                    const uint8x16_t v = vld1q_u8(W + p * 128 + g * 16);
+                    const int8x16_t w0 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(v, m3)), one);
+                    const int8x16_t w1 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(v, 2), m3)), one);
+                    const int8x16_t w2 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(v, 4), m3)), one);
+                    const int8x16_t w3 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(v, 6), m3)), one);
+                    acc[p] = vdotq_s32(acc[p], w0, a0);
+                    acc[p] = vdotq_s32(acc[p], w1, a1);
+                    acc[p] = vdotq_s32(acc[p], w2, a2);
+                    acc[p] = vdotq_s32(acc[p], w3, a3);
+                }
+            }
+
+            const float ad = a_ptr[l].d;
+            for (int p = 0; p < 4; p++) {
+                int32_t t[4];
+                vst1q_s32(t, acc[p]);
+                // lanes 0,1 -> row 2p ; lanes 2,3 -> row 2p+1
+                sumf[2 * p + 0] += (GGML_CPU_FP16_TO_FP32(b_ptr[l].d[2 * p + 0]) * ad) * (float) (t[0] + t[1]);
+                sumf[2 * p + 1] += (GGML_CPU_FP16_TO_FP32(b_ptr[l].d[2 * p + 1]) * ad) * (float) (t[2] + t[3]);
+            }
+        }
+        for (int j = 0; j < ncols_interleaved; j++) s[x * ncols_interleaved + j] = sumf[j];
+    }
+    return;
+#endif  // defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+    ggml_gemv_tq2_0_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
+}
+
+void ggml_gemm_tq2_0_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK_K;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert (n % qk == 0);
+    assert (nc % ncols_interleaved == 0);
+    assert (nr % 4 == 0);
+
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
+    const uint8x16_t m3  = vdupq_n_u8(3);
+    const int8x16_t  one = vdupq_n_s8(1);
+
+    for (int y = 0; y < nr / 4; y++) {
+        const block_q8_Kx4 * a_ptr = (const block_q8_Kx4 *) vy + (y * nb);
+        for (int x = 0; x < nc / ncols_interleaved; x++) {
+            const block_tq2_0x8 * b_ptr = (const block_tq2_0x8 *) vx + (x * nb);
+
+            float sumf[4][8];
+            for (int m = 0; m < 4; m++) for (int j = 0; j < ncols_interleaved; j++) sumf[m][j] = 0.0f;
+
+            for (int l = 0; l < nb; l++) {
+                int32x4_t acc[4][2];
+                for (int p = 0; p < 4; p++) { acc[p][0] = vdupq_n_s32(0); acc[p][1] = vdupq_n_s32(0); }
+
+                const uint8_t * W = b_ptr[l].qs;
+                const int8_t  * A = a_ptr[l].qs;
+
+                for (int g = 0; g < 8; g++) {
+                    const int8_t * a0 = A + (4 * g + 0) * 32;
+                    const int8_t * a1 = A + (4 * g + 1) * 32;
+                    const int8_t * a2 = A + (4 * g + 2) * 32;
+                    const int8_t * a3 = A + (4 * g + 3) * 32;
+
+                    for (int p = 0; p < 4; p++) {
+                        const uint8x16_t v = vld1q_u8(W + p * 128 + g * 16);
+                        const int8x16_t w0 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(v, m3)), one);
+                        const int8x16_t w1 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(v, 2), m3)), one);
+                        const int8x16_t w2 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(v, 4), m3)), one);
+                        const int8x16_t w3 = vsubq_s8(vreinterpretq_s8_u8(vandq_u8(vshrq_n_u8(v, 6), m3)), one);
+
+                        acc[p][0] = vmmlaq_s32(acc[p][0], w0, vld1q_s8(a0));
+                        acc[p][1] = vmmlaq_s32(acc[p][1], w0, vld1q_s8(a0 + 16));
+                        acc[p][0] = vmmlaq_s32(acc[p][0], w1, vld1q_s8(a1));
+                        acc[p][1] = vmmlaq_s32(acc[p][1], w1, vld1q_s8(a1 + 16));
+                        acc[p][0] = vmmlaq_s32(acc[p][0], w2, vld1q_s8(a2));
+                        acc[p][1] = vmmlaq_s32(acc[p][1], w2, vld1q_s8(a2 + 16));
+                        acc[p][0] = vmmlaq_s32(acc[p][0], w3, vld1q_s8(a3));
+                        acc[p][1] = vmmlaq_s32(acc[p][1], w3, vld1q_s8(a3 + 16));
+                    }
+                }
+
+                for (int p = 0; p < 4; p++) {
+                    int32_t t0[4], t1[4];
+                    vst1q_s32(t0, acc[p][0]);
+                    vst1q_s32(t1, acc[p][1]);
+                    const float d0 = GGML_CPU_FP16_TO_FP32(b_ptr[l].d[2 * p + 0]);
+                    const float d1 = GGML_CPU_FP16_TO_FP32(b_ptr[l].d[2 * p + 1]);
+                    // acc[p][0] = [r0*c0, r0*c1, r1*c0, r1*c1]; acc[p][1] = same for c2,c3
+                    sumf[0][2 * p + 0] += (d0 * a_ptr[l].d[0]) * (float) t0[0];
+                    sumf[1][2 * p + 0] += (d0 * a_ptr[l].d[1]) * (float) t0[1];
+                    sumf[0][2 * p + 1] += (d1 * a_ptr[l].d[0]) * (float) t0[2];
+                    sumf[1][2 * p + 1] += (d1 * a_ptr[l].d[1]) * (float) t0[3];
+                    sumf[2][2 * p + 0] += (d0 * a_ptr[l].d[2]) * (float) t1[0];
+                    sumf[3][2 * p + 0] += (d0 * a_ptr[l].d[3]) * (float) t1[1];
+                    sumf[2][2 * p + 1] += (d1 * a_ptr[l].d[2]) * (float) t1[2];
+                    sumf[3][2 * p + 1] += (d1 * a_ptr[l].d[3]) * (float) t1[3];
+                }
+            }
+            for (int m = 0; m < 4; m++) {
+                for (int j = 0; j < ncols_interleaved; j++) {
+                    s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+                }
+            }
+        }
+    }
+    return;
+#endif  // defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
+    ggml_gemm_tq2_0_8x8_q8_K_generic(n, s, bs, vx, vy, nr, nc);
+}

--- a/ggml/src/ggml-cpu/repack.cpp
+++ b/ggml/src/ggml-cpu/repack.cpp
@@ -955,6 +955,94 @@ void ggml_gemv_q4_K_8x4_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, 
     }
 }
 
+// Decode one weight of a repacked tq2_0 block: canonical element e, interleaved row j.
+static inline int tq2_0x8_weight(const block_tq2_0x8 * b, int e, int j) {
+    const int g = (e >> 3) >> 2;
+    const int f = (e >> 3) & 3;
+    const int p = j >> 1;
+    const int c = ((j & 1) << 3) | (e & 7);
+    return (int) ((b->qs[p * 128 + g * 16 + c] >> (2 * f)) & 3) - 1;
+}
+
+void ggml_gemv_tq2_0_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK_K;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert (n % qk == 0);
+    assert (nc % ncols_interleaved == 0);
+
+    UNUSED(bs);
+    UNUSED(nr);
+
+    for (int x = 0; x < nc / ncols_interleaved; x++) {
+        const block_tq2_0x8 * b_ptr = (const block_tq2_0x8 *) vx + (x * nb);
+        const block_q8_K    * a_ptr = (const block_q8_K *) vy;
+
+        float sumf[8];
+        for (int j = 0; j < ncols_interleaved; j++) sumf[j] = 0.0f;
+
+        for (int l = 0; l < nb; l++) {
+            int32_t sumi[8];
+            for (int j = 0; j < ncols_interleaved; j++) sumi[j] = 0;
+            for (int e = 0; e < qk; e++) {
+                for (int j = 0; j < ncols_interleaved; j++) {
+                    sumi[j] += tq2_0x8_weight(&b_ptr[l], e, j) * a_ptr[l].qs[e];
+                }
+            }
+            for (int j = 0; j < ncols_interleaved; j++) {
+                sumf[j] += (GGML_CPU_FP16_TO_FP32(b_ptr[l].d[j]) * a_ptr[l].d) * (float) sumi[j];
+            }
+        }
+        for (int j = 0; j < ncols_interleaved; j++) s[x * ncols_interleaved + j] = sumf[j];
+    }
+}
+
+void ggml_gemm_tq2_0_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
+    const int qk = QK_K;
+    const int nb = n / qk;
+    const int ncols_interleaved = 8;
+
+    assert (n % qk == 0);
+    assert (nc % ncols_interleaved == 0);
+    assert (nr % 4 == 0);
+
+    for (int y = 0; y < nr / 4; y++) {
+        const block_q8_Kx4 * a_ptr = (const block_q8_Kx4 *) vy + (y * nb);
+        for (int x = 0; x < nc / ncols_interleaved; x++) {
+            const block_tq2_0x8 * b_ptr = (const block_tq2_0x8 *) vx + (x * nb);
+
+            float sumf[4][8];
+            for (int m = 0; m < 4; m++) for (int j = 0; j < ncols_interleaved; j++) sumf[m][j] = 0.0f;
+
+            for (int l = 0; l < nb; l++) {
+                int32_t sumi[4][8];
+                for (int m = 0; m < 4; m++) for (int j = 0; j < ncols_interleaved; j++) sumi[m][j] = 0;
+
+                for (int e = 0; e < qk; e++) {
+                    const int kb = e >> 3;
+                    for (int j = 0; j < ncols_interleaved; j++) {
+                        const int w = tq2_0x8_weight(&b_ptr[l], e, j);
+                        for (int m = 0; m < 4; m++) {
+                            sumi[m][j] += w * a_ptr[l].qs[kb * 32 + m * 8 + (e & 7)];
+                        }
+                    }
+                }
+                for (int m = 0; m < 4; m++) {
+                    for (int j = 0; j < ncols_interleaved; j++) {
+                        sumf[m][j] += (GGML_CPU_FP16_TO_FP32(b_ptr[l].d[j]) * a_ptr[l].d[m]) * (float) sumi[m][j];
+                    }
+                }
+            }
+            for (int m = 0; m < 4; m++) {
+                for (int j = 0; j < ncols_interleaved; j++) {
+                    s[(y * 4 + m) * bs + x * ncols_interleaved + j] = sumf[m][j];
+                }
+            }
+        }
+    }
+}
+
 void ggml_gemv_q4_K_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc) {
     const int qk = QK_K;
     const int nb = n / qk;
@@ -3877,6 +3965,57 @@ template <> int repack<block_q4_0, 8, 8>(struct ggml_tensor * t, const void * da
     return repack_q4_0_to_q4_0_8_bl(t, 8, data, data_size);
 }
 
+static int repack_tq2_0_to_tq2_0_8_bl(struct ggml_tensor * t, int interleave_block, const void * GGML_RESTRICT data, size_t data_size) {
+    GGML_ASSERT(t->type == GGML_TYPE_TQ2_0);
+    GGML_ASSERT(interleave_block == 8);
+    constexpr int nrows_interleaved = 8;
+
+    block_tq2_0x8 * dst = (block_tq2_0x8 *) t->data;
+    const block_tq2_0 * src = (const block_tq2_0 *) data;
+    int nrow = ggml_nrows(t);
+    int nblocks = t->ne[0] / QK_K;
+
+    GGML_ASSERT(data_size == (size_t) nrow * nblocks * sizeof(block_tq2_0));
+
+    if (t->ne[1] % nrows_interleaved != 0 || t->ne[0] % QK_K != 0) {
+        return -1;
+    }
+
+    for (int b = 0; b < nrow; b += nrows_interleaved) {
+        for (int64_t x = 0; x < nblocks; x++) {
+            memset(dst->qs, 0, sizeof(dst->qs));
+            for (int i = 0; i < nrows_interleaved; i++) {
+                const block_tq2_0 * sb = src + x + i * nblocks;
+                dst->d[i] = sb->d;
+                for (int e = 0; e < QK_K; e++) {
+                    // source: e = j*4 + l*32 + k  ->  qs[j + k], field l
+                    const int j   = (e >= 128) ? 32 : 0;
+                    const int rem = e - j * 4;
+                    const int l   = rem / 32;
+                    const int k   = rem % 32;
+                    const uint8_t code = (sb->qs[j + k] >> (2 * l)) & 3;
+
+                    // destination: SMMLA-shaped (see block_tq2_0x8 in repack.h)
+                    const int g  = (e >> 3) >> 2;
+                    const int f  = (e >> 3) & 3;
+                    const int p  = i >> 1;
+                    const int c  = ((i & 1) << 3) | (e & 7);
+                    dst->qs[p * 128 + g * 16 + c] |= (uint8_t) (code << (2 * f));
+                }
+            }
+            dst++;
+        }
+        src += nrows_interleaved * nblocks;
+    }
+    return 0;
+
+    GGML_UNUSED(data_size);
+}
+
+template <> int repack<block_tq2_0, 8, 8>(struct ggml_tensor * t, const void * data, size_t data_size) {
+    return repack_tq2_0_to_tq2_0_8_bl(t, 8, data, data_size);
+}
+
 template <> int repack<block_q4_K, 8, 8>(struct ggml_tensor * t, const void * data, size_t data_size) {
     return repack_q4_K_to_q4_K_8_bl(t, 8, data, data_size);
 }
@@ -3991,6 +4130,10 @@ template <> void gemv<block_q4_K, 8, 8, GGML_TYPE_Q8_K>(int n, float * s, size_t
     ggml_gemv_q4_K_8x8_q8_K(n, s, bs, vx, vy, nr, nc);
 }
 
+template <> void gemv<block_tq2_0, 8, 8, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemv_tq2_0_8x8_q8_K(n, s, bs, vx, vy, nr, nc);
+}
+
 template <> void gemv<block_q5_K, 4, 8, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
     ggml_gemv_q5_K_8x4_q8_K(n, s, bs, vx, vy, nr, nc);
 }
@@ -4086,6 +4229,10 @@ template <> void gemm<block_q4_K, 4, 8, GGML_TYPE_Q8_K>(int n, float * s, size_t
 
 template <> void gemm<block_q4_K, 8, 8, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
     ggml_gemm_q4_K_8x8_q8_K(n, s, bs, vx, vy, nr, nc);
+}
+
+template <> void gemm<block_tq2_0, 8, 8, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
+    ggml_gemm_tq2_0_8x8_q8_K(n, s, bs, vx, vy, nr, nc);
 }
 
 template <> void gemm<block_q5_K, 4, 8, GGML_TYPE_Q8_K>(int n, float * s, size_t bs, const void * vx, const void * vy, int nr, int nc) {
@@ -4534,6 +4681,7 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
     // instance for Q4_K
     static const ggml::cpu::repack::tensor_traits<block_q4_K, 4, 8, GGML_TYPE_Q8_K> q4_K_8x4_q8_K;
     static const ggml::cpu::repack::tensor_traits<block_q4_K, 8, 8, GGML_TYPE_Q8_K> q4_K_8x8_q8_K;
+    static const ggml::cpu::repack::tensor_traits<block_tq2_0, 8, 8, GGML_TYPE_Q8_K> tq2_0_8x8_q8_K;
 
     // instance for Q5_K
     static const ggml::cpu::repack::tensor_traits<block_q5_K, 4, 8, GGML_TYPE_Q8_K> q5_K_8x4_q8_K;
@@ -4623,6 +4771,12 @@ static const ggml::cpu::tensor_traits * ggml_repack_get_optimal_repack_type(cons
                 default:   { return nullptr; }
             }
             #endif
+        }
+    } else if (cur->type == GGML_TYPE_TQ2_0) {
+        if (ggml_cpu_has_neon() && ggml_cpu_has_matmul_int8()) {
+            if (cur->ne[1] % 8 == 0) {
+                return &tq2_0_8x8_q8_K;
+            }
         }
     } else if (cur->type == GGML_TYPE_Q2_K) {
         if (ggml_cpu_has_avx512()) {

--- a/ggml/src/ggml-cpu/repack.h
+++ b/ggml/src/ggml-cpu/repack.h
@@ -48,6 +48,17 @@ struct block_q4_Kx8 {
 };
 
 static_assert(sizeof(block_q4_Kx8) == sizeof(ggml_half) * 16 + K_SCALE_SIZE * 8 + QK_K * 4, "wrong q4_K block size/padding");
+
+// 8 interleaved rows of block_tq2_0, ordered so that a single 16-byte load plus
+// four shift/mask steps yields operands already shaped for SMMLA (vmmlaq_s32):
+//   byte = p*128 + g*16 + b, field f at shift 2*f
+//   -> row = 2*p + (b >> 3), element = 8*(4*g + f) + (b & 7)
+struct block_tq2_0x8 {
+    ggml_half d[8];         // super-block scale, one per interleaved row
+    uint8_t   qs[QK_K * 2]; // 8 rows x QK_K 2-bit quants
+};
+
+static_assert(sizeof(block_tq2_0x8) == sizeof(ggml_half) * 8 + QK_K * 2, "wrong tq2_0x8 block size/padding");
 struct block_q4_Kx16 {
     ggml_half d[16];      // super-block scale for quantized scales
     ggml_half dmin[16];   // super-block scale for quantized mins
@@ -149,6 +160,7 @@ void ggml_gemv_q4_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
 void ggml_gemv_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q5_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q5_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemv_tq2_0_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q6_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q6_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
@@ -165,6 +177,7 @@ void ggml_gemm_q4_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
 void ggml_gemm_q4_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q5_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q5_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemm_tq2_0_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q6_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q6_K_8x8_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_iq4_nl_4x4_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
@@ -201,6 +214,7 @@ void ggml_gemv_q4_K_8x4_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, 
 void ggml_gemv_q4_K_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q5_K_8x4_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q5_K_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemv_tq2_0_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q6_K_8x4_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_q6_K_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemv_iq4_nl_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
@@ -217,6 +231,7 @@ void ggml_gemm_q4_K_8x4_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, 
 void ggml_gemm_q4_K_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q5_K_8x4_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q5_K_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
+void ggml_gemm_tq2_0_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q6_K_8x4_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_q6_K_8x8_q8_K_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);
 void ggml_gemm_iq4_nl_4x4_q8_0_generic(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, const void * GGML_RESTRICT vy, int nr, int nc);


### PR DESCRIPTION
## Overview

This PR implements the missing 8x8 repack and GEMM paths for the existing `TQ2_0` type on ARM architectures with `+i8mm` support.

Currently, `TQ1_0` and `TQ2_0` formats fall back entirely to scalar `ggml_vec_dot` paths on ARM CPUs. On Apple Silicon (M2 Pro), this makes `TQ2_0` prompt processing (`pp512`) 1.56x slower than `Q4_K_M`, despite being smaller, because it cannot utilize the `i8mm` (`vmmlaq_s32`) matrix instructions.

**Key structural details:**
1. **Vectorized Unpack:** Implemented a purely register-based unpack using NEON shifts (`vshrq_n_u8`) and masks (`vandq_u8`). A single 16-byte load unpacks cleanly into 4 SMMLA-shaped operands. The scalar fallback is fully bypassed.
2. **`bsums` Elimination:** `vmmlaq_s32` performs native signed accumulation. By unpacking the 2-bit values to `{-1, 0, 1}` via a simple subtract (`vsubq_s8`), this bypasses the block sum (`bsums`) correction step entirely, saving cycles.
3. **Floating-Point Equivalence:** Maintained the exact `(d_x * d_y) * sumi` accumulation order. Perplexity is bit-identical across all chunks compared to the scalar path.

## Additional information

Addresses #27276 (Feature Request: [CPU] ARM i8mm 8x8 blocked GEMM/GEMV paths for TQ1_0 and TQ2_0).

**Benchmarks:**
*Hardware: Apple M2 Pro (10-core), pure CPU build (`-mcpu=native+dotprod+i8mm`)*
*Command: `./llama-bench -t 4 -p 512 -n 128 -r 7 -m qwen2.5-1.5b-tq2_0.gguf`*

| Path | `pp512` (t/s) | `tg128` (t/s) |
|---|---:|---:|
| Scalar SDOT (Master) | 116.09 ± 2.46 | 74.54 ± 2.13 |
| **8x8 SMMLA (This PR)** | **215.46 ± 0.31 (+85.6%)** | 72.49 ± 0.84 (-2.7%) |

`pp512` now exceeds `Q4_K_M`'s 181.89 t/s on this machine. 
*(Note: There is a marginal ~2.7% regression on `tg128` (GEMV) because single-row activations force a fallback to a duplicated `vdotq_s32` width. I left this as-is to keep the PR focused on the GEMM/SMMLA integration, but I can address the GEMV path in a follow-up if requested).*

*Note on `TQ1_0`: I excluded the `TQ1_0` blocked path here. Its radix-3 packing (5 trits/byte) does not align cleanly to SMMLA's 8-element groups (`LCM(5,8)=40`), forcing the decode chain into the inner loop. It requires a different architectural approach.*

**Testing:**
- `test-backend-ops` executed locally and passed.
- Output validation verified via `llama-perplexity` (integer-exact match with scalar path).

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES. I used AI (Claude 3.5 Sonnet) as a pair-programming assistant during this PR. Specifically, I used it to: 1) Help map the exact byte layout (`p*128 + g*16 + b`) of `ggml`'s TQ2_0 format into the `vshrq_n_u8` NEON shift sequences. 2) Debug a numeric divergence (which turned out to be an IEEE floating-point associativity mismatch in my initial implementation of the multiply-add order). 3) Draft the layout of this PR description. I manually designed the `bsums` elimination logic, ran all microbenchmarks/profiling via Apple Instruments, verified the `test-backend-ops`, and take 100% responsibility for every line of C++ in this diff. I am fully prepared to explain the instruction mapping to reviewers.