### PR TITLE
ggml-cuda : fix cpy transposed path corrupting non-contiguous dst

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -459,7 +459,8 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
 
     const bool contiguous_srcs = ggml_is_contiguous(src0) && ggml_is_contiguous(src1);
     const bool can_be_transposed = nb01 == (int64_t)ggml_element_size(src0) &&
-        src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0);
+        src0->ne[3] == 1 && nb02 == ne00 * ne01 * (int64_t)ggml_element_size(src0) &&
+        ggml_is_contiguous(src1);
 
     size_t mc_width = 0, mc_height = 0, mc_spitch = 0, mc_dpitch = 0;
 


### PR DESCRIPTION
## Overview

`ggml_cuda_cpy`'s `can_be_transposed` gate only inspects the layout of `src0`. When the destination `src1` is non-contiguous, for example a strided `view_2d` slot such as a KV-cache column write, a same-type F32/F16/BF16/I32 copy still takes the transposed scalar kernel.

That kernel writes the destination with a contiguous index derived from `ne00` and `ne01`, and it ignores the destination strides `nb10` to `nb13`. They are passed to `GGML_UNUSED_VARS` at `ggml/src/ggml-cuda/cpy.cu:96`. The result is silent corruption of the strided destination.

The fix requires `ggml_is_contiguous(src1)` for the transposed fast path. A non-contiguous destination now falls back to the general `cpy_scalar` kernel, which honors `nb10` to `nb13`. A contiguous destination, which is the common case, takes the same path as before, so the normal path does not change.

The change is 2 lines.

## Additional information

This is the same fix as ggml-org/ggml#1570, moved to this repository. The ggml PR is 36 days old and has no reviewer. I opened it there first, and I will close it in favour of this one.

The root-cause analysis and a reproduction, 16 ops plus a real transformer decode, are in ggml-org/ggml#1497. @OriPekelman pinpointed the exact gate and proposed this fix; the credit is theirs.

I re-verified against current `master` (`b3c3b96a1`) before opening this:

- `can_be_transposed` at `ggml/src/ggml-cuda/cpy.cu:461` still tests only `nb01`, `src0->ne[3]` and `nb02`. It does not test the destination.
- `cpy_scalar_transpose` at line 45 still passes `nb10`, `nb11`, `nb12` and `nb13` to `GGML_UNUSED_VARS` at line 96, so the destination strides are still discarded on that path.

I could not build or run this locally. This is CUDA-only and I am on macOS with no CUDA toolkit, so there is no local build evidence for this change. The correctness argument is the source reading above. CI is the only build signal here.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I use Claude Code CLI

