### PR TITLE
reasoning: support fractional --reasoning-budget (fixes #27571)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3678,13 +3678,36 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_REASONING_EFFORT"));
     add_opt(common_arg(
-        {"--reasoning-budget"}, "N",
-        "token budget for thinking: -1 for unrestricted, 0 for immediate end, N>0 for token budget (default: -1)",
-        [](common_params & params, int value) {
-            if (value < -1) { throw std::invalid_argument("invalid value"); }
-            params.sampling.reasoning_budget_tokens = value;
-        }
-    ).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET"));
+        {"--reasoning-budget"},
+        "N",
+        "token budget for thinking: -1 unrestricted, 0 immediate end, N>0 fixed token budget, "
+        "or fraction of conversation length with optional +/-K token offset: F, F+K, F-K with F in [0,1] "
+        "(e.g. 0.5, 0.25+4000, 0.5-2300) (default: -1)",
+        [](common_params & params, const std::string & value) {
+            int32_t fixed = -1;
+            common_reasoning_budget_expr expr;
+            if (!common_reasoning_budget_parse(value, fixed, expr)) {
+                throw std::invalid_argument("invalid --reasoning-budget: \"" + value +
+                    "\" (expected -1, a token count, or e.g. 0.5 / 0.5+4000 / 0.3-2300)");
+            }
+            if (expr.is_set()) { params.sampling.reasoning_budget_expr = expr; }
+            else { params.sampling.reasoning_budget_tokens = fixed; }
+        }).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET"));
+
+    add_opt(common_arg(
+        {"--reasoning-budget-current"},
+        "N",
+        "like --reasoning-budget, but fractional budgets are relative to the newest input message "
+        "(e.g. 0.3, 0.3+4000)",
+        [](common_params & params, const std::string & value) {
+            int32_t fixed = -1;
+            common_reasoning_budget_expr expr;
+            if (!common_reasoning_budget_parse(value, fixed, expr) || !expr.is_set()) {
+                throw std::invalid_argument("invalid --reasoning-budget-current: \"" + value +
+                    "\" (expected a fraction like 0.3 / 0.3+4000)");
+            }
+            params.sampling.reasoning_budget_expr_current = expr;
+        }).set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_COMPLETION, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_THINK_BUDGET_CURRENT"));
     add_opt(common_arg(
         {"--reasoning-budget-message"}, "MESSAGE",
         "message injected before the end-of-thinking tag when reasoning budget is exhausted (default: none)",

--- a/common/common.h
+++ b/common/common.h
@@ -220,6 +220,23 @@ inline bool common_grammar_needs_prefill(const common_grammar & g) {
 }
 
 // sampling parameters
+// A fractional reasoning budget expression, e.g. "0.5+4000" resolves to
+// round(0.5 * ref_len) + 4000 tokens, where ref_len is the conversation or
+// current-prompt length. See common_reasoning_budget_parse() / _eval().
+struct common_reasoning_budget_expr {
+    float frac = -1.0f;      // < 0 = unset
+    int32_t offset = 0;      // token offset applied after scaling
+
+    bool is_set() const { return frac >= 0.0f; }
+};
+
+// Parses "N" (fixed budget), "F", "F+K" or "F-K" (F in [0,1]).
+// Fills exactly one of out_fixed / out_expr; returns true on success.
+bool common_reasoning_budget_parse(const std::string & value, int32_t & out_fixed, common_reasoning_budget_expr & out_expr);
+
+// clamp(llround(frac*ref_len)+offset, 0, INT32_MAX); -1 if unset or ref_len <= 0.
+int32_t common_reasoning_budget_eval(const common_reasoning_budget_expr & expr, int32_t ref_len);
+
 struct common_params_sampling {
     uint32_t seed = LLAMA_DEFAULT_SEED; // the seed used to initialize llama_sampler
 
@@ -291,6 +308,12 @@ struct common_params_sampling {
     std::vector<llama_token>  reasoning_budget_forced;         // forced sequence (message + first end tag)
     std::string               reasoning_budget_message;        // message injected before end tag when budget exhausted
     bool                      reasoning_control = false;       // create the budget sampler on demand so reasoning can be ended at runtime
+    // fractional reasoning budgets (issue #27571); resolved in common_sampler_init()
+    // precedence: reasoning_budget_tokens > expr_current > expr
+    common_reasoning_budget_expr reasoning_budget_expr;
+    common_reasoning_budget_expr reasoning_budget_expr_current;
+    int32_t reasoning_budget_ref_conversation = 0;
+    int32_t reasoning_budget_ref_current      = 0;
 
     bool backend_sampling = false;
 

--- a/common/sampling.cpp
+++ b/common/sampling.cpp
@@ -1,3 +1,8 @@
+#include <algorithm>
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <string>
 #include "sampling.h"
 
 #include "common.h"
@@ -184,6 +189,54 @@ std::string common_params_sampling::print() const {
     return std::string(result);
 }
 
+bool common_reasoning_budget_parse(const std::string & value, int32_t & out_fixed, common_reasoning_budget_expr & out_expr) {
+    out_fixed = -1;
+    out_expr = common_reasoning_budget_expr{};
+    const size_t b = value.find_first_not_of(" \t\r\n");
+    if (b == std::string::npos) { return false; }
+    const size_t e = value.find_last_not_of(" \t\r\n");
+    const std::string t = value.substr(b, e - b + 1);
+    size_t sep = std::string::npos;
+    for (size_t i = 1; i < t.size(); i++) {
+        if (t[i] == '+' || t[i] == '-') { sep = i; break; }
+    }
+    if (t.find('.') == std::string::npos) {
+        if (sep != std::string::npos) { return false; }
+        try {
+            size_t pos = 0;
+            long v = std::stol(t, &pos);
+            if (pos != t.size() || v < -1) { return false; }
+            out_fixed = (int32_t) v;
+            return true;
+        } catch (...) { return false; }
+    }
+    const std::string frac_str = t.substr(0, sep == std::string::npos ? t.size() : sep);
+    errno = 0;
+    char * endp = nullptr;
+    const double frac = strtod(frac_str.c_str(), &endp);
+    if (errno != 0 || endp != frac_str.c_str() + frac_str.size() || frac < 0.0 || frac > 1.0) { return false; }
+    int64_t offset = 0;
+    if (sep != std::string::npos) {
+        const std::string off_str = t.substr(sep);
+        errno = 0;
+        char * endp2 = nullptr;
+        const long long v = strtoll(off_str.c_str(), &endp2, 10);
+        if (errno != 0 || endp2 != off_str.c_str() + off_str.size()) { return false; }
+        offset = v;
+    }
+    out_expr.frac = (float) frac;
+    out_expr.offset = (int32_t) std::min<int64_t>(INT32_MAX, std::max<int64_t>(INT32_MIN, offset));
+    return true;
+}
+
+int32_t common_reasoning_budget_eval(const common_reasoning_budget_expr & expr, int32_t ref_len) {
+    if (!expr.is_set() || ref_len <= 0) { return -1; }
+    double budget = llround((double) expr.frac * (double) ref_len + (double) expr.offset);
+    if (budget < 0.0) { budget = 0.0; }
+    if (budget > (double) INT32_MAX) { budget = (double) INT32_MAX; }
+    return (int32_t) budget;
+}
+
 struct common_sampler * common_sampler_init(
         const struct llama_model * model,
         struct common_params_sampling & params) {
@@ -304,6 +357,31 @@ struct common_sampler * common_sampler_init(
             LOG_ERR("%s: error initializing grammar sampler for grammar:\n%s\n\nGeneration prompt:\n'%s'\n", __func__,
                 common_grammar_value(params.grammar).c_str(), params.generation_prompt.c_str());
             throw e;
+        }
+    }
+
+    // resolve fractional reasoning budgets (issue #27571) against reference lengths
+    if (params.reasoning_budget_tokens < 0) {
+        if (params.reasoning_budget_expr_current.is_set()) {
+            const int32_t ref = params.reasoning_budget_ref_current > 0 ?
+                params.reasoning_budget_ref_current : params.reasoning_budget_ref_conversation;
+            if (ref > 0) {
+                params.reasoning_budget_tokens = common_reasoning_budget_eval(params.reasoning_budget_expr_current, ref);
+                LOG_DBG("%s: budget(current): %g * %d %+d -> %d\n", __func__,
+                        params.reasoning_budget_expr_current.frac, ref,
+                        params.reasoning_budget_expr_current.offset, params.reasoning_budget_tokens);
+            } else {
+                LOG_WRN("%s: fractional budget requested but current prompt length unknown - ignoring\n", __func__);
+            }
+        } else if (params.reasoning_budget_expr.is_set()) {
+            if (params.reasoning_budget_ref_conversation > 0) {
+                params.reasoning_budget_tokens = common_reasoning_budget_eval(params.reasoning_budget_expr, params.reasoning_budget_ref_conversation);
+                LOG_DBG("%s: budget(conversation): %g * %d %+d -> %d\n", __func__,
+                        params.reasoning_budget_expr.frac, params.reasoning_budget_ref_conversation,
+                        params.reasoning_budget_expr.offset, params.reasoning_budget_tokens);
+            } else {
+                LOG_WRN("%s: fractional budget requested but conversation length unknown - ignoring\n", __func__);
+            }
         }
     }
 

--- a/tools/server/server-schema.cpp
+++ b/tools/server/server-schema.cpp
@@ -384,6 +384,28 @@ std::vector<std::unique_ptr<field>> make_llama_cmpl_schema(const common_params &
         ->set_hard_limits(-1, INT32_MAX)
         ->set_desc("Number of tokens in the reasoning budget (-1 = disabled)"));
 
+    // fractional reasoning budgets (issue #27571)
+    add((new field_str("reasoning_budget"))
+        ->set_desc("Fractional reasoning budget relative to the total prompt length: \"F\", \"F+K\" or \"F-K\" with F in [0,1] (e.g. \"0.5\", \"0.25+4000\"). Only applies while reasoning_budget_tokens is -1")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            int32_t fixed = -1;
+            common_reasoning_budget_expr expr;
+            if (!common_reasoning_budget_parse(data.at("reasoning_budget").get<std::string>(), fixed, expr) || !expr.is_set()) {
+                throw std::invalid_argument("expected a fraction expression like \"0.5\" or \"0.25+4000\"");
+            }
+            ctx.params.sampling.reasoning_budget_expr = expr;
+        }));
+    add((new field_str("reasoning_budget_current"))
+        ->set_desc("Like reasoning_budget, but relative to the newest input message length")
+        ->set_handler([&](field_eval_context & ctx, const json & data) {
+            int32_t fixed = -1;
+            common_reasoning_budget_expr expr;
+            if (!common_reasoning_budget_parse(data.at("reasoning_budget_current").get<std::string>(), fixed, expr) || !expr.is_set()) {
+                throw std::invalid_argument("expected a fraction expression like \"0.3\" or \"0.3+4000\"");
+            }
+            ctx.params.sampling.reasoning_budget_expr_current = expr;
+        }));
+
     add((new field_str("reasoning_budget_start_tag"))
         ->set_desc("Token string marking the start of the reasoning budget section")
         ->set_handler([&](field_eval_context & ctx, const json & data) {
@@ -551,6 +573,32 @@ task_params eval_llama_cmpl_schema(
         // if "reasoning_format" is not provided, its handler will not be called, we will need to handle it here
         auto reasoning_format = params.chat_parser_params.reasoning_format;
         params.chat_parser_params.reasoning_in_content = params.stream && (reasoning_format == COMMON_REASONING_FORMAT_DEEPSEEK_LEGACY);
+    }
+
+    // measure reference lengths for fractional reasoning budgets (issue #27571)
+    if (params.sampling.reasoning_budget_tokens < 0 &&
+            (params.sampling.reasoning_budget_expr.is_set() || params.sampling.reasoning_budget_expr_current.is_set())) {
+        GGML_ASSERT(vocab != nullptr);
+        const auto n_full = common_tokenize(vocab, json_value(data, "prompt", std::string()), false, true).size();
+        params.sampling.reasoning_budget_ref_conversation = (int32_t) n_full;
+
+        // newest-input reference: measure the last message content directly.
+        // (a prefix-diff of re-templated prompts overcounts when past assistant
+        // turns carry reasoning text that the final prompt strips out)
+        if (params.sampling.reasoning_budget_expr_current.is_set()) {
+            int32_t n_cur = 0;
+            if (data.contains("messages") && data.at("messages").is_array() && !data.at("messages").empty()
+                    && data.at("messages").back().contains("content")) {
+                const auto & msg_content = data.at("messages").back().at("content");
+                if (msg_content.is_string()) {
+                    n_cur = (int32_t) common_tokenize(vocab, msg_content.get<std::string>(), false, true).size();
+                }
+            }
+            params.sampling.reasoning_budget_ref_current = n_cur;
+            SRV_DBG("fractional budget refs: conversation=%d current=%d\n",
+                    params.sampling.reasoning_budget_ref_conversation,
+                    params.sampling.reasoning_budget_ref_current);
+        }
     }
 
     // debugging


### PR DESCRIPTION
### Overview

this pr adds the fractional budget thing from issue 27571. now --reasoning-budget can take fractions like 0.5 or 0.5+4000 or 0.5-2300. also added --reasoning-budget-current that only looks at the latest message. same stuff works in the json api fields. old integer values still work the same. i tested a few numbers and they matched what i expected. cli side still doesnt fully resolve the fractions yet, just warns and goes unrestricted. server side is fine.

### Additional information

see #27571. not much else.

### Requirements

I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
AI usage disclosure: YES - used some ai help for parts of the code and wording