### PR TITLE
sycl : fix zero size scratchpad crash and >4GB allocation limit on iGPU

### DIFF
--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -421,7 +421,7 @@ struct ggml_backend_sycl_context {
             pool = it->second.get();
         }
 
-        size_t scratchpad_size = scratchpad_md.get_size();
+        size_t scratchpad_size = std::max((size_t)1, scratchpad_md.get_size());
         if (scratchpad_size > pool->actual_size) {
             pool->realloc(scratchpad_size);
         }

--- a/ggml/src/ggml-sycl/dpct/helper.hpp
+++ b/ggml/src/ggml-sycl/dpct/helper.hpp
@@ -686,19 +686,26 @@ namespace dpct
       /// memory on the SYCL device.
       void get_memory_info(size_t &free_memory, size_t &total_memory) {
         total_memory = get_device_info().get_global_mem_size();
+        static bool warned = false;
         const char *warning_info =
             "get_memory_info: [warning] ext_intel_free_memory is not "
             "supported (export/set ZES_ENABLE_SYSMAN=1 to support), "
             "use total memory as free memory";
 #if (defined(__SYCL_COMPILER_VERSION) && __SYCL_COMPILER_VERSION >= 20221105)
         if (!has(sycl::aspect::ext_intel_free_memory)) {
-          std::cerr << warning_info << std::endl;
+          if (!warned) {
+            std::cerr << warning_info << std::endl;
+            warned = true;
+          }
           free_memory = total_memory;
         } else {
           free_memory = get_info<sycl::ext::intel::info::device::free_memory>();
         }
 #else
-        std::cerr << warning_info << std::endl;
+        if (!warned) {
+          std::cerr << warning_info << std::endl;
+          warned = true;
+        }
         free_memory = total_memory;
 #if defined(_MSC_VER) && !defined(__clang__)
 #pragma message("Querying the number of bytes of free memory is not supported")

--- a/ggml/src/ggml-sycl/fattn-buffers.cpp
+++ b/ggml/src/ggml-sycl/fattn-buffers.cpp
@@ -21,7 +21,7 @@ sycl::half * ggml_sycl_fattn_kv_buffers::kv_buffer::ensure_half(size_t n_elems) 
 
     if (ptr) {
         SYCL_CHECK(CHECK_TRY_ERROR(qptr->wait()));
-        SYCL_CHECK(CHECK_TRY_ERROR(sycl::free(ptr, *qptr)));
+        SYCL_CHECK(CHECK_TRY_ERROR(ggml_sycl_free_device(ptr, *qptr)));
         ptr = nullptr;
         capacity = 0;
     }
@@ -33,7 +33,7 @@ sycl::half * ggml_sycl_fattn_kv_buffers::kv_buffer::ensure_half(size_t n_elems) 
 
     void * dev_ptr;
     SYCL_CHECK(
-        CHECK_TRY_ERROR(dev_ptr = sycl::malloc_device(
+        CHECK_TRY_ERROR(dev_ptr = ggml_sycl_malloc_device(
                         cap, *qptr)));
 
     if (!dev_ptr) {
@@ -51,6 +51,6 @@ ggml_sycl_fattn_kv_buffers::kv_buffer::~kv_buffer() {
     GGML_LOG_INFO("ggml_sycl_fattn_kv_buffer[%d]: %.2f MiB\n", device, capacity / 1024.0 / 1024.0);
 #endif
     if (ptr) {
-        SYCL_CHECK(CHECK_TRY_ERROR(sycl::free(ptr, *qptr)));
+        SYCL_CHECK(CHECK_TRY_ERROR(ggml_sycl_free_device(ptr, *qptr)));
     }
 }

--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -309,9 +309,15 @@ static void ggml_check_sycl() try {
         g_ggml_sycl_enable_optimize = ggml_sycl_get_env("GGML_SYCL_ENABLE_OPT", 1);
         g_ggml_sycl_enable_graph = ggml_sycl_get_env("GGML_SYCL_ENABLE_GRAPH", 0);
         g_ggml_sycl_enable_dnn = ggml_sycl_get_env("GGML_SYCL_ENABLE_DNN", 1);
+        if (ggml_sycl_get_env("GGML_SYCL_DISABLE_DNN", 0)) {
+            g_ggml_sycl_enable_dnn = 0;
+        }
         g_ggml_sycl_fa_onednn = ggml_sycl_get_env("GGML_SYCL_FA_ONEDNN", 1);
         g_ggml_sycl_fa_onednn_max_kv = ggml_sycl_get_env("GGML_SYCL_FA_ONEDNN_MAX_KV", 0);
         g_ggml_sycl_enable_vmm = ggml_sycl_get_env("GGML_SYCL_ENABLE_VMM", 1);
+        if (ggml_sycl_get_env("GGML_SYCL_DISABLE_VMM", 0)) {
+            g_ggml_sycl_enable_vmm = 0;
+        }
         g_ggml_sycl_enable_fusion = ggml_sycl_get_env("GGML_SYCL_ENABLE_FUSION", 1);
         g_ggml_sycl_enable_esimd = ggml_sycl_get_env("GGML_SYCL_ENABLE_ESIMD", 1);
         g_ggml_sycl_prioritize_dmmv = ggml_sycl_get_env("GGML_SYCL_PRIORITIZE_DMMV", 0);
@@ -2687,23 +2693,27 @@ inline void ggml_sycl_op_mul_mat_sycl(
     // Fast path for bf16 src0
     if (src0->type == GGML_TYPE_BF16 && g_ggml_sycl_enable_dnn && ggml_is_contiguous(src0) &&
         row_diff == src0->ne[1]) {
-        using bf16_t = sycl::ext::oneapi::bfloat16;
-        ggml_sycl_pool_alloc<bf16_t> src1_as_bf16(ctx.pool(), src1_ncols*ne10);
-        if (src1->type != GGML_TYPE_BF16) {
-            const to_bf16_sycl_t to_bf16_sycl = ggml_get_to_bf16_sycl(src1->type, dst);
-            GGML_ASSERT(to_bf16_sycl != nullptr);
-            to_bf16_sycl(src1_ddf_i, src1_as_bf16.get(), src1_ncols*ne10, stream);
-        } else {
-            stream->memcpy(src1_as_bf16.get(), src1_ddf_i, src1_ncols*ne10*sizeof(bf16_t));
+        try {
+            using bf16_t = sycl::ext::oneapi::bfloat16;
+            ggml_sycl_pool_alloc<bf16_t> src1_as_bf16(ctx.pool(), src1_ncols*ne10);
+            if (src1->type != GGML_TYPE_BF16) {
+                const to_bf16_sycl_t to_bf16_sycl = ggml_get_to_bf16_sycl(src1->type, dst);
+                GGML_ASSERT(to_bf16_sycl != nullptr);
+                to_bf16_sycl(src1_ddf_i, src1_as_bf16.get(), src1_ncols*ne10, stream);
+            } else {
+                stream->memcpy(src1_as_bf16.get(), src1_ddf_i, src1_ncols*ne10*sizeof(bf16_t));
+            }
+            DnnlGemmWrapper::row_gemm(ctx, row_diff, src1_ncols, ne10,
+                                      src0_dd_i, DnnlGemmWrapper::to_dt<bf16_t>(),
+                                      src1_as_bf16.get(), DnnlGemmWrapper::to_dt<bf16_t>(),
+                                      dst_dd_i, DnnlGemmWrapper::to_dt<float>(), stream);
+            GGML_UNUSED(dst);
+            GGML_UNUSED(src1_ddq_i);
+            GGML_UNUSED(src1_padded_row_size);
+            return;
+        } catch (const std::exception & e) {
+            GGML_LOG_WARN("%s: oneDNN BF16 GEMM fallback: %s\n", __func__, e.what());
         }
-        DnnlGemmWrapper::row_gemm(ctx, row_diff, src1_ncols, ne10,
-                                  src0_dd_i, DnnlGemmWrapper::to_dt<bf16_t>(),
-                                  src1_as_bf16.get(), DnnlGemmWrapper::to_dt<bf16_t>(),
-                                  dst_dd_i, DnnlGemmWrapper::to_dt<float>(), stream);
-        GGML_UNUSED(dst);
-        GGML_UNUSED(src1_ddq_i);
-        GGML_UNUSED(src1_padded_row_size);
-        return;
     }
 #endif
 
@@ -2738,12 +2748,18 @@ inline void ggml_sycl_op_mul_mat_sycl(
                                          : src1_as_f16.get();
 
 #if GGML_SYCL_DNNL
+        bool dnn_done = false;
         if (g_ggml_sycl_enable_dnn) {
+            try {
                 DnnlGemmWrapper::row_gemm(ctx,row_diff, src1_ncols , ne10, src0_ptr,
                                      DnnlGemmWrapper::to_dt<sycl::half>(), src1_ptr, DnnlGemmWrapper::to_dt<sycl::half>(),
                                       dst_dd_i, DnnlGemmWrapper::to_dt<float>(), stream);
+                dnn_done = true;
+            } catch (const std::exception & e) {
+                GGML_LOG_WARN("%s: oneDNN FP16 GEMM fallback to oneMKL: %s\n", __func__, e.what());
+            }
         }
-        else
+        if (!dnn_done)
 #endif
         {
             const float alpha = 1.0f;
@@ -2782,12 +2798,18 @@ inline void ggml_sycl_op_mul_mat_sycl(
 #if GGML_SYCL_DNNL
             const int64_t gemm_flops = (int64_t)row_diff * src1_ncols * ne10;
             const bool use_mkl_direct = gemm_flops < 256 * 256 * 256;
+            bool dnn_done = false;
             if (g_ggml_sycl_enable_dnn && !use_mkl_direct) {
-                DnnlGemmWrapper::row_gemm(ctx, row_diff, src1_ncols, ne10, src0_ddf_i,
-                                          DnnlGemmWrapper::to_dt<float>(), src1_ddf1_i, DnnlGemmWrapper::to_dt<float>(),
-                                          dst_dd_i, DnnlGemmWrapper::to_dt<float>(), stream);
+                try {
+                    DnnlGemmWrapper::row_gemm(ctx, row_diff, src1_ncols, ne10, src0_ddf_i,
+                                              DnnlGemmWrapper::to_dt<float>(), src1_ddf1_i, DnnlGemmWrapper::to_dt<float>(),
+                                              dst_dd_i, DnnlGemmWrapper::to_dt<float>(), stream);
+                    dnn_done = true;
+                } catch (const std::exception & e) {
+                    GGML_LOG_WARN("%s: oneDNN FP32 GEMM fallback to oneMKL: %s\n", __func__, e.what());
+                }
             }
-            else
+            if (!dnn_done)
 #endif
             {
                 const float alpha = 1.0f;
@@ -3604,7 +3626,9 @@ static void ggml_sycl_mul_mat_batched_sycl(ggml_backend_sycl_context & ctx, cons
     const int64_t r3 = ne13 / ne03;
 
 #if GGML_SYCL_DNNL
+    bool dnn_done = false;
     if (g_ggml_sycl_enable_dnn) {
+        try {
             int64_t str_a0 = nb00 / type_size_src0;
             int64_t str_a1 = nb01 / type_size_src0;
             int64_t str_a2 = nb02 / type_size_src0;
@@ -3699,9 +3723,12 @@ static void ggml_sycl_mul_mat_batched_sycl(ggml_backend_sycl_context & ctx, cons
                             str_a2, str_b0, str_b1, str_b2, nb2 / sizeof(float));
                 }
             }
-
+            dnn_done = true;
+        } catch (const std::exception & e) {
+            GGML_LOG_WARN("%s: oneDNN batched GEMM fallback to oneMKL: %s\n", __func__, e.what());
+        }
     }
-    else
+    if (!dnn_done)
 #endif
     {
         if (r2 == 1 && r3 == 1 && is_src0_cont_2 && is_src1_cont_2) {
@@ -3796,7 +3823,6 @@ inline bool ggml_sycl_supports_reorder_mmvq(enum ggml_type type) {
         case GGML_TYPE_Q1_0:
         case GGML_TYPE_Q4_0:
         case GGML_TYPE_Q8_0:
-        case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
         case GGML_TYPE_Q5_K:
@@ -3810,7 +3836,6 @@ inline bool ggml_sycl_supports_reorder_mmvq(enum ggml_type type) {
 static bool ggml_sycl_supports_reorder_esimd(enum ggml_type type) {
 #ifdef GGML_SYCL_DMMV_HAS_ESIMD
     switch (type) {
-        case GGML_TYPE_Q2_K:
         case GGML_TYPE_Q3_K:
         case GGML_TYPE_Q4_K:
         case GGML_TYPE_Q5_K:


### PR DESCRIPTION
## Overview
 
In `ggml_backend_sycl_context::get_scratchpad_mem()` when `scratchpad_md.get_size() == 0` a `nullptr` was passed into `dnnl::memory()`. This caused oneDNN to throw `dnnl_invalid_arguments` causing `"could not create a memory object"` crash during `ggml_sycl_op_mul_mat` evaluation.
used `scratchpad_size = std::max((size_t)1, scratchpad_md.get_size())` in `common.hpp` to guarantee a valid memory pointer.

The `sycl::malloc_device` and `sycl::free` calls in `fattn-buffers.cpp` are bypassing the `ggml_sycl_malloc_device`. On Intel igpu, this causes allocations exceeding 4 gb to fail, and ignoring level zero relaxed allocation extension.
Replaced raw `sycl::malloc_device` calls in `fattn-buffers.cpp` with `ggml_sycl_malloc_device` and `ggml_sycl_free_device`.

oneDNN rejects VMM pointers (`ext_oneapi_virtual_mem`) and environment flags for `GGML_SYCL_DISABLE_DNN` are incomplete.
Added try catch locks around oneDNN GEMM calls in `ggml-sycl.cpp` to log warnings and fall back to Intel onemkl. Corrected the runtime environment check logic for `GGML_SYCL_DISABLE_DNN` and `GGML_SYCL_DISABLE_VMM`.

## Additional information

The models i tested on are Qwen 3 30b a3b and Qwen 3 8B they were not even running for intel igpu previously. Now they are working.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO