### PR TITLE
server: clear stale state when reusing LRU-selected slots

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -276,9 +276,9 @@ struct server_slot {
         return true;
     }
 
-    bool prompt_load(server_prompt_cache & prompt_cache, const server_tokens & tokens) {
-        bool res = prompt_cache.load(prompt, tokens, ctx_tgt, ctx_dft, id);
-        if (!res) {
+    server_prompt_cache_load_result prompt_load(server_prompt_cache & prompt_cache, const server_tokens & tokens) {
+        const auto res = prompt_cache.load(prompt, tokens, ctx_tgt, ctx_dft, id);
+        if (res == SERVER_PROMPT_CACHE_LOAD_RESULT_FAILED) {
             SLT_WRN(*this, "%s", "failed to load prompt from cache\n");
         }
 
@@ -1454,6 +1454,7 @@ private:
     server_slot * get_available_slot(const server_task & task) {
         server_slot * ret = nullptr;
 
+        bool selected_by_lru = false;
         bool update_cache = false;
 
         // if a specific slot is requested, use it (still goes through cache update logic below)
@@ -1536,6 +1537,7 @@ private:
             if (ret != nullptr) {
                 SLT_INF(*ret, "selected slot by LRU, t_last = %" PRId64 "\n", t_last);
 
+                selected_by_lru = true;
                 update_cache = true;
             }
         }
@@ -1546,6 +1548,11 @@ private:
             // cache prompts only for completion tasks
             update_cache = update_cache && task.type == SERVER_TASK_TYPE_COMPLETION;
 
+            // an LRU-selected slot is a victim, not a verified cache hit
+            if (selected_by_lru && !prompt_cache && task.type == SERVER_TASK_TYPE_COMPLETION) {
+                ret->prompt_clear();
+            }
+
             if (update_cache) {
                 SRV_TRC("%s", "updating prompt cache\n");
 
@@ -1553,7 +1560,10 @@ private:
 
                 ret->prompt_save(*prompt_cache);
 
-                if (!ret->prompt_load(*prompt_cache, task.tokens)) {
+                const auto load_result = ret->prompt_load(*prompt_cache, task.tokens);
+
+                if (load_result == SERVER_PROMPT_CACHE_LOAD_RESULT_FAILED ||
+                    (selected_by_lru && load_result == SERVER_PROMPT_CACHE_LOAD_RESULT_NO_MATCH)) {
                     ret->prompt_clear();
                 }
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1790,7 +1790,11 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
     return &states.back();
 }
 
-bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_tgt, llama_context * ctx_dft, int32_t id_slot) {
+server_prompt_cache_load_result server_prompt_cache::load(server_prompt &       prompt,
+                                                          const server_tokens & tokens_new,
+                                                          llama_context *       ctx_tgt,
+                                                          llama_context *       ctx_dft,
+                                                          int32_t               id_slot) {
     const int lcp_best = prompt.tokens.get_common_prefix(tokens_new);
 
     float f_keep_best = prompt.tokens.size() > 0 ? float(lcp_best) / prompt.tokens.size() : -1.0f; // empty slot: any cache entry wins
@@ -1833,7 +1837,7 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
             if (n != size) {
                 SRV_ERR("failed to restore state with size %zu\n", size);
 
-                return false;
+                return SERVER_PROMPT_CACHE_LOAD_RESULT_FAILED;
             }
 
             data.clear();
@@ -1851,7 +1855,7 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
                 if (n != size) {
                     SRV_WRN("failed to restore state with size %zu\n", size);
 
-                    return false;
+                    return SERVER_PROMPT_CACHE_LOAD_RESULT_FAILED;
                 }
 
                 data.clear();
@@ -1862,9 +1866,11 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
         prompt = std::move(it_best->prompt);
 
         states.erase(it_best);
+
+        return SERVER_PROMPT_CACHE_LOAD_RESULT_RESTORED;
     }
 
-    return true;
+    return SERVER_PROMPT_CACHE_LOAD_RESULT_NO_MATCH;
 }
 
 void server_prompt_cache::update() {

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -609,6 +609,12 @@ struct server_prompt_cache_state {
     }
 };
 
+enum server_prompt_cache_load_result {
+    SERVER_PROMPT_CACHE_LOAD_RESULT_RESTORED,
+    SERVER_PROMPT_CACHE_LOAD_RESULT_NO_MATCH,
+    SERVER_PROMPT_CACHE_LOAD_RESULT_FAILED,
+};
+
 struct server_prompt_cache {
     server_prompt_cache(int32_t limit_size_mib, size_t limit_tokens) {
         this->limit_size   = 1024ull*1024ull*(limit_size_mib < 0 ? 0 : limit_size_mib);
@@ -629,7 +635,11 @@ struct server_prompt_cache {
 
     server_prompt_cache_state * alloc(const server_prompt & prompt, size_t state_size_main, size_t state_size_drft);
 
-    bool load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_tgt, llama_context * ctx_dft, int32_t id_slot);
+    server_prompt_cache_load_result load(server_prompt &       prompt,
+                                         const server_tokens & tokens_new,
+                                         llama_context *       ctx_tgt,
+                                         llama_context *       ctx_dft,
+                                         int32_t               id_slot);
 
     void update();
 };

--- a/tools/server/tests/unit/test_kv_keep_only_active.py
+++ b/tools/server/tests/unit/test_kv_keep_only_active.py
@@ -113,3 +113,99 @@ def test_disabled_with_flag():
     })
     assert res.status_code == 200
     assert "__TEST_TAG_CACHE_IDLE_SLOT__" not in log.drain()
+
+
+@pytest.mark.parametrize("cache_ram", [0, 100])
+def test_lru_cache_miss_clears_victim(cache_ram):
+    global server
+    server.cache_ram = cache_ram
+    server.kv_unified = False
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_PROMPT,
+        "id_slot": 0,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    log.drain()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": (
+            "A database transaction must remain atomic when two clients "
+            "update unrelated account records at the same time."
+        ),
+        "id_slot": 1,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    log.drain()
+
+    request = {
+        "prompt": (
+            "Quantum mechanics describes particles with wave functions "
+            "and predicts measurement probabilities from their amplitudes."
+        ),
+        "cache_prompt": True,
+        "return_tokens": True,
+        "n_predict": 4,
+        "seed": 42,
+        "temperature": 0.0,
+    }
+    res = server.make_request("POST", "/completion", data=request)
+    assert res.status_code == 200
+    assert res.body["id_slot"] == 0
+    assert res.body["timings"]["cache_n"] == 0
+    lru_prompt_n = res.body["timings"]["prompt_n"]
+    lru_tokens = res.body["tokens"]
+    lru_content = res.body["content"]
+
+    output = log.drain()
+    assert "selected slot by LRU" in output
+    assert "clearing prompt with" in output
+
+    server.stop()
+    server = ServerPreset.tinyllama2()
+    server.n_slots = 1
+    server.n_predict = 4
+    server.temperature = 0.0
+    server.kv_unified = False
+    server.start()
+
+    res = server.make_request("POST", "/completion", data=request)
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] == 0
+    assert res.body["timings"]["prompt_n"] == lru_prompt_n
+    assert res.body["tokens"] == lru_tokens
+    assert res.body["content"] == lru_content
+
+
+def test_live_lcp_cache_miss_keeps_slot():
+    global server
+    server.n_slots = 1
+    server.kv_unified = False
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": " ".join([LONG_PROMPT] * 2) + " Extra words ensure a prompt-cache update.",
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    log.drain()
+
+    res = server.make_request("POST", "/completion", data={
+        "prompt": LONG_PROMPT,
+        "cache_prompt": True,
+    })
+    assert res.status_code == 200
+    assert res.body["timings"]["cache_n"] > 0
+    assert res.body["timings"]["prompt_n"] == 1
+
+    output = log.drain()
+    assert "selected slot by LCP similarity" in output
+    assert "updating prompt cache" in output
+    assert "clearing prompt with" not in output


