### PR TITLE
fix: Prevent Qwen3 reranker from allocating exponential memory as physical batch size increases

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2040,8 +2040,6 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
     const auto n_embd     = hparams.n_embd;
     const auto n_embd_out = hparams.n_embd_out();
 
-    // embedding/reranking contexts never produce logits (see build_pooling), so
-    // reserving n_vocab*n_outputs_max floats for them wastes GBs of host RAM
     bool has_logits     = !cparams.embeddings;
     bool has_embd       = cparams.embeddings;
     bool has_embd_nextn = cparams.embeddings_nextn;

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2040,7 +2040,9 @@ uint32_t llama_context::output_reserve(int32_t n_outputs) {
     const auto n_embd     = hparams.n_embd;
     const auto n_embd_out = hparams.n_embd_out();
 
-    bool has_logits     = true;
+    // embedding/reranking contexts never produce logits (see build_pooling), so
+    // reserving n_vocab*n_outputs_max floats for them wastes GBs of host RAM
+    bool has_logits     = !cparams.embeddings;
     bool has_embd       = cparams.embeddings;
     bool has_embd_nextn = cparams.embeddings_nextn;
 

--- a/src/models/qwen3.cpp
+++ b/src/models/qwen3.cpp
@@ -149,9 +149,6 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_norm", -1);
     res->t_embd = cur;
 
-    // embedding/reranking contexts never consume logits, and because embeddings
-    // mode marks every token as an output this would reserve an [n_vocab, n_ubatch]
-    // buffer (~0.58 MiB per ubatch token) that is then thrown away
     if (!cparams.embeddings) {
         // lm_head
         cur = build_lora_mm(model.output, cur, model.output_s);

--- a/src/models/qwen3.cpp
+++ b/src/models/qwen3.cpp
@@ -149,11 +149,16 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
     cb(cur, "result_norm", -1);
     res->t_embd = cur;
 
-    // lm_head
-    cur = build_lora_mm(model.output, cur, model.output_s);
+    // embedding/reranking contexts never consume logits, and because embeddings
+    // mode marks every token as an output this would reserve an [n_vocab, n_ubatch]
+    // buffer (~0.58 MiB per ubatch token) that is then thrown away
+    if (!cparams.embeddings) {
+        // lm_head
+        cur = build_lora_mm(model.output, cur, model.output_s);
 
-    cb(cur, "result_output", -1);
-    res->t_logits = cur;
+        cb(cur, "result_output", -1);
+        res->t_logits = cur;
+    }
 
     ggml_build_forward_expand(gf, cur);
 }


### PR DESCRIPTION
## Overview

Reranker mode requires that all of the prompt fits in a single ubatch.

Today, trying to allocate larger ubatches results in roughly O(n^2) memory growth.

This patch removes some unnecessary allocations to minimize memory consumption.

## Additional information

Tested locally, all queries I tried are identical before and after. The same build runs my normal LLMs and embeddings with no noticeable impact.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) - Yes
- AI usage disclosure: Yes - The bug was discovered by my lab agent. Testing also done by my agent, final validation done by me.