### PR TITLE
llama : fix NaN default tensor split when devices report zero free memory

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1378,8 +1378,20 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         split_sum += splits[i];
         splits[i] = split_sum;
     }
-    for (size_t i = 0; i < n_devices(); ++i) {
-        splits[i] /= split_sum;
+    if (split_sum <= 0.0f) {
+        // all devices reported zero free memory (e.g. Windows/WDDM after another model
+        // filled VRAM, common when loading a speculative draft model second).
+        // normalizing would produce NaN split points and send the upper_bound search in
+        // get_layer_buft_list past the end of `devices` -> out_of_range on devices.at().
+        // fall back to an even split instead.
+        LLAMA_LOG_WARN("%s: all devices report zero free memory, falling back to an even tensor split\n", __func__);
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] = float(i + 1) / n_devices();
+        }
+    } else {
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] /= split_sum;
+        }
     }
 
     const int i_gpu_start = std::max(n_layer_all + 1 - n_gpu_layers, 0);


### PR DESCRIPTION
Fixes #24795 ("invalid vector subscript" loading MTP draft models — regression b9553→b9702).

## Root cause

When no `tensor_split` is provided, `llama_model_base::load_tensors` sizes the default split points by free device memory. If every device reports `free == 0` with `total != 0` — which Windows/WDDM CUDA commonly does once VRAM is filled, i.e. exactly when a speculative **draft** model loads second after the target — `split_sum` is 0 and the normalization computes `0/0 = NaN` for every split point. `std::upper_bound` over NaNs returns past-the-end, and `devices.at(layer_gpu)` throws `out_of_range` ("invalid vector subscript" on the MSVC STL), surfacing as `error loading model: invalid vector subscript`.

This is why the crash looked MTP/arch-specific in #24795: the draft is just the model that loads second. Reproduced with both gemma4-assistant (OP) and qwen35 (Qwen3.8-27B-MTP-ONLY) drafters.

## Fix

Guard the zero sum and fall back to an even split (with a warning) instead of dividing by zero.

## Verification

Experiments on Windows 11, RTX 4090 Laptop 16 GB, official b10581/b10603 CUDA 12.4 builds, Qwen3.8-27B UD-Q3_K_XL target + [a4lg/Qwen3.8-27B-MTP-ONLY-GGUF](https://huggingface.co/a4lg/Qwen3.8-27B-MTP-ONLY-GGUF) Q4_K_M draft via `--spec-type draft-mtp --spec-draft-model`:

| condition | result |
|---|---|
| `--ctx-size 512` (VRAM headroom left when the draft loads) | loads |
| `--ctx-size 8192` / `65536` | crashes |
| `--ctx-size 8192/65536` + `--fit off` | still crashes (matches OP) |
| `--ctx-size 8192/65536` + explicit `--tensor-split 1` (skips the free-memory branch) | loads |
| same source, CPU-only build (no devices → branch never runs) | loads |

The explicit-`--tensor-split` result isolates the free-memory branch as the crash site; the `free==0` + NaN mechanism is the only failure path in it that ends at `devices.at()`. Patch build compiles and passes a load test (CPU build; no local CUDA toolchain to rebuild the CUDA backend, but the change is backend-agnostic host code).

Full write-up with logs in https://github.com/ggml-org/llama.cpp/issues/24795#issuecomment-5391866172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PwFYMMdiGG5jC3mdZcafxK
