### PR TITLE
llama-quantize: Add MoE chunk queue for faster multi-threaded quant creation

### DIFF
--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -724,41 +724,57 @@ static ggml_type llama_tensor_get_type(quantize_state_impl & qs, const llama_mod
 // quantization implementation
 //
 
-static size_t llama_tensor_quantize_impl(enum ggml_type new_type, const float * f32_data, void * new_data, const int64_t chunk_size, int64_t nrows, int64_t n_per_row, const float * imatrix, std::vector<std::thread> & workers, const int nthread) {
+static size_t llama_tensor_quantize_impl(enum ggml_type new_type, const float * f32_data, void * new_data, const int64_t chunk_size, int64_t ne2, int64_t nrows, int64_t n_per_row, const float * imatrix, std::vector<std::thread> & workers, const int nthread) {
+    const int64_t nelements_matrix = nrows * n_per_row;
+    const size_t  row_size         = ggml_row_size(new_type, n_per_row);
+
     if (nthread < 2) {
         // single-thread
-        size_t new_size = ggml_quantize_chunk(new_type, f32_data, new_data, 0, nrows, n_per_row, imatrix);
-        if (!ggml_validate_row_data(new_type, new_data, new_size)) {
-            throw std::runtime_error("quantized data validation failed");
+        size_t new_size = 0;
+        for (int64_t i02 = 0; i02 < ne2; ++i02) {
+            const float * imatrix_02 = imatrix ? imatrix + i02 * n_per_row : nullptr;
+            void * this_data = (char *) new_data + i02 * nrows * row_size;
+            size_t this_size = ggml_quantize_chunk(new_type, f32_data + i02 * nelements_matrix, this_data, 0, nrows, n_per_row, imatrix_02);
+            if (!ggml_validate_row_data(new_type, this_data, this_size)) {
+                throw std::runtime_error("quantized data validation failed");
+            }
+            new_size += this_size;
         }
         return new_size;
     }
 
     std::mutex mutex;
-    int64_t counter = 0;
+    int64_t counter = 0; // rows handed out, counted across all ne2 expert matrices
     size_t new_size = 0;
     bool valid = true;
+    const int64_t total_rows = ne2 * nrows;
     auto compute = [&mutex, &counter, &new_size, &valid, new_type, f32_data, new_data, chunk_size,
-            nrows, n_per_row, imatrix]() {
+            nrows, n_per_row, imatrix, nelements_matrix, row_size, total_rows]() {
         const int64_t nrows_per_chunk = chunk_size / n_per_row;
         size_t local_size = 0;
         while (true) {
             std::unique_lock<std::mutex> lock(mutex);
-            int64_t first_row = counter; counter += nrows_per_chunk;
-            if (first_row >= nrows) {
+            if (counter >= total_rows) {
                 if (local_size > 0) {
                     new_size += local_size;
                 }
                 break;
             }
+            const int64_t first_row  = counter;
+            const int64_t i02        = first_row / nrows;
+            const int64_t local_row  = first_row - i02 * nrows;
+            // clamp to the end of this expert matrix: its imatrix slice differs
+            const int64_t this_nrow  = std::min(nrows - local_row, nrows_per_chunk);
+            counter += this_nrow;
             lock.unlock();
-            const int64_t this_nrow = std::min(nrows - first_row, nrows_per_chunk);
-            size_t this_size = ggml_quantize_chunk(new_type, f32_data, new_data, first_row * n_per_row, this_nrow, n_per_row, imatrix);
+
+            const float * imatrix_02 = imatrix ? imatrix + i02 * n_per_row : nullptr;
+            const float * this_src   = f32_data + i02 * nelements_matrix + local_row * n_per_row;
+            void        * this_data  = (char *) new_data + (i02 * nrows + local_row) * row_size;
+            size_t this_size = ggml_quantize_chunk(new_type, this_src, this_data, 0, this_nrow, n_per_row, imatrix_02);
             local_size += this_size;
 
             // validate the quantized data
-            const size_t row_size  = ggml_row_size(new_type, n_per_row);
-            void * this_data = (char *) new_data + first_row * row_size;
             if (!ggml_validate_row_data(new_type, this_data, this_size)) {
                 std::unique_lock<std::mutex> lock(mutex);
                 valid = false;
@@ -1252,19 +1268,13 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
                 static const int64_t min_chunk_size = 32 * 512;
                 const int64_t chunk_size = (n_per_row >= min_chunk_size ? n_per_row : n_per_row * ((min_chunk_size + n_per_row - 1)/n_per_row));
 
-                const int64_t nelements_matrix = tensor->ne[0] * tensor->ne[1];
-                const int64_t nchunk = (nelements_matrix + chunk_size - 1)/chunk_size;
+                const int64_t nelements_all = tensor->ne[0] * tensor->ne[1] * tensor->ne[2];
+                const int64_t nchunk = (nelements_all + chunk_size - 1)/chunk_size;
                 const int64_t nthread_use = nthread > 1 ? std::max((int64_t)1, std::min((int64_t)nthread, nchunk)) : 1;
 
-                // quantize each expert separately since they have different importance matrices
-                new_size = 0;
-                for (int64_t i03 = 0; i03 < tensor->ne[2]; ++i03) {
-                    const float * f32_data_03 = f32_data + i03 * nelements_matrix;
-                    void * new_data_03 = (char *)new_data + ggml_row_size(new_type, n_per_row) * i03 * nrows;
-                    const float * imatrix_03 = imatrix ? imatrix + i03 * n_per_row : nullptr;
-
-                    new_size += llama_tensor_quantize_impl(new_type, f32_data_03, new_data_03, chunk_size, nrows, n_per_row, imatrix_03, workers, nthread_use);
-                }
+                // all experts of a 3D tensor share one chunk queue; chunks never cross
+                // expert boundaries since each expert has its own importance matrix
+                new_size = llama_tensor_quantize_impl(new_type, f32_data, new_data, chunk_size, tensor->ne[2], nrows, n_per_row, imatrix, workers, nthread_use);
                 LLAMA_LOG_INFO("size = %8.2f MiB -> %8.2f MiB\n", tensor_size/1024.0/1024.0, new_size/1024.0/1024.0);
             }
             total_size_org += tensor_size;


### PR DESCRIPTION
## Overview

This changes how experts are chunked and queued into the llama-quantize process

This does **NOT** speed up running models, so don't get excited.. But MoE model creation speed does go up by a good margin with identical sha256sum

In ideal scenarios, we can see a 5x speedup in creation time for the particularly tricky tensor types when using 192 threads on Qwen3.6-35B-A3B:

| type | master (s) | PR (s) | difference |
|---|---:|---:|---:|
| Q4_0 | 153.36 | 47.21 | -106.15 (-69.2%) |
| Q4_1 | 265.71 | 77.50 | -188.21 (-70.8%) |
| Q5_0 | 156.00 | 48.94 | -107.06 (-68.6%) |
| Q5_1 | 269.04 | 80.43 | -188.61 (-70.1%) |
| IQ2_XXS | 590.17 | 149.41 | -440.76 (-74.7%) |
| IQ2_XS | 791.68 | 275.75 | -515.93 (-65.2%) |
| IQ2_S | 797.29 | 278.07 | -519.22 (-65.1%) |
| IQ2_M | 419.22 | 93.67 | -325.55 (-77.7%) |
| IQ1_S | 314.58 | 77.56 | -237.02 (-75.3%) |
| IQ1_M | 822.69 | 230.83 | -591.86 (-71.9%) |
| Q2_K | 243.53 | 64.44 | -179.09 (-73.5%) |
| Q2_K_S | 284.82 | 73.42 | -211.40 (-74.2%) |
| IQ3_XXS | 665.13 | 161.75 | -503.38 (-75.7%) |
| IQ3_XS | 623.36 | 144.56 | -478.80 (-76.8%) |
| IQ3_S | 578.11 | 126.46 | -451.65 (-78.1%) |
| IQ3_M | 567.43 | 124.53 | -442.90 (-78.1%) |
| Q3_K_S | 167.77 | 44.97 | -122.80 (-73.2%) |
| Q3_K_M | 200.14 | 56.10 | -144.04 (-72.0%) |
| Q3_K_L | 203.06 | 56.79 | -146.27 (-72.0%) |
| IQ4_NL | 372.72 | 96.15 | -276.57 (-74.2%) |
| IQ4_XS | 370.21 | 94.87 | -275.34 (-74.4%) |
| Q4_K_S | 268.32 | 76.46 | -191.86 (-71.5%) |
| Q4_K_M | 250.21 | 72.93 | -177.28 (-70.9%) |
| Q5_K_S | 275.51 | 80.41 | -195.10 (-70.8%) |
| Q5_K_M | 256.68 | 75.99 | -180.69 (-70.4%) |
| Q6_K | 162.85 | 53.28 | -109.57 (-67.3%) |
| Q8_0 | 156.70 | 52.10 | -104.60 (-66.8%) |

At 48 threads on 24 cores the numbers are more modest, somewhere more like 1.5-2x increase

CPU usage goes from ~60-80% on each provided core to 100%

## Additional information

The main change is that we no longer spin up a single thread per-expert, now it handles the whole 3D tensor in one threaded pass

`this_nrow = min(nrows - local_row, nrows_per_chunk)` guarantees that chunks get truncated at the end of its expert so we don't span expert boundaries (which would have different imatrix data)

`ggml_quantize_chunk` now receives `start = 0` for every call here, instead of using `first_row * n_per_row`. Since we need the per-expert base pointers anyways, we just increment them all ahead of time.

It also uses better logic for deciding the threads to use per expert, if the matrices were small we'd end up with a low thread count, now it's based on the size of the whole tensor.

Checked the sha256sum of every file with and without this PR and they're identical, also checked on a dense model for sanity and it was the same.

Also compared this PR vs master with a single thread (since it's a different path) and also same sha256sum on https://huggingface.co/hf-internal-testing/Mixtral-tiny (can't afford the days it would take to quantize a 35B on a single thread..), time is same because this is a multi-threaded improvement.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, this is part of a sweep of quantization creation speedups found by Claude, but this one is byte-identical so the easiest to justify <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
