### PR TITLE
CUDA graphs on Pascal (sm_61): +40% on MoE, +7% on dense, no regression

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4232,7 +4232,7 @@ static bool ggml_cuda_graph_set_enabled(ggml_backend_cuda_context * cuda_ctx, co
     ggml_cuda_graph * graph = cuda_ctx->cuda_graph(graph_key);
 
     if (graph->graph == nullptr) {
-        if (ggml_cuda_info().devices[cuda_ctx->device].cc < GGML_CUDA_CC_VOLTA) {
+        if (ggml_cuda_info().devices[cuda_ctx->device].cc < GGML_CUDA_CC_DP4A) {
             if (!graph->disable_due_to_gpu_arch) {
                 GGML_LOG_DEBUG("%s: disabling CUDA graphs due to GPU architecture\n", __func__);
             }


### PR DESCRIPTION
## Overview

This enables CUDA graphs on Pascal (sm_61) by changing one line in `ggml_cuda_graph_set_enabled`: the architecture gate goes from `GGML_CUDA_CC_VOLTA` to `GGML_CUDA_CC_DP4A`.

With the help of Claude, and for purely personal needs at the beginning, i have been exploring ways to speed up inference on a GTX 1080 (pascal, sm_61), an old card that still holds enormous value for running today's state-of-the-art small models (8gb vRam)

One of these is manually unlocking CUDA graphs. Below are tests run on both dense and MoE models, with very positive results.

GTX 1080, driver 581.57, CUDA 12.4, build b10549 / commit b2e5e9b, MSVC 14.38, Windows

MoE Ling-3.0-tiny Q6_K, from 41.2 to 57.6 tok/s (+39.8%)
47.7 to 72.2 long gen (+51.4%)
prefill 857.0 to 853.0 tok/s (-0.5%)

Dense Qwen-based 9B Q5_K_M, from 26.3 to 28.0 tok/s (+6.4%), and again on a second run 25.3 to 27.2 (+7.7%)
prefill 586.7 to 583.7 (-0.5%) and 582.6 to 580.0 (-0.4%)

With llama-bench the gain is even higher(no context so ofc)
| build | pp512 | tg64 |
| --- | ---: | ---: |
| graphs off | 1935.42 ± 27.27 | 41.47 ± 6.15 |
| graphs on  | 1908.80 ± 40.07 | 73.85 ± 4.63 |

pp512 -1.4% (noise), tg64 +78%.

The less context there is, the bigger the gain. +78% on an almost empty context (llama-bench tg64), +51% on short prompts, +40% with a 7000 token prompt. That is what you would expect if graphs remove a fixed per-token launch cost: with a large KV cache the per-token work grows and the saved fixed cost weighs relatively less.

So prefill doesn't change much, it stays inside the noise, the whole gain is in generation. How i measured: median of 3 samples, one thrown as warmup, alternating A-B-A-B for thermal drift and anything under 3% i call it noise.


I checked correctness and speed. temperature 0, top_k 1, fixed seed, same prompts on both builds. 10 different prompts of 200 tokens each (math, prose, translation, python, sql, lists), 10/10 identical. Dense too. With --verbose the line "disabling CUDA graphs due to GPU architecture" disappears.

## Additional information

GGML_CUDA_CC_DP4A is 610 so this only opens sm_61 and leaves sm_60 (P100) alone, i have no sm_60 to test on. GGML_CUDA_DISABLE_GRAPHS=1 still works if someone needs to turn it off.

About the 2024 regression that explains why was disabled on purpose. PR #6766 turned graphs off for CC<8 after measuring a regression on a P40 (53.84 to 51.67 tok/s). The P40 is GP102 so it's the same sm_61 as my card, but that test was a dense model with around 700 graph nodes, and back then MoE was excluded from graphs completely. Two years later, a dense model doesn't regress anymore (+6.4% and +7.7% on two runs) BUT MOST IMPORTANTLY a MoE with 1794 nodes gains 40%. The gain follows the number of nodes in the graph, which makes sense if the decode is launch bound. Volta was already re-enabled by #25749.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to produce the patch, to run the benchmarks, and to translate this description from italian. Some of the explanation paragraphs were drafted by it too and then reviewed by me. I have reviewed the change and the benchmarks myself and can explain them, and i am responsible for everything submitted here.
