### PR TITLE
examples/funasr: add Fun-ASR-Nano single-binary ASR CLI (CPU + CUDA)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
     add_subdirectory(debug)
     add_subdirectory(embedding)
     add_subdirectory(eval-callback)
+    add_subdirectory(funasr)
 
     add_subdirectory(gguf-hash)
     add_subdirectory(gguf)

--- a/examples/funasr/CMakeLists.txt
+++ b/examples/funasr/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Fun-ASR-Nano llama.cpp runtime (single-binary ASR, CUDA/CPU)
+#   ported from FunAudioLLM/FunASR runtime-llamacpp:
+#   - encoder (SAN-M) + adaptor run on ggml (CUDA backend when available)
+#   - LLM (Qwen3-0.6B) runs via llama (offloaded to GPU)
+#   - built-in FSMN-VAD front end
+
+set(FUNASR_COMMON ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_subdirectory(nano-cli)

--- a/examples/funasr/funasr_audio.h
+++ b/examples/funasr/funasr_audio.h
@@ -1,0 +1,49 @@
+// funasr_audio.h — load any audio file (WAV/MP3/FLAC/OGG...) as 16 kHz mono f32,
+// via miniaudio's decoder (handles arbitrary sample rate, channels, bit depth).
+// One TU must define FUNASR_AUDIO_IMPLEMENTATION before including.
+#ifndef FUNASR_AUDIO_H
+#define FUNASR_AUDIO_H
+#include <vector>
+// returns true on success; out = mono 16 kHz float samples in [-1,1]
+inline bool funasr_load_audio_16k_mono(const char * path, std::vector<float> & out);
+#endif
+
+#ifdef FUNASR_AUDIO_IMPLEMENTATION
+// keep only the decoder + data conversion (resampler/channel mixer); drop playback/capture
+#define MA_NO_DEVICE_IO
+#define MA_NO_ENGINE
+#define MA_NO_GENERATION
+#define MA_NO_THREADING
+#define MINIAUDIO_IMPLEMENTATION
+#include "miniaudio.h"
+#include <cstdio>
+inline bool funasr_load_audio_16k_mono(const char * path, std::vector<float> & out) {
+    if (!path) { fprintf(stderr, "audio: null path\n"); return false; }
+    ma_decoder_config cfg = ma_decoder_config_init(ma_format_f32, 1, 16000); // f32, mono, 16k
+    ma_decoder dec;
+    if (ma_decoder_init_file(path, &cfg, &dec) != MA_SUCCESS) {
+        fprintf(stderr, "audio: failed to open/decode %s (supported: wav/mp3/flac)\n", path);
+        return false;
+    }
+    out.clear();
+    ma_uint64 nframes = 0;
+    if (ma_decoder_get_length_in_pcm_frames(&dec, &nframes) == MA_SUCCESS && nframes > 0) {
+        out.resize(nframes);
+        ma_uint64 got = 0;
+        ma_result r = ma_decoder_read_pcm_frames(&dec, out.data(), nframes, &got);
+        if (r != MA_SUCCESS && r != MA_AT_END) { ma_decoder_uninit(&dec); fprintf(stderr, "audio: decode error\n"); return false; }
+        out.resize(got);
+    } else {
+        // length unknown (e.g. some mp3 streams): read in chunks until EOF
+        std::vector<float> buf(16000);
+        for (;;) {
+            ma_uint64 got = 0;
+            ma_result r = ma_decoder_read_pcm_frames(&dec, buf.data(), buf.size(), &got);
+            out.insert(out.end(), buf.begin(), buf.begin() + got);
+            if (got < buf.size() || (r != MA_SUCCESS && r != MA_AT_END)) break;
+        }
+    }
+    ma_decoder_uninit(&dec);
+    return !out.empty();
+}
+#endif

--- a/examples/funasr/funasr_audio.h
+++ b/examples/funasr/funasr_audio.h
@@ -1,4 +1,4 @@
-// funasr_audio.h — load any audio file (WAV/MP3/FLAC/OGG...) as 16 kHz mono f32,
+// funasr_audio.h - load any audio file (WAV/MP3/FLAC/OGG...) as 16 kHz mono f32,
 // via miniaudio's decoder (handles arbitrary sample rate, channels, bit depth).
 // One TU must define FUNASR_AUDIO_IMPLEMENTATION before including.
 #ifndef FUNASR_AUDIO_H

--- a/examples/funasr/funasr_vad.h
+++ b/examples/funasr/funasr_vad.h
@@ -1,0 +1,161 @@
+// funasr_vad.h — single-header FSMN-VAD for the funasr ggml runtime.
+// Exposes funasr_vad_segments(): 16k mono wav -> speech segments [start_ms,end_ms].
+// Front end (80-mel fbank + LFR m5n1 + CMVN) and FSMN encoder validated bit-exact vs
+// PyTorch fsmn-vad; the host state machine reproduces E2EVadModel (DEFAULT_SILENCE_SCHEDULE,
+// chunk-stepped) to within 1 frame (10ms) of fsmn-vad.generate on the 184-clip set.
+#pragma once
+#include "ggml.h"
+#include "ggml-cpu.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "gguf.h"
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846   // not guaranteed by <cmath> on MSVC
+#endif
+
+namespace funasr_vad_impl {
+static const int FS=16000,WINLEN=400,SHIFT=160,NFFT=512,NMEL=80;
+static const float PREEMPH=0.97f,LOWF=20.0f,HIGHF=8000.0f;
+static inline float melf(float f){return 1127.0f*logf(1.0f+f/700.0f);}
+static void fftc(std::vector<float>&re,std::vector<float>&im,int n){for(int i=1,j=0;i<n;i++){int b=n>>1;for(;j&b;b>>=1)j^=b;j^=b;if(i<j){std::swap(re[i],re[j]);std::swap(im[i],im[j]);}}
+  for(int len=2;len<=n;len<<=1){double a=-2.0*M_PI/len;float wr=cosf(a),wi=sinf(a);for(int i=0;i<n;i+=len){float cr=1,ci=0;for(int k=0;k<len/2;k++){float ur=re[i+k],ui=im[i+k];
+    float vr=re[i+k+len/2]*cr-im[i+k+len/2]*ci,vi=re[i+k+len/2]*ci+im[i+k+len/2]*cr;re[i+k]=ur+vr;im[i+k]=ui+vi;re[i+k+len/2]=ur-vr;im[i+k+len/2]=ui-vi;float nc=cr*wr-ci*wi;ci=cr*wi+ci*wr;cr=nc;}}}}
+static std::vector<std::vector<float>> fbank80(std::vector<float> wav){
+  for(auto&v:wav)v*=32768.0f; std::vector<float>win(WINLEN);
+  for(int i=0;i<WINLEN;i++)win[i]=0.54f-0.46f*cosf(2.0f*M_PI*i/(WINLEN-1));
+  const int NB=NFFT/2+1; float bw=(float)FS/NFFT,ml=melf(LOWF),mh=melf(HIGHF),dm=(mh-ml)/(NMEL+1);
+  std::vector<std::vector<float>>fb(NMEL,std::vector<float>(NB,0.0f));
+  for(int m=0;m<NMEL;m++){float L=ml+m*dm,C=ml+(m+1)*dm,R=ml+(m+2)*dm;for(int k=0;k<NB;k++){float mf=melf(bw*k);if(mf>L&&mf<R)fb[m][k]=mf<=C?(mf-L)/(C-L):(R-mf)/(R-C);}}
+  int N=wav.size(),T=(N-WINLEN)/SHIFT+1; if(T<1)T=0; std::vector<std::vector<float>>feat(T,std::vector<float>(NMEL));
+  std::vector<float>re(NFFT),im(NFFT),fr(WINLEN);const float fl=1.1920929e-07f;
+  for(int t=0;t<T;t++){const float*s=wav.data()+t*SHIFT;double mn=0;for(int i=0;i<WINLEN;i++)mn+=s[i];mn/=WINLEN;
+    for(int i=0;i<WINLEN;i++)fr[i]=s[i]-(float)mn;for(int i=WINLEN-1;i>0;i--)fr[i]-=PREEMPH*fr[i-1];fr[0]-=PREEMPH*fr[0];
+    for(int i=0;i<NFFT;i++){re[i]=i<WINLEN?fr[i]*win[i]:0.0f;im[i]=0.0f;}fftc(re,im,NFFT);
+    for(int m=0;m<NMEL;m++){float e=0;for(int k=0;k<NB;k++)if(fb[m][k]>0)e+=fb[m][k]*(re[k]*re[k]+im[k]*im[k]);feat[t][m]=logf(e>fl?e:fl);}}
+  return feat;
+}
+static std::vector<float> lfr(const std::vector<std::vector<float>>&feat,int m,int n,int&T_out){
+  int T=feat.size(); if(T<1){T_out=0;return {};}     // empty (audio shorter than one frame)
+  int D=NMEL,pad=(m-1)/2; int Tl=(T+n-1)/n;
+  std::vector<std::vector<float>> pf; pf.reserve(T+pad+m);
+  for(int i=0;i<pad;i++)pf.push_back(feat[0]);
+  for(int t=0;t<T;t++)pf.push_back(feat[t]);
+  while((int)pf.size()<(Tl-1)*n+m)pf.push_back(feat[T-1]);
+  std::vector<float> out((size_t)Tl*m*D);
+  for(int i=0;i<Tl;i++)for(int j=0;j<m;j++)memcpy(&out[((size_t)i*m+j)*D],pf[i*n+j].data(),D*sizeof(float));
+  T_out=Tl; return out;
+}
+struct vad{ggml_context*ctx=nullptr;std::map<std::string,ggml_tensor*>t;
+  ggml_tensor*g(const std::string&n){auto it=t.find(n);if(it==t.end()){fprintf(stderr,"vad: missing %s\n",n.c_str());return nullptr;}return it->second;}};
+static ggml_tensor* lin(ggml_context*c,ggml_tensor*w,ggml_tensor*b,ggml_tensor*x){auto y=ggml_mul_mat(c,w,x);return b?ggml_add(c,y,b):y;}
+} // namespace funasr_vad_impl
+
+// Run FSMN-VAD on a 16k mono float waveform; fills segs with [start_ms,end_ms] speech spans.
+// max_seg_ms caps a single segment (e.g. 30000); pass <=0 to use 60000 (model default).
+inline bool funasr_vad_segments(const std::string& gguf_path, const std::vector<float>& wav,
+                                int max_seg_ms, std::vector<std::pair<int,int>>& segs, int nthreads=8){
+  using namespace funasr_vad_impl;
+  segs.clear();
+  vad m; gguf_init_params ip={false,&m.ctx}; gguf_context*gg=gguf_init_from_file(gguf_path.c_str(),ip);
+  if(!gg){fprintf(stderr,"vad: cannot load %s\n",gguf_path.c_str());return false;}
+  auto rd=[&](const char*k,int d){int i=gguf_find_key(gg,k);return i<0?d:(int)gguf_get_val_u32(gg,i);};
+  int idim=rd("vad.input_dim",400),pd=rd("vad.proj_dim",128),nl=rd("vad.fsmn_layers",4),lorder=rd("vad.lorder",20),
+      od=rd("vad.output_dim",248),lm=rd("vad.lfr_m",5),ln=rd("vad.lfr_n",1);
+  for(int i=0;i<gguf_get_n_tensors(gg);i++){const char*nm=gguf_get_tensor_name(gg,i);m.t[nm]=ggml_get_tensor(m.ctx,nm);}
+  gguf_free(gg);
+
+  // fail fast (not segfault) if the GGUF is missing tensors the graph dereferences
+  auto need=[&](const std::string&n){ return m.g(n)!=nullptr; };
+  bool ok_t = need("cmvn.shift")&&need("cmvn.scale")&&need("encoder.in_linear1.linear.weight")
+            &&need("encoder.in_linear2.linear.weight")&&need("encoder.out_linear1.linear.weight")
+            &&need("encoder.out_linear2.linear.weight");
+  for(int i=0;i<nl&&ok_t;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
+    ok_t=need(p+"linear.linear.weight")&&need(p+"fsmn_block.conv_left.weight")&&need(p+"affine.linear.weight");}
+  if(!ok_t){fprintf(stderr,"vad: gguf missing required tensors\n"); if(m.ctx)ggml_free(m.ctx); return false;}
+
+  auto feat=fbank80(wav); int T=0; auto feats=lfr(feat,lm,ln,T);   // [T,400]
+  if(T<1){if(m.ctx)ggml_free(m.ctx);return true;}                  // too short -> no speech
+  float*shift=(float*)m.g("cmvn.shift")->data,*scale=(float*)m.g("cmvn.scale")->data;
+  for(int t=0;t<T;t++)for(int d=0;d<idim;d++)feats[(size_t)t*idim+d]=(feats[(size_t)t*idim+d]+shift[d])*scale[d];
+
+  ggml_backend_t be=ggml_backend_cpu_init();
+  // no_alloc=true -> ctx holds only tensor/graph metadata (the real compute buffer is
+  // allocated by gallocr below), so a few MB is plenty regardless of clip length.
+  ggml_init_params cp={(size_t)16*1024*1024,nullptr,true}; ggml_context*c=ggml_init(cp);
+  ggml_tensor*x=ggml_new_tensor_2d(c,GGML_TYPE_F32,idim,T); ggml_set_input(x);
+  ggml_tensor*h=lin(c,m.g("encoder.in_linear1.linear.weight"),m.g("encoder.in_linear1.linear.bias"),x);
+  h=lin(c,m.g("encoder.in_linear2.linear.weight"),m.g("encoder.in_linear2.linear.bias"),h); h=ggml_relu(c,h);
+  for(int i=0;i<nl;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
+    ggml_tensor*z=ggml_mul_mat(c,m.g(p+"linear.linear.weight"),h);
+    ggml_tensor*fk=m.g(p+"fsmn_block.conv_left.weight"); ggml_tensor*zp=ggml_pad_ext(c,z,0,0,lorder-1,0,0,0,0,0); ggml_tensor*acc=z;
+    // sl is a full-row slice of the contiguous padded tensor -> already contiguous, no ggml_cont needed
+    for(int j=0;j<lorder;j++){auto sl=ggml_view_2d(c,zp,pd,T,zp->nb[1],(size_t)j*zp->nb[1]);auto wj=ggml_view_1d(c,fk,pd,(size_t)j*fk->nb[1]);acc=ggml_add(c,acc,ggml_mul(c,sl,wj));}
+    ggml_tensor*a=lin(c,m.g(p+"affine.linear.weight"),m.g(p+"affine.linear.bias"),acc); h=ggml_relu(c,a);}
+  h=lin(c,m.g("encoder.out_linear1.linear.weight"),m.g("encoder.out_linear1.linear.bias"),h);
+  h=lin(c,m.g("encoder.out_linear2.linear.weight"),m.g("encoder.out_linear2.linear.bias"),h);
+  h=ggml_soft_max(c,h); ggml_set_output(h);
+  ggml_cgraph*gf=ggml_new_graph(c); ggml_build_forward_expand(gf,h);
+  ggml_gallocr_t ga=ggml_gallocr_new(ggml_backend_cpu_buffer_type()); ggml_gallocr_alloc_graph(ga,gf);
+  ggml_backend_tensor_set(x,feats.data(),0,ggml_nbytes(x)); ggml_backend_cpu_set_n_threads(be,nthreads);
+  bool ok=ggml_backend_graph_compute(be,gf)==GGML_STATUS_SUCCESS;
+  std::vector<float> sc((size_t)od*T); if(ok)ggml_backend_tensor_get(h,sc.data(),0,ggml_nbytes(h));
+  ggml_gallocr_free(ga);ggml_free(c);ggml_backend_free(be);if(m.ctx)ggml_free(m.ctx);
+  if(!ok)return false;
+
+  // ===== E2EVadModel state machine (host) -> speech segments [start_ms,end_ms] =====
+  const int FR=10;                 // ms per frame (frame_in_ms)
+  const int win=20;                // window_size_ms 200 / 10
+  const int s2s=15, sp2s=15;       // sil_to_speech / speech_to_sil thres (150/10)
+  const int lookahead_end=100/FR;  // lookahead_time_end_point 100/10 = 10 (do_extend)
+  int max_seg = (max_seg_ms>0 ? max_seg_ms : 60000)/FR;       // max_single_segment frames
+  const int start_lookback = win + 200/FR;                   // LatencyFrmNumAtStartPoint = 40
+  // End-silence threshold from DEFAULT_SILENCE_SCHEDULE, stepped at chunk boundaries (chunk_size
+  // 60000ms = 6000 frames). At each boundary, if mid-segment (InSpeech) or in_speech latched,
+  // accumulated_ms += 60000; threshold = schedule(accumulated). Reset to 0 on each segment emit.
+  const int CHUNK=60000/FR;
+  int acc=0, insp=0; int max_end_sil, end_lookback;
+  auto recompute=[&](){
+    int s; if(acc<=10000)s=2000; else if(acc<=20000)s=1000; else if(acc<=30000)s=800;
+    else if(acc<=40000)s=600; else if(acc<=50000)s=400; else if(acc<=60000)s=200; else s=100;
+    int ms=s-150; if(ms<0)ms=0; max_end_sil=ms/FR;
+    end_lookback=max_end_sil-lookahead_end-1; if(end_lookback<0)end_lookback=0;
+  };
+  recompute();
+  std::vector<int> wbuf(win,0); int wpos=0,wsum=0,pre=0;
+  int st=0, cstart=-1, csil=0, prev_end=0;
+  auto reset=[&](){ std::fill(wbuf.begin(),wbuf.end(),0); wpos=0; wsum=0; pre=0; csil=0; st=0; cstart=-1; acc=0; insp=0; };
+  auto emit=[&](int s,int e){ if(s<prev_end)s=prev_end; if(s<0)s=0; if(e>T)e=T; if(e>s){segs.push_back({s,e}); prev_end=e;} };
+  for(int t=0;t<T;t++){
+    if(t>0 && t%CHUNK==0){ if(st==1||insp){acc+=60000; insp=1;} recompute(); }
+    float sil=sc[(size_t)t*od+0];
+    int fs = ((1.0f-sil) >= sil + 0.5f) ? 1 : 0;               // speech_noise_thres=0.5
+    wsum -= wbuf[wpos]; wsum += fs; wbuf[wpos]=fs; wpos=(wpos+1)%win;
+    int ch;
+    if(pre==0 && wsum>=s2s){pre=1; ch=3;}
+    else if(pre==1 && wsum<=sp2s){pre=0; ch=1;}
+    else ch = pre==0?0:2;
+    if(ch==3){ csil=0;
+      if(st==0){ cstart=t-start_lookback; if(cstart<prev_end)cstart=prev_end; if(cstart<0)cstart=0; st=1; }
+      else if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+    } else if(ch==1||ch==2){ csil=0;
+      if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+    } else { csil++;
+      if(st==1){
+        if(csil>=max_end_sil){ emit(cstart, t-end_lookback); reset(); }
+        else if(t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+      }
+    }
+  }
+  if(st==1) emit(cstart,T);
+  // convert frame indices -> ms
+  for(auto&s:segs){ s.first*=FR; s.second*=FR; }
+  return true;
+}

--- a/examples/funasr/funasr_vad.h
+++ b/examples/funasr/funasr_vad.h
@@ -1,4 +1,4 @@
-// funasr_vad.h — single-header FSMN-VAD for the funasr ggml runtime.
+// funasr_vad.h - single-header FSMN-VAD for the funasr ggml runtime.
 // Exposes funasr_vad_segments(): 16k mono wav -> speech segments [start_ms,end_ms].
 // Front end (80-mel fbank + LFR m5n1 + CMVN) and FSMN encoder validated bit-exact vs
 // PyTorch fsmn-vad; the host state machine reproduces E2EVadModel (DEFAULT_SILENCE_SCHEDULE,
@@ -26,136 +26,136 @@ static const int FS=16000,WINLEN=400,SHIFT=160,NFFT=512,NMEL=80;
 static const float PREEMPH=0.97f,LOWF=20.0f,HIGHF=8000.0f;
 static inline float melf(float f){return 1127.0f*logf(1.0f+f/700.0f);}
 static void fftc(std::vector<float>&re,std::vector<float>&im,int n){for(int i=1,j=0;i<n;i++){int b=n>>1;for(;j&b;b>>=1)j^=b;j^=b;if(i<j){std::swap(re[i],re[j]);std::swap(im[i],im[j]);}}
-  for(int len=2;len<=n;len<<=1){double a=-2.0*M_PI/len;float wr=cosf(a),wi=sinf(a);for(int i=0;i<n;i+=len){float cr=1,ci=0;for(int k=0;k<len/2;k++){float ur=re[i+k],ui=im[i+k];
-    float vr=re[i+k+len/2]*cr-im[i+k+len/2]*ci,vi=re[i+k+len/2]*ci+im[i+k+len/2]*cr;re[i+k]=ur+vr;im[i+k]=ui+vi;re[i+k+len/2]=ur-vr;im[i+k+len/2]=ui-vi;float nc=cr*wr-ci*wi;ci=cr*wi+ci*wr;cr=nc;}}}}
+    for(int len=2;len<=n;len<<=1){double a=-2.0*M_PI/len;float wr=cosf(a),wi=sinf(a);for(int i=0;i<n;i+=len){float cr=1,ci=0;for(int k=0;k<len/2;k++){float ur=re[i+k],ui=im[i+k];
+        float vr=re[i+k+len/2]*cr-im[i+k+len/2]*ci,vi=re[i+k+len/2]*ci+im[i+k+len/2]*cr;re[i+k]=ur+vr;im[i+k]=ui+vi;re[i+k+len/2]=ur-vr;im[i+k+len/2]=ui-vi;float nc=cr*wr-ci*wi;ci=cr*wi+ci*wr;cr=nc;}}}}
 static std::vector<std::vector<float>> fbank80(std::vector<float> wav){
-  for(auto&v:wav)v*=32768.0f; std::vector<float>win(WINLEN);
-  for(int i=0;i<WINLEN;i++)win[i]=0.54f-0.46f*cosf(2.0f*M_PI*i/(WINLEN-1));
-  const int NB=NFFT/2+1; float bw=(float)FS/NFFT,ml=melf(LOWF),mh=melf(HIGHF),dm=(mh-ml)/(NMEL+1);
-  std::vector<std::vector<float>>fb(NMEL,std::vector<float>(NB,0.0f));
-  for(int m=0;m<NMEL;m++){float L=ml+m*dm,C=ml+(m+1)*dm,R=ml+(m+2)*dm;for(int k=0;k<NB;k++){float mf=melf(bw*k);if(mf>L&&mf<R)fb[m][k]=mf<=C?(mf-L)/(C-L):(R-mf)/(R-C);}}
-  int N=wav.size(),T=(N-WINLEN)/SHIFT+1; if(T<1)T=0; std::vector<std::vector<float>>feat(T,std::vector<float>(NMEL));
-  std::vector<float>re(NFFT),im(NFFT),fr(WINLEN);const float fl=1.1920929e-07f;
-  for(int t=0;t<T;t++){const float*s=wav.data()+t*SHIFT;double mn=0;for(int i=0;i<WINLEN;i++)mn+=s[i];mn/=WINLEN;
-    for(int i=0;i<WINLEN;i++)fr[i]=s[i]-(float)mn;for(int i=WINLEN-1;i>0;i--)fr[i]-=PREEMPH*fr[i-1];fr[0]-=PREEMPH*fr[0];
-    for(int i=0;i<NFFT;i++){re[i]=i<WINLEN?fr[i]*win[i]:0.0f;im[i]=0.0f;}fftc(re,im,NFFT);
-    for(int m=0;m<NMEL;m++){float e=0;for(int k=0;k<NB;k++)if(fb[m][k]>0)e+=fb[m][k]*(re[k]*re[k]+im[k]*im[k]);feat[t][m]=logf(e>fl?e:fl);}}
-  return feat;
+    for(auto&v:wav)v*=32768.0f; std::vector<float>win(WINLEN);
+    for(int i=0;i<WINLEN;i++)win[i]=0.54f-0.46f*cosf(2.0f*M_PI*i/(WINLEN-1));
+    const int NB=NFFT/2+1; float bw=(float)FS/NFFT,ml=melf(LOWF),mh=melf(HIGHF),dm=(mh-ml)/(NMEL+1);
+    std::vector<std::vector<float>>fb(NMEL,std::vector<float>(NB,0.0f));
+    for(int m=0;m<NMEL;m++){float L=ml+m*dm,C=ml+(m+1)*dm,R=ml+(m+2)*dm;for(int k=0;k<NB;k++){float mf=melf(bw*k);if(mf>L&&mf<R)fb[m][k]=mf<=C?(mf-L)/(C-L):(R-mf)/(R-C);}}
+    int N=wav.size(),T=(N-WINLEN)/SHIFT+1; if(T<1)T=0; std::vector<std::vector<float>>feat(T,std::vector<float>(NMEL));
+    std::vector<float>re(NFFT),im(NFFT),fr(WINLEN);const float fl=1.1920929e-07f;
+    for(int t=0;t<T;t++){const float*s=wav.data()+t*SHIFT;double mn=0;for(int i=0;i<WINLEN;i++)mn+=s[i];mn/=WINLEN;
+        for(int i=0;i<WINLEN;i++)fr[i]=s[i]-(float)mn;for(int i=WINLEN-1;i>0;i--)fr[i]-=PREEMPH*fr[i-1];fr[0]-=PREEMPH*fr[0];
+        for(int i=0;i<NFFT;i++){re[i]=i<WINLEN?fr[i]*win[i]:0.0f;im[i]=0.0f;}fftc(re,im,NFFT);
+        for(int m=0;m<NMEL;m++){float e=0;for(int k=0;k<NB;k++)if(fb[m][k]>0)e+=fb[m][k]*(re[k]*re[k]+im[k]*im[k]);feat[t][m]=logf(e>fl?e:fl);}}
+    return feat;
 }
 static std::vector<float> lfr(const std::vector<std::vector<float>>&feat,int m,int n,int&T_out){
-  int T=feat.size(); if(T<1){T_out=0;return {};}     // empty (audio shorter than one frame)
-  int D=NMEL,pad=(m-1)/2; int Tl=(T+n-1)/n;
-  std::vector<std::vector<float>> pf; pf.reserve(T+pad+m);
-  for(int i=0;i<pad;i++)pf.push_back(feat[0]);
-  for(int t=0;t<T;t++)pf.push_back(feat[t]);
-  while((int)pf.size()<(Tl-1)*n+m)pf.push_back(feat[T-1]);
-  std::vector<float> out((size_t)Tl*m*D);
-  for(int i=0;i<Tl;i++)for(int j=0;j<m;j++)memcpy(&out[((size_t)i*m+j)*D],pf[i*n+j].data(),D*sizeof(float));
-  T_out=Tl; return out;
+    int T=feat.size(); if(T<1){T_out=0;return {};}     // empty (audio shorter than one frame)
+    int D=NMEL,pad=(m-1)/2; int Tl=(T+n-1)/n;
+    std::vector<std::vector<float>> pf; pf.reserve(T+pad+m);
+    for(int i=0;i<pad;i++)pf.push_back(feat[0]);
+    for(int t=0;t<T;t++)pf.push_back(feat[t]);
+    while((int)pf.size()<(Tl-1)*n+m)pf.push_back(feat[T-1]);
+    std::vector<float> out((size_t)Tl*m*D);
+    for(int i=0;i<Tl;i++)for(int j=0;j<m;j++)memcpy(&out[((size_t)i*m+j)*D],pf[i*n+j].data(),D*sizeof(float));
+    T_out=Tl; return out;
 }
 struct vad{ggml_context*ctx=nullptr;std::map<std::string,ggml_tensor*>t;
-  ggml_tensor*g(const std::string&n){auto it=t.find(n);if(it==t.end()){fprintf(stderr,"vad: missing %s\n",n.c_str());return nullptr;}return it->second;}};
+    ggml_tensor*g(const std::string&n){auto it=t.find(n);if(it==t.end()){fprintf(stderr,"vad: missing %s\n",n.c_str());return nullptr;}return it->second;}};
 static ggml_tensor* lin(ggml_context*c,ggml_tensor*w,ggml_tensor*b,ggml_tensor*x){auto y=ggml_mul_mat(c,w,x);return b?ggml_add(c,y,b):y;}
 } // namespace funasr_vad_impl
 
 // Run FSMN-VAD on a 16k mono float waveform; fills segs with [start_ms,end_ms] speech spans.
 // max_seg_ms caps a single segment (e.g. 30000); pass <=0 to use 60000 (model default).
 inline bool funasr_vad_segments(const std::string& gguf_path, const std::vector<float>& wav,
-                                int max_seg_ms, std::vector<std::pair<int,int>>& segs, int nthreads=8){
-  using namespace funasr_vad_impl;
-  segs.clear();
-  vad m; gguf_init_params ip={false,&m.ctx}; gguf_context*gg=gguf_init_from_file(gguf_path.c_str(),ip);
-  if(!gg){fprintf(stderr,"vad: cannot load %s\n",gguf_path.c_str());return false;}
-  auto rd=[&](const char*k,int d){int i=gguf_find_key(gg,k);return i<0?d:(int)gguf_get_val_u32(gg,i);};
-  int idim=rd("vad.input_dim",400),pd=rd("vad.proj_dim",128),nl=rd("vad.fsmn_layers",4),lorder=rd("vad.lorder",20),
-      od=rd("vad.output_dim",248),lm=rd("vad.lfr_m",5),ln=rd("vad.lfr_n",1);
-  for(int i=0;i<gguf_get_n_tensors(gg);i++){const char*nm=gguf_get_tensor_name(gg,i);m.t[nm]=ggml_get_tensor(m.ctx,nm);}
-  gguf_free(gg);
+        int max_seg_ms, std::vector<std::pair<int,int>>& segs, int nthreads=8){
+    using namespace funasr_vad_impl;
+    segs.clear();
+    vad m; gguf_init_params ip={false,&m.ctx}; gguf_context*gg=gguf_init_from_file(gguf_path.c_str(),ip);
+    if(!gg){fprintf(stderr,"vad: cannot load %s\n",gguf_path.c_str());return false;}
+    auto rd=[&](const char*k,int d){int i=gguf_find_key(gg,k);return i<0?d:(int)gguf_get_val_u32(gg,i);};
+    int idim=rd("vad.input_dim",400),pd=rd("vad.proj_dim",128),nl=rd("vad.fsmn_layers",4),lorder=rd("vad.lorder",20),
+            od=rd("vad.output_dim",248),lm=rd("vad.lfr_m",5),ln=rd("vad.lfr_n",1);
+    for(int i=0;i<gguf_get_n_tensors(gg);i++){const char*nm=gguf_get_tensor_name(gg,i);m.t[nm]=ggml_get_tensor(m.ctx,nm);}
+    gguf_free(gg);
 
-  // fail fast (not segfault) if the GGUF is missing tensors the graph dereferences
-  auto need=[&](const std::string&n){ return m.g(n)!=nullptr; };
-  bool ok_t = need("cmvn.shift")&&need("cmvn.scale")&&need("encoder.in_linear1.linear.weight")
+    // fail fast (not segfault) if the GGUF is missing tensors the graph dereferences
+    auto need=[&](const std::string&n){ return m.g(n)!=nullptr; };
+    bool ok_t = need("cmvn.shift")&&need("cmvn.scale")&&need("encoder.in_linear1.linear.weight")
             &&need("encoder.in_linear2.linear.weight")&&need("encoder.out_linear1.linear.weight")
             &&need("encoder.out_linear2.linear.weight");
-  for(int i=0;i<nl&&ok_t;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
-    ok_t=need(p+"linear.linear.weight")&&need(p+"fsmn_block.conv_left.weight")&&need(p+"affine.linear.weight");}
-  if(!ok_t){fprintf(stderr,"vad: gguf missing required tensors\n"); if(m.ctx)ggml_free(m.ctx); return false;}
+    for(int i=0;i<nl&&ok_t;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
+        ok_t=need(p+"linear.linear.weight")&&need(p+"fsmn_block.conv_left.weight")&&need(p+"affine.linear.weight");}
+    if(!ok_t){fprintf(stderr,"vad: gguf missing required tensors\n"); if(m.ctx)ggml_free(m.ctx); return false;}
 
-  auto feat=fbank80(wav); int T=0; auto feats=lfr(feat,lm,ln,T);   // [T,400]
-  if(T<1){if(m.ctx)ggml_free(m.ctx);return true;}                  // too short -> no speech
-  float*shift=(float*)m.g("cmvn.shift")->data,*scale=(float*)m.g("cmvn.scale")->data;
-  for(int t=0;t<T;t++)for(int d=0;d<idim;d++)feats[(size_t)t*idim+d]=(feats[(size_t)t*idim+d]+shift[d])*scale[d];
+    auto feat=fbank80(wav); int T=0; auto feats=lfr(feat,lm,ln,T);   // [T,400]
+    if(T<1){if(m.ctx)ggml_free(m.ctx);return true;}                  // too short -> no speech
+    float*shift=(float*)m.g("cmvn.shift")->data,*scale=(float*)m.g("cmvn.scale")->data;
+    for(int t=0;t<T;t++)for(int d=0;d<idim;d++)feats[(size_t)t*idim+d]=(feats[(size_t)t*idim+d]+shift[d])*scale[d];
 
-  ggml_backend_t be=ggml_backend_cpu_init();
-  // no_alloc=true -> ctx holds only tensor/graph metadata (the real compute buffer is
-  // allocated by gallocr below), so a few MB is plenty regardless of clip length.
-  ggml_init_params cp={(size_t)16*1024*1024,nullptr,true}; ggml_context*c=ggml_init(cp);
-  ggml_tensor*x=ggml_new_tensor_2d(c,GGML_TYPE_F32,idim,T); ggml_set_input(x);
-  ggml_tensor*h=lin(c,m.g("encoder.in_linear1.linear.weight"),m.g("encoder.in_linear1.linear.bias"),x);
-  h=lin(c,m.g("encoder.in_linear2.linear.weight"),m.g("encoder.in_linear2.linear.bias"),h); h=ggml_relu(c,h);
-  for(int i=0;i<nl;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
-    ggml_tensor*z=ggml_mul_mat(c,m.g(p+"linear.linear.weight"),h);
-    ggml_tensor*fk=m.g(p+"fsmn_block.conv_left.weight"); ggml_tensor*zp=ggml_pad_ext(c,z,0,0,lorder-1,0,0,0,0,0); ggml_tensor*acc=z;
-    // sl is a full-row slice of the contiguous padded tensor -> already contiguous, no ggml_cont needed
-    for(int j=0;j<lorder;j++){auto sl=ggml_view_2d(c,zp,pd,T,zp->nb[1],(size_t)j*zp->nb[1]);auto wj=ggml_view_1d(c,fk,pd,(size_t)j*fk->nb[1]);acc=ggml_add(c,acc,ggml_mul(c,sl,wj));}
-    ggml_tensor*a=lin(c,m.g(p+"affine.linear.weight"),m.g(p+"affine.linear.bias"),acc); h=ggml_relu(c,a);}
-  h=lin(c,m.g("encoder.out_linear1.linear.weight"),m.g("encoder.out_linear1.linear.bias"),h);
-  h=lin(c,m.g("encoder.out_linear2.linear.weight"),m.g("encoder.out_linear2.linear.bias"),h);
-  h=ggml_soft_max(c,h); ggml_set_output(h);
-  ggml_cgraph*gf=ggml_new_graph(c); ggml_build_forward_expand(gf,h);
-  ggml_gallocr_t ga=ggml_gallocr_new(ggml_backend_cpu_buffer_type()); ggml_gallocr_alloc_graph(ga,gf);
-  ggml_backend_tensor_set(x,feats.data(),0,ggml_nbytes(x)); ggml_backend_cpu_set_n_threads(be,nthreads);
-  bool ok=ggml_backend_graph_compute(be,gf)==GGML_STATUS_SUCCESS;
-  std::vector<float> sc((size_t)od*T); if(ok)ggml_backend_tensor_get(h,sc.data(),0,ggml_nbytes(h));
-  ggml_gallocr_free(ga);ggml_free(c);ggml_backend_free(be);if(m.ctx)ggml_free(m.ctx);
-  if(!ok)return false;
+    ggml_backend_t be=ggml_backend_cpu_init();
+    // no_alloc=true -> ctx holds only tensor/graph metadata (the real compute buffer is
+    // allocated by gallocr below), so a few MB is plenty regardless of clip length.
+    ggml_init_params cp={(size_t)16*1024*1024,nullptr,true}; ggml_context*c=ggml_init(cp);
+    ggml_tensor*x=ggml_new_tensor_2d(c,GGML_TYPE_F32,idim,T); ggml_set_input(x);
+    ggml_tensor*h=lin(c,m.g("encoder.in_linear1.linear.weight"),m.g("encoder.in_linear1.linear.bias"),x);
+    h=lin(c,m.g("encoder.in_linear2.linear.weight"),m.g("encoder.in_linear2.linear.bias"),h); h=ggml_relu(c,h);
+    for(int i=0;i<nl;i++){std::string p="encoder.fsmn."+std::to_string(i)+".";
+        ggml_tensor*z=ggml_mul_mat(c,m.g(p+"linear.linear.weight"),h);
+        ggml_tensor*fk=m.g(p+"fsmn_block.conv_left.weight"); ggml_tensor*zp=ggml_pad_ext(c,z,0,0,lorder-1,0,0,0,0,0); ggml_tensor*acc=z;
+        // sl is a full-row slice of the contiguous padded tensor -> already contiguous, no ggml_cont needed
+        for(int j=0;j<lorder;j++){auto sl=ggml_view_2d(c,zp,pd,T,zp->nb[1],(size_t)j*zp->nb[1]);auto wj=ggml_view_1d(c,fk,pd,(size_t)j*fk->nb[1]);acc=ggml_add(c,acc,ggml_mul(c,sl,wj));}
+        ggml_tensor*a=lin(c,m.g(p+"affine.linear.weight"),m.g(p+"affine.linear.bias"),acc); h=ggml_relu(c,a);}
+    h=lin(c,m.g("encoder.out_linear1.linear.weight"),m.g("encoder.out_linear1.linear.bias"),h);
+    h=lin(c,m.g("encoder.out_linear2.linear.weight"),m.g("encoder.out_linear2.linear.bias"),h);
+    h=ggml_soft_max(c,h); ggml_set_output(h);
+    ggml_cgraph*gf=ggml_new_graph(c); ggml_build_forward_expand(gf,h);
+    ggml_gallocr_t ga=ggml_gallocr_new(ggml_backend_cpu_buffer_type()); ggml_gallocr_alloc_graph(ga,gf);
+    ggml_backend_tensor_set(x,feats.data(),0,ggml_nbytes(x)); ggml_backend_cpu_set_n_threads(be,nthreads);
+    bool ok=ggml_backend_graph_compute(be,gf)==GGML_STATUS_SUCCESS;
+    std::vector<float> sc((size_t)od*T); if(ok)ggml_backend_tensor_get(h,sc.data(),0,ggml_nbytes(h));
+    ggml_gallocr_free(ga);ggml_free(c);ggml_backend_free(be);if(m.ctx)ggml_free(m.ctx);
+    if(!ok)return false;
 
-  // ===== E2EVadModel state machine (host) -> speech segments [start_ms,end_ms] =====
-  const int FR=10;                 // ms per frame (frame_in_ms)
-  const int win=20;                // window_size_ms 200 / 10
-  const int s2s=15, sp2s=15;       // sil_to_speech / speech_to_sil thres (150/10)
-  const int lookahead_end=100/FR;  // lookahead_time_end_point 100/10 = 10 (do_extend)
-  int max_seg = (max_seg_ms>0 ? max_seg_ms : 60000)/FR;       // max_single_segment frames
-  const int start_lookback = win + 200/FR;                   // LatencyFrmNumAtStartPoint = 40
-  // End-silence threshold from DEFAULT_SILENCE_SCHEDULE, stepped at chunk boundaries (chunk_size
-  // 60000ms = 6000 frames). At each boundary, if mid-segment (InSpeech) or in_speech latched,
-  // accumulated_ms += 60000; threshold = schedule(accumulated). Reset to 0 on each segment emit.
-  const int CHUNK=60000/FR;
-  int acc=0, insp=0; int max_end_sil, end_lookback;
-  auto recompute=[&](){
-    int s; if(acc<=10000)s=2000; else if(acc<=20000)s=1000; else if(acc<=30000)s=800;
-    else if(acc<=40000)s=600; else if(acc<=50000)s=400; else if(acc<=60000)s=200; else s=100;
-    int ms=s-150; if(ms<0)ms=0; max_end_sil=ms/FR;
-    end_lookback=max_end_sil-lookahead_end-1; if(end_lookback<0)end_lookback=0;
-  };
-  recompute();
-  std::vector<int> wbuf(win,0); int wpos=0,wsum=0,pre=0;
-  int st=0, cstart=-1, csil=0, prev_end=0;
-  auto reset=[&](){ std::fill(wbuf.begin(),wbuf.end(),0); wpos=0; wsum=0; pre=0; csil=0; st=0; cstart=-1; acc=0; insp=0; };
-  auto emit=[&](int s,int e){ if(s<prev_end)s=prev_end; if(s<0)s=0; if(e>T)e=T; if(e>s){segs.push_back({s,e}); prev_end=e;} };
-  for(int t=0;t<T;t++){
-    if(t>0 && t%CHUNK==0){ if(st==1||insp){acc+=60000; insp=1;} recompute(); }
-    float sil=sc[(size_t)t*od+0];
-    int fs = ((1.0f-sil) >= sil + 0.5f) ? 1 : 0;               // speech_noise_thres=0.5
-    wsum -= wbuf[wpos]; wsum += fs; wbuf[wpos]=fs; wpos=(wpos+1)%win;
-    int ch;
-    if(pre==0 && wsum>=s2s){pre=1; ch=3;}
-    else if(pre==1 && wsum<=sp2s){pre=0; ch=1;}
-    else ch = pre==0?0:2;
-    if(ch==3){ csil=0;
-      if(st==0){ cstart=t-start_lookback; if(cstart<prev_end)cstart=prev_end; if(cstart<0)cstart=0; st=1; }
-      else if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
-    } else if(ch==1||ch==2){ csil=0;
-      if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
-    } else { csil++;
-      if(st==1){
-        if(csil>=max_end_sil){ emit(cstart, t-end_lookback); reset(); }
-        else if(t-cstart+1>max_seg){ emit(cstart,t); reset(); }
-      }
+    // ===== E2EVadModel state machine (host) -> speech segments [start_ms,end_ms] =====
+    const int FR=10;                 // ms per frame (frame_in_ms)
+    const int win=20;                // window_size_ms 200 / 10
+    const int s2s=15, sp2s=15;       // sil_to_speech / speech_to_sil thres (150/10)
+    const int lookahead_end=100/FR;  // lookahead_time_end_point 100/10 = 10 (do_extend)
+    int max_seg = (max_seg_ms>0 ? max_seg_ms : 60000)/FR;       // max_single_segment frames
+    const int start_lookback = win + 200/FR;                   // LatencyFrmNumAtStartPoint = 40
+    // End-silence threshold from DEFAULT_SILENCE_SCHEDULE, stepped at chunk boundaries (chunk_size
+    // 60000ms = 6000 frames). At each boundary, if mid-segment (InSpeech) or in_speech latched,
+    // accumulated_ms += 60000; threshold = schedule(accumulated). Reset to 0 on each segment emit.
+    const int CHUNK=60000/FR;
+    int acc=0, insp=0; int max_end_sil, end_lookback;
+    auto recompute=[&](){
+        int s; if(acc<=10000)s=2000; else if(acc<=20000)s=1000; else if(acc<=30000)s=800;
+        else if(acc<=40000)s=600; else if(acc<=50000)s=400; else if(acc<=60000)s=200; else s=100;
+        int ms=s-150; if(ms<0)ms=0; max_end_sil=ms/FR;
+        end_lookback=max_end_sil-lookahead_end-1; if(end_lookback<0)end_lookback=0;
+    };
+    recompute();
+    std::vector<int> wbuf(win,0); int wpos=0,wsum=0,pre=0;
+    int st=0, cstart=-1, csil=0, prev_end=0;
+    auto reset=[&](){ std::fill(wbuf.begin(),wbuf.end(),0); wpos=0; wsum=0; pre=0; csil=0; st=0; cstart=-1; acc=0; insp=0; };
+    auto emit=[&](int s,int e){ if(s<prev_end)s=prev_end; if(s<0)s=0; if(e>T)e=T; if(e>s){segs.push_back({s,e}); prev_end=e;} };
+    for(int t=0;t<T;t++){
+        if(t>0 && t%CHUNK==0){ if(st==1||insp){acc+=60000; insp=1;} recompute(); }
+        float sil=sc[(size_t)t*od+0];
+        int fs = ((1.0f-sil) >= sil + 0.5f) ? 1 : 0;               // speech_noise_thres=0.5
+        wsum -= wbuf[wpos]; wsum += fs; wbuf[wpos]=fs; wpos=(wpos+1)%win;
+        int ch;
+        if(pre==0 && wsum>=s2s){pre=1; ch=3;}
+        else if(pre==1 && wsum<=sp2s){pre=0; ch=1;}
+        else ch = pre==0?0:2;
+        if(ch==3){ csil=0;
+            if(st==0){ cstart=t-start_lookback; if(cstart<prev_end)cstart=prev_end; if(cstart<0)cstart=0; st=1; }
+            else if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+        } else if(ch==1||ch==2){ csil=0;
+            if(st==1 && t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+        } else { csil++;
+            if(st==1){
+                if(csil>=max_end_sil){ emit(cstart, t-end_lookback); reset(); }
+                else if(t-cstart+1>max_seg){ emit(cstart,t); reset(); }
+            }
+        }
     }
-  }
-  if(st==1) emit(cstart,T);
-  // convert frame indices -> ms
-  for(auto&s:segs){ s.first*=FR; s.second*=FR; }
-  return true;
+    if(st==1) emit(cstart,T);
+    // convert frame indices -> ms
+    for(auto&s:segs){ s.first*=FR; s.second*=FR; }
+    return true;
 }

--- a/examples/funasr/nano-cli/CMakeLists.txt
+++ b/examples/funasr/nano-cli/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(TARGET llama-funasr-cli)
+add_executable(${TARGET} funasr-cli.cpp)
+install(TARGETS ${TARGET} RUNTIME)
+target_include_directories(${TARGET} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/miniaudio)
+target_link_libraries(${TARGET} PRIVATE llama ggml ${CMAKE_THREAD_LIBS_INIT})
+target_compile_features(${TARGET} PRIVATE cxx_std_17)
+if(MSVC)
+    # 源文件含 UTF-8 中文(如 "语音转写" / "no(截断)"), 避免 MSVC 按 GBK 解析报错
+    target_compile_options(${TARGET} PRIVATE /utf-8)
+    # Windows min/max 宏会污染 std::min/std::max; M_PI 需要 _USE_MATH_DEFINES
+    target_compile_definitions(${TARGET} PRIVATE NOMINMAX _USE_MATH_DEFINES)
+endif()
+

--- a/examples/funasr/nano-cli/CMakeLists.txt
+++ b/examples/funasr/nano-cli/CMakeLists.txt
@@ -7,9 +7,9 @@ target_include_directories(${TARGET} PRIVATE
 target_link_libraries(${TARGET} PRIVATE llama ggml ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
 if(MSVC)
-    # 源文件含 UTF-8 中文(如 "语音转写" / "no(截断)"), 避免 MSVC 按 GBK 解析报错
+    # the source contains a UTF-8 Chinese prompt string; tell MSVC not to parse as GBK
     target_compile_options(${TARGET} PRIVATE /utf-8)
-    # Windows min/max 宏会污染 std::min/std::max; M_PI 需要 _USE_MATH_DEFINES
+    # Windows min/max macros clash with std::min/std::max; M_PI needs _USE_MATH_DEFINES
     target_compile_definitions(${TARGET} PRIVATE NOMINMAX _USE_MATH_DEFINES)
 endif()
 

--- a/examples/funasr/nano-cli/funasr-cli.cpp
+++ b/examples/funasr/nano-cli/funasr-cli.cpp
@@ -1,0 +1,348 @@
+// funasr-cli: end-to-end Fun-ASR-Nano in C++ on the llama.cpp / ggml stack.
+//
+//   wav(16k mono) -> kaldi fbank -> SAN-M encoder + adaptor (ggml) ->
+//   low-frame-rate truncation -> [prefix tokens | audio embeds | suffix tokens]
+//   -> Qwen3 LLM (llama.cpp) -> transcription.
+//
+// This is the whisper.cpp-style single-binary path: no Python at runtime.
+//
+//   funasr-cli --enc funasr-encoder.gguf -m qwen3-0.6b.gguf -a audio.wav
+
+#include "ggml.h"
+#include "ggml-cpu.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "gguf.h"
+#include "llama.h"
+
+#include <cmath>
+#include <cctype>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+// any audio (wav/mp3/flac, any rate/channels) -> 16 kHz mono f32, via miniaudio
+#define FUNASR_AUDIO_IMPLEMENTATION
+#include "funasr_audio.h"
+// built-in FSMN-VAD front end (single-binary --vad segmentation)
+#include "funasr_vad.h"
+#include <utility>
+
+// ======================= kaldi fbank + LFR =======================
+static const int FS=16000, WINLEN=400, SHIFT=160, NFFT=512, NMEL=80, LFR_M=7, LFR_N=6;
+static const float PREEMPH=0.97f, LOWF=20.0f, HIGHF=8000.0f;
+static inline float mel(float f){ return 1127.0f*logf(1.0f+f/700.0f); }
+static void fft(std::vector<float>&re,std::vector<float>&im,int n){
+    for(int i=1,j=0;i<n;i++){int b=n>>1;for(;j&b;b>>=1)j^=b;j^=b;if(i<j){std::swap(re[i],re[j]);std::swap(im[i],im[j]);}}
+    for(int len=2;len<=n;len<<=1){double a=-2.0*M_PI/len;float wr=cosf(a),wi=sinf(a);
+        for(int i=0;i<n;i+=len){float cr=1,ci=0;for(int k=0;k<len/2;k++){
+            float ur=re[i+k],ui=im[i+k];float vr=re[i+k+len/2]*cr-im[i+k+len/2]*ci,vi=re[i+k+len/2]*ci+im[i+k+len/2]*cr;
+            re[i+k]=ur+vr;im[i+k]=ui+vi;re[i+k+len/2]=ur-vr;im[i+k+len/2]=ui-vi;
+            float n2=cr*wr-ci*wi;ci=cr*wi+ci*wr;cr=n2;}}}
+}
+// returns [T x 560] row-major, sets T
+static std::vector<float> compute_fbank(std::vector<float> wav, int & T_out) {
+    for (auto & v : wav) v *= 32768.0f;
+    std::vector<float> win(WINLEN);
+    for (int i=0;i<WINLEN;i++) win[i]=0.54f-0.46f*cosf(2.0f*M_PI*i/(WINLEN-1));
+    const int NBIN=NFFT/2+1; float bw=(float)FS/NFFT, ml=mel(LOWF), mh=mel(HIGHF), dm=(mh-ml)/(NMEL+1);
+    std::vector<std::vector<float>> fb(NMEL, std::vector<float>(NBIN,0.0f));
+    for(int m=0;m<NMEL;m++){float L=ml+m*dm,C=ml+(m+1)*dm,R=ml+(m+2)*dm;
+        for(int k=0;k<NBIN;k++){float mf=mel(bw*k); if(mf>L&&mf<R) fb[m][k]=mf<=C?(mf-L)/(C-L):(R-mf)/(R-C);}}
+    int N=wav.size(); int T=(N-WINLEN)/SHIFT+1;
+    std::vector<std::vector<float>> feat(T, std::vector<float>(NMEL));
+    std::vector<float> re(NFFT),im(NFFT),fr(WINLEN);
+    const float fl=1.1920929e-07f;
+    for(int t=0;t<T;t++){const float*s=wav.data()+t*SHIFT;
+        double mn=0;for(int i=0;i<WINLEN;i++)mn+=s[i];mn/=WINLEN;
+        for(int i=0;i<WINLEN;i++)fr[i]=s[i]-(float)mn;
+        for(int i=WINLEN-1;i>0;i--)fr[i]-=PREEMPH*fr[i-1];fr[0]-=PREEMPH*fr[0];
+        for(int i=0;i<NFFT;i++){re[i]=i<WINLEN?fr[i]*win[i]:0.0f;im[i]=0.0f;}
+        fft(re,im,NFFT);
+        for(int m=0;m<NMEL;m++){float e=0;for(int k=0;k<NBIN;k++)if(fb[m][k]>0)e+=fb[m][k]*(re[k]*re[k]+im[k]*im[k]);
+            feat[t][m]=logf(e>fl?e:fl);}}
+    // LFR
+    const int pad=(LFR_M-1)/2; int T_lfr=(T+LFR_N-1)/LFR_N;
+    std::vector<std::vector<float>> pd; pd.reserve(T+pad+LFR_M);
+    for(int i=0;i<pad;i++)pd.push_back(feat[0]);
+    for(int t=0;t<T;t++)pd.push_back(feat[t]);
+    while((int)pd.size()<(T_lfr-1)*LFR_N+LFR_M)pd.push_back(feat[T-1]);
+    int D=LFR_M*NMEL; std::vector<float> out((size_t)T_lfr*D);
+    for(int i=0;i<T_lfr;i++)for(int j=0;j<LFR_M;j++)
+        memcpy(&out[(size_t)i*D+j*NMEL],pd[i*LFR_N+j].data(),NMEL*sizeof(float));
+    T_out=T_lfr; return out;
+}
+
+// ======================= ggml SAN-M encoder + adaptor =======================
+struct cfg { int d_model=512,n_head=4,num_blocks=50,tp_blocks=20,kernel=11,adp_llm=1024,adp_layers=2,adp_head=8; };
+struct enc_model { cfg c; ggml_context*ctx_w=nullptr; std::map<std::string,ggml_tensor*> t;
+    // 原始 CPU 权重字节副本(load_enc 时固化); run_encoder 每段上传 GPU 时从它取源数据,
+    // 避免 tensor->data 被改为 GPU buffer 后原始数据悬垂。
+    std::vector<std::pair<struct ggml_tensor*,std::vector<uint8_t>>> cpu_w;
+    ggml_tensor* g(const std::string&n){auto it=t.find(n);if(it==t.end()){fprintf(stderr,"missing %s\n",n.c_str());exit(1);}return it->second;} };
+static const float LN_EPS=1e-5f;
+static bool load_enc(const char*p, enc_model&m){
+    gguf_init_params gp={false,&m.ctx_w}; gguf_context*g=gguf_init_from_file(p,gp); if(!g)return false;
+    auto rd=[&](const char*k,int d){int i=gguf_find_key(g,k);return i<0?d:(int)gguf_get_val_u32(g,i);};
+    m.c.d_model=rd("funasr.enc.output_size",512); m.c.n_head=rd("funasr.enc.attention_heads",4);
+    m.c.num_blocks=rd("funasr.enc.num_blocks",50); m.c.tp_blocks=rd("funasr.enc.tp_blocks",20);
+    m.c.kernel=rd("funasr.enc.kernel_size",11); m.c.adp_llm=rd("funasr.adp.llm_dim",1024);
+    m.c.adp_layers=rd("funasr.adp.n_layer",2); m.c.adp_head=rd("funasr.adp.attention_heads",8);
+    int n=gguf_get_n_tensors(g); for(int i=0;i<n;i++){const char*nm=gguf_get_tensor_name(g,i);m.t[nm]=ggml_get_tensor(m.ctx_w,nm);}
+    for(struct ggml_tensor*ct=ggml_get_first_tensor(m.ctx_w);ct;ct=ggml_get_next_tensor(m.ctx_w,ct)){
+        size_t nb=ggml_nbytes(ct); std::vector<uint8_t> buf(nb);
+        if(ct->data) memcpy(buf.data(),ct->data,nb);
+        m.cpu_w.push_back({ct,std::move(buf)});
+    }
+    gguf_free(g); return true;
+}
+static ggml_tensor* lin(ggml_context*c,ggml_tensor*w,ggml_tensor*b,ggml_tensor*x){auto y=ggml_mul_mat(c,w,x);return b?ggml_add(c,y,b):y;}
+static ggml_tensor* lnorm(ggml_context*c,ggml_tensor*x,ggml_tensor*g,ggml_tensor*b){return ggml_add(c,ggml_mul(c,ggml_norm(c,x,LN_EPS),g),b);}
+static ggml_tensor* sanm_attn(ggml_context*c,enc_model&m,const std::string&p,ggml_tensor*x,int T){
+    const int D=m.c.d_model,H=m.c.n_head,dk=D/H,K=m.c.kernel;
+    ggml_tensor*qkv=lin(c,m.g(p+"linear_q_k_v.weight"),m.g(p+"linear_q_k_v.bias"),x); size_t nb1=qkv->nb[1];
+    ggml_tensor*q=ggml_cont(c,ggml_view_2d(c,qkv,D,T,nb1,0));
+    ggml_tensor*k=ggml_cont(c,ggml_view_2d(c,qkv,D,T,nb1,(size_t)D*sizeof(float)));
+    ggml_tensor*v=ggml_cont(c,ggml_view_2d(c,qkv,D,T,nb1,(size_t)2*D*sizeof(float)));
+    const int pad=(K-1)/2; ggml_tensor*fk=m.g(p+"fsmn_block.weight");
+    ggml_tensor*vp=ggml_pad_ext(c,v,0,0,pad,pad,0,0,0,0); ggml_tensor*fsmn=v;
+    for(int j=0;j<K;j++){auto sl=ggml_view_2d(c,vp,D,T,vp->nb[1],(size_t)j*vp->nb[1]);
+        auto wj=ggml_view_1d(c,fk,D,(size_t)j*fk->nb[1]); fsmn=ggml_add(c,fsmn,ggml_mul(c,ggml_cont(c,sl),wj));}
+    q=ggml_permute(c,ggml_reshape_3d(c,q,dk,H,T),0,2,1,3); k=ggml_permute(c,ggml_reshape_3d(c,k,dk,H,T),0,2,1,3);
+    ggml_tensor*vh=ggml_cont(c,ggml_permute(c,ggml_reshape_3d(c,v,dk,H,T),1,2,0,3));
+    ggml_tensor*kq=ggml_soft_max(c,ggml_scale(c,ggml_mul_mat(c,k,q),1.0f/sqrtf((float)dk)));
+    ggml_tensor*o=ggml_cont_2d(c,ggml_permute(c,ggml_mul_mat(c,vh,kq),0,2,1,3),D,T);
+    return ggml_add(c,lin(c,m.g(p+"linear_out.weight"),m.g(p+"linear_out.bias"),o),fsmn);
+}
+static ggml_tensor* sanm_layer(ggml_context*c,enc_model&m,const std::string&p,ggml_tensor*x,int T,bool res){
+    auto r=x; auto h=lnorm(c,x,m.g(p+"norm1.weight"),m.g(p+"norm1.bias"));
+    auto sa=sanm_attn(c,m,p+"self_attn.",h,T); x=res?ggml_add(c,r,sa):sa; r=x;
+    h=lnorm(c,x,m.g(p+"norm2.weight"),m.g(p+"norm2.bias"));
+    h=lin(c,m.g(p+"feed_forward.w_1.weight"),m.g(p+"feed_forward.w_1.bias"),h); h=ggml_relu(c,h);
+    h=lin(c,m.g(p+"feed_forward.w_2.weight"),m.g(p+"feed_forward.w_2.bias"),h); return ggml_add(c,r,h);
+}
+static ggml_tensor* adp_layer(ggml_context*c,enc_model&m,const std::string&p,ggml_tensor*x,int T){
+    const int D=m.c.adp_llm,H=m.c.adp_head,dk=D/H; auto r=x;
+    auto h=lnorm(c,x,m.g(p+"norm1.weight"),m.g(p+"norm1.bias"));
+    auto q=ggml_permute(c,ggml_reshape_3d(c,lin(c,m.g(p+"self_attn.linear_q.weight"),m.g(p+"self_attn.linear_q.bias"),h),dk,H,T),0,2,1,3);
+    auto k=ggml_permute(c,ggml_reshape_3d(c,lin(c,m.g(p+"self_attn.linear_k.weight"),m.g(p+"self_attn.linear_k.bias"),h),dk,H,T),0,2,1,3);
+    auto vh=ggml_cont(c,ggml_permute(c,ggml_reshape_3d(c,lin(c,m.g(p+"self_attn.linear_v.weight"),m.g(p+"self_attn.linear_v.bias"),h),dk,H,T),1,2,0,3));
+    auto kq=ggml_soft_max(c,ggml_scale(c,ggml_mul_mat(c,k,q),1.0f/sqrtf((float)dk)));
+    auto o=ggml_cont_2d(c,ggml_permute(c,ggml_mul_mat(c,vh,kq),0,2,1,3),D,T);
+    x=ggml_add(c,r,lin(c,m.g(p+"self_attn.linear_out.weight"),m.g(p+"self_attn.linear_out.bias"),o)); r=x;
+    h=lnorm(c,x,m.g(p+"norm2.weight"),m.g(p+"norm2.bias"));
+    h=lin(c,m.g(p+"feed_forward.w_1.weight"),m.g(p+"feed_forward.w_1.bias"),h); h=ggml_relu(c,h);
+    h=lin(c,m.g(p+"feed_forward.w_2.weight"),m.g(p+"feed_forward.w_2.bias"),h); return ggml_add(c,r,h);
+}
+static void add_posenc(std::vector<float>&x,int T,int depth){
+    double inc=log(10000.0)/(depth/2.0-1.0);
+    for(int t=0;t<T;t++){double pos=t+1;for(int i=0;i<depth/2;i++){double its=exp(i*-inc),st=pos*its;
+        x[(size_t)t*depth+i]+=(float)sin(st);x[(size_t)t*depth+depth/2+i]+=(float)cos(st);}}
+}
+// find a GPU backend device by name ("cuda"/"vulkan"/...); returns nullptr if absent
+static bool icontains(const std::string&s,const std::string&needle){
+  if(needle.size()>s.size()) return false;
+  for(size_t i=0;i+needle.size()<=s.size();i++){
+    size_t j=0; for(;j<needle.size();j++){
+      if(std::tolower((unsigned char)s[i+j])!=std::tolower((unsigned char)needle[j])) break;
+    }
+    if(j==needle.size()) return true;
+  }
+  return false;
+}
+static ggml_backend_dev_t find_gpu_backend_device(const std::string&backend_name){
+  ggml_backend_load_all();
+  for(size_t i=0;i<ggml_backend_dev_count();i++){
+    ggml_backend_dev_t dev=ggml_backend_dev_get(i);
+    if(ggml_backend_dev_type(dev)!=GGML_BACKEND_DEVICE_TYPE_GPU) continue;
+    std::string reg=ggml_backend_reg_name(ggml_backend_dev_backend_reg(dev));
+    std::string dev_name=ggml_backend_dev_name(dev);
+    if(icontains(reg,backend_name)||icontains(dev_name,backend_name)){
+      return dev;
+    }
+  }
+  return nullptr;
+}
+
+// fbank [T x F] -> adaptor out [T x adp_llm] row-major
+static std::vector<float> run_encoder(enc_model&m,std::vector<float> fbank,int T,int F,int&Dout){
+    float sc=sqrtf((float)m.c.d_model); for(auto&v:fbank)v*=sc; add_posenc(fbank,T,F);
+    // prefer CUDA backend if available; fall back to CPU
+    ggml_backend_dev_t gpu_dev=find_gpu_backend_device("cuda");
+    ggml_backend_t be=nullptr;
+    if(gpu_dev){ be=ggml_backend_dev_init(gpu_dev,nullptr); if(be){ fprintf(stderr,"[encoder] using CUDA backend\n"); } }
+    if(!be){ be=ggml_backend_cpu_init(); fprintf(stderr,"[encoder] using CPU backend\n"); }
+    if(be){
+        size_t vfree=0,vtotal=0;
+        if(gpu_dev) ggml_backend_dev_memory(gpu_dev,&vfree,&vtotal);
+        fprintf(stderr,"[encoder] backend=%s VRAM free=%.1fMB total=%.1fMB\n",
+            ggml_backend_name(be), vfree/1048576.0, vtotal/1048576.0);
+    }
+    ggml_init_params cp={(size_t)1024*1024*1024,nullptr,true}; ggml_context*c=ggml_init(cp);
+    // copy encoder weights from CPU ctx into a GPU buffer (only when running on GPU)
+    ggml_backend_buffer_t wbuf=nullptr;
+    if(gpu_dev&&be){
+        ggml_backend_buffer_t probe=ggml_backend_alloc_buffer(be,4096);
+        size_t total=0; for(struct ggml_tensor*t=ggml_get_first_tensor(m.ctx_w);t;t=ggml_get_next_tensor(m.ctx_w,t)) total+=ggml_backend_buffer_get_alloc_size(probe,t);
+        ggml_backend_buffer_free(probe);
+        wbuf=ggml_backend_alloc_buffer(be,total);
+        char* base=(char*)ggml_backend_buffer_get_base(wbuf); size_t off=0;
+        fprintf(stderr,"[encoder] weight buffer %zu bytes on GPU\n",total);
+        // 源数据取自 m.cpu_w 的 CPU 副本, 避免 tensor->data 已被上一轮改成 GPU buffer 而悬垂
+        for(auto&cw:m.cpu_w){
+            struct ggml_tensor*t=cw.first; size_t n=ggml_nbytes(t);
+            t->buffer=wbuf; t->data=base+off; off+=ggml_backend_buffer_get_alloc_size(wbuf,t);
+            ggml_backend_tensor_set(t,cw.second.data(),0,n);
+        }
+    }
+    ggml_tensor*inp=ggml_new_tensor_2d(c,GGML_TYPE_F32,F,T); ggml_set_input(inp);
+    ggml_tensor*x=sanm_layer(c,m,"audio_encoder.encoders0.0.",inp,T,false);
+    for(int i=0;i<m.c.num_blocks-1;i++) x=sanm_layer(c,m,"audio_encoder.encoders."+std::to_string(i)+".",x,T,true);
+    x=lnorm(c,x,m.g("audio_encoder.after_norm.weight"),m.g("audio_encoder.after_norm.bias"));
+    for(int i=0;i<m.c.tp_blocks;i++) x=sanm_layer(c,m,"audio_encoder.tp_encoders."+std::to_string(i)+".",x,T,true);
+    x=lnorm(c,x,m.g("audio_encoder.tp_norm.weight"),m.g("audio_encoder.tp_norm.bias"));
+    x=lin(c,m.g("audio_adaptor.linear1.weight"),m.g("audio_adaptor.linear1.bias"),x); x=ggml_relu(c,x);
+    x=lin(c,m.g("audio_adaptor.linear2.weight"),m.g("audio_adaptor.linear2.bias"),x);
+    for(int i=0;i<m.c.adp_layers;i++) x=adp_layer(c,m,"audio_adaptor.blocks."+std::to_string(i)+".",x,T);
+    ggml_set_output(x);
+    ggml_cgraph*gf=ggml_new_graph_custom(c,32768,false); ggml_build_forward_expand(gf,x);
+    ggml_gallocr_t ga=ggml_gallocr_new(ggml_backend_get_default_buffer_type(be)); ggml_gallocr_alloc_graph(ga,gf);
+    ggml_backend_tensor_set(inp,fbank.data(),0,ggml_nbytes(inp));
+    if(!gpu_dev) ggml_backend_cpu_set_n_threads(be,8);
+    ggml_backend_graph_compute(be,gf);
+    Dout=(int)x->ne[0]; std::vector<float> out((size_t)Dout*T); ggml_backend_tensor_get(x,out.data(),0,ggml_nbytes(x));
+    ggml_gallocr_free(ga); ggml_free(c);
+    if(wbuf) ggml_backend_buffer_free(wbuf);
+    ggml_backend_free(be); return out;
+}
+
+// ======================= LLM (llama.cpp) =======================
+static int decode_batch(llama_context*ctx,int n,llama_token*tok,float*embd,int n_embd,int&n_past,bool last_logits){
+    std::vector<llama_pos> pos(n); std::vector<int32_t> nsid(n,1);
+    std::vector<llama_seq_id> s0(1,0); std::vector<llama_seq_id*> sid(n); std::vector<int8_t> lg(n,0);
+    for(int i=0;i<n;i++){pos[i]=n_past+i;sid[i]=s0.data();}
+    if(last_logits) lg[n-1]=1;
+    llama_batch b={n,tok,embd,pos.data(),nsid.data(),sid.data(),lg.data()};
+    int r=llama_decode(ctx,b); n_past+=n; return r;
+}
+
+int main(int argc,char**argv){
+    static int64_t _t0log=0;
+    auto LOG=[&](const char*fmt,...){
+        char b[1024]; va_list ap; va_start(ap,fmt); vsnprintf(b,sizeof(b),fmt,ap); va_end(ap);
+        int64_t us=ggml_time_us(); double s=_t0log?((double)us-_t0log)/1e6:0.0;
+        fprintf(stderr,"[%8.2fs] %s\n",s,b); fflush(stderr);
+    };
+    std::string enc_path,llm_path,wav_path,vad_path; int npred=512; double chunk_sec=0; float rep=1.0f;
+    int vad_maxseg=30000;
+    for(int i=1;i<argc;i++){
+        if(!strcmp(argv[i],"--enc")&&i+1<argc)enc_path=argv[++i];
+        else if(!strcmp(argv[i],"-m")&&i+1<argc)llm_path=argv[++i];
+        else if(!strcmp(argv[i],"-a")&&i+1<argc)wav_path=argv[++i];
+        else if(!strcmp(argv[i],"-n")&&i+1<argc)npred=atoi(argv[++i]);
+        else if(!strcmp(argv[i],"--chunk")&&i+1<argc)chunk_sec=atof(argv[++i]);
+        else if(!strcmp(argv[i],"--vad")&&i+1<argc)vad_path=argv[++i];
+        else if(!strcmp(argv[i],"--vad-maxseg")&&i+1<argc)vad_maxseg=atoi(argv[++i]);
+        else if(!strcmp(argv[i],"--rep")&&i+1<argc)rep=atof(argv[++i]);
+        else {fprintf(stderr,"usage: %s --enc enc.gguf -m llm.gguf -a audio.wav [-n npred] [--chunk sec] [--vad fsmn-vad.gguf [--vad-maxseg ms]]\n",argv[0]);return 1;}
+    }
+    if(enc_path.empty()||llm_path.empty()||wav_path.empty()){fprintf(stderr,"missing args\n");return 1;}
+    ggml_time_init();
+    _t0log=ggml_time_us();
+    LOG("start enc=%s llm=%s wav=%s vad=%s npred=%d chunk=%.0fs vad_maxseg=%dms",
+        enc_path.c_str(),llm_path.c_str(),wav_path.c_str(),vad_path.empty()?"-":vad_path.c_str(),npred,chunk_sec,vad_maxseg);
+
+    std::vector<float> wav;
+    if(!funasr_load_audio_16k_mono(wav_path.c_str(),wav)){LOG("failed to read audio");return 1;}
+    LOG("audio loaded %.1f sec (%zu samples)", (double)wav.size()/16000.0, wav.size());
+    int64_t t0=ggml_time_us();
+
+    enc_model em; if(!load_enc(enc_path.c_str(),em)){LOG("failed to load encoder");return 1;}
+    LOG("encoder loaded: d_model=%d blocks=%d tp_blocks=%d kernel=%d adp_llm=%d adp_layers=%d",
+        em.c.d_model,em.c.num_blocks,em.c.tp_blocks,em.c.kernel,em.c.adp_llm,em.c.adp_layers);
+    ggml_backend_load_all();
+    llama_model_params mp=llama_model_default_params(); mp.n_gpu_layers=999; // offload all LLM layers to GPU
+    llama_model*model=llama_model_load_from_file(llm_path.c_str(),mp); if(!model){LOG("failed to load LLM model");return 1;}
+    LOG("LLM model loaded");
+    const llama_vocab*vocab=llama_model_get_vocab(model);
+    llama_context_params cp=llama_context_default_params();
+    cp.n_ctx=2048; cp.n_batch=2048; cp.n_ubatch=2048;
+    llama_context*ctx=llama_init_from_model(model,cp);
+    if(!ctx){LOG("failed to create llama context");llama_model_free(model);return 1;}
+    LOG("llama context ready");
+    auto sp=llama_sampler_chain_default_params(); llama_sampler*smpl=llama_sampler_chain_init(sp);
+    if(rep!=1.0f) llama_sampler_chain_add(smpl,llama_sampler_init_penalties(llama_vocab_n_tokens(vocab),256,rep,0.0f,0.0f));
+    llama_sampler_chain_add(smpl,llama_sampler_init_greedy());
+
+    const char*prefix="<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n语音转写：";
+    const char*suffix="<|im_end|>\n<|im_start|>assistant\n";
+    auto tokenize=[&](const char*s){int n=-llama_tokenize(vocab,s,strlen(s),nullptr,0,false,true);
+        std::vector<llama_token> v(n); llama_tokenize(vocab,s,strlen(s),v.data(),n,false,true); return v;};
+    auto pre=tokenize(prefix); auto suf=tokenize(suffix);
+
+    // Build the list of [offset,len] windows to transcribe (in samples).
+    //   --vad : FSMN-VAD speech segments (single-binary front end, replaces fixed chunking)
+    //   --chunk sec : fixed-size chunks ; otherwise the whole file in one window
+    std::vector<std::pair<int,int>> wins;   // {sample offset, sample len}
+    if(!vad_path.empty()){
+        std::vector<std::pair<int,int>> segs; // ms
+        if(!funasr_vad_segments(vad_path,wav,vad_maxseg,segs)){LOG("vad failed");return 1;}
+        for(auto&s:segs){ int off=(int)((int64_t)s.first*16000/1000), end=(int)((int64_t)s.second*16000/1000);
+            if(end>(int)wav.size())end=wav.size(); if(end-off>0) wins.push_back({off,end-off}); }
+        LOG("vad segments=%zu audio=%.1fs", wins.size(), (double)wav.size()/16000.0);
+        for(size_t i=0;i<wins.size();i++)
+            LOG("  seg[%zu/%zu] %.2fs-%.2fs (len=%.2fs)", i+1, wins.size(),
+                (double)wins[i].first/16000.0, (double)(wins[i].first+wins[i].second)/16000.0,
+                (double)wins[i].second/16000.0);
+    } else {
+        int chunk_n = chunk_sec > 0 ? std::max(1, (int)(chunk_sec*16000)) : (int)wav.size();
+        for(size_t off=0; off<wav.size(); off+=chunk_n) wins.push_back({(int)off,(int)std::min((size_t)chunk_n,wav.size()-off)});
+        LOG("fixed chunks=%zu chunk=%.1fs", wins.size(), chunk_sec>0?chunk_sec:(double)wav.size()/16000.0);
+    }
+    std::string full;
+    for (size_t wi=0; wi<wins.size(); wi++) {
+        auto& w = wins[wi];
+        int off = w.first, len = w.second;
+        if (len < WINLEN) { LOG("  skip seg[%zu/%zu] len=%d < WINLEN", wi+1, wins.size(), len); continue; }
+        int64_t st=ggml_time_us();
+        std::vector<float> seg(wav.begin()+off, wav.begin()+off+len);
+        int T=0; auto fbank=compute_fbank(seg,T);
+        int D=0; auto adp=run_encoder(em,fbank,T,560,D);
+        int64_t st2=ggml_time_us();
+        int ol=1+(T-3+2)/2; ol=1+(ol-3+2)/2; int n_aud=(ol-1)/2+1;
+        LOG("  transcribe seg[%zu/%zu] len=%.1fs T=%d adp=%d n_aud=%d enc=%.2fs",
+            wi+1, wins.size(), (double)len/16000.0, T, D, n_aud, (st2-st)/1e6);
+
+        llama_memory_clear(llama_get_memory(ctx), true);  // fresh context per chunk
+        int n_past=0;
+        int rc=decode_batch(ctx,pre.size(),pre.data(),nullptr,0,n_past,false);
+        if(rc) { LOG("  [err] llama_decode(prefix) rc=%d at seg[%zu/%zu]", rc, wi+1, wins.size()); break; }
+        rc=decode_batch(ctx,n_aud,nullptr,adp.data(),D,n_past,false);
+        if(rc) { LOG("  [err] llama_decode(audio) rc=%d at seg[%zu/%zu]", rc, wi+1, wins.size()); break; }
+        rc=decode_batch(ctx,suf.size(),suf.data(),nullptr,0,n_past,true);
+        if(rc) { LOG("  [err] llama_decode(suffix) rc=%d at seg[%zu/%zu]", rc, wi+1, wins.size()); break; }
+        llama_token tk=llama_sampler_sample(smpl,ctx,-1);
+        int gen=0;
+        for(int i=0;i<npred;i++){
+            if(llama_vocab_is_eog(vocab,tk))break;
+            char buf[256]; int k=llama_token_to_piece(vocab,tk,buf,sizeof(buf),0,true);
+            if(k>0) full.append(buf,k);
+            gen++;
+            rc=decode_batch(ctx,1,&tk,nullptr,0,n_past,true);
+            if(rc) { LOG("  [err] llama_decode(token) rc=%d at seg[%zu/%zu] tok=%d", rc, wi+1, wins.size(), gen); break; }
+            tk=llama_sampler_sample(smpl,ctx,-1);
+        }
+        LOG("  seg[%zu/%zu] done gen_tokens=%d eog=%s total=%.2fs full_chars=%zu",
+            wi+1, wins.size(), gen, llama_vocab_is_eog(vocab,tk)?"yes":"no(截断)", (ggml_time_us()-st)/1e6, full.size());
+    }
+    printf("%s\n", full.c_str());
+    int64_t t2=ggml_time_us();
+    LOG("done %.2fs ; chunk=%.0fs ; chars=%zu", (t2-t0)/1e6, chunk_sec, full.size());
+    llama_sampler_free(smpl); llama_free(ctx); llama_model_free(model);
+    if(em.ctx_w) ggml_free(em.ctx_w);
+    return 0;
+}

--- a/examples/funasr/nano-cli/funasr-cli.cpp
+++ b/examples/funasr/nano-cli/funasr-cli.cpp
@@ -6,6 +6,10 @@
 //
 // This is the whisper.cpp-style single-binary path: no Python at runtime.
 //
+// NOTE: this source contains one non-ASCII string, the Chinese transcript prompt
+// "语音转写：" ("transcribe:") - it is required verbatim by the trained model.
+// Everything else in the file is ASCII.
+//
 //   funasr-cli --enc funasr-encoder.gguf -m qwen3-0.6b.gguf -a audio.wav
 
 #include "ggml.h"
@@ -15,6 +19,7 @@
 #include "gguf.h"
 #include "llama.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cctype>
 #include <cstdarg>
@@ -24,6 +29,10 @@
 #include <map>
 #include <string>
 #include <vector>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846   // not guaranteed by <cmath> on MSVC
+#endif
 
 // any audio (wav/mp3/flac, any rate/channels) -> 16 kHz mono f32, via miniaudio
 #define FUNASR_AUDIO_IMPLEMENTATION
@@ -80,8 +89,9 @@ static std::vector<float> compute_fbank(std::vector<float> wav, int & T_out) {
 // ======================= ggml SAN-M encoder + adaptor =======================
 struct cfg { int d_model=512,n_head=4,num_blocks=50,tp_blocks=20,kernel=11,adp_llm=1024,adp_layers=2,adp_head=8; };
 struct enc_model { cfg c; ggml_context*ctx_w=nullptr; std::map<std::string,ggml_tensor*> t;
-    // 原始 CPU 权重字节副本(load_enc 时固化); run_encoder 每段上传 GPU 时从它取源数据,
-    // 避免 tensor->data 被改为 GPU buffer 后原始数据悬垂。
+    // CPU byte copies of the weights (fixed at load_enc time); run_encoder uploads each
+    // segment from these, so the source data is not dangling after tensor->data is
+    // repointed at a GPU buffer.
     std::vector<std::pair<struct ggml_tensor*,std::vector<uint8_t>>> cpu_w;
     ggml_tensor* g(const std::string&n){auto it=t.find(n);if(it==t.end()){fprintf(stderr,"missing %s\n",n.c_str());exit(1);}return it->second;} };
 static const float LN_EPS=1e-5f;
@@ -145,27 +155,27 @@ static void add_posenc(std::vector<float>&x,int T,int depth){
 }
 // find a GPU backend device by name ("cuda"/"vulkan"/...); returns nullptr if absent
 static bool icontains(const std::string&s,const std::string&needle){
-  if(needle.size()>s.size()) return false;
-  for(size_t i=0;i+needle.size()<=s.size();i++){
-    size_t j=0; for(;j<needle.size();j++){
-      if(std::tolower((unsigned char)s[i+j])!=std::tolower((unsigned char)needle[j])) break;
+    if(needle.size()>s.size()) return false;
+    for(size_t i=0;i+needle.size()<=s.size();i++){
+        size_t j=0; for(;j<needle.size();j++){
+            if(std::tolower((unsigned char)s[i+j])!=std::tolower((unsigned char)needle[j])) break;
+        }
+        if(j==needle.size()) return true;
     }
-    if(j==needle.size()) return true;
-  }
-  return false;
+    return false;
 }
 static ggml_backend_dev_t find_gpu_backend_device(const std::string&backend_name){
-  ggml_backend_load_all();
-  for(size_t i=0;i<ggml_backend_dev_count();i++){
-    ggml_backend_dev_t dev=ggml_backend_dev_get(i);
-    if(ggml_backend_dev_type(dev)!=GGML_BACKEND_DEVICE_TYPE_GPU) continue;
-    std::string reg=ggml_backend_reg_name(ggml_backend_dev_backend_reg(dev));
-    std::string dev_name=ggml_backend_dev_name(dev);
-    if(icontains(reg,backend_name)||icontains(dev_name,backend_name)){
-      return dev;
+    ggml_backend_load_all();
+    for(size_t i=0;i<ggml_backend_dev_count();i++){
+        ggml_backend_dev_t dev=ggml_backend_dev_get(i);
+        if(ggml_backend_dev_type(dev)!=GGML_BACKEND_DEVICE_TYPE_GPU) continue;
+        std::string reg=ggml_backend_reg_name(ggml_backend_dev_backend_reg(dev));
+        std::string dev_name=ggml_backend_dev_name(dev);
+        if(icontains(reg,backend_name)||icontains(dev_name,backend_name)){
+            return dev;
+        }
     }
-  }
-  return nullptr;
+    return nullptr;
 }
 
 // fbank [T x F] -> adaptor out [T x adp_llm] row-major
@@ -192,7 +202,8 @@ static std::vector<float> run_encoder(enc_model&m,std::vector<float> fbank,int T
         wbuf=ggml_backend_alloc_buffer(be,total);
         char* base=(char*)ggml_backend_buffer_get_base(wbuf); size_t off=0;
         fprintf(stderr,"[encoder] weight buffer %zu bytes on GPU\n",total);
-        // 源数据取自 m.cpu_w 的 CPU 副本, 避免 tensor->data 已被上一轮改成 GPU buffer 而悬垂
+        // source data comes from the m.cpu_w CPU copies, so tensor->data repointed at
+        // a GPU buffer in a previous segment is not read from while dangling
         for(auto&cw:m.cpu_w){
             struct ggml_tensor*t=cw.first; size_t n=ggml_nbytes(t);
             t->buffer=wbuf; t->data=base+off; off+=ggml_backend_buffer_get_alloc_size(wbuf,t);
@@ -265,7 +276,10 @@ int main(int argc,char**argv){
     LOG("encoder loaded: d_model=%d blocks=%d tp_blocks=%d kernel=%d adp_llm=%d adp_layers=%d",
         em.c.d_model,em.c.num_blocks,em.c.tp_blocks,em.c.kernel,em.c.adp_llm,em.c.adp_layers);
     ggml_backend_load_all();
-    llama_model_params mp=llama_model_default_params(); mp.n_gpu_layers=999; // offload all LLM layers to GPU
+    // n_gpu_layers=999: offload every layer to the GPU backend (CUDA when available,
+    // falls back to CPU automatically). The value is larger than any real model's
+    // layer count, so effectively means "all layers".
+    llama_model_params mp=llama_model_default_params(); mp.n_gpu_layers=999;
     llama_model*model=llama_model_load_from_file(llm_path.c_str(),mp); if(!model){LOG("failed to load LLM model");return 1;}
     LOG("LLM model loaded");
     const llama_vocab*vocab=llama_model_get_vocab(model);
@@ -278,6 +292,8 @@ int main(int argc,char**argv){
     if(rep!=1.0f) llama_sampler_chain_add(smpl,llama_sampler_init_penalties(llama_vocab_n_tokens(vocab),256,rep,0.0f,0.0f));
     llama_sampler_chain_add(smpl,llama_sampler_init_greedy());
 
+    // the transcript prompt is Chinese ("语音转写：" = "transcribe:"): the model was
+    // trained with this exact prompt, so the non-ASCII bytes are required here
     const char*prefix="<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n<|im_start|>user\n语音转写：";
     const char*suffix="<|im_end|>\n<|im_start|>assistant\n";
     auto tokenize=[&](const char*s){int n=-llama_tokenize(vocab,s,strlen(s),nullptr,0,false,true);
@@ -337,7 +353,7 @@ int main(int argc,char**argv){
             tk=llama_sampler_sample(smpl,ctx,-1);
         }
         LOG("  seg[%zu/%zu] done gen_tokens=%d eog=%s total=%.2fs full_chars=%zu",
-            wi+1, wins.size(), gen, llama_vocab_is_eog(vocab,tk)?"yes":"no(截断)", (ggml_time_us()-st)/1e6, full.size());
+            wi+1, wins.size(), gen, llama_vocab_is_eog(vocab,tk)?"yes":"no (truncated)", (ggml_time_us()-st)/1e6, full.size());
     }
     printf("%s\n", full.c_str());
     int64_t t2=ggml_time_us();


### PR DESCRIPTION
Fixes: #27636

## Overview

Port Fun-ASR-Nano (SAN-M encoder + adaptor + Qwen3-0.6B LLM) to a single llama.cpp binary with an embedded FSMN-VAD front end. This is the whisper.cpp-style single-binary path: wav -> kaldi fbank -> SAN-M encoder/adaptor (ggml) -> [prefix tokens | audio embeds | suffix tokens] -> Qwen3 LLM (llama.cpp) -> transcription, with no Python at runtime.

- encoder + adaptor run on ggml; CUDA backend used when available, weights are uploaded to a GPU buffer per segment and freed properly
- LLM runs through llama with all layers offloaded to GPU
- built-in FSMN-VAD front end (single-binary `--vad` segmentation)
- detailed stderr logging (VAD segments, per-segment progress, llama_decode error checks, VRAM usage)
- audio decode via the already-vendored miniaudio (ma_decoder), no new third-party dependency

## Additional information

Why CPU + CUDA are in the same PR: this is a single example binary where the CUDA backend is detected at runtime (`find_gpu_backend_device`) and falls back to plain CPU automatically. Splitting would require two nearly identical binaries; keeping one binary that runs on both keeps the example minimal and self-contained.

Why the source contains one non-ASCII string: the Chinese transcript prompt `"语音转写："` ("transcribe:") is required verbatim by the trained model. Everything else in the source is ASCII, and the CMake only adds `/utf-8` on MSVC for this one string.

Tested: 45s wav transcribes correctly on CPU and CUDA (RTX 3060 Ti, ~18.7x faster than CPU-only).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the code was ported and debugged with the assistance of an AI coding agent; every line was manually reviewed and tested (CPU + CUDA) by a human before submission.
