### PR TITLE
server : report live generation throughput

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -313,12 +313,15 @@ struct server_slot {
     // not in server_slot_stats to avoid copying to every task result
     std::vector<uint64_t> n_accepted_per_pos;
 
-    std::function<void(int /* id_slot */)>   callback_on_release;
-    std::function<void(const server_slot &)> callback_on_reset; // called before reset()
+    std::function<void(int /* id_slot */)> callback_on_release;
+    std::function<void(server_slot &)>      callback_on_reset; // called before reset()
 
     // this is for printing timings with slot progress, not part of metrics
     int64_t t_print_last = 0;
     int32_t n_gen_last = 0;
+
+    uint64_t metrics_n_gen    = 0;
+    uint64_t metrics_t_gen_us = 0;
 
     void reset() {
         SLT_DBG(*this, "%s", "\n");
@@ -348,6 +351,8 @@ struct server_slot {
         // note: callback_on_reset() must have run before this, see release()
         stats = {};
         n_accepted_per_pos.clear();
+        metrics_n_gen    = 0;
+        metrics_t_gen_us = 0;
 
         n_predict_max = -1;
 
@@ -1221,7 +1226,7 @@ private:
                 queue_tasks.pop_deferred_task(id_slot);
             };
 
-            slot.callback_on_reset = [this](const server_slot & slot) {
+            slot.callback_on_reset = [this](server_slot & slot) {
                 // flush the generated token stats before reset()
                 if (slot.stats.n_gen > 0) {
                     metrics_on_prediction(slot);
@@ -3756,6 +3761,7 @@ private:
             }
 
             slot.stats.update_gen_last();
+            metrics_update_prediction(slot);
 
             completion_token_output result;
             result.tok          = id;
@@ -3886,6 +3892,7 @@ private:
                 // TODO: set result.probs
 
                 slot.stats.n_gen += 1;
+                metrics_update_prediction(slot);
 
                 if (!process_token(result, slot)) {
                     slot.print_timings();
@@ -3998,13 +4005,22 @@ private:
         metrics_flush_prompt();
     }
 
-    void metrics_on_prediction(const server_slot & slot) {
-        const uint64_t t_us    = slot.stats.t_gen_us();
-        const uint64_t n       = slot.stats.n_gen;
-        const uint64_t n_steps = slot.stats.n_gen_steps();
+    void metrics_update_prediction(server_slot & slot) {
+        const uint64_t t_us        = slot.stats.t_gen_us();
+        const uint64_t n           = slot.stats.n_gen;
+        const uint64_t n_steps     = slot.stats.n_gen_steps();
+        const uint64_t n_steps_old = slot.metrics_n_gen > 0 ? slot.metrics_n_gen - 1 : 0;
 
-        metrics.predict       .add(n, n_steps, t_us);
-        metrics.predict_bucket.add(n, n_steps, t_us);
+        metrics.predict_bucket.add(n - slot.metrics_n_gen, n_steps - n_steps_old, t_us - slot.metrics_t_gen_us);
+
+        slot.metrics_n_gen    = n;
+        slot.metrics_t_gen_us = t_us;
+    }
+
+    void metrics_on_prediction(server_slot & slot) {
+        metrics_update_prediction(slot);
+
+        metrics.predict.add(slot.stats.n_gen, slot.stats.n_gen_steps(), slot.stats.t_gen_us());
 
         metrics.n_draft_tokens      += slot.stats.n_draft_tokens;
         metrics.n_draft_accepted    += slot.stats.n_draft_accepted;

--- a/tools/server/tests/unit/test_metrics.py
+++ b/tools/server/tests/unit/test_metrics.py
@@ -142,6 +142,37 @@ def test_metrics_generation_rate_excludes_first_token():
     assert abs(timings["predicted_per_second"] - expected) < 1e-6
 
 
+def test_metrics_generation_rate_during_active_request():
+    global server
+    server.start()
+
+    stream = server.make_stream_request("POST", "/completion", data={
+        "prompt": "I believe",
+        "n_predict": 128,
+        "ignore_eos": True,
+        "stream": True,
+    })
+    try:
+        for _ in range(4):
+            next(stream)
+
+        metrics = parse_metrics(fetch_metrics(server))
+        assert metrics["llamacpp:requests_processing"][1] == 1
+        assert metrics["llamacpp:predicted_tokens_seconds"][1] > 0
+
+        for _ in range(4):
+            next(stream)
+
+        metrics = parse_metrics(fetch_metrics(server))
+        assert metrics["llamacpp:requests_processing"][1] == 1
+        assert metrics["llamacpp:predicted_tokens_seconds"][1] > 0
+    finally:
+        list(stream)
+
+    metrics = parse_metrics(fetch_metrics(server))
+    assert metrics["llamacpp:tokens_predicted_total"][1] == 128
+
+
 @pytest.mark.parametrize("n_predict", [1, 8])
 def test_metrics_timings_are_finite(n_predict: int):
     global server


### PR DESCRIPTION
## Overview

### Problem

While a completion is active, `/metrics` can report
`requests_processing = 1` and `predicted_tokens_seconds = 0`. Prediction
throughput was added to the scrape bucket only when the request finished, while
each scrape clears that bucket.

### Solution

Update prediction metrics after every normal or speculative generation step.
Each slot tracks its previously reported token count and generation time so only
new deltas are added. The first token remains excluded from decode steps, and
cumulative counters are still committed once at completion.

### Test

The new regression starts a 128-token streaming completion and scrapes metrics
twice before it finishes. It reproduces the zero-throughput result without the
fix and verifies with the fix that:

- both active-generation scrapes report positive throughput
- the final cumulative token count remains exactly 128

### Validation

- `llama-server` build: passed
- metrics tests: 11 passed
- sleep/reset and speculative/concurrent tests: 4 passed
- `git diff --check`: passed

### Not fixed

Live prompt-processing throughput remains inaccurate and will require a separate
change. Response streaming and generated output are unchanged.

## Additional information

Partial fix for #27436. This change adds no public API, dependency, or new file.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted with root-cause analysis, implementation, regression-test development, validation, and review.
