### PR TITLE
server : make /v1/models created timestamp stable

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -4093,6 +4093,7 @@ server_context_meta server_context::get_meta() const {
         /* model_n_params         */ llama_model_n_params(impl->model_tgt),
         /* model_size             */ llama_model_size(impl->model_tgt),
         /* model_ftype            */ ftype_name,
+        /* created                */ std::time(nullptr),
     };
 }
 
@@ -4420,7 +4421,7 @@ static json get_res_model_info(const server_context_meta & meta) {
         {"aliases",  meta.model_aliases},
         {"tags",     meta.model_tags},
         {"object",   "model"},
-        {"created",  std::time(0)},
+        {"created",  meta.created},
         {"owned_by", "llamacpp"},
         {"meta",     {
             {"vocab_type",  meta.model_vocab_type},

--- a/tools/server/server-context.h
+++ b/tools/server/server-context.h
@@ -7,6 +7,7 @@
 #include "json.h"
 
 #include <cstddef>
+#include <ctime>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -52,6 +53,7 @@ struct server_context_meta {
     uint64_t model_n_params;
     uint64_t model_size;
     std::string model_ftype;
+    std::time_t created; // set once at model load, for /v1/models
 };
 
 enum server_state {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1968,7 +1968,6 @@ void server_models_routes::init_routes() {
         auto res = std::make_unique<server_http_res>();
         json models_json = json::array();
         auto all_models = models.get_all_meta();
-        std::time_t t = std::time(0);
         for (const auto & meta : all_models) {
             if (meta.hidden) {
                 continue; // cache model deduplicated by a preset
@@ -2010,7 +2009,7 @@ void server_models_routes::init_routes() {
                 {"tags",          meta.tags},
                 {"object",        "model"},    // for OAI-compat
                 {"owned_by",      "llamacpp"}, // for OAI-compat
-                {"created",       t},          // for OAI-compat
+                {"created",       meta.created},  // for OAI-compat
                 {"status",        status},
                 {"architecture",  architecture},
                 {"source",        server_model_source_to_string(meta.source)},

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -9,6 +9,7 @@
 
 #include <mutex>
 #include <condition_variable>
+#include <ctime>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -85,6 +86,7 @@ struct server_model_meta {
     int stop_timeout = 0; // seconds to wait before force-killing the model instance during shutdown
     mtmd_caps multimodal; // multimodal capabilities
     bool hidden = false; // hidden from GET /models, but still accept if requested
+    std::time_t created = std::time(nullptr); // when the model was registered, for /v1/models
 
     bool is_ready() const {
         return status == SERVER_MODEL_STATUS_LOADED;

--- a/tools/server/tests/unit/test_basic.py
+++ b/tools/server/tests/unit/test_basic.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+import time
 from utils import *
 
 server = ServerPreset.tinyllama2()
@@ -38,6 +39,14 @@ def test_server_models():
     assert res.status_code == 200
     assert len(res.body["data"]) == 1
     assert res.body["data"][0]["id"] == server.model_alias
+
+    # 'created' must be stable across requests, not regenerated per request
+    created = res.body["data"][0]["created"]
+    assert isinstance(created, int)
+
+    time.sleep(1.1)
+    res = server.make_request("GET", "/models")
+    assert res.body["data"][0]["created"] == created
 
 
 def test_server_slots():

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -118,6 +118,24 @@ def test_router_unload_model():
     _wait_for_model_status(model_id, {"unloaded"})
 
 
+def test_router_models_created_stable():
+    global server
+    server.start()
+    model_id = "ggml-org/tinygemma3-GGUF:Q8_0"
+
+    _load_model_and_wait(model_id)
+
+    res = server.make_request("GET", "/models")
+    assert res.status_code == 200
+    created = next(item["created"] for item in res.body["data"] if item["id"] == model_id)
+    assert isinstance(created, int)
+
+    # 'created' must be stable across requests, not regenerated per request
+    time.sleep(1.1)
+    res = server.make_request("GET", "/models")
+    assert next(item["created"] for item in res.body["data"] if item["id"] == model_id) == created
+
+
 def test_router_models_max_evicts_lru():
     global server
     server.models_max = 2


### PR DESCRIPTION
The created field in /v1/models was regenerated per request, breaking client caching. Capture it once at model load (single-model server) or model registration (router) and reuse it for every response.

## Overview

The fix captures load/registration stages and reuses it in single-model and router paths. 
This fixes #26169 

## Additional information

Regresstion tests added to test_basic.py + test_router.py (it correctly fails without the fix, stashed and checked) 

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, to find segments affecting the changes after a fix was made and for tests (both), fully reviewed by me
- I have another issue open even though I am a new contributor (completely unrelated to this, but mentioning because of the new contributor 1 PR maximum at a time) 


