### PR TITLE
opencl: route the FA prefill split kernels through the per-kernel workgroup guard (a bug exposed in Adreno 660)

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -5377,6 +5377,13 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
         case FA_VARIANT_F32_F16_SPLIT: {
             cl_kernel k;
             CL_CHECK((k = clCreateKernel(prog, "flash_attn_f32_f16", &err), err));
+            // Dispatched with WG = bm * n_split. Leaving the map empty makes
+            // use_split_kernel false, falling back to the un-split BM-tile kernel.
+            const size_t need_wg = (size_t) (cfg->bm * cfg->n_split);
+            if (!ggml_opencl_fa_kernel_fits_wg(backend_ctx, k, need_wg, "flash_attn_f32_f16 (split)", dk, dv)) {
+                CL_CHECK(clReleaseKernel(k));
+                break;
+            }
             backend_ctx->fa.f32_f16_split[{dk, dv}]               = k;
             backend_ctx->fa.f32_f16_split_wg_size[{dk, dv}]       = cfg->bm * cfg->n_split;
             backend_ctx->fa.f32_f16_split_nkv_threshold[{dk, dv}] = cfg->nkv_split_threshold;
@@ -5391,6 +5398,13 @@ static bool ggml_opencl_ensure_fa_variant(ggml_backend_opencl_context * backend_
             auto & split_wg     = is_q8 ? backend_ctx->fa.f32_q8_0_split_wg_size        : backend_ctx->fa.f32_q4_0_split_wg_size;
             auto & split_bm     = is_q8 ? backend_ctx->fa.f32_q8_0_split_bm             : backend_ctx->fa.f32_q4_0_split_bm;
             auto & split_thresh = is_q8 ? backend_ctx->fa.f32_q8_0_split_nkv_threshold  : backend_ctx->fa.f32_q4_0_split_nkv_threshold;
+            // Same WG = bm * n_split as the mixed split kernel above.
+            const size_t need_wg = (size_t) (cfg->bm * cfg->n_split);
+            if (!ggml_opencl_fa_kernel_fits_wg(backend_ctx, k, need_wg,
+                                               is_q8 ? "flash_attn_f32_q8_0 (split)" : "flash_attn_f32_q4_0 (split)", dk, dv)) {
+                CL_CHECK(clReleaseKernel(k));
+                break;
+            }
             split[{dk, dv}]        = k;
             split_wg[{dk, dv}]     = cfg->bm * cfg->n_split;
             split_bm[{dk, dv}]     = cfg->bm;


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This PR is to fix an FA bug in the split flash-attention prefill kernels for low tier devices (Adreno 660) where the WGsize is capped to 128,  where the kernel flash_attn_f32_f16 required 256.  The split flash-attention prefill kernels are dispatched with a workgroup of bm * n_split, but registered themselves without consulting ggml_opencl_fa_kernel_fits_wg. When CL_KERNEL_WORK_GROUP_SIZE for the kernel is below that, CL_INVALID_WORK_GROUP_SIZE aborts the execution.
 
With the fix, use_split_kernel (and the q8_0/q4_0 equivalents, all keyed off .count()) becomes false for that DK/DV, and the prefill falls back to the un-split BM-tile kernel.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) Yes
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, testing and profiling. Code reviewed manually. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
