### PR TITLE
opencl: choose the MoE expert matmul by batch size for speculative decoding/MTP

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -24491,10 +24491,51 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     CL_CHECK(clReleaseMemObject(buf_src2));
 
                 } else { // for gemm
-                    kernel = backend_ctx->kernel_gemm_moe_q4_0_f32_ns;
-                    if (backend_ctx->kernel_gemm_moe_q4_0_f32_ns_bin) {
-                        kernel = backend_ctx->kernel_gemm_moe_q4_0_f32_ns_bin;
-                    }
+                    // dp4a (int8) prefill GEMM variant
+                    static const char * q4_0_moe_dp4a_env = getenv("GGML_OPENCL_Q4_0_MOE_DP4A");
+
+                    // The prebuilt kernel-lib GEMM is tuned for prefill-sized work, but it was
+                    // selected whenever it was loaded, and its presence also disabled the dp4a GEMM
+                    // for every shape. A speculative-decode verify step reaches this path at a
+                    // handful of tokens, and so does every short prefill chunk; both ran a
+                    // prefill-tuned kernel. Gate it on size instead.
+                    //
+                    // The size is the total routing count, ne20*ne21 (n_expert_used * n_tokens) -
+                    // the quantity max_post_router_tile, and so the GEMM's N, is derived from. Not
+                    // ne11: for mul_mat_id src1 is [n_embd, n_expert_used, n_tokens], so ne11 is
+                    // n_expert_used (or 1 for the down projection) and does not move with the batch.
+                    //
+                    // Measured on Adreno X2-90 by sweeping the physical batch with the kernel lib
+                    // loaded and only the threshold moving, dp4a relative to the prebuilt kernel
+                    // (pp512 t/s, gemma-4-26B-A4B-QAT-Q4_0 and Qwen3-30B-A3B-Q4_0):
+                    //
+                    //   routings    32    64   128   256   512  1024  2048   4096
+                    //   26B       +26%  +17%  +18%  +16%  +12%   +6%   +1%  -2.5%
+                    //   30B       +31%  +18%  +16%  +14%  +12%   +7%   +1%  -0.8%
+                    //
+                    // The prebuilt kernel leads only at a full 512-token ubatch, so keep it exactly
+                    // there. GGML_OPENCL_MOE_BIN_MIN_ROUTINGS overrides the threshold.
+                    static const char * moe_bin_min_env = getenv("GGML_OPENCL_MOE_BIN_MIN_ROUTINGS");
+                    const int  moe_bin_min   = moe_bin_min_env ? atoi(moe_bin_min_env) : 4096;
+                    const bool bin_available = backend_ctx->kernel_gemm_moe_q4_0_f32_ns_bin != nullptr;
+                    // A dp4a kernel-lib GEMM outranks the plain kernel-lib one (upstream rule,
+                    // added with kernel_gemm_moe_q4_0_q8_1_dp4a_bin): where it exists, the plain
+                    // prebuilt kernel must not be the reason dp4a is declined, at any size.
+                    const bool dp4a_bin_available = backend_ctx->kernel_gemm_moe_q4_0_q8_1_dp4a_bin != nullptr;
+
+                    bool use_moe_dp4a = q4_0_moe_dp4a_env
+                        ? (atoi(q4_0_moe_dp4a_env) != 0)
+                        : (backend_ctx->adreno_gen == ADRENO_GPU_GEN::X2E
+                           && (dp4a_bin_available || !bin_available
+                               || (int)(ne20 * ne21) < moe_bin_min));
+                    // dot prod has to be available
+                    use_moe_dp4a = backend_ctx->has_integer_dot && use_moe_dp4a;
+
+                    const bool use_bin_kernel = bin_available && !use_moe_dp4a;
+
+                    kernel = use_bin_kernel
+                        ? backend_ctx->kernel_gemm_moe_q4_0_f32_ns_bin
+                        : backend_ctx->kernel_gemm_moe_q4_0_f32_ns;
 
                     // Reorder router if called from test-backend-ops or when new router is generated.
                     // Otherwise reuse the reordered result from previous mul_mat_id call.
@@ -24506,18 +24547,6 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     cl_mem sub_buf_src1_pre, sub_buf_dst, buf_dst_image;
                     cl_mem buf_src1_reordered = nullptr, image_src1_reordered = nullptr;
                     cl_mem buf_src2, buf_src2_emap;
-
-                    // dp4a (int8) prefill GEMM variant
-                    static const char * q4_0_moe_dp4a_env = getenv("GGML_OPENCL_Q4_0_MOE_DP4A");
-                    bool use_moe_dp4a = q4_0_moe_dp4a_env
-                        ? (atoi(q4_0_moe_dp4a_env) != 0)
-                        : (backend_ctx->adreno_gen == ADRENO_GPU_GEN::X2E);
-                    // dot prod has to be available
-                    use_moe_dp4a = backend_ctx->has_integer_dot && use_moe_dp4a;
-                    // bin kernel takes precedence
-                    if (backend_ctx->kernel_gemm_moe_q4_0_q8_1_dp4a_bin == nullptr) {
-                        use_moe_dp4a = use_moe_dp4a && backend_ctx->kernel_gemm_moe_q4_0_f32_ns_bin == nullptr;
-                    }
 
                     cl_buffer_region region;
                     region.origin = 0;
@@ -24557,7 +24586,7 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                         cl_image_desc image_desc_buf_src1;
                         image_format_buf_src1 = {CL_RGBA, CL_FLOAT};
                         image_desc_buf_src1 = {CL_MEM_OBJECT_IMAGE1D_BUFFER, static_cast<size_t>(ne00 * max_post_router_tile * n_tile_size / 4), 0,0,0,0,0,0,0, {buf_src1_reordered}};
-                        if (backend_ctx->kernel_gemm_moe_q4_0_f32_ns_bin) {
+                        if (use_bin_kernel) {
                             // bin kernel uses slightly different image format
                             image_format_buf_src1 = {CL_R, CL_FLOAT};
                             image_desc_buf_src1.image_width = static_cast<size_t>(ne00 * max_post_router_tile * n_tile_size);

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -24494,33 +24494,15 @@ static void ggml_cl_mul_mat_id(ggml_backend_t backend, const ggml_tensor * src0,
                     // dp4a (int8) prefill GEMM variant
                     static const char * q4_0_moe_dp4a_env = getenv("GGML_OPENCL_Q4_0_MOE_DP4A");
 
-                    // The prebuilt kernel-lib GEMM is tuned for prefill-sized work, but it was
-                    // selected whenever it was loaded, and its presence also disabled the dp4a GEMM
-                    // for every shape. A speculative-decode verify step reaches this path at a
-                    // handful of tokens, and so does every short prefill chunk; both ran a
-                    // prefill-tuned kernel. Gate it on size instead.
-                    //
-                    // The size is the total routing count, ne20*ne21 (n_expert_used * n_tokens) -
-                    // the quantity max_post_router_tile, and so the GEMM's N, is derived from. Not
-                    // ne11: for mul_mat_id src1 is [n_embd, n_expert_used, n_tokens], so ne11 is
-                    // n_expert_used (or 1 for the down projection) and does not move with the batch.
-                    //
-                    // Measured on Adreno X2-90 by sweeping the physical batch with the kernel lib
-                    // loaded and only the threshold moving, dp4a relative to the prebuilt kernel
-                    // (pp512 t/s, gemma-4-26B-A4B-QAT-Q4_0 and Qwen3-30B-A3B-Q4_0):
-                    //
-                    //   routings    32    64   128   256   512  1024  2048   4096
-                    //   26B       +26%  +17%  +18%  +16%  +12%   +6%   +1%  -2.5%
-                    //   30B       +31%  +18%  +16%  +14%  +12%   +7%   +1%  -0.8%
-                    //
-                    // The prebuilt kernel leads only at a full 512-token ubatch, so keep it exactly
-                    // there. GGML_OPENCL_MOE_BIN_MIN_ROUTINGS overrides the threshold.
+                    // It turns out that the prebuilt kernel only outperforms the dp4a variant (on X2-90)
+                    // at very large routing counts, so we gate its use accordingly using moe_bin_min,
+                    // which can be overridden via the GGML_OPENCL_MOE_BIN_MIN_ROUTINGS environment variable.
+                    // The routing count is ne20 * ne21 (n_expert_used * n_tokens).
                     static const char * moe_bin_min_env = getenv("GGML_OPENCL_MOE_BIN_MIN_ROUTINGS");
                     const int  moe_bin_min   = moe_bin_min_env ? atoi(moe_bin_min_env) : 4096;
+
+                    // whether bin kernels are available
                     const bool bin_available = backend_ctx->kernel_gemm_moe_q4_0_f32_ns_bin != nullptr;
-                    // A dp4a kernel-lib GEMM outranks the plain kernel-lib one (upstream rule,
-                    // added with kernel_gemm_moe_q4_0_q8_1_dp4a_bin): where it exists, the plain
-                    // prebuilt kernel must not be the reason dp4a is declined, at any size.
                     const bool dp4a_bin_available = backend_ctx->kernel_gemm_moe_q4_0_q8_1_dp4a_bin != nullptr;
 
                     bool use_moe_dp4a = q4_0_moe_dp4a_env

--- a/ggml/src/ggml-opencl/kernels/moe_reorder_b.cl
+++ b/ggml/src/ggml-opencl/kernels/moe_reorder_b.cl
@@ -20,11 +20,15 @@ kernel void kernel_moe_reorder_b(
 
     uint router_idx = router[post_router_idx];
 
-    float4 out = (float4)(0);
-    if (router_idx != 0xFFFFFFFF) {
-        ushort activation_idx = router_idx / map_ratio;
-        out = src[activation_idx * K / 4 + k_4];
+    // Padded slots need not be written at all. The MoE GEMMs accumulate per output
+    // column and scatter only the real columns, so whatever sits in a padded slot
+    // never reaches dst -- verified by filling them with 1e30 and re-running
+    // test-backend-ops MUL_MAT_ID (383 OK / 0 FAIL, unchanged), against a positive
+    // control that poisons the real gather too and fails 188 of 383.
+    if (router_idx == 0xFFFFFFFF) {
+        return;
     }
 
-    dst[post_router_idx * K / 4 + k_4] = out;
+    ushort activation_idx = router_idx / map_ratio;
+    dst[post_router_idx * K / 4 + k_4] = src[activation_idx * K / 4 + k_4];
 }

--- a/ggml/src/ggml-opencl/kernels/moe_reorder_b.cl
+++ b/ggml/src/ggml-opencl/kernels/moe_reorder_b.cl
@@ -22,9 +22,7 @@ kernel void kernel_moe_reorder_b(
 
     // Padded slots need not be written at all. The MoE GEMMs accumulate per output
     // column and scatter only the real columns, so whatever sits in a padded slot
-    // never reaches dst -- verified by filling them with 1e30 and re-running
-    // test-backend-ops MUL_MAT_ID (383 OK / 0 FAIL, unchanged), against a positive
-    // control that poisons the real gather too and fails 188 of 383.
+    // never reaches dst
     if (router_idx == 0xFFFFFFFF) {
         return;
     }


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
This PR is to better choose the more performant MoE Matmul based on batch size, not just availability.  This is important for the speculative decoding where the MoE Matmul batch size is small vs the regular prefill. 

Current issue: a mixture-of-experts model routes each token to a few experts, and those expert matmuls are the bulk of its compute. Two decisions about *which* kernel runs them never look at how much work is actually being asked for.

**1. The prebuilt kernel is picked simply because it exists.**

When the vendor kernel library is loaded, its MoE matmul is selected for every shape — and its mere presence also disables the dp4a MoE matmul entirely. But that prebuilt kernel is tuned for prefill-sized work. So a speculative-decode verify step, which reaches this path with only a handful of tokens, runs a kernel built for a full 512-token batch. Every short prefill chunk does too.

The choice is now made on how many expert routings the batch actually produces, which is what the kernel's width is derived from. Below a full batch the dp4a kernel wins and is used; at a full batch the prebuilt kernel still wins and is still selected.
 
**2. Padded slots were being zero-filled for nothing.**

The activation buffer is padded out to a tile boundary, and every padded slot was written with zeros first. But the MoE matmuls accumulate per output column and scatter only the real columns, so whatever sits in a padded slot never reaches the output. The zero-fill was pure memory traffic.

## Additional information

Gemma-4-26B-A4B: Recorded as 33.91 → 41.33 t/s (+21.9%), and the drafters are on Adreno X2E GPU.
 

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
