### PR TITLE
metal : fix memory query under low-memory conditions

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1471,15 +1471,10 @@ void ggml_metal_device_event_synchronize(ggml_metal_device_t dev, ggml_metal_eve
 
 void ggml_metal_device_get_memory(ggml_metal_device_t dev, size_t * free, size_t * total) {
     if (@available(macOS 10.12, iOS 16.0, *)) {
-        *total = dev->mtl_device.recommendedMaxWorkingSetSize;
+        *total     = dev->mtl_device.recommendedMaxWorkingSetSize;
         size_t cur = dev->mtl_device.currentAllocatedSize;
-        if (*total >= cur) {
-            *free  = *total - cur;
-        } else {
-            // We could have allocated above `recommendedMaxWorkingSetSize`,
-            // if that's the case report no free memory.
-            *free  = 0;
-        }
+        // it's possible to allocate more than `recommendedMaxWorkingSetSize`
+        *free      = *total > cur ? *total - cur : 0;
     } else {
         *free = 0;
         *total = 0;

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1472,9 +1472,9 @@ void ggml_metal_device_event_synchronize(ggml_metal_device_t dev, ggml_metal_eve
 void ggml_metal_device_get_memory(ggml_metal_device_t dev, size_t * free, size_t * total) {
     if (@available(macOS 10.12, iOS 16.0, *)) {
         *total = dev->mtl_device.recommendedMaxWorkingSetSize;
-        size_t current_allocated_size = dev->mtl_device.currentAllocatedSize;
-        if (*total >= current_allocated_size) {
-            *free  = *total - dev->mtl_device.currentAllocatedSize;
+        size_t cur = dev->mtl_device.currentAllocatedSize;
+        if (*total >= cur) {
+            *free  = *total - cur;
         } else {
             // We could have allocated above `recommendedMaxWorkingSetSize`,
             // if that's the case report no free memory.

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1472,7 +1472,14 @@ void ggml_metal_device_event_synchronize(ggml_metal_device_t dev, ggml_metal_eve
 void ggml_metal_device_get_memory(ggml_metal_device_t dev, size_t * free, size_t * total) {
     if (@available(macOS 10.12, iOS 16.0, *)) {
         *total = dev->mtl_device.recommendedMaxWorkingSetSize;
-        *free  = *total - dev->mtl_device.currentAllocatedSize;
+        size_t current_allocated_size = dev->mtl_device.currentAllocatedSize;
+        if (*total >= current_allocated_size) {
+            *free  = *total - dev->mtl_device.currentAllocatedSize;
+        } else {
+            // We could have allocated above `recommendedMaxWorkingSetSize`,
+            // if that's the case report no free memory.
+            *free  = 0;
+        }
     } else {
         *free = 0;
         *total = 0;


### PR DESCRIPTION
## Overview

`MTLDevice.recommendedMaxWorkingSetSize` is what it says, a recommendation, not a maximum, meaning that `MTLDevice.currentAllocatedSize` can be higher (so subtracting `MTLDevice.currentAllocatedSize` from it can underflow).

This causes us to report a very large amount of free memory in low-memory conditions.

Tested on iPhone 13 Pro running iOS 18.7.8.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO (I have not used AI to generate this PR)

CC @ggerganov