### PR DESCRIPTION
## Overview
Fixes #27148.

This PR fixes a server slot-lifecycle issue where a slot selected through LRU fallback could retain prompt tokens, checkpoints, and KV/recurrent state from an unrelated previous request.

An LRU-selected slot is an eviction victim, not a confirmed cache hit. Before processing a new request, it must either receive a successfully restored state valid for that request or be fully cleared.

The previous LRU fallback path performed:

```cpp
ret->prompt_save(*prompt_cache);
ret->prompt_load(*prompt_cache, task.tokens);
```

However, `server_prompt_cache::load()` returned `true` even when no eligible cache entry better than the live-slot baseline was selected. The caller treated this no-op as a successful restore and skipped `prompt_clear()`, leaving the victim slot's previous prompt metadata and model state in place.

The same issue occurred with `cache_ram=0`, where the prompt-cache update block was skipped entirely and the LRU victim was not cleared.

This PR:

* replaces the Boolean result of `server_prompt_cache::load()` with explicit `RESTORED`, `NO_MATCH`, and `FAILED` results;
* records whether a slot was selected through LRU fallback;
* clears an LRU victim when restoration fails, no eligible RAM-cache entry is selected, or `cache_ram=0`;
* preserves a valid live slot selected through LCP similarity when the RAM cache has no better entry.

