### PR TITLE
server : expose the speculative verification-step count per request

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -80,8 +80,9 @@ json server_slot_stats::to_json() const {
     };
 
     if (n_draft_tokens > 0) {
-        base["draft_n"]          = n_draft_tokens;
-        base["draft_n_accepted"] = n_draft_accepted;
+        base["draft_n"]             = n_draft_tokens;
+        base["draft_n_accepted"]    = n_draft_accepted;
+        base["draft_n_verif_steps"] = n_draft_verif_steps;
     }
 
     return base;

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -47,7 +47,11 @@ def test_with_and_without_draft():
     server.start()
     res = server.make_request("POST", "/completion", data=request)
     assert res.status_code == 200
-    assert res.body["timings"]["draft_n"] > 0
+    timings = res.body["timings"]
+    assert timings["draft_n"] > 0
+    assert timings["draft_n_accepted"] <= timings["draft_n"]
+    # mean acceptance length needs this, the other two only give the rate
+    assert timings["draft_n_verif_steps"] > 0
     tokens_draft = res.body["tokens"]
 
     assert tokens_no_draft == tokens_draft


### PR DESCRIPTION
## Overview

The server already tracks `n_draft_verif_steps`, but the corresponding `draft_n_verif_steps` value is not included in the per-request timings JSON.

The existing `draft_n` and `draft_n_accepted` fields are enough to calculate the draft acceptance rate, but not the mean acceptance length, because the latter also needs the number of verification steps.

The server already computes mean acceptance length from:

`1 + n_draft_accepted / n_draft_verif_steps`

No new state is introduced; the patch only exposes a counter that is already maintained by the server.

## Additional information

I ran into this while checking some speculative decoding benchmarks. The server log had the mean length I needed, but I could not reproduce it exactly from the per-request response because the verification-step count was missing.

The Prometheus metric is useful for server-wide monitoring, but it is cumulative. For request-level benchmarks, the value still needs to be available in the request timings.

I extended the existing speculative decoding test:

`tools/server/tests/unit/test_speculative.py::test_with_and_without_draft`

Before this change, accessing the new timings field fails because the field is not present. With the change, the same speculative request reports a positive `draft_n_verif_steps` value. The test also checks that `draft_n_accepted` does not exceed `draft_n`.

Tested with, from `tools/server/tests` on a CPU-only build of c060ca9:

```
LLAMA_SERVER_BIN_PATH=/tmp/llamacpp-p1/build/bin/llama-server LLAMA_CACHE=/tmp/p1cache \
  /tmp/p1venv/bin/python -m pytest unit/test_speculative.py::test_with_and_without_draft -x -q
```

Without the change to `server-common.cpp`, with the new test present:

```
FAILED unit/test_speculative.py::test_with_and_without_draft - KeyError: 'draft_n_verif_steps'
1 failed in 12.57s
```

The response body captured by that failure ends with `"draft_n": 64, "draft_n_accepted": 4`, and no verification-step field.

With the change:

```
1 passed in 15.42s
```

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I used AI for code research and English learning. I checked the code and test results myself, and I wrote this description myself.
