### PR TITLE
json-schema : handle escaped slashes in regex patterns

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -280,7 +280,7 @@ static std::unordered_map<char, std::string> GRAMMAR_LITERAL_ESCAPES = {
 static const int MAX_PATTERN_DEPTH = 100;
 
 static std::unordered_set<char> NON_LITERAL_SET = {'|', '.', '(', ')', '[', ']', '{', '}', '*', '+', '?', '^', '$'};
-static std::unordered_set<char> ESCAPED_IN_REGEXPS_BUT_NOT_IN_LITERALS = {'^', '$', '.', '[', ']', '(', ')', '|', '{', '}', '*', '+', '?'};
+static std::unordered_set<char> ESCAPED_IN_REGEXPS_BUT_NOT_IN_LITERALS = {'^', '$', '.', '[', ']', '(', ')', '|', '{', '}', '*', '+', '?', '/'};
 
 static std::string replacePattern(const std::string & input, const std::regex & regex, const std::function<std::string(const std::smatch  &)> & replacement) {
     std::smatch match;
@@ -495,6 +495,11 @@ private:
                     i++;
                     while (i < length && sub_pattern[i] != ']') {
                         if (sub_pattern[i] == '\\') {
+                            if (i + 1 < length && sub_pattern[i + 1] == '/') {
+                                square_brackets += '/';
+                                i += 2;
+                                continue;
+                            }
                             auto escape_length = gbnf_escape_length(sub_pattern, i);
                             if (escape_length == 0) {
                                 throw unsupported_pattern("unsupported escape in character class: " + sub_pattern.substr(i, 2));

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -1567,6 +1567,19 @@ int main() {
 
         run({
             SUCCESS,
+            "regexp with escaped slash",
+            R"""({
+                "type": "string",
+                "pattern": "^https:\\/\\/example\\.com\\/[a-z\\/]+$"
+            })""",
+            R"""(
+                root ::= "\"" ("https://example.com/" [a-z/]+) "\""
+                space ::= | " " | "\n"{1,2} [ \t]{0,20}
+            )""",
+        });
+
+        run({
+            SUCCESS,
             "unanchored regexp",
             R"""({
                 "type": "string",


### PR DESCRIPTION
## Overview

This PR fixes the handling of the valid JSON escape sequence `\/` in JSON Schema regex patterns.

The converter now normalizes `\/` to `/` in both regular regex literals and character classes. Other unknown escape sequences continue to be treated as unsupported.

A regression test has been added to cover both cases.

Fixes #27397

## Additional information

This change is based on `master` at commit `c060ca974`.

Validation completed:

- `test-json-schema-to-grammar` built successfully.
- The test executable passed.
- CTest passed: 1/1 tests.
- `git diff --check` passed.

AI assisted with implementation suggestions and test preparation. I reviewed every change line by line, understand the implementation, and accept responsibility for maintaining the code and addressing reviewer feedback.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI assisted with implementation suggestions and test preparation. I reviewed and understood every change and accept responsibility for the submitted code and its subsequent maintenance.