### PR TITLE
common : fix unsigned underflow in common_opt_dataset_init (#27648)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2118,9 +2118,16 @@ common_control_vector_data common_control_vector_load(const std::vector<common_c
     return result;
 }
 
+int64_t common_opt_dataset_ndata(size_t n_tokens, int64_t n_ctx, int64_t stride) {
+    // use signed arithmetic: n_tokens is size_t, and subtracting a larger value would
+    // silently wrap to a huge unsigned number (underflow) when the training text is
+    // shorter than the context size, producing an invalid dataset size
+    return ((int64_t) n_tokens - n_ctx - 1) / stride;
+}
+
 ggml_opt_dataset_t common_opt_dataset_init(struct llama_context * ctx, const std::vector<llama_token> & tokens, int64_t stride) {
     const int64_t ne_datapoint = llama_n_ctx(ctx);
-    const int64_t ndata        = (tokens.size() - ne_datapoint - 1) / stride;
+    const int64_t ndata        = common_opt_dataset_ndata(tokens.size(), ne_datapoint, stride);
     ggml_opt_dataset_t result = ggml_opt_dataset_init(
         GGML_TYPE_I32, GGML_TYPE_I32, ne_datapoint, ne_datapoint, ndata, /*ndata_shard =*/ 1);
 

--- a/common/common.h
+++ b/common/common.h
@@ -1183,3 +1183,7 @@ struct common_prompt_checkpoint {
     void clear_tgt();
     void clear_dft();
 };
+
+// compute the number of training data points for a token sequence of length n_tokens
+// (used by common_opt_dataset_init; extracted for unit testing, see tests/test-opt-dataset)
+int64_t common_opt_dataset_ndata(size_t n_tokens, int64_t n_ctx, int64_t stride);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -280,6 +280,7 @@ llama_build_and_test(test-thread-safety.cpp ARGS -m "${MODEL_DEST}" -ngl 99 -p "
 set_tests_properties(test-thread-safety PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 llama_build_and_test(test-arg-parser.cpp)
+llama_build_and_test(test-opt-dataset.cpp)
 llama_build_and_test(test-model-resolution.cpp)
 # the test serves its repos from an httplib server, and the library links it privately
 target_link_libraries(test-model-resolution PRIVATE cpp-httplib)

--- a/tests/test-opt-dataset.cpp
+++ b/tests/test-opt-dataset.cpp
@@ -1,0 +1,48 @@
+#include "common.h"
+
+#include <cstdio>
+
+// Regression test for https://github.com/ggml-org/llama.cpp/issues/27648
+//
+// common_opt_dataset_init() used to compute the number of training data points with
+// unsigned size_t arithmetic:
+//     const int64_t ndata = (tokens.size() - ne_datapoint - 1) / stride;
+// When the training text is shorter than the context size, the subtraction wraps to
+// a huge unsigned value (e.g. 400 - 512 - 1 -> 2^64 - 113), and the division yields
+// 2^56 - 1 instead of a non-positive count. The dataset tensors were then created
+// with an absurd size, and the first training graph allocation crashed with
+// "failed to allocate buffer of size 18446744073709547520".
+//
+// The computation now uses signed arithmetic via common_opt_dataset_ndata().
+
+int main() {
+    // text shorter than the context: must yield a non-positive count (was 72057594037927935)
+    {
+        const int64_t ndata = common_opt_dataset_ndata(/*n_tokens =*/ 400, /*n_ctx =*/ 512, /*stride =*/ 256);
+        if (ndata > 0) {
+            fprintf(stderr, "test-opt-dataset: FAIL: short text produced ndata = %lld\n", (long long) ndata);
+            return 1;
+        }
+    }
+
+    // text exactly at the boundary n_ctx + 1: no data points
+    {
+        const int64_t ndata = common_opt_dataset_ndata(513, 512, 256);
+        if (ndata != 0) {
+            fprintf(stderr, "test-opt-dataset: FAIL: boundary text produced ndata = %lld\n", (long long) ndata);
+            return 1;
+        }
+    }
+
+    // adequate text: exact expected number of data points
+    {
+        const int64_t ndata = common_opt_dataset_ndata(819, 256, 128);
+        if (ndata != 4) {
+            fprintf(stderr, "test-opt-dataset: FAIL: expected ndata = 4, got %lld\n", (long long) ndata);
+            return 1;
+        }
+    }
+
+    printf("test-opt-dataset: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Overview

Fixes #27648

This PR fixes the crash in Issue #27648. Note that llama-finetune may still be blocked during training by the separate backward-pass issue (view tensors), tracked in #22479.

tokens.size() is of size_t type. Subtracting a larger ne_datapoint wraps to a huge unsigned value when the training text is shorter than the context, producing dataset tensors shaped [n_ctx, 2^56-1] whose size overflows to 2^64 - 4096 and crashes the first graph allocation with failed to allocate buffer of size 18446744073709547520.

Cast to int64_t (via the new common_opt_dataset_ndata helper) so the computation stays signed; too-short datasets now fail cleanly through the existing GGML_ASSERT(ndata > 0) instead.

Adds a regression test (tests/test-opt-dataset) that fails on the old unsigned expression and passes after the fix.

## Additional information

Regression test:
- 'tests/test-opt-dataset.cpp' covers three cases.
- short text ( 400 tokens, -c 512 ) -> expects non-positive result (the old expression returned 2^56 - 1, so the test fails before this fix).
- boundary ( 513 tokens, -c 512 ) -> expects 0
- adequate data ( 819 tokens, -c 256 , stride 128 ) -> expects 4

- Before: reproduced with three models (F32 / F16 / Q4_K_M) any training text shorter than the context crashes the first graph allocation.
- After: too-short data fails with a clean 'GGML_ASSERT(ndata > 0)', adequate data starts normally (ndata = 4 ).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - 
  AI was used to assist with debugging and root-cause analysis of the crash and helping me translate the description into English.

