### PR TITLE
webui : pass original PDFs to tools and inject chat files into MCP calls

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatAttachments/ChatAttachmentsList/ChatAttachmentsListItem/ChatAttachmentsListItemThumbnailFile.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatAttachments/ChatAttachmentsList/ChatAttachmentsListItem/ChatAttachmentsListItemThumbnailFile.svelte
@@ -2,10 +2,12 @@
 	import { Music, Video, X } from '@lucide/svelte';
 	import { ActionIcon } from '$lib/components/app';
 	import { ICON_CLASS_DEFAULT } from '$lib/constants';
-	import { AttachmentType } from '$lib/enums';
+	import { settingsStore } from '$lib/stores/settings/index.svelte';
 	import {
 		formatFileSize,
 		getFileTypeLabel,
+		getPdfParseMode,
+		getPdfProcessingLabel,
 		getPreviewText,
 		isAudioFile,
 		isPdfFile,
@@ -67,13 +69,11 @@
 	});
 
 	let pdfProcessingMode = $derived.by(() => {
-		if (attachment?.type === AttachmentType.PDF) {
-			const pdfAttachment = attachment as DatabaseMessageExtraPdfFile;
-
-			return pdfAttachment.processedAsImages ? 'Sent as Image' : 'Sent as Text';
+		if (!isPdf) {
+			return null;
 		}
 
-		return null;
+		return getPdfProcessingLabel(attachment, getPdfParseMode(settingsStore.config));
 	});
 </script>
 

--- a/tools/ui/src/lib/constants/settings-keys.constants.ts
+++ b/tools/ui/src/lib/constants/settings-keys.constants.ts
@@ -39,6 +39,8 @@ export const SETTINGS_KEYS = {
 	MIN_P: 'min_p',
 	PASTE_LONG_TEXT_TO_FILE_LEN: 'pasteLongTextToFileLen',
 	PDF_AS_IMAGE: 'pdfAsImage',
+	PDF_PARSE_NONE: 'pdfParseNone',
+	PDF_PARSE_TEXT: 'pdfParseText',
 	// Performance
 	PRE_ENCODE_CONVERSATION: 'preEncodeConversation',
 	PRESENCE_PENALTY: 'presence_penalty',

--- a/tools/ui/src/lib/constants/settings.constants.ts
+++ b/tools/ui/src/lib/constants/settings.constants.ts
@@ -171,9 +171,42 @@ export const SETTINGS_REGISTRY: SettingsSectionEntry[] = [
 			},
 			{
 				defaultValue: false,
-				help: 'Parse PDF as image instead of text. Automatically falls back to text processing for non-vision models.',
+				help: 'How to prepare attached PDFs. No parse keeps the original file for tools such as thaiocr. Parse as text extracts page text into the chat. Parse as image renders pages as images for vision models.',
+				key: SETTINGS_KEYS.PDF_PARSE_NONE,
+				label: 'PDF handling',
+				radioOptions: [
+					{
+						key: SETTINGS_KEYS.PDF_PARSE_NONE,
+						label: 'No parse PDF (pass original file to tools)',
+						value: 'none'
+					},
+					{
+						key: SETTINGS_KEYS.PDF_PARSE_TEXT,
+						label: 'Parse PDF as text',
+						value: 'text'
+					},
+					{
+						key: SETTINGS_KEYS.PDF_AS_IMAGE,
+						label: 'Parse PDF as image',
+						value: 'image'
+					}
+				],
+				type: SettingsFieldType.RADIO
+			},
+			{
+				defaultValue: false,
+				help: 'Counterpart of PDF handling radio: parse attached PDFs as text.',
+				key: SETTINGS_KEYS.PDF_PARSE_TEXT,
+				label: 'Parse PDF as text',
+				standaloneField: false,
+				type: SettingsFieldType.CHECKBOX
+			},
+			{
+				defaultValue: false,
+				help: 'Counterpart of PDF handling radio: render attached PDFs as images for vision models.',
 				key: SETTINGS_KEYS.PDF_AS_IMAGE,
 				label: 'Parse PDF as image',
+				standaloneField: false,
 				type: SettingsFieldType.CHECKBOX
 			},
 			{

--- a/tools/ui/src/lib/services/chat.service.ts
+++ b/tools/ui/src/lib/services/chat.service.ts
@@ -276,6 +276,11 @@ export class ChatService {
 						type: ContentPartType.IMAGE_URL
 					});
 				}
+			} else if (pdfFile.parsedAs === 'none' || !pdfFile.content) {
+				contentParts.push({
+					text: `[PDF attached: ${pdfFile.name} — original file, not parsed. Use a file tool to read it.]`,
+					type: ContentPartType.TEXT
+				});
 			} else {
 				contentParts.push({
 					text: formatAttachmentText(AttachmentLabel.PDF_FILE, pdfFile.name, pdfFile.content),

--- a/tools/ui/src/lib/stores/agentic/index.svelte.ts
+++ b/tools/ui/src/lib/stores/agentic/index.svelte.ts
@@ -75,6 +75,10 @@ import type {
 	DatabaseMessageExtraImageFile
 } from '$lib/types/database';
 import {
+	collectLastUserMessageExtras,
+	injectChatFilesIntoToolArgs
+} from '$lib/utils/inject-chat-files';
+import {
 	executeBrowserInfoTool,
 	executeGetDatetimeTool,
 	getAudioInputFormat,
@@ -343,6 +347,8 @@ class AgenticStore {
 
 		console.log(`[AgenticStore] Starting agentic flow with ${tools.length} tools`);
 
+		const chatFileExtras = collectLastUserMessageExtras(messages);
+
 		const normalizedMessages: ApiChatMessageData[] =
 			await ChatService.normalizeMessagesForApi(messages);
 
@@ -361,6 +367,7 @@ class AgenticStore {
 			await this.executeAgenticLoop({
 				agenticConfig,
 				callbacks,
+				chatFileExtras,
 				conversationId,
 				messages: normalizedMessages,
 				options,
@@ -425,8 +432,18 @@ class AgenticStore {
 		agenticConfig: AgenticConfig;
 		callbacks: AgenticFlowCallbacks;
 		signal?: AbortSignal;
+		chatFileExtras: DatabaseMessageExtra[];
 	}): Promise<void> {
-		const { agenticConfig, callbacks, conversationId, messages, options, signal, tools } = params;
+		const {
+			agenticConfig,
+			callbacks,
+			chatFileExtras,
+			conversationId,
+			messages,
+			options,
+			signal,
+			tools
+		} = params;
 		const {
 			createAssistantMessage,
 			createToolResultMessage,
@@ -772,13 +789,17 @@ class AgenticStore {
 					toolSuccess = false;
 				} else {
 					try {
+						const args = injectChatFilesIntoToolArgs(
+							this.parseToolArguments(toolCall.function.arguments),
+							chatFileExtras
+						);
+
 						if (
 							toolSource === ToolSource.SERVER &&
 							toolName === BuiltInTool.SERVER_EXEC_SHELL_COMMAND &&
 							createToolResultMessage &&
 							updateToolResultMessage
 						) {
-							const args = this.parseToolArguments(toolCall.function.arguments);
 							const cwd = conversationsStore.activeConversation?.cwd;
 							const msg = await createToolResultMessage(toolCall.id, '', undefined, cwd);
 
@@ -806,7 +827,6 @@ class AgenticStore {
 							}
 							result = accumulated;
 						} else if (toolSource === ToolSource.SERVER) {
-							const args = this.parseToolArguments(toolCall.function.arguments);
 							const cwd = conversationsStore.activeConversation?.cwd;
 							const executionResult = await ToolsService.executeTool(toolName, args, signal, cwd);
 
@@ -814,8 +834,6 @@ class AgenticStore {
 
 							if (executionResult.isError) toolSuccess = false;
 						} else if (toolSource === ToolSource.BROWSER) {
-							const args = this.parseToolArguments(toolCall.function.arguments);
-
 							let executionResult: ToolExecutionResult;
 
 							if (toolName === BuiltInTool.BROWSER_GET_DATETIME) {
@@ -841,7 +859,7 @@ class AgenticStore {
 							if (executionResult.isError) toolSuccess = false;
 						} else {
 							const mcpCall: MCPToolCall = {
-								function: { arguments: toolCall.function.arguments, name: toolName },
+								function: { arguments: JSON.stringify(args), name: toolName },
 								id: toolCall.id
 							};
 							const executionResult = await mcpStore.executeTool(mcpCall, signal);

--- a/tools/ui/src/lib/types/database.d.ts
+++ b/tools/ui/src/lib/types/database.d.ts
@@ -61,6 +61,8 @@ export interface DatabaseMessageExtraPdfFile {
 	content: string;
 	images?: string[];
 	processedAsImages: boolean;
+	/** How this PDF was prepared. `none` keeps the original file for tools. */
+	parsedAs?: 'none' | 'text' | 'image';
 }
 
 export interface DatabaseMessageExtraTextFile {

--- a/tools/ui/src/lib/utils/convert-files-to-extra.ts
+++ b/tools/ui/src/lib/utils/convert-files-to-extra.ts
@@ -2,12 +2,11 @@ import { convertPDFToImage, convertPDFToText } from './pdf-processing';
 import { isSvgMimeType, svgBase64UrlToPngDataURL } from './svg-to-png';
 import { isLikelyTextFile, readFileAsText } from './text-files';
 import { isWebpMimeType, webpBase64UrlToPngDataURL } from './webp-to-png';
-import { SETTINGS_KEYS } from '$lib/constants';
 import { AttachmentType, FileTypeCategory, SpecialFileType } from '$lib/enums';
 import { modelsStore } from '$lib/stores/models/index.svelte';
 import { settingsStore } from '$lib/stores/settings/index.svelte';
 import type { ChatUploadedFile, DatabaseMessageExtra, FileProcessingResult } from '$lib/types';
-import { getFileTypeCategory } from '$lib/utils';
+import { getFileTypeCategory, getPdfParseMode } from '$lib/utils';
 import { toast } from 'svelte-sonner';
 
 function readFileAsBase64(file: File): Promise<string> {
@@ -109,39 +108,22 @@ export async function parseFilesToMessageExtras(
 			try {
 				// Always get base64 data for preview functionality
 				const base64Data = await readFileAsBase64(file.file);
-				const currentConfig = settingsStore.config;
-				// Use per-model vision check for router mode
+				const parseMode = getPdfParseMode(settingsStore.config);
 				const hasVisionSupport = activeModelId
 					? modelsStore.props.modelSupportsVision(activeModelId)
 					: false;
 
-				// Force PDF-to-text for non-vision models
-				let shouldProcessAsImages = Boolean(currentConfig.pdfAsImage) && hasVisionSupport;
-
-				// If user had pdfAsImage enabled but model doesn't support vision, update setting and notify
-				if (currentConfig.pdfAsImage && !hasVisionSupport) {
-					console.log('Non-vision model detected: forcing PDF-to-text mode and updating settings');
-
-					// Update the setting in localStorage
-					settingsStore.updateConfig(SETTINGS_KEYS.PDF_AS_IMAGE, false);
-
-					// Show toast notification to user
+				if (parseMode === 'image' && !hasVisionSupport) {
 					toast.warning(
-						'PDF setting changed: Non-vision model detected, PDFs will be processed as text instead of images.',
-						{
-							duration: 5000
-						}
+						`PDF "${file.name}" kept as original file: Parse as image needs a vision model.`,
+						{ duration: 5000 }
 					);
-
-					shouldProcessAsImages = false;
 				}
 
-				if (shouldProcessAsImages) {
-					// Process PDF as images (only for vision models)
+				if (parseMode === 'image' && hasVisionSupport) {
 					try {
 						const images = await convertPDFToImage(file.file);
 
-						// Show success toast for PDF image processing
 						toast.success(
 							`PDF "${file.name}" processed as ${images.length} images for vision model.`,
 							{
@@ -154,33 +136,34 @@ export async function parseFilesToMessageExtras(
 							content: `PDF file with ${images.length} pages`,
 							images: images,
 							name: file.name,
+							parsedAs: 'image',
 							processedAsImages: true,
 							size: file.size,
 							type: AttachmentType.PDF
 						});
 					} catch (imageError) {
 						console.warn(
-							`Failed to process PDF ${file.name} as images, falling back to text:`,
+							`Failed to process PDF ${file.name} as images, keeping original file:`,
 							imageError
 						);
 
-						// Fallback to text processing
-						const content = await convertPDFToText(file.file);
+						toast.warning(`Could not render PDF "${file.name}" as images; keeping original file.`, {
+							duration: 4000
+						});
 
 						extras.push({
 							base64Data: base64Data,
-							content: content,
+							content: '',
 							name: file.name,
+							parsedAs: 'none',
 							processedAsImages: false,
 							size: file.size,
 							type: AttachmentType.PDF
 						});
 					}
-				} else {
-					// Process PDF as text (default or forced for non-vision models)
+				} else if (parseMode === 'text') {
 					const content = await convertPDFToText(file.file);
 
-					// Show success toast for PDF text processing
 					toast.success(`PDF "${file.name}" processed as text content.`, {
 						duration: 3000
 					});
@@ -189,6 +172,17 @@ export async function parseFilesToMessageExtras(
 						base64Data: base64Data,
 						content: content,
 						name: file.name,
+						parsedAs: 'text',
+						processedAsImages: false,
+						size: file.size,
+						type: AttachmentType.PDF
+					});
+				} else {
+					extras.push({
+						base64Data: base64Data,
+						content: '',
+						name: file.name,
+						parsedAs: 'none',
 						processedAsImages: false,
 						size: file.size,
 						type: AttachmentType.PDF

--- a/tools/ui/src/lib/utils/index.ts
+++ b/tools/ui/src/lib/utils/index.ts
@@ -15,6 +15,18 @@ export { validateApiKey } from './api-key-validation';
 // Attachment utilities
 export { getAttachmentDisplayItems, isMcpPrompt, isMcpResource } from './attachment-display';
 export { isTextFile, isImageFile, isPdfFile, isAudioFile, isVideoFile } from './attachment-type';
+export {
+	collectLastUserMessageExtras,
+	extrasToChatFiles,
+	injectChatFilesIntoToolArgs,
+	type ChatFileInjection
+} from './inject-chat-files';
+export {
+	getPdfParseMode,
+	getPdfProcessingLabel,
+	resolvePdfParseModeFromExtra,
+	type PdfParseMode
+} from './pdf-parse-mode';
 
 // Textarea utilities
 export { default as autoResizeTextarea } from './autoresize-textarea';

--- a/tools/ui/src/lib/utils/inject-chat-files.ts
+++ b/tools/ui/src/lib/utils/inject-chat-files.ts
@@ -1,0 +1,135 @@
+import { AttachmentType, MessageRole } from '$lib/enums';
+import type { DatabaseMessage, DatabaseMessageExtra } from '$lib/types/database';
+
+/**
+ * Open WebUI-style file object injected into tool arguments so MCP tools
+ * (e.g. thaiocr) can read chat attachments the model did not pass itself.
+ */
+export interface ChatFileInjection {
+	id: string;
+	type: 'image' | 'file';
+	name: string;
+	mimeType: string;
+	url: string;
+	data: string;
+	base64: string;
+}
+
+function mimeFromDataUrl(url: string): string | undefined {
+	const match = /^data:([^;,]+)/i.exec(url);
+
+	return match?.[1];
+}
+
+function stripDataUrl(payload: string): string {
+	const comma = payload.indexOf(',');
+
+	return comma >= 0 ? payload.slice(comma + 1) : payload;
+}
+
+export function extrasToChatFiles(extras: DatabaseMessageExtra[]): ChatFileInjection[] {
+	const files: ChatFileInjection[] = [];
+
+	for (const extra of extras) {
+		if (extra.type === AttachmentType.IMAGE && extra.base64Url) {
+			const url = extra.base64Url;
+			const data = stripDataUrl(url);
+
+			files.push({
+				base64: url,
+				data,
+				id: extra.name,
+				mimeType: mimeFromDataUrl(url) || 'image/png',
+				name: extra.name,
+				type: 'image',
+				url
+			});
+			continue;
+		}
+
+		if (extra.type === AttachmentType.PDF && extra.base64Data) {
+			const data = extra.base64Data;
+			const url = `data:application/pdf;base64,${data}`;
+
+			files.push({
+				base64: url,
+				data,
+				id: extra.name,
+				mimeType: 'application/pdf',
+				name: extra.name,
+				type: 'file',
+				url
+			});
+		}
+	}
+
+	return files;
+}
+
+/**
+ * Last user message extras in a conversation (chat-level attachments).
+ * API-normalized messages without `extra` are skipped.
+ */
+export function collectLastUserMessageExtras(messages: unknown[]): DatabaseMessageExtra[] {
+	let last: DatabaseMessageExtra[] = [];
+
+	for (const raw of messages) {
+		if (!raw || typeof raw !== 'object') continue;
+
+		const msg = raw as Partial<DatabaseMessage>;
+
+		if (msg.role !== MessageRole.USER && msg.role !== 'user') continue;
+
+		if (Array.isArray(msg.extra) && msg.extra.length > 0) {
+			last = msg.extra;
+		}
+	}
+
+	return last;
+}
+
+function isBlank(value: unknown): boolean {
+	return value === undefined || value === null || value === '';
+}
+
+/**
+ * Inject `__files__`, `__file__`, and `__image__` (Open WebUI extra params)
+ * into tool-call arguments. Does not overwrite values the model already set.
+ * Also fills empty `image` / `file_id` so file-input tools receive a data URI.
+ */
+export function injectChatFilesIntoToolArgs(
+	args: Record<string, unknown>,
+	extras: DatabaseMessageExtra[]
+): Record<string, unknown> {
+	const files = extrasToChatFiles(extras);
+
+	if (files.length === 0) {
+		return args;
+	}
+
+	const firstImage = files.find((file) => file.type === 'image');
+	const firstFile = files.find((file) => file.type === 'file') ?? files[0];
+	const out: Record<string, unknown> = { ...args };
+
+	if (out.__files__ === undefined) {
+		out.__files__ = files;
+	}
+
+	if (out.__file__ === undefined) {
+		out.__file__ = firstFile;
+	}
+
+	if (out.__image__ === undefined && firstImage) {
+		out.__image__ = firstImage.url;
+	}
+
+	if (isBlank(out.image)) {
+		out.image = firstImage?.url ?? firstFile.url;
+	}
+
+	if (isBlank(out.file_id)) {
+		out.file_id = firstFile.id;
+	}
+
+	return out;
+}

--- a/tools/ui/src/lib/utils/pdf-parse-mode.ts
+++ b/tools/ui/src/lib/utils/pdf-parse-mode.ts
@@ -1,0 +1,55 @@
+import { SETTINGS_KEYS } from '$lib/constants';
+import { AttachmentType } from '$lib/enums';
+import type { DatabaseMessageExtra, DatabaseMessageExtraPdfFile } from '$lib/types/database';
+
+export type PdfParseMode = 'none' | 'text' | 'image';
+
+const PDF_PARSE_LABEL: Record<PdfParseMode, string> = {
+	image: 'Sent as Image',
+	none: 'Original file',
+	text: 'Sent as Text'
+};
+
+/**
+ * Resolve how attached PDFs should be prepared.
+ * Image wins if the legacy `pdfAsImage` checkbox (now a radio option) is set.
+ */
+export function getPdfParseMode(config: Record<string, unknown> | undefined): PdfParseMode {
+	if (!config) {
+		return 'none';
+	}
+
+	if (config[SETTINGS_KEYS.PDF_AS_IMAGE]) {
+		return 'image';
+	}
+
+	if (config[SETTINGS_KEYS.PDF_PARSE_TEXT]) {
+		return 'text';
+	}
+
+	return 'none';
+}
+
+/** Infer how a stored PDF extra was prepared. */
+export function resolvePdfParseModeFromExtra(extra: DatabaseMessageExtraPdfFile): PdfParseMode {
+	if (extra.parsedAs) {
+		return extra.parsedAs;
+	}
+
+	if (extra.processedAsImages) {
+		return 'image';
+	}
+
+	return extra.content ? 'text' : 'none';
+}
+
+export function getPdfProcessingLabel(
+	attachment: DatabaseMessageExtra | undefined,
+	settingsParseMode: PdfParseMode
+): string | null {
+	if (attachment?.type === AttachmentType.PDF) {
+		return PDF_PARSE_LABEL[resolvePdfParseModeFromExtra(attachment)];
+	}
+
+	return PDF_PARSE_LABEL[settingsParseMode];
+}

--- a/tools/ui/src/lib/utils/process-uploaded-files.ts
+++ b/tools/ui/src/lib/utils/process-uploaded-files.ts
@@ -2,12 +2,9 @@ import { heicFileToJpegDataURL, isHeicMimeType } from './heic-to-jpeg';
 import { convertPDFToText } from './pdf-processing';
 import { isSvgMimeType, svgBase64UrlToPngDataURL } from './svg-to-png';
 import { isWebpMimeType, webpBase64UrlToPngDataURL } from './webp-to-png';
-import { SETTINGS_KEYS } from '$lib/constants';
 import { FileTypeCategory } from '$lib/enums';
-import { modelsStore } from '$lib/stores/models/index.svelte';
 import { settingsStore } from '$lib/stores/settings/index.svelte';
-import { getFileTypeCategory } from '$lib/utils';
-import { toast } from 'svelte-sonner';
+import { getFileTypeCategory, getPdfParseMode } from '$lib/utils';
 
 /**
  * Read a file as a data URL (base64 encoded)
@@ -96,35 +93,19 @@ export async function processFilesToChatUploaded(
 
 				results.push({ ...base, preview });
 			} else if (getFileTypeCategory(file.type) === FileTypeCategory.PDF) {
-				// Extract text content from PDF for preview
-				try {
-					const textContent = await convertPDFToText(file);
+				const parseMode = getPdfParseMode(settingsStore.config);
 
-					results.push({ ...base, textContent });
-				} catch (err) {
-					console.warn('Failed to extract text from PDF, adding without content:', err);
+				if (parseMode === 'text') {
+					try {
+						const textContent = await convertPDFToText(file);
+
+						results.push({ ...base, textContent });
+					} catch (err) {
+						console.warn('Failed to extract text from PDF, adding without content:', err);
+						results.push(base);
+					}
+				} else {
 					results.push(base);
-				}
-
-				// Show suggestion toast if vision model is available but PDF as image is disabled
-				const hasVisionSupport = activeModelId
-					? modelsStore.props.modelSupportsVision(activeModelId)
-					: false;
-				const currentConfig = settingsStore.config;
-
-				if (hasVisionSupport && !currentConfig.pdfAsImage) {
-					toast.info(`You can enable parsing PDF as images with vision models.`, {
-						action: {
-							label: 'Enable PDF as Images',
-							onClick: () => {
-								settingsStore.updateConfig(SETTINGS_KEYS.PDF_AS_IMAGE, true);
-								toast.success('PDF parsing as images enabled!', {
-									duration: 3000
-								});
-							}
-						},
-						duration: 8000
-					});
 				}
 			} else if (getFileTypeCategory(file.type) === FileTypeCategory.AUDIO) {
 				// Generate preview URL for audio files

--- a/tools/ui/tests/unit/inject-chat-files.test.ts
+++ b/tools/ui/tests/unit/inject-chat-files.test.ts
@@ -1,0 +1,113 @@
+import { AttachmentType, MessageRole } from '$lib/enums';
+import type { DatabaseMessageExtra } from '$lib/types/database';
+import {
+	collectLastUserMessageExtras,
+	extrasToChatFiles,
+	injectChatFilesIntoToolArgs
+} from '$lib/utils/inject-chat-files';
+import { describe, expect, it } from 'vitest';
+
+const pngDataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+
+describe('injectChatFilesIntoToolArgs', () => {
+	it('injects __files__, __file__, __image__, image, and file_id for a PNG', () => {
+		const extras: DatabaseMessageExtra[] = [
+			{ base64Url: pngDataUrl, name: 'scan.png', type: AttachmentType.IMAGE }
+		];
+		const out = injectChatFilesIntoToolArgs({}, extras);
+
+		expect(out.__image__).toBe(pngDataUrl);
+		expect(out.image).toBe(pngDataUrl);
+		expect(out.file_id).toBe('scan.png');
+		expect(out.__file__).toMatchObject({ name: 'scan.png', type: 'image', url: pngDataUrl });
+		expect(out.__files__).toHaveLength(1);
+	});
+
+	it('injects a PDF as type file with a data URI', () => {
+		const extras: DatabaseMessageExtra[] = [
+			{
+				base64Data: 'JVBERi0=',
+				content: '',
+				name: 'doc.pdf',
+				processedAsImages: false,
+				type: AttachmentType.PDF
+			}
+		];
+		const out = injectChatFilesIntoToolArgs({ task: 'v1.5' }, extras);
+
+		expect(out.image).toBe('data:application/pdf;base64,JVBERi0=');
+		expect(out.__file__).toMatchObject({
+			mimeType: 'application/pdf',
+			name: 'doc.pdf',
+			type: 'file'
+		});
+		expect(out.task).toBe('v1.5');
+	});
+
+	it('does not overwrite image or __files__ the model already set', () => {
+		const extras: DatabaseMessageExtra[] = [
+			{ base64Url: pngDataUrl, name: 'scan.png', type: AttachmentType.IMAGE }
+		];
+		const out = injectChatFilesIntoToolArgs(
+			{ __files__: ['keep'], image: '/tmp/explicit.png' },
+			extras
+		);
+
+		expect(out.image).toBe('/tmp/explicit.png');
+		expect(out.__files__).toEqual(['keep']);
+		expect(out.__image__).toBe(pngDataUrl);
+	});
+
+	it('returns args unchanged when there are no file extras', () => {
+		const extras: DatabaseMessageExtra[] = [
+			{ content: 'hello', name: 'notes.txt', type: AttachmentType.TEXT }
+		];
+
+		expect(injectChatFilesIntoToolArgs({ page: '1' }, extras)).toEqual({ page: '1' });
+	});
+});
+
+describe('collectLastUserMessageExtras', () => {
+	it('returns extras from the last user message', () => {
+		const extras = collectLastUserMessageExtras([
+			{
+				extra: [{ base64Url: pngDataUrl, name: 'old.png', type: AttachmentType.IMAGE }],
+				role: MessageRole.USER
+			},
+			{ extra: [], role: MessageRole.ASSISTANT },
+			{
+				extra: [
+					{
+						base64Data: 'JVBERi0=',
+						content: '',
+						name: 'latest.pdf',
+						processedAsImages: false,
+						type: AttachmentType.PDF
+					}
+				],
+				role: MessageRole.USER
+			}
+		]);
+
+		expect(extras).toHaveLength(1);
+		expect(extras[0]).toMatchObject({ name: 'latest.pdf' });
+	});
+});
+
+describe('extrasToChatFiles', () => {
+	it('maps image and pdf extras and skips text', () => {
+		const files = extrasToChatFiles([
+			{ base64Url: pngDataUrl, name: 'a.png', type: AttachmentType.IMAGE },
+			{ content: 'x', name: 'a.txt', type: AttachmentType.TEXT },
+			{
+				base64Data: 'JVBERi0=',
+				content: '',
+				name: 'a.pdf',
+				processedAsImages: false,
+				type: AttachmentType.PDF
+			}
+		]);
+
+		expect(files.map((f) => f.type)).toEqual(['image', 'file']);
+	});
+});

--- a/tools/ui/tests/unit/pdf-parse-mode.test.ts
+++ b/tools/ui/tests/unit/pdf-parse-mode.test.ts
@@ -1,0 +1,68 @@
+import { SETTINGS_KEYS } from '$lib/constants';
+import { AttachmentType } from '$lib/enums';
+import {
+	getPdfParseMode,
+	getPdfProcessingLabel,
+	resolvePdfParseModeFromExtra
+} from '$lib/utils/pdf-parse-mode';
+import { describe, expect, it } from 'vitest';
+
+describe('getPdfParseMode', () => {
+	it('defaults to none', () => {
+		expect(getPdfParseMode(undefined)).toBe('none');
+		expect(getPdfParseMode({})).toBe('none');
+	});
+
+	it('returns image when pdfAsImage is set', () => {
+		expect(
+			getPdfParseMode({
+				[SETTINGS_KEYS.PDF_AS_IMAGE]: true,
+				[SETTINGS_KEYS.PDF_PARSE_TEXT]: true
+			})
+		).toBe('image');
+	});
+
+	it('returns text when parse-text is set and image is not', () => {
+		expect(getPdfParseMode({ [SETTINGS_KEYS.PDF_PARSE_TEXT]: true })).toBe('text');
+	});
+
+	it('returns none when parse-none is set', () => {
+		expect(getPdfParseMode({ [SETTINGS_KEYS.PDF_PARSE_NONE]: true })).toBe('none');
+	});
+});
+
+describe('getPdfProcessingLabel', () => {
+	it('labels a no-parse extra as original file, not text', () => {
+		expect(
+			getPdfProcessingLabel(
+				{
+					base64Data: 'JVBERi0=',
+					content: '',
+					name: 'doc.pdf',
+					parsedAs: 'none',
+					processedAsImages: false,
+					type: AttachmentType.PDF
+				},
+				'text'
+			)
+		).toBe('Original file');
+	});
+
+	it('falls back to settings mode for a draft without extras', () => {
+		expect(getPdfProcessingLabel(undefined, 'none')).toBe('Original file');
+		expect(getPdfProcessingLabel(undefined, 'text')).toBe('Sent as Text');
+		expect(getPdfProcessingLabel(undefined, 'image')).toBe('Sent as Image');
+	});
+
+	it('treats a legacy extra with extracted content as text', () => {
+		expect(
+			resolvePdfParseModeFromExtra({
+				base64Data: 'JVBERi0=',
+				content: 'hello',
+				name: 'doc.pdf',
+				processedAsImages: false,
+				type: AttachmentType.PDF
+			})
+		).toBe('text');
+	});
+});


### PR DESCRIPTION
webui : pass original PDFs to tools and inject chat files into MCP calls

Add a PDF handling radio (no parse / text / image) so attachments are not always converted to text. Default is original file. Inject last-user-message files into tool arguments as __files__, __file__, and __image__ so MCP tools can OCR PDFs and images the model did not pass itself.

AI usage: used an agent to locate the WebUI attachment/MCP paths, implement the setting and injection helpers, and add unit tests. Design and behavior were specified by the contributor.

## Overview

Attached PDFs are always turned into text (or into images when "Parse PDF as image" is on). That means MCP tools never see the original file, so OCR tools cannot work on the PDF the user attached.

This PR:

1. Replaces the PDF checkbox with a radio in Settings → General:
   - No parse PDF (default) — keep the original file for tools
   - Parse PDF as text
   - Parse PDF as image (vision models)
2. Injects files from the last user message into tool-call arguments as `__files__`, `__file__`, and `__image__` (and fills empty `image` / `file_id`) so MCP tools can read PDFs and images the model did not pass.
3. Shows Original file / Sent as Text / Sent as Image on the attachment chip.

## Additional information

Unit tests:

```bash
cd tools/ui
npx vitest --project=unit --run tests/unit/inject-chat-files.test.ts tests/unit/pdf-parse-mode.test.ts
```

Branch: `phattja:webui-pdf-passthrough-mcp-files`

Compare: https://github.com/ggml-org/llama.cpp/compare/master...phattja:webui-pdf-passthrough-mcp-files?expand=1

llama.cpp prefers an issue before a feature PR. This can stay a draft until there is an issue.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES — an agent helped locate the WebUI attachment/MCP paths, implement the setting and injection helpers, and add unit tests. I specified the design (PDF radio, original-file default, `__files__` / `__file__` / `__image__`) and I am responsible for every line.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->

