### PR TITLE
rpc: add timestamps to rpc logs

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1785,26 +1785,27 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
 void ggml_backend_rpc_start_server(const char * endpoint, const char * cache_dir,
                                    size_t n_threads, size_t n_devices, ggml_backend_dev_t * devices) {
     if (n_devices == 0 || devices == nullptr) {
-        fprintf(stderr, "Invalid arguments to ggml_backend_rpc_start_server\n");
+        GGML_LOG_ERROR("%s: invalid arguments to ggml_backend_rpc_start_server\n", __func__);
         return;
     }
     std::vector<ggml_backend_t> backends;
-    printf("Starting RPC server v%d.%d.%d\n",
+    GGML_LOG_INFO("%s: Starting RPC server v%d.%d.%d\n",
+        __func__,
         RPC_PROTO_MAJOR_VERSION,
         RPC_PROTO_MINOR_VERSION,
         RPC_PROTO_PATCH_VERSION);
-    printf("  endpoint       : %s\n", endpoint);
-    printf("  local cache    : %s\n", cache_dir ? cache_dir : "n/a");
-    printf("Devices:\n");
+    GGML_LOG_INFO("  endpoint       : %s\n", endpoint);
+    GGML_LOG_INFO("  local cache    : %s\n", cache_dir ? cache_dir : "n/a");
+    GGML_LOG_INFO("Devices:\n");
     for (size_t i = 0; i < n_devices; i++) {
         auto dev = devices[i];
         size_t free, total;
         ggml_backend_dev_memory(dev, &free, &total);
-        printf("  %s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev),
+        GGML_LOG_INFO("  %s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev),
                total / 1024 / 1024, free / 1024 / 1024);
         auto backend = ggml_backend_dev_init(dev, nullptr);
         if (!backend) {
-            fprintf(stderr, "Failed to create backend for device %s\n", dev->iface.get_name(dev));
+            GGML_LOG_ERROR("%s: failed to create backend for device %s\n", __func__, dev->iface.get_name(dev));
             return;
         }
         backends.push_back(backend);
@@ -1824,30 +1825,28 @@ void ggml_backend_rpc_start_server(const char * endpoint, const char * cache_dir
     }
 
 #ifdef GGML_RPC_RDMA
-    printf("  transport      : TCP (RDMA auto-negotiate enabled)\n");
+    GGML_LOG_INFO("  transport      : TCP (RDMA auto-negotiate enabled)\n");
 #else
-    printf("  transport      : TCP\n");
+    GGML_LOG_INFO("  transport      : TCP\n");
 #endif // GGML_RPC_RDMA
     if (!rpc_transport_init()) {
-        fprintf(stderr, "Failed to initialize RPC transport\n");
+        GGML_LOG_ERROR("%s: failed to initialize RPC transport\n", __func__);
         return;
     }
     auto server_socket = socket_t::create_server(host.c_str(), port);
     if (server_socket == nullptr) {
-        fprintf(stderr, "Failed to create server socket\n");
+        GGML_LOG_ERROR("%s: failed to create server socket\n", __func__);
         return;
     }
     while (true) {
         auto client_socket = server_socket->accept();
         if (client_socket == nullptr) {
-            fprintf(stderr, "Failed to accept client connection\n");
+            GGML_LOG_ERROR("%s: failed to accept client connection\n", __func__);
             return;
         }
-        printf("Accepted client connection\n");
-        fflush(stdout);
+        GGML_LOG_INFO("%s: accepted client connection\n", __func__);
         rpc_serve_client(backends, cache_dir, client_socket);
-        printf("Client connection closed\n");
-        fflush(stdout);
+        GGML_LOG_INFO("%s: client connection closed\n", __func__);
     }
     rpc_transport_shutdown();
     for (auto backend : backends) {

--- a/tools/rpc/rpc-server.cpp
+++ b/tools/rpc/rpc-server.cpp
@@ -5,15 +5,21 @@
 #  include <windows.h>
 #  include <fcntl.h>
 #  include <io.h>
+#  define isatty _isatty
+#  define fileno _fileno
 #else
 #  define DIRECTORY_SEPARATOR '/'
 #  include <unistd.h>
 #  include <sys/stat.h>
 #endif
 #include <algorithm>
+#include <chrono>
 #include <clocale>
 #include <codecvt>
+#include <cstdarg>
+#include <cstring>
 #include <filesystem>
+#include <mutex>
 #include <regex>
 #include <stdio.h>
 #include <string>
@@ -169,6 +175,125 @@ static std::string fs_get_cache_directory() {
     return ensure_trailing_slash(cache_directory);
 }
 
+// NOTE: this is copied from common/log.h to avoid linking with libcommon
+#define LOG_LEVEL_DEBUG  5
+#define LOG_LEVEL_TRACE  4
+#define LOG_LEVEL_INFO   3
+#define LOG_LEVEL_WARN   2
+#define LOG_LEVEL_ERROR  1
+#define LOG_LEVEL_OUTPUT 0 // output data from tools
+
+static int              g_log_verbosity = LOG_LEVEL_INFO;
+static bool             g_log_colors    = false;
+static int64_t          g_log_t_start   = 0;
+static std::mutex       g_log_mtx;
+
+// NOTE: this is copied from common/log.cpp to avoid linking with libcommon
+static int64_t t_us() {
+    return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+// NOTE: this is copied from common.cpp to avoid linking with libcommon
+static bool tty_can_use_colors() {
+    // Check NO_COLOR environment variable (https://no-color.org/)
+    if (const char * no_color = std::getenv("NO_COLOR")) {
+        if (no_color[0] != '\0') {
+            return false;
+        }
+    }
+
+    // Check TERM environment variable
+    if (const char * term = std::getenv("TERM")) {
+        if (std::strcmp(term, "dumb") == 0) {
+            return false;
+        }
+    }
+
+    // Check if stdout and stderr are connected to a terminal
+    // We check both because log messages can go to either
+    bool stdout_is_tty = isatty(fileno(stdout));
+    bool stderr_is_tty = isatty(fileno(stderr));
+
+    return stdout_is_tty || stderr_is_tty;
+}
+
+// NOTE: this is copied from common/log.cpp to avoid linking with libcommon
+static int common_get_verbosity(enum ggml_log_level level) {
+    switch (level) {
+        case GGML_LOG_LEVEL_DEBUG: return LOG_LEVEL_DEBUG;
+        case GGML_LOG_LEVEL_INFO:  return LOG_LEVEL_TRACE;
+        case GGML_LOG_LEVEL_WARN:  return LOG_LEVEL_WARN;
+        case GGML_LOG_LEVEL_ERROR: return LOG_LEVEL_ERROR;
+        case GGML_LOG_LEVEL_CONT:  return LOG_LEVEL_TRACE;
+        case GGML_LOG_LEVEL_NONE:
+        default:
+            return LOG_LEVEL_OUTPUT;
+    }
+}
+
+// NOTE: this is copied (and simplified) from common/log.cpp to avoid linking with libcommon
+static void log_add(enum ggml_log_level level, const char * fmt, ...) {
+    if (common_get_verbosity(level) > g_log_verbosity) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    std::vector<char> buf(256);
+    int n = vsnprintf(buf.data(), buf.size(), fmt, args);
+    if (n >= (int) buf.size()) {
+        buf.resize(n + 1);
+        va_list args_copy;
+        va_copy(args_copy, args);
+        vsnprintf(buf.data(), buf.size(), fmt, args_copy);
+        va_end(args_copy);
+    }
+    va_end(args);
+
+    std::lock_guard<std::mutex> lock(g_log_mtx);
+
+    FILE * f = stderr;
+
+    if (level != GGML_LOG_LEVEL_NONE) {
+        const char * col_blue    = g_log_colors ? "\033[34m" : "";
+        const char * col_default = g_log_colors ? "\033[0m"  : "";
+
+        const int64_t ts = t_us() - g_log_t_start;
+        fprintf(f, "%s%d.%02d.%03d.%03d%s ",
+                col_blue,
+                (int) (ts / 1000000 / 60),
+                (int) (ts / 1000000 % 60),
+                (int) (ts / 1000 % 1000),
+                (int) (ts % 1000),
+                col_default);
+
+        switch (level) {
+            case GGML_LOG_LEVEL_INFO:  fprintf(f, "%sI %s", g_log_colors ? "\033[32m" : "", col_default); break;
+            case GGML_LOG_LEVEL_WARN:  fprintf(f, "%sW %s", g_log_colors ? "\033[35m" : "", "");          break;
+            case GGML_LOG_LEVEL_ERROR: fprintf(f, "%sE %s", g_log_colors ? "\033[31m" : "", "");          break;
+            case GGML_LOG_LEVEL_DEBUG: fprintf(f, "%sD %s", g_log_colors ? "\033[33m" : "", "");          break;
+            default:
+                break;
+        }
+    }
+
+    fprintf(f, "%s", buf.data());
+
+    if (level == GGML_LOG_LEVEL_WARN || level == GGML_LOG_LEVEL_ERROR || level == GGML_LOG_LEVEL_DEBUG) {
+        fprintf(f, "%s", g_log_colors ? "\033[0m" : "");
+    }
+
+    fflush(f);
+}
+
+static void log_callback(enum ggml_log_level level, const char * text, void * /*user_data*/) {
+    log_add(level, "%s", text);
+}
+
+#define RPC_INF(fmt, ...) log_add(GGML_LOG_LEVEL_INFO,  "%s: " fmt, __func__, __VA_ARGS__)
+#define RPC_WRN(fmt, ...) log_add(GGML_LOG_LEVEL_WARN,  "%s: " fmt, __func__, __VA_ARGS__)
+#define RPC_ERR(fmt, ...) log_add(GGML_LOG_LEVEL_ERROR, "%s: " fmt, __func__, __VA_ARGS__)
+
 struct rpc_server_params {
     std::string              host        = "127.0.0.1";
     int                      port        = 50052;
@@ -204,7 +329,7 @@ static bool rpc_server_params_parse(int argc, char ** argv, rpc_server_params & 
             }
             params.n_threads = std::stoi(argv[i]);
             if (params.n_threads <= 0) {
-                fprintf(stderr, "error: invalid number of threads: %d\n", params.n_threads);
+                RPC_ERR("error: invalid number of threads: %d\n", params.n_threads);
                 return false;
             }
         } else if (arg == "-d" || arg == "--device") {
@@ -219,7 +344,7 @@ static bool rpc_server_params_parse(int argc, char ** argv, rpc_server_params & 
                 try {
                     params.devices.push_back(*iter);
                 } catch (const std::exception & ) {
-                    fprintf(stderr, "error: invalid device: %s\n", iter->str().c_str());
+                    RPC_ERR("error: invalid device: %s\n", iter->str().c_str());
                     return false;
                 }
             }
@@ -237,7 +362,7 @@ static bool rpc_server_params_parse(int argc, char ** argv, rpc_server_params & 
             print_usage(argc, argv, params);
             exit(0);
         } else {
-            fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
+            RPC_ERR("error: unknown argument: %s\n", arg.c_str());
             print_usage(argc, argv, params);
             exit(0);
         }
@@ -253,13 +378,13 @@ static std::vector<ggml_backend_dev_t> get_devices(const rpc_server_params & par
             if (dev) {
                 devices.push_back(dev);
             } else {
-                fprintf(stderr, "error: unknown device: %s\n", device.c_str());
-                fprintf(stderr, "available devices:\n");
+                RPC_ERR("error: unknown device: %s\n", device.c_str());
+                RPC_INF("%s", "available devices:\n");
                 for (size_t i = 0; i < ggml_backend_dev_count(); i++) {
                     auto * dev = ggml_backend_dev_get(i);
                     size_t free, total;
                     ggml_backend_dev_memory(dev, &free, &total);
-                    printf("  %s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev), total / 1024 / 1024, free / 1024 / 1024);
+                    RPC_INF("  %s: %s (%zu MiB, %zu MiB free)\n", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev), total / 1024 / 1024, free / 1024 / 1024);
                 }
                 return {};
             }
@@ -290,27 +415,30 @@ static std::vector<ggml_backend_dev_t> get_devices(const rpc_server_params & par
 int main(int argc, char * argv[]) {
     std::setlocale(LC_NUMERIC, "C");
 
-    ggml_backend_load_all();
+    g_log_t_start = t_us();
+    g_log_colors  = tty_can_use_colors();
+    g_log_verbosity = std::getenv("GGML_RPC_DEBUG") ? LOG_LEVEL_DEBUG : common_get_verbosity(GGML_LOG_LEVEL_INFO);
+    ggml_log_set(log_callback, NULL);
 
     rpc_server_params params;
     if (!rpc_server_params_parse(argc, argv, params)) {
-        fprintf(stderr, "Invalid parameters\n");
+        RPC_ERR("%s", "Invalid parameters\n");
         return 1;
     }
 
+    ggml_backend_load_all();
+
     if (params.host != "127.0.0.1") {
-        fprintf(stderr, "\n");
-        fprintf(stderr, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
-        fprintf(stderr, "WARNING: Host ('%s') is != '127.0.0.1'\n", params.host.c_str());
-        fprintf(stderr, "         Never expose the RPC server to an open network!\n");
-        fprintf(stderr, "         This is an experimental feature and is not secure!\n");
-        fprintf(stderr, "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
-        fprintf(stderr, "\n");
+        RPC_WRN("%s", "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
+        RPC_WRN("WARNING: Host ('%s') is != '127.0.0.1'\n", params.host.c_str());
+        RPC_WRN("%s", "         Never expose the RPC server to an open network!\n");
+        RPC_WRN("%s", "         This is an experimental feature and is not secure!\n");
+        RPC_WRN("%s", "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
     }
 
     auto devices = get_devices(params);
     if (devices.empty()) {
-        fprintf(stderr, "No devices found\n");
+        RPC_ERR("%s", "No devices found\n");
         return 1;
     }
     std::string endpoint = params.host + ":" + std::to_string(params.port);
@@ -319,7 +447,7 @@ int main(int argc, char * argv[]) {
     if (params.use_cache) {
         cache_dir_str = fs_get_cache_directory() + "rpc" + DIRECTORY_SEPARATOR;
         if (!fs_create_directory_with_parents(cache_dir_str)) {
-            fprintf(stderr, "Failed to create cache directory: %s\n", cache_dir_str.c_str());
+            RPC_ERR("Failed to create cache directory: %s\n", cache_dir_str.c_str());
             return 1;
         }
         cache_dir = cache_dir_str.c_str();
@@ -327,13 +455,13 @@ int main(int argc, char * argv[]) {
 
     ggml_backend_reg_t reg = ggml_backend_reg_by_name("RPC");
     if (!reg) {
-        fprintf(stderr, "Failed to find RPC backend\n");
+        RPC_ERR("%s", "Failed to find RPC backend\n");
         return 1;
     }
 
     auto start_server_fn = (decltype(ggml_backend_rpc_start_server)*) ggml_backend_reg_get_proc_address(reg, "ggml_backend_rpc_start_server");
     if (!start_server_fn) {
-        fprintf(stderr, "Failed to obtain RPC backend start server function\n");
+        RPC_ERR("%s", "Failed to obtain RPC backend start server function\n");
         return 1;
     }
 


### PR DESCRIPTION
## Overview

Adds logs formatting to rpc server. Same format as used in other tools.
`GGML_RPC_DEBUG=1` is still being used to enable debug output.

While the change may seem cosmetic the important part are the timestamps. With timestamp we can easily correlate client and server logs (filter out parts that are not important for debugging specific problems etc.).

## Additional information

Before:
```

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
WARNING: Host ('0.0.0.0') is != '127.0.0.1'
         Never expose the RPC server to an open network!
         This is an experimental feature and is not secure!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

Starting RPC server v5.1.0
  endpoint       : 0.0.0.0:50052
  local cache    : n/a
Devices:
  CPU: AMD Ryzen 7 5700U with Radeon Graphics (63676 MiB, 63676 MiB free)
  transport      : TCP (RDMA auto-negotiate enabled)
Accepted client connection
[hello] version: 5.1.0
RDMA probed: dev=mlx4_0 gid=2 RoCEv1 qpn=566 inline=448
RDMA activated: qpn=566->751 mtu=1024 rx_depth=24
Client connection closed
[~impl] closing socket 4
Accepted client connection
[hello] version: 5.1.0
RDMA probed: dev=mlx4_0 gid=2 RoCEv1 qpn=567 inline=448
RDMA activated: qpn=567->752 mtu=1024 rx_depth=24
[get_device_memory] device: 0, free_mem: 66769473536, total_mem: 66769473536
```
After:
```
0.00.001.001 W main: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
0.00.001.015 W main: WARNING: Host ('0.0.0.0') is != '127.0.0.1'
0.00.001.026 W main:          Never expose the RPC server to an open network!
0.00.001.032 W main:          This is an experimental feature and is not secure!
0.00.001.040 W main: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
0.00.002.242 I ggml_backend_rpc_start_server: Starting RPC server v5.1.0
0.00.002.249 I   endpoint       : 0.0.0.0:50052
0.00.002.254 I   local cache    : n/a
0.00.002.261 I Devices:
0.00.002.270 I   CPU: AMD Ryzen 7 5700U with Radeon Graphics (63676 MiB, 63676 MiB free)
0.00.002.278 I   transport      : TCP (RDMA auto-negotiate enabled)
0.33.964.209 I ggml_backend_rpc_start_server: accepted client connection
0.33.970.168 D [hello] version: 5.1.0
0.33.977.440 I RDMA probed: dev=mlx4_0 gid=2 RoCEv1 qpn=573 inline=448
0.33.978.128 I RDMA activated: qpn=573->536 mtu=1024 rx_depth=24
0.33.985.145 I ggml_backend_rpc_start_server: client connection closed
0.33.986.607 D [~impl] closing socket 4
0.33.986.643 I ggml_backend_rpc_start_server: accepted client connection
0.33.986.652 D [hello] version: 5.1.0
0.33.990.872 I RDMA probed: dev=mlx4_0 gid=2 RoCEv1 qpn=574 inline=448
0.33.991.452 I RDMA activated: qpn=574->537 mtu=1024 rx_depth=24
0.33.991.853 D [get_device_memory] device: 0, free_mem: 66769473536, total_mem: 66769473536
0.33.998.102 I ggml_backend_rpc_start_server: client connection closed
0.33.999.632 D [~impl] closing socket 4
0.34.120.102 I ggml_backend_rpc_start_server: accepted client connection
0.34.122.207 D [hello] version: 5.1.0
0.34.127.465 I RDMA probed: dev=mlx4_0 gid=2 RoCEv1 qpn=575 inline=448
```

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, DSv4f 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
