### PR TITLE
cuda: disable GDN cache fusion on HIP — hangs RDNA3 iGPUs

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3284,6 +3284,9 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
     ggml_tensor * node = cgraph->nodes[i];
 
     // gated_delta_net -> cpy: scatter recurrent-state snapshots into the cache
+    // HIP: the fused snapshot write path hangs RDNA3 iGPUs (gfx1102/gfx1103) —
+    // the unfused kernel + plain cpy is correct there, so skip the fusion.
+#if !defined(GGML_USE_HIP)
     if (node->op == GGML_OP_GATED_DELTA_NET) {
         ggml_cuda_gated_delta_net_fused_cache fused_state_cpy;
         const int nodes_to_skip = ggml_cuda_try_gdn_cache_fusion(cgraph, i, fused_state_cpy);
@@ -3296,6 +3299,7 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
             return nodes_to_skip;
         }
     }
+#endif
 
     //topk-moe
     if (cgraph->nodes[i]->op == GGML_OP_UNARY || cgraph->nodes[i]->op == GGML_OP_SOFT_MAX ||


### PR DESCRIPTION
## Problem

On a Radeon 780M (gfx1103 RDNA3 iGPU; tested with gfx1102 code objects and `HSA_OVERRIDE_GFX_VERSION=11.0.2`), running any Qwen3.6 model (hybrid gated-delta-net/attention) with the HIP backend hangs the whole GPU:

```
HW Exception by GPU node-1 (Agent handle: ...) reason :GPU Hang
```

followed by an unrecoverable amdgpu device reset that takes down every other GPU client on the device. This reproduces at **any `-ngl` value, including `-ngl 0`**, because the scheduler hoists the fused GDN ops onto the GPU even when all layers are assigned to the CPU (the CPU backend lacks the fused variants), so a nominal CPU-only run still executes the fused GDN path on the GPU.

## Root cause (bisected)

Narrowed to the **GDN cache-fusion scheduler path** — `ggml_cuda_try_gdn_cache_fusion()` + `ggml_cuda_op_gated_delta_net_fused_cache()`, the variant that redirects the kernel's recurrent-state snapshot writes directly into the rollback-cache view (skipping the subsequent `cpy` node).

| configuration | result |
|---|---|
| default build (`-ngl 99` / `-ngl 0`) | GPU hang → device reset (3 faults in 4 runs) |
| `GGML_CUDA_DISABLE_FUSION=1` | clean completion |
| this patch — skip only GDN cache fusion on HIP, all other fusions live | **clean 5/5 runs**, 27B Q4_K_M fully offloaded, 32-token generations complete (~3.5 t/s generation on the iGPU) |

The unfused GDN kernels themselves are correct: `tests/test-backend-ops` passes all GATED_DELTA_NET / SSM_CONV(+BIAS_SILU) / SSM_SCAN / SSM_SCAN_ROLLBACK cases on ROCm0 with CPU comparison.

## The fix

Guard the GDN cache-fusion dispatch with `#if !defined(GGML_USE_HIP)` — 4 lines. The unfused kernel plus the plain `cpy` produces identical results, so this only affects performance of the snapshot scatter on HIP.

## Scope / open questions

- Guarded for **all HIP targets** since I could only test gfx1102/gfx1103; happy to narrow (e.g. to RDNA3) if a maintainer can verify MI300/CDNA or other RDNA parts.
- This restores usability on affected hardware but does not isolate the underlying defect in the fused write path (suspects: the snapshot-stride write pattern into the cache view, or its interaction with graph splits). Someone with HIP tooling on a discrete card may be able to dig further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)