### PR TITLE
fix(gguf_filename_is_model): avoid excluding valid primary GGUFs with speculative-role keywords

### DIFF
--- a/common/download.cpp
+++ b/common/download.cpp
@@ -658,7 +658,9 @@ static hf_cache::hf_file find_best_dspark(const hf_cache::hf_files & files,
     return find_best_sibling(files, model, "dspark-", tag);
 }
 
-static bool gguf_filename_is_model(const std::string & filepath) {
+static const char * ROLE_KEYWORDS[] = {"mtp-", "eagle3-", "dflash-", "dspark-"};
+
+static bool gguf_filename_is_model(const std::string & filepath, bool allow_role_infix = false) {
     if (!string_ends_with(filepath, ".gguf")) {
         return false;
     }
@@ -668,12 +670,18 @@ static bool gguf_filename_is_model(const std::string & filepath) {
         filename = filename.substr(pos + 1);
     }
 
-    return filename.find("mmproj")  == std::string::npos &&
-           filename.find("imatrix") == std::string::npos &&
-           filename.find("mtp-")    == std::string::npos &&
-           filename.find("eagle3-") == std::string::npos &&
-           filename.find("dflash-") == std::string::npos &&
-           filename.find("dspark-") == std::string::npos;
+    if (filename.find("mmproj")  != std::string::npos ||
+        filename.find("imatrix") != std::string::npos) {
+        return false;
+    }
+    for (const char * keyword : ROLE_KEYWORDS) {
+        bool excluded = allow_role_infix ? filename.rfind(keyword, 0) == 0
+                                         : filename.find(keyword) != std::string::npos;
+        if (excluded) {
+            return false;
+        }
+    }
+    return true;
 }
 
 static hf_cache::hf_file find_best_model(const hf_cache::hf_files & files,
@@ -688,9 +696,14 @@ static hf_cache::hf_file find_best_model(const hf_cache::hf_files & files,
 
     for (const auto & t : tags) {
         std::regex pattern(t + "[.-]", std::regex::icase);
-        for (const auto & f : files) {
-            if (gguf_filename_is_model(f.path) &&
-                std::regex_search(f.path, pattern)) {
+
+        // prefer unambiguous model names before allowing role keywords after the basename prefix
+        for (int pass = 0; pass < 2; pass++) {
+            for (const auto & f : files) {
+                if (!gguf_filename_is_model(f.path, pass == 1) ||
+                    !std::regex_search(f.path, pattern)) {
+                    continue;
+                }
                 auto split = get_gguf_split_info(f.path);
                 if (split.count > 1 && split.index != 1) {
                     continue;

--- a/tests/test-model-resolution.cpp
+++ b/tests/test-model-resolution.cpp
@@ -187,6 +187,27 @@ static const std::vector<std::string> dspark_dflash = {
     "dspark-model-Q8_0.gguf",
 };
 
+// primary quants with a mid-name role keyword and unrelated GGUF files
+static const std::vector<std::string> midname = {
+    "model-abliterated-IQ2_M-custom.gguf",
+    "model-abliterated-IQ2_M.gguf",
+    "model-abliterated-imatrix-cpu.gguf",
+    "model-abliterated-mtp-IQ4_NL-mixed.gguf",
+    "model-abliterated-mtp-IQ4_NL.gguf",
+    "model-abliterated-mtp-Q4_K_M.gguf",
+    "model-abliterated-mtp-Q6_K-mixed.gguf",
+    "model-abliterated-mtp-Q6_K.gguf",
+    "model-abliterated-mtp-Q8_0.gguf",
+    "model-abliterated-mtp-f16.gguf",
+    "mmproj-model.gguf",
+};
+
+// a sharded primary with an infix role keyword
+static const std::vector<std::string> midname_split = {
+    "Q4_K_M/model-mtp-Q4_K_M-00001-of-00002.gguf",
+    "Q4_K_M/model-mtp-Q4_K_M-00002-of-00002.gguf",
+};
+
 //
 // table-driven plan resolution through the real entry point,
 // each case replayed on multiple deterministic reorderings of the listing,
@@ -283,6 +304,27 @@ static const plan_case plan_cases[] = {
     {"spark tag sidecar", spark, "test/repo:BF16", "", true, false,
      "", {},
      "", "", "", "", "dspark-model-BF16.gguf"},
+
+    // preserve first-match tag semantics: Q6_K also matches Q6_K-mixed
+    {"midname explicit tag", midname, "test/repo:Q6_K", "", false, true,
+     "model-abliterated-mtp-Q6_K-mixed.gguf", {"model-abliterated-mtp-Q6_K-mixed.gguf"},
+     "", "", "", "", ""},
+
+    // apply the default quant preference to infix role names
+    {"midname default", midname, "test/repo", "", false, false,
+     "model-abliterated-mtp-Q4_K_M.gguf", {"model-abliterated-mtp-Q4_K_M.gguf"},
+     "", "", "", "", ""},
+
+    // strict primary candidates retain precedence over ambiguous mid-name files
+    {"midname strict tier", midname, "test/repo:IQ2_M", "", false, true,
+     "model-abliterated-IQ2_M-custom.gguf", {"model-abliterated-IQ2_M-custom.gguf"},
+     "", "", "", "", ""},
+
+    {"midname split", midname_split, "test/repo:Q4_K_M", "", false, false,
+     "Q4_K_M/model-mtp-Q4_K_M-00001-of-00002.gguf",
+     {"Q4_K_M/model-mtp-Q4_K_M-00001-of-00002.gguf",
+      "Q4_K_M/model-mtp-Q4_K_M-00002-of-00002.gguf"},
+     "", "", "", "", ""},
 };
 
 static void check_plan(const plan_case & c) {
@@ -373,6 +415,7 @@ static void test_task_assembly() {
     g_repos["test/pair"]   = dspark_dflash;
     g_repos["test/small"]  = {"draft-model-Q4_K_M.gguf"};
     g_repos["test/preset"] = {"preset.ini", "model-Q8_0.gguf"};
+    g_repos["test/midname"] = midname;
 
     {
         // plain -hf wires the model and its mmproj, nothing speculative
@@ -381,6 +424,12 @@ static void test_task_assembly() {
         REQUIRE_EQ(params.model.path,  cached("test/main", "model-Q8_0.gguf"));
         REQUIRE_EQ(params.mmproj.path, cached("test/main", "mmproj-model-Q8_0.gguf"));
         REQUIRE(params.speculative.draft.mparams.path.empty());
+    }
+    {
+        // resolve an infix role name through CLI parsing and handler assembly
+        common_params params;
+        assemble({"server", "-hf", "test/midname:Q6_K", "--no-mmproj"}, params);
+        REQUIRE_EQ(params.model.path, cached("test/midname", "model-abliterated-mtp-Q6_K-mixed.gguf"));
     }
     {
         // --no-mmproj disables the mmproj discovery


### PR DESCRIPTION
## Overview

Fixes [#27201](https://github.com/ggml-org/llama.cpp/issues/27201), where `-hf repo:quant` reports “no GGUF files found” when a valid primary GGUF contains a speculative-role keyword such as `mtp-` in the middle of its basename.

`gguf_filename_is_model()` rejects any basename containing `mtp-`, `eagle3-`, `dflash-`, or `dspark-`. As a result, all matching tagged quantizations are discarded before tag matching, with no fallback when a tag was explicitly requested.

When strict selection finds no match, `find_best_model()` now performs a second-tier search that admits files whose role keyword appears only mid-name. Role-prefixed basenames and files containing `mmproj` or `imatrix` remain excluded. Existing strict behavior and first-match-per-tag ordering are unchanged whenever the strict tier succeeds.


## Additional information

A new `midname` fixture and regression cases were added to `tests/test-model-resolution.cpp`. The test fails at base `b3c3b96a` with an empty `plan.primary.path` and passes with this change. All 18 model-resolution plan cases pass across listing reorderings; `test-arg-parser` and `test-download-model` also pass.

A non-regression control was validated against the live Hugging Face metadata for `stepfun-ai/Step-3.7-Flash-GGUF` without downloading model payloads. Its mid-name `-mtp-` files are genuine sidecars, and resolution is identical before and after this change: a sharded Q8_0 primary plus the `mmproj` and MTP sidecars. This is why the fallback demotes the broad exclusion instead of replacing it with prefix-only classification.

Related issues:

* #27231 improves the missing-quant error message but does not fix this case because the requested quant exists, as confirmed by the reporter.
* #23489 addresses the inverse sibling-selection problem, where a mid-name-MTP primary may select itself as a draft. This change does not modify that path.

Known bounded limitation: if the only file for a requested tag is a mid-name-role sidecar and no primary exists at that tag, the fallback may select that sidecar as the primary. No known real repository has this layout.

## Requirements

* I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES. Codex actively participated in: resolver/root-cause analysis; C++ patch refinement; writing or modifying regression tests; and live-repo validation. I have manually reviewed all the submitted changes and test results, understand these changes, and take full responsibility for this PR.
