### PR TITLE
ggml : shorten virtual device naming in CUDA and Metal

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4611,8 +4611,8 @@ static std::string ggml_cuda_device_description(int device) {
     const ggml_cuda_device_info & info = ggml_cuda_info();
     std::string description = prop.name;
     if (info.device_count > info.physical_device_count) {
-        description += " (physical device " + std::to_string(info.devices[device].physical_device) +
-                       ", virtual device " + std::to_string(info.devices[device].virtual_index) + ")";
+        description += " (dev p" + std::to_string(info.devices[device].physical_device) +
+                       "/v" + std::to_string(info.devices[device].virtual_index) + ")";
     }
     return description;
 }

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -17,10 +17,10 @@ struct ggml_metal_device_deleter {
 
 typedef std::unique_ptr<ggml_metal_device, ggml_metal_device_deleter> ggml_metal_device_ptr;
 
-ggml_metal_device_t ggml_metal_device_get(int device) {
+ggml_metal_device_t ggml_metal_device_get(int device, int n_devices) {
     static std::vector<ggml_metal_device_ptr> devs;
 
-    devs.emplace_back(ggml_metal_device_init(device));
+    devs.emplace_back(ggml_metal_device_init(device, n_devices));
 
     return devs.back().get();
 }

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -259,6 +259,8 @@ enum ggml_metal_device_id {
 
 struct ggml_metal_device_props {
     int device;
+    int physical_device;
+    int virtual_index;
     char name[128];
     char desc[128];
 

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -288,10 +288,10 @@ typedef struct ggml_metal_event * ggml_metal_event_t;
 void ggml_metal_event_encode_signal(ggml_metal_event_t ev, ggml_metal_cmd_buf_t cmd_buf);
 void ggml_metal_event_encode_wait  (ggml_metal_event_t ev, ggml_metal_cmd_buf_t cmd_buf);
 
-ggml_metal_device_t ggml_metal_device_init(int device);
+ggml_metal_device_t ggml_metal_device_init(int device, int n_devices);
 void ggml_metal_device_free(ggml_metal_device_t dev);
 
-ggml_metal_device_t ggml_metal_device_get(int device);
+ggml_metal_device_t ggml_metal_device_get(int device, int n_devices);
 
 void * ggml_metal_device_get_obj  (ggml_metal_device_t dev); // id<MTLDevice>
 void * ggml_metal_device_get_queue(ggml_metal_device_t dev); // id<MTLCommandQueue>

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -259,8 +259,8 @@ enum ggml_metal_device_id {
 
 struct ggml_metal_device_props {
     int device;
-    int physical_device;
-    int virtual_index;
+    int device_phys;
+    int device_virt;
     char name[128];
     char desc[128];
 

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -728,6 +728,10 @@ ggml_metal_device_t ggml_metal_device_init(int device) {
             dev->addr_virt = 0x000000400ULL;
 
             dev->props.device = device;
+            // the Metal backend uses the system default device as the single physical device;
+            // additional (virtual) devices are emulated on top of it via GGML_METAL_DEVICES
+            dev->props.physical_device = 0;
+            dev->props.virtual_index = device;
             dev->props.has_simdgroup_reduction  = [dev->mtl_device supportsFamily:MTLGPUFamilyApple7];
             dev->props.has_simdgroup_reduction |= [dev->mtl_device supportsFamily:MTLGPUFamilyMetal3_GGML];
 

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -711,7 +711,7 @@ static enum ggml_metal_device_id ggml_metal_device_id_parse(const char * name) {
     return GGML_METAL_DEVICE_GENERIC;
 }
 
-ggml_metal_device_t ggml_metal_device_init(int device) {
+ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
     ggml_metal_device_t dev = calloc(1, sizeof(struct ggml_metal_device));
 
     assert(dev != NULL);
@@ -895,7 +895,13 @@ ggml_metal_device_t ggml_metal_device_init(int device) {
             }
 
             snprintf(dev->props.name, sizeof(dev->props.name), "%s%d", "MTL", device);
-            snprintf(dev->props.desc, sizeof(dev->props.desc), "%s", [[dev->mtl_device name] UTF8String]);
+            const char * gpu_name = [[dev->mtl_device name] UTF8String];
+            if (n_devices > 1) {
+                snprintf(dev->props.desc, sizeof(dev->props.desc), "%s (dev p%d/v%d)",
+                         gpu_name, dev->props.physical_device, dev->props.virtual_index);
+            } else {
+                snprintf(dev->props.desc, sizeof(dev->props.desc), "%s", gpu_name);
+            }
 
             dev->library = ggml_metal_library_init(dev);
             if (!dev->library) {

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -728,10 +728,12 @@ ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
             dev->addr_virt = 0x000000400ULL;
 
             dev->props.device = device;
+
             // the Metal backend uses the system default device as the single physical device;
             // additional (virtual) devices are emulated on top of it via GGML_METAL_DEVICES
-            dev->props.physical_device = 0;
-            dev->props.virtual_index = device;
+            dev->props.device_phys = 0;
+            dev->props.device_virt = device;
+
             dev->props.has_simdgroup_reduction  = [dev->mtl_device supportsFamily:MTLGPUFamilyApple7];
             dev->props.has_simdgroup_reduction |= [dev->mtl_device supportsFamily:MTLGPUFamilyMetal3_GGML];
 
@@ -898,7 +900,7 @@ ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
             const char * gpu_name = [[dev->mtl_device name] UTF8String];
             if (n_devices > 1) {
                 snprintf(dev->props.desc, sizeof(dev->props.desc), "%s (dev p%d/v%d)",
-                         gpu_name, dev->props.physical_device, dev->props.virtual_index);
+                         gpu_name, dev->props.device_phys, dev->props.device_virt);
             } else {
                 snprintf(dev->props.desc, sizeof(dev->props.desc), "%s", gpu_name);
             }

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -655,7 +655,16 @@ static const char * ggml_backend_metal_device_get_name(ggml_backend_dev_t dev) {
 static const char * ggml_backend_metal_device_get_description(ggml_backend_dev_t dev) {
     ggml_metal_device_t ctx_dev = (ggml_metal_device_t)dev->context;
 
-    return ggml_metal_device_get_props(ctx_dev)->desc;
+    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx_dev);
+
+    // when emulating multiple (virtual) devices on the single physical device, report the mapping
+    static std::string description;
+    description = props_dev->desc;
+    if (g_devices > 1) {
+        description += " (dev p" + std::to_string(props_dev->physical_device) +
+                       "/v" + std::to_string(props_dev->virtual_index) + ")";
+    }
+    return description.c_str();
 }
 
 static void ggml_backend_metal_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -655,16 +655,7 @@ static const char * ggml_backend_metal_device_get_name(ggml_backend_dev_t dev) {
 static const char * ggml_backend_metal_device_get_description(ggml_backend_dev_t dev) {
     ggml_metal_device_t ctx_dev = (ggml_metal_device_t)dev->context;
 
-    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx_dev);
-
-    // when emulating multiple (virtual) devices on the single physical device, report the mapping
-    static std::string description;
-    description = props_dev->desc;
-    if (g_devices > 1) {
-        description += " (dev p" + std::to_string(props_dev->physical_device) +
-                       "/v" + std::to_string(props_dev->virtual_index) + ")";
-    }
-    return description.c_str();
+    return ggml_metal_device_get_props(ctx_dev)->desc;
 }
 
 static void ggml_backend_metal_device_get_memory(ggml_backend_dev_t dev, size_t * free, size_t * total) {
@@ -900,7 +891,7 @@ static ggml_backend_dev_t ggml_backend_metal_device_init(ggml_backend_reg_t reg,
     return new ggml_backend_device {
         /* .iface   = */ ggml_backend_metal_device_i,
         /* .reg     = */ reg,
-        /* .context = */ ggml_metal_device_get(device),
+        /* .context = */ ggml_metal_device_get(device, g_devices),
     };
 }
 


### PR DESCRIPTION
## Overview

Adds physical/virtual device mapping to the Metal backend device description, mirroring the existing CUDA behavior when emulating multiple devices (GGML_CUDA_DEVICES / GGML_METAL_DEVICES), and shortens the format for both backends.

Examples when emulating 3 devices:

```
NVIDIA GB10 (dev p0/v0)
NVIDIA GB10 (dev p0/v1)
NVIDIA GB10 (dev p0/v2)

Apple M4 (dev p0/v0)
Apple M4 (dev p0/v1)
Apple M4 (dev p0/v2)
```

The suffix is only appended when more than one virtual device is exposed; with a single device the plain GPU name is kept, matching CUDA.

## Additional information

Changes:
- ggml-cuda : shorten description suffix to "(dev pX/vY)"
- ggml-metal: add physical_device/virtual_index props and append the same suffix when GGML_METAL_DEVICES > 1

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: YES. llama.cpp:DeepSeek-V4-Flash-0731