### PR TITLE
ggml-vulkan: allow fp32-only devices (Haswell hasvk)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6807,12 +6807,20 @@ static vk_device ggml_vk_get_device(size_t idx) {
 #endif
         }
 
-        if (!vk11_features.storageBuffer16BitAccess) {
+        // OPTIPLEX-HASWELL: hasvk exposes no 16-bit storage feature bits
+        // (storageBuffer16BitAccess = false, shaderFloat16 = false).
+        // Only hard-require 16-bit storage when fp16 will actually be used;
+        // otherwise continue with the existing fp32 fallback path.
+        const bool has_16bit_storage = vk11_features.storageBuffer16BitAccess ||
+                                       vk11_features.uniformAndStorageBuffer16BitAccess;
+        if (!has_16bit_storage && device->fp16) {
             std::cerr << "ggml_vulkan: device " << GGML_VK_NAME << idx << " does not support 16-bit storage." << std::endl;
             throw std::runtime_error("Unsupported device");
         }
 
-        device_extensions.push_back("VK_KHR_16bit_storage");
+        if (device->fp16) {
+            device_extensions.push_back("VK_KHR_16bit_storage");
+        }
 
 #ifdef GGML_VULKAN_VALIDATE
         device_extensions.push_back("VK_KHR_shader_non_semantic_info");


### PR DESCRIPTION
## Summary

Mesa's Haswell Vulkan driver (`hasvk`) does not expose `VkVulkan11Features::storageBuffer16BitAccess` or `shaderFloat16`, so the device ends up with `device->fp16 == false` and the existing fp32 fallback path is selected. However, the backend unconditionally threw `"Unsupported device"` when `storageBuffer16BitAccess` was missing, rejecting such devices *before* the fallback could ever be used.

This makes the 16-bit-storage requirement conditional on fp16 actually being enabled, and only pushes `VK_KHR_16bit_storage` onto the extension list when needed.

## Test on Intel HD Graphics 4600 (HSW GT2, Mesa 26.1.7 hasvk)

Before:
```
ggml_vulkan: device Vulkan0 does not support 16-bit storage.
E llama_model_load: error loading model: Unsupported device
Segmentation fault
```

After (fully offloaded, UMA heap 1.5 GiB):
```
llama-bench -m gemma-3-1b-q4_0.gguf -ngl 99 -fa off -ub 64 -p 512 -n 128
pp512 = 44.7 t/s   tg128 = 7.9 t/s
```
Three consecutive stability probes pass with zero GPU hangs (i915 heartbeat clean). Note this GPU also requires `-fa off` and small `-ub` due to separate hasvk/i915 limitations, but model load and inference are otherwise fully functional.

Also verified on a 3B Q4_K_S hybrid split (partial offload) without regressions.

## Notes

- The unconditional check was introduced when 16-bit storage became standard on all supported devices; older Gen7.5 hardware is the remaining population that still needs the fp32 path.
- LM Studio's bundled llama.cpp engines fail identically on these devices today; this patch restores Vulkan usability for the Haswell era.