### PR TITLE
llama-model: fix NaN device splits when no memory info is available (Windows load crash)

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1442,8 +1442,17 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         split_sum += splits[i];
         splits[i] = split_sum;
     }
-    for (size_t i = 0; i < n_devices(); ++i) {
-        splits[i] /= split_sum;
+    if (split_sum <= 0.0f) {
+        // no device memory info available (common on Windows where the CPU
+        // backend does not report memory and VRAM may read as momentarily 0):
+        // fall back to an even split instead of dividing by zero (NaN)
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] = float(i + 1)/float(n_devices());
+        }
+    } else {
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] /= split_sum;
+        }
     }
 
     const int i_gpu_start = std::max(n_layer_all + 1 - n_gpu_layers, 0);


### PR DESCRIPTION
## Summary

On Windows, loading a **second model into an already-loaded process** (e.g. a
speculative draft model after the main model is already in VRAM) crashes the
loader with:

```
llama_model_load: error loading model: invalid vector subscript
```

This is a `std::out_of_range` thrown by `devices.at(layer_gpu)` in
`llama_model_base::load_tensors` when layer device assignment is computed.

## Root cause

`src/llama-model.cpp` builds `splits` (cumulative device weights for layer
placement) from `ggml_backend_dev_memory()`:

1. When **every** device reports `0` free bytes, all `splits` stay `0`.
   This realistically happens on Windows:
   - the CPU backend does **not** report memory (`free == 0 && total == 0`), so
     the existing fallback to the CPU device does not help;
   - the CUDA device can read as momentarily `0` free during a second model
     load, once the first model has consumed most of VRAM.
2. `split_sum` is then `0` and the normalization `splits[i] /= split_sum`
   produces **NaN**.
3. The layer placement uses
   `std::upper_bound(splits.begin(), ..., float(il - i_gpu_start)/act_gpu_layers)`
   — with a **NaN** threshold every comparison is `false`, so the iterator
   returned is `end()`.
4. `layer_gpu` equals `n_devices()` and `devices.at(layer_gpu)` throws
   `std::out_of_range` ("invalid vector subscript" with the MSVC STL), aborting
   the model load.

The main model usually loads fine because VRAM still reports free memory at
that point; the crash surfaces when a second model is loaded (draft models,
`--mmproj`, v-server, ...) or when VRAM is nearly exhausted.

## Fix

Skip the normalization and fall back to an **even split** when `split_sum` is
not positive. The cumulative split still ends at exactly `1.0`, so
`std::upper_bound()` always returns an index in `[0, n_devices())` and
`devices.at()` cannot go out of range.

```cpp
if (split_sum <= 0.0f) {
    // no device memory info available (common on Windows where the CPU
    // backend does not report memory and VRAM may read as momentarily 0):
    // fall back to an even split instead of dividing by zero (NaN)
    for (size_t i = 0; i < n_devices(); ++i) {
        splits[i] = float(i + 1)/float(n_devices());
    }
} else {
    for (size_t i = 0; i < n_devices(); ++i) {
        splits[i] /= split_sum;
    }
}
```

## Reproduction

- Windows 11, MSVC 19.44, CUDA 13.3, single GPU (RTX 5080), 16 GB VRAM.
- Load the main model (14 GB in VRAM), then load a draft model as the second
  load in the same process: `--spec-draft-model` (any draft; observed with a
  DFlash2 draft) or an `--mmproj` model.
- Fails deterministically at the second model's `load_tensors` with
  `invalid vector subscript`.

## Testing

- Built with MSVC 19.44 + CUDA 13.3 (`-DGGML_CUDA=ON`, `sm_120`) and
  CPU-only (`-DGGML_CUDA=OFF`): both compile cleanly.
- Before the fix: second model load crashes with `invalid vector subscript`.
- After the fix: the draft model loads and speculative decoding runs
  correctly (`draft acceptance` reported per request); the even-split
  fallback also protects single-GPU setups (split `[1.0]`).