### PR TITLE
fix(chat): parse array/object tool params in TAG_WITH_TAGGED, stop partial tool_call leak

### DIFF
--- a/common/chat-auto-parser-generator.cpp
+++ b/common/chat-auto-parser-generator.cpp
@@ -410,7 +410,7 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
                                 p.ac(p.tool_arg_string_value(until_suffix) +
                                     p.tool_arg_close(p.literal(arguments.value_suffix)), arguments.value_suffix) :
                                 (p.tool_arg_json_value(p.schema(
-                                    p.json(), "tool-" + name + "-arg-" + param_name + "-schema", param_schema, false)) +
+                                    until_suffix, "tool-" + name + "-arg-" + param_name + "-schema", param_schema, false)) +
                                     p.tool_arg_close(p.literal(arguments.value_suffix)))));
 
             auto named_arg = p.rule("tool-" + name + "-arg-" + param_name, arg);

--- a/common/chat-peg-parser.cpp
+++ b/common/chat-peg-parser.cpp
@@ -361,9 +361,12 @@ void common_chat_peg_mapper::map(const common_peg_ast_node & node) {
         if (!args_buffer.empty()) {
             current_tool->arguments = args_buffer;
             args_buffer.clear();
-        } else if (current_tool->arguments.empty()) {
-            current_tool->arguments = "{";
         }
+        // Do NOT initialize arguments to "{" here. A lone opening brace would be
+        // streamed to the client as a partial tool_call delta and, if the stream
+        // later fails to parse, would poison replayed history. The opening brace
+        // is added lazily at the first argument name (see is_arg_name below) or
+        // as "{}" at tool close when no arguments were emitted.
         // Add the tool call to results so streaming can see it
         if (pending_tool_call.has_value()) {
             result.tool_calls.push_back(pending_tool_call.value());
@@ -440,6 +443,11 @@ void common_chat_peg_mapper::map(const common_peg_ast_node & node) {
         if (closing_quote_pending) {
             current_tool->arguments += "\"";
             closing_quote_pending = false;
+        }
+        // A named tool call with no emitted arguments still needs a valid,
+        // empty JSON object as its arguments.
+        if (current_tool->arguments.empty()) {
+            current_tool->arguments = "{}";
         }
         // Close any unclosed braces (accounts for nested objects)
         for (int d = json_brace_depth(current_tool->arguments); d > 0; d--) {

--- a/common/chat.cpp
+++ b/common/chat.cpp
@@ -1269,7 +1269,7 @@ static common_chat_params common_chat_params_init_qwen3_coder(const common_chat_
 
                     auto arg_value = schema_info.resolves_to_string(param_schema) ?
                         arg_string :
-                        p.tool_arg_json_value(p.schema(p.json(), rule_name + "-schema", param_schema)) + arg_close;
+                        p.tool_arg_json_value(p.schema(p.until("\n</parameter>\n"), rule_name + "-schema", param_schema)) + arg_close;
 
                     auto arg_rule = p.rule(rule_name, p.tool_arg(arg_open + arg_value));
 

--- a/tests/test-chat-auto-parser.cpp
+++ b/tests/test-chat-auto-parser.cpp
@@ -97,6 +97,8 @@ static void test_normalize_quotes_with_embedded_quotes(testing & t);
 
 // TAG_WITH_TAGGED argument parsing tests
 static void test_tagged_args_with_embedded_quotes(testing & t);
+static void test_tagged_args_array_object(testing & t);
+static void test_tagged_args_array_object_partial(testing & t);
 static void test_bailing_v3_tool_format(testing & t);
 
 static void test_role_markers_all_templates(testing & t);
@@ -562,6 +564,8 @@ int main(int argc, char * argv[]) {
     t.test("standard_json_tools", test_standard_json_tools_formats);
     t.test("normalize_quotes_to_json", test_normalize_quotes_to_json);
     t.test("tagged_args_embedded_quotes", test_tagged_args_with_embedded_quotes);
+    t.test("tagged_args_array_object", test_tagged_args_array_object);
+    t.test("tagged_args_array_object_partial", test_tagged_args_array_object_partial);
     t.test("bailing_v3", test_bailing_v3_tool_format);
     t.test("role_markers_all_templates", test_role_markers_all_templates);
 
@@ -2586,6 +2590,160 @@ static void test_bailing_v3_tool_format(testing & t) {
         "</tool_call>";
     common_peg_parse_context ctx(output, COMMON_PEG_PARSE_FLAG_LENIENT);
     t.assert_true("multi-argument tool call", parser.parse(ctx).success());
+}
+
+// Test that reproduces #21771: array<object> tool params in TAG_WITH_TAGGED
+// format (Qwen3 family). A parameter whose JSON schema resolves to an array
+// of objects must parse cleanly through build_tool_parser_tag_tagged.
+static common_chat_template build_qwen3_style_tagged_template() {
+    // Qwen3-style tagged tool call rendering, same shape as Qwen3-Coder:
+    // <tool_call>\n<function=name>\n<parameter=key>\nvalue\n</parameter>\n</function>\n</tool_call>
+    const std::string template_source = R"JINJA(
+{%- for message in messages %}
+{%- if message.role == "assistant" and message.tool_calls is defined and message.tool_calls %}
+<|im_start|>assistant
+{%- for tool_call in message.tool_calls %}
+{%- set tc = tool_call.function %}
+<tool_call>
+<function={{ tc.name }}>
+{%- for args_name, args_value in tc.arguments|items %}
+{%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+<parameter={{ args_name }}>
+{{ args_value }}
+</parameter>
+{%- endfor %}
+</function>
+</tool_call>
+{%- endfor %}
+<|im_end|>
+{%- elif message.role == "user" or message.role == "assistant" %}
+<|im_start|>{{ message.role }}
+{{ message.content }}
+<|im_end|>
+{%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}<|im_start|>assistant
+{%- endif %}
+)JINJA";
+    return common_chat_template(template_source, "", "");
+}
+
+// Tool set with an array<object> parameter, mirroring e.g. a web_search tool
+// whose "queries" parameter is an array of objects like [{"type":"web"}].
+static json build_array_object_tools() {
+    return json::array({
+        {
+            { "type", "function" },
+            { "function", {
+                { "name", "web_search" },
+                { "parameters", {
+                    { "type", "object" },
+                    { "properties", {
+                        { "queries", {
+                            { "type", "array" },
+                            { "items", { { "type", "object" } } }
+                        } }
+                    } },
+                    { "required", json::array({ "queries" }) }
+                } }
+            } }
+        }
+    });
+}
+
+static void test_tagged_args_array_object(testing & t) {
+    common_chat_template tmpl = build_qwen3_style_tagged_template();
+    struct autoparser analysis;
+    analysis.analyze_template(tmpl);
+
+    t.assert_true("tool format should be TAG_WITH_TAGGED",
+                  analysis.tools.format.mode == tool_format::TAG_WITH_TAGGED);
+
+    generation_params inputs;
+    inputs.tools            = build_array_object_tools();
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_NONE;
+    auto parser = analysis.build_parser(inputs, "");
+
+    const std::string output =
+        "<tool_call>\n"
+        "<function=web_search>\n"
+        "<parameter=queries>\n"
+        "[{\"type\":\"web\"}]\n"
+        "</parameter>\n"
+        "</function>\n"
+        "</tool_call>";
+
+    common_peg_parse_context ctx(output, COMMON_PEG_PARSE_FLAG_LENIENT);
+    auto result = parser.parse(ctx);
+    t.assert_true("array<object> tool param parses cleanly", result.success());
+
+    if (!result.success()) {
+        return;
+    }
+
+    common_chat_msg msg;
+    auto mapper = common_chat_peg_mapper(msg);
+    mapper.from_ast(ctx.ast, result);
+
+    t.assert_equal("tool calls count", 1u, msg.tool_calls.size());
+    if (msg.tool_calls.empty()) {
+        return;
+    }
+
+    t.assert_equal("tool name", "web_search", msg.tool_calls[0].name);
+
+    std::string args = msg.tool_calls[0].arguments;
+    try {
+        json parsed = json::parse(args);
+        t.assert_true("arguments is valid JSON", true);
+        if (parsed.contains("queries")) {
+            t.assert_true("queries is an array", parsed["queries"].is_array());
+            if (parsed["queries"].is_array() && !parsed["queries"].empty()) {
+                t.assert_true("queries[0] is an object", parsed["queries"][0].is_object());
+                t.assert_equal("queries[0].type", "web", parsed["queries"][0].value("type", ""));
+            }
+        }
+    } catch (const std::exception & e) {
+        t.assert_true(std::string("arguments should be valid JSON: ") + e.what() + " args=" + args, false);
+    }
+}
+
+// Streaming regression for #21771: while the model is still emitting an
+// array<object> value inside a <parameter> tag, the partial parse must not
+// leak a malformed single-char "arguments" that would poison replayed history.
+static void test_tagged_args_array_object_partial(testing & t) {
+    common_chat_template tmpl = build_qwen3_style_tagged_template();
+    struct autoparser analysis;
+    analysis.analyze_template(tmpl);
+
+    generation_params inputs;
+    inputs.tools            = build_array_object_tools();
+    inputs.reasoning_format = COMMON_REASONING_FORMAT_NONE;
+    auto parser = analysis.build_parser(inputs, "");
+
+    common_chat_parser_params params;
+    params.format = COMMON_CHAT_FORMAT_PEG_SIMPLE;
+    params.parser = parser;
+
+    // Simulate streaming prefixes of the full tool call. None of the partial
+    // states should surface a tool_call whose arguments are a lone "{".
+    const std::vector<std::string> prefixes = {
+        "<tool_call>\n",
+        "<tool_call>\n<function=web_search>\n",
+        "<tool_call>\n<function=web_search>\n<parameter=queries>\n",
+        "<tool_call>\n<function=web_search>\n<parameter=queries>\n[",
+        "<tool_call>\n<function=web_search>\n<parameter=queries>\n[{\"type\":\"web\"}",
+        "<tool_call>\n<function=web_search>\n<parameter=queries>\n[{\"type\":\"web\"}]\n",
+    };
+
+    for (size_t i = 0; i < prefixes.size(); i++) {
+        common_chat_msg msg = common_chat_peg_parse(parser, prefixes[i], /* is_partial = */ true, params);
+        for (const auto & tc : msg.tool_calls) {
+            const std::string & a = tc.arguments;
+            t.assert_true("partial arguments must not be a lone brace",
+                          a != "{" && a != "\"" && !(a.size() == 1));
+        }
+    }
 }
 
 // Test that reproduces the Seed-OSS template issue with embedded quotes


### PR DESCRIPTION
## What

Fixes #21771. Qwen3 `TAG_WITH_TAGGED` tool calls with an `array<object>` parameter value (e.g. `[{"type":"web"}]`) failed to parse and could permanently wedge the conversation.

## Problem

Two compounding defects:

1. **Parse failure.** `build_tool_parser_tag_tagged` and the `qwen3_coder` parser used `p.json()` for any parameter that did not resolve to a string schema. On an `array<object>` value the PEG parser aborts and the request ends in a 500 (`Failed to parse input at pos N`).
2. **History poisoning.** Before the failure, the partial-parse fallback streamed a lone `"{"` as `tool_calls[0].function.arguments`. The client correctly appends that tool_call to history, and every follow-up request then crashes in `func_args_not_string` (eager JSON parse of the bare `{`), so the conversation stays wedged until the client manually strips the assistant message.

## Fix

- **`build_tool_parser_tag_tagged`**: capture non-string parameter values with `until_suffix` (everything up to the closing tag) instead of `p.json()`, then normalize at map time. The value is a real JSON array when the model renders it, and the existing mapper already normalizes the captured buffer.
- **`qwen3_coder` parser**: same until-based capture for non-string params, mirroring the existing `arg_string` pattern.
- **Mapper**: stop eagerly seeding `arguments = "{"` at the tool name. The opening brace is now added lazily at the first argument name, and an empty call closes as `{}`. This removes the partial single-char leak entirely, so streaming can never emit a malformed `arguments = "{"` delta.
- **Tests**: two regression tests in `test-chat-auto-parser.cpp`:
  - `tagged_args_array_object`: an `array<object>` param parses cleanly and produces valid JSON arguments.
  - `tagged_args_array_object_partial`: across 6 streaming prefixes, no single-char `arguments` value is ever emitted.

## Verification

CPU-only build (CUDA/METAL/VULKAN off):

- New regression tests: PASS (8 + 5 assertions).
- `test-chat-auto-parser`: 113 tests, 537 assertions, 0 failures.
- `test-chat-peg-parser`: 39 tests, 210 assertions, 0 failures.
- `ctest -R "chat|peg"`: 5/5 PASS.

Honest limitation: a full `llama-server` e2e with a real GGUF model over SSE was not run in this environment; the fix is verified at the unit-level grammar/parser/mapper path. `func_args_not_string` was intentionally left unchanged: the wedge required a poisoned bare `{` in replayed history, which this fix prevents from ever being created. Histories already poisoned before this fix would still need manual stripping.

## Related

Prior attempts on this bug: #22089, #22115, #22624 (all closed without merge). This change takes a different approach: it fixes the root parse and removes the partial-state leak rather than degrading gracefully after the damage.
