### PR TITLE
server : accept data: URLs for input_video and input_audio

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1057,8 +1057,7 @@ json oaicompat_completion_params_parse(const json & body) {
 static void handle_media(
         std::vector<raw_buffer> & out_files,
         const std::string & url,
-        const std::string & media_path,
-        bool accept_base64_uri) {
+        const std::string & media_path) {
     if (!media_path.empty()) {
         // should already be enforced by arg.cpp, but checking just in case
         GGML_ASSERT(media_path.back() == DIRECTORY_SEPARATOR);
@@ -1099,7 +1098,7 @@ static void handle_media(
         data.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
         out_files.push_back(data);
 
-    } else if (accept_base64_uri && string_starts_with(url, "data:")) {
+    } else if (string_starts_with(url, "data:")) {
         // try to decode base64 image
         std::vector<std::string> parts = string_split<std::string>(url, /*separator*/ ',');
         if (parts.size() != 2) {
@@ -1116,9 +1115,6 @@ static void handle_media(
             out_files.push_back(decoded_data);
         }
 
-    } else if (string_starts_with(url, "data:")) {
-        // data: URLs are not valid raw base64 - fail with an actionable error
-        throw std::invalid_argument("Invalid uri format: " + url.substr(0, url.find(',')));
     } else {
         // try as raw base64 string
         auto decoded_data = base64_decode(url);
@@ -1219,7 +1215,7 @@ json oaicompat_chat_params_parse(
 
                 json image_url = json_value(p, "image_url", json::object());
                 std::string url = json_value(image_url, "url", std::string());
-                handle_media(out_files, url, opt.media_path, true);
+                handle_media(out_files, url, opt.media_path);
 
                 p["type"] = "media_marker";
                 p["text"] = get_media_marker();
@@ -1234,7 +1230,7 @@ json oaicompat_chat_params_parse(
                 json input_audio = json_value(p, "input_audio", json::object());
                 std::string url  = json_value(input_audio, "data",
                                         json_value(input_audio, "url", std::string()));
-                handle_media(out_files, url, opt.media_path, true);
+                handle_media(out_files, url, opt.media_path);
 
                 p["type"] = "media_marker";
                 p["text"] = get_media_marker();
@@ -1248,7 +1244,7 @@ json oaicompat_chat_params_parse(
                 json input_video = json_value(p, "input_video", json::object());
                 std::string url  = json_value(input_video, "data",
                                         json_value(input_video, "url", std::string()));
-                handle_media(out_files, url, opt.media_path, true);
+                handle_media(out_files, url, opt.media_path);
 
                 p["type"] = "media_marker";
                 p["text"] = get_media_marker();

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1099,7 +1099,7 @@ static void handle_media(
         out_files.push_back(data);
 
     } else if (string_starts_with(url, "data:")) {
-        // try to decode base64 image
+        // try to decode base64 image, video, or audio
         std::vector<std::string> parts = string_split<std::string>(url, /*separator*/ ',');
         if (parts.size() != 2) {
             throw std::invalid_argument("Invalid uri-encoded base64 value");

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1103,17 +1103,22 @@ static void handle_media(
         // try to decode base64 image
         std::vector<std::string> parts = string_split<std::string>(url, /*separator*/ ',');
         if (parts.size() != 2) {
-            throw std::runtime_error("Invalid uri-encoded base64 value");
-        } else if (!string_starts_with(parts[0], "data:image/")) {
-            throw std::runtime_error("Invalid uri format: " + parts[0]);
+            throw std::invalid_argument("Invalid uri-encoded base64 value");
+        } else if (!string_starts_with(parts[0], "data:image/")
+                && !string_starts_with(parts[0], "data:video/")
+                && !string_starts_with(parts[0], "data:audio/")) {
+            throw std::invalid_argument("Invalid uri format: " + parts[0]);
         } else if (!string_ends_with(parts[0], "base64")) {
-            throw std::runtime_error("uri must be base64 encoded");
+            throw std::invalid_argument("uri must be base64 encoded");
         } else {
             auto base64_data = parts[1];
             auto decoded_data = base64_decode(base64_data);
             out_files.push_back(decoded_data);
         }
 
+    } else if (string_starts_with(url, "data:")) {
+        // data: URLs are not valid raw base64 - fail with an actionable error
+        throw std::invalid_argument("Invalid uri format: " + url.substr(0, url.find(',')));
     } else {
         // try as raw base64 string
         auto decoded_data = base64_decode(url);
@@ -1229,7 +1234,7 @@ json oaicompat_chat_params_parse(
                 json input_audio = json_value(p, "input_audio", json::object());
                 std::string url  = json_value(input_audio, "data",
                                         json_value(input_audio, "url", std::string()));
-                handle_media(out_files, url, opt.media_path, false);
+                handle_media(out_files, url, opt.media_path, true);
 
                 p["type"] = "media_marker";
                 p["text"] = get_media_marker();
@@ -1243,7 +1248,7 @@ json oaicompat_chat_params_parse(
                 json input_video = json_value(p, "input_video", json::object());
                 std::string url  = json_value(input_video, "data",
                                         json_value(input_video, "url", std::string()));
-                handle_media(out_files, url, opt.media_path, false);
+                handle_media(out_files, url, opt.media_path, true);
 
                 p["type"] = "media_marker";
                 p["text"] = get_media_marker();

--- a/tools/server/tests/unit/test_vision_api.py
+++ b/tools/server/tests/unit/test_vision_api.py
@@ -71,6 +71,7 @@ def test_v1_models_supports_multimodal_capability():
         ("What is this:\n", "malformed",              False, None),
         ("What is this:\n", "https://google.com/404", False, None), # non-existent image
         ("What is this:\n", "https://ggml.ai",        False, None), # non-image data
+        ("What is this:\n", "data:text/html;base64,aGVsbG8=", False, None), # unsupported data uri mime
         # TODO @ngxson : test with multiple images, no images and with audio
     ]
 )


### PR DESCRIPTION
## Overview

`input_video` and `input_audio` content parts were previously not handled as `data:` URLs in `handle_media()`, so a standard data: URL like `data:video/mp4;base64,...` was decoded directly as raw base64. That decode produced garbage bytes, the media probe failed afterwards, and the request died with a misleading `"Failed to load image or audio file"` 400 error (#27724).

This PR extends `data:` URL parsing in `handle_media()` to accept `data:image/`, `data:video/`, and `data:audio/` uniformly across `image_url`, `input_audio`, and `input_video`, and removes the now-redundant `accept_base64_uri` flag. Malformed data URLs and unsupported MIME types throw `std::invalid_argument` so they return `400 invalid_request_error` instead of 500, matching the rest of the file.

## Additional information

Tested locally on an Apple Silicon Metal build with `ggml-org/SmolVLM2-500M-Video-Instruct-GGUF` and a short MP4:

- `input_video` with a `data:` URL decodes and the model answers correctly (previously 400 from #27724)
- Raw base64 video and image data URLs continue to work as before
- `data:text/html;base64,...` returns `400 {"type":"invalid_request_error","message":"Invalid uri format: data:text/html;base64"}`

Kept the MIME check to an explicit image/video/audio allowlist rather than accepting arbitrary `data:*` prefixes.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used an AI assistant to help draft the patch. I reproduced the bug, ran the tests above on my own machine, reviewed every line of the diff, and take responsibility for the change.