The existing `prompt_clear()` path removes the slot sequence through `common_memory::seq_rm()`, covering both target and draft contexts, and clears prompt tokens and checkpoints.

This enforces the following invariant:

> After LRU reassignment, the slot contains either a successfully restored state for the new request or no state belonging to its previous owner.

## Additional information

### Load-result semantics

`server_prompt_cache::load()` now returns one of:

```cpp
SERVER_PROMPT_CACHE_LOAD_RESULT_RESTORED
SERVER_PROMPT_CACHE_LOAD_RESULT_NO_MATCH
SERVER_PROMPT_CACHE_LOAD_RESULT_FAILED
```

A simple Boolean failure result is insufficient because `prompt_load()` is also used for slots selected through live LCP similarity.

For an LCP-selected live slot, the absence of a better RAM-cache entry does not invalidate the slot's existing common prefix. Clearing that slot would unnecessarily turn valid prefix reuse into a full prefill.

A full `prompt_clear()` is therefore performed only when:

* a cache restore fails;
* an LRU victim has no eligible RAM-cache entry better than its baseline;
* an LRU victim is selected while `cache_ram=0`.

An LCP-selected live slot is retained when the RAM cache has no better entry.

### Tests

The LRU regression test covers:

```text
cache_ram=0
cache_ram=100
kv_unified=false
parallel=2
cache_prompt=true
```

The test fills both slots with unrelated requests, forces LRU reassignment, and compares the new request with a fresh-server cold-start baseline.

It verifies that:

* the victim is selected through LRU fallback;
* its previous state is explicitly cleared;
* `cache_n == 0`;
* the prompt-processing count matches the cold-start baseline;
* the complete generated-token sequence matches the cold-start baseline;
* the generated text matches the cold-start baseline.

Before the fix, both tested `cache_ram` configurations reused one token from the victim slot:

```text
cache_n == 1
```

A positive-control test verifies that a live slot selected through LCP similarity remains reusable when the RAM cache has no better entry:

```text
cache_n > 0
prompt_n == 1
prompt_clear() is not called
```

Existing tests for successful RAM-cache restoration and disabled idle-slot caching also continue to pass.

### Validation

Validated against upstream commit:

```text
ccc8fd2baa64ab26c7210b02765d3604069ec7ee
```

Results:

```text
cmake --build build --target llama-server -j4
passed

5 focused pytest cases
passed

clang-format 22.1.8 changed-lines check
passed

git diff --check
passed
```

The focused local validation used a CPU-only Release build. Real draft/MTP runtimes, GPU backends, and the complete upstream CI matrix were not tested locally.

## Requirements

* I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES — AI assistance was used for code investigation, implementation support, and local validation. The design, review, and submission are owned by the contributor.