### PR TITLE
fix: model loader tensor count mismatch when MTP block contains NVFP4 weights with scales / input scales.

### DIFF
--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1123,11 +1123,24 @@ struct ggml_tensor * llama_model_loader::create_tensor(
 
         // skip unused tensors
         if (info.op == GGML_OP_NONE || (flags & TENSOR_SKIP)) {
-            const size_t nbytes = ggml_nbytes(t_meta);
-            LLAMA_LOG_WARN("model has unused tensor %s (size = %zu bytes) -- ignoring\n", tn.str().c_str(), nbytes);
+            auto skip_tensor = [&](const ggml_tensor * tensor) {
+                const size_t nbytes = ggml_nbytes(tensor);
+                LLAMA_LOG_WARN("model has unused tensor %s (size = %zu bytes) -- ignoring\n", tensor->name, nbytes);
 
-            size_data -= nbytes;
-            n_created++;
+                size_data -= nbytes;
+                n_created++;
+            };
+
+            skip_tensor(t_meta);
+
+            if ((flags & TENSOR_SKIP) && tn.suffix && strcmp(tn.suffix, "weight") == 0) {
+                for (const char * suffix : { "scale", "input_scale" }) {
+                    const LLM_TN_IMPL sidecar_tn(tn.arch, tn.tensor, suffix, tn.bid, tn.xid);
+                    if (const ggml_tensor * sidecar = get_tensor_meta(sidecar_tn.str().c_str())) {
+                        skip_tensor(sidecar);
+                    }
+                }
+            }
 
             return nullptr;
         }


### PR DESCRIPTION
## Overview

Fixed the loader skipping where nvfp4 mtp weights are in gguf but not enabled, model loader would skip weights only but not the weight scales and input scales.

## Additional information

Reproduce with loading a model that contains MTP block with scaled NVFP4 tensors, and not enabling MTP.

```(pwsh)
0.00.416.020 E llama_model_load: error loading model: done_getting_tensors: wrong number of tensors; expected 1194, got 1178
0.00.416.027 E llama_model_load_from_file_impl: failed to load model
0.00.416.055 E common_fit_params: encountered an error while trying to fit params to free device memory: failed to load model
0.00.669.618 W model has unused tensor blk.64.attn_norm.weight (size = 20480 bytes) -- ignoring
0.00.669.628 W model has unused tensor blk.64.post_attention_norm.weight (size = 20480 bytes) -- ignoring     
0.00.669.642 W model has unused tensor blk.64.attn_q.weight (size = 35389440 bytes) -- ignoring
0.00.669.647 W model has unused tensor blk.64.attn_k.weight (size = 2949120 bytes) -- ignoring
0.00.669.652 W model has unused tensor blk.64.attn_v.weight (size = 2949120 bytes) -- ignoring
0.00.669.670 W model has unused tensor blk.64.attn_output.weight (size = 17694720 bytes) -- ignoring
0.00.669.675 W model has unused tensor blk.64.attn_q_norm.weight (size = 1024 bytes) -- ignoring
0.00.669.680 W model has unused tensor blk.64.attn_k_norm.weight (size = 1024 bytes) -- ignoring
0.00.669.685 W model has unused tensor blk.64.ffn_gate.weight (size = 50135040 bytes) -- ignoring
0.00.669.690 W model has unused tensor blk.64.ffn_down.weight (size = 50135040 bytes) -- ignoring
0.00.669.695 W model has unused tensor blk.64.ffn_up.weight (size = 50135040 bytes) -- ignoring
0.00.669.702 W model has unused tensor blk.64.nextn.eh_proj.weight (size = 29491200 bytes) -- ignoring        
0.00.669.708 W model has unused tensor blk.64.nextn.enorm.weight (size = 20480 bytes) -- ignoring
0.00.669.714 W model has unused tensor blk.64.nextn.hnorm.weight (size = 20480 bytes) -- ignoring
0.00.669.730 W model has unused tensor blk.64.nextn.shared_head_norm.weight (size = 20480 bytes) -- ignoring  
0.00.697.417 E llama_model_load: error loading model: done_getting_tensors: wrong number of tensors; expected 1194, got 1178
0.00.697.443 E llama_model_load_from_file_impl: failed to load model
0.00.697.450 E cmn  common_init_: failed to load model 'F:\llama-cpp\models\qwen3.8-27B-nvfp4-dynamic.gguf' 
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, qwen3.8 27B is used to help find the root cause, as well as making sure we don't miss anything. I reviewed and understood the fix.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
