### PR TITLE
opencl: perf optimization for mamba2 ssm_scan by folding 4 dim rows into one workgroup and add more coverage

### DIFF
--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -7729,10 +7729,25 @@ static bool ggml_opencl_supports_op(ggml_backend_dev_t dev, const struct ggml_te
             if (op->type != GGML_TYPE_F32) {
                 return false;
             }
+            // Rollback snapshots (ggml_ssm_scan's K argument) ask the op to emit K intermediate
+            // copies of the state, not just the final one. The kernel now writes slots 1..K-1
+            // inside its token loop, so any K >= 1 is served. Speculative decoding on a hybrid
+            // model is the only producer of K > 1 (K = n_rs_seq + 1); previously every verify
+            // batch fell back to the CPU for each SSM layer.
             const int K = ggml_get_op_params_i32(op, 0);
+            if (K < 1) {
+                return false;
+            }
+            // Snapshots cover the last K-1 tokens, which is the regime a speculative verify runs
+            // in: the draft is at most n_max tokens and K = n_max + 1, so the batch is never
+            // wider than K. Wider batches keep the existing CPU path.
+            const int n_tokens_ssm = (int) op->src[1]->ne[2];
+            if (K > 1 && n_tokens_ssm > K) {
+                return false;
+            }
             const int d_state = (int) op->src[0]->ne[0];
             const bool is_mamba2 = (op->src[3]->ne[0] == 1);
-            return is_mamba2 && (d_state == 128 || d_state == 256) && (K == 1);
+            return is_mamba2 && (d_state == 128 || d_state == 256);
         }
         case GGML_OP_GATED_DELTA_NET:
             {
@@ -12757,6 +12772,14 @@ static void ggml_cl_ssm_scan(ggml_backend_t backend, ggml_tensor * dst) {
     const int n_tokens = (int) src1->ne[2];
     const int n_seqs   = (int) src1->ne[3];
 
+    // Rollback snapshots: the op is asked for K state copies, not just the final
+    // one. K > 1 comes from speculative decoding (K = n_rs_seq + 1), where a
+    // rejected draft token has to rewind the recurrent state.
+    const int K_param = ggml_get_op_params_i32(dst, 0);
+    const int K       = K_param > 0 ? K_param : 1;
+    GGML_ASSERT((cl_long) ggml_nelements(src1) +
+                (cl_long) K * d_state * head_dim * n_head * n_seqs == (cl_long) ggml_nelements(dst));
+
     // Mirror CPU ref: s_off = ggml_nelements(src1) * sizeof(float)
     const cl_ulong s_off_bytes = (cl_ulong) ggml_nelements(src1) * sizeof(float);
 
@@ -12828,6 +12851,8 @@ static void ggml_cl_ssm_scan(ggml_backend_t backend, ggml_tensor * dst) {
     CL_CHECK(clSetKernelArg(kernel, 29, sizeof(int),      &n_head));
     CL_CHECK(clSetKernelArg(kernel, 30, sizeof(int),      &n_group));
     CL_CHECK(clSetKernelArg(kernel, 31, sizeof(int),      &n_tokens));
+    CL_CHECK(clSetKernelArg(kernel, 32, sizeof(int),      &K));
+    CL_CHECK(clSetKernelArg(kernel, 33, sizeof(int),      &n_seqs));
 
     // 64 threads (= Adreno half wave, REQD_SUBGROUP_SIZE_64) per workgroup.
     // Each thread holds ssm_rows * d_state/64 state elements in private.

--- a/ggml/src/ggml-opencl/ggml-opencl.cpp
+++ b/ggml/src/ggml-opencl/ggml-opencl.cpp
@@ -877,6 +877,7 @@ struct ggml_backend_opencl_context {
     // tgpp 0 = TG variant (COLS_PER_LANE_GROUP=1), tgpp 1 = prefill variant (COLS_PER_LANE_GROUP=4).
     cl_kernel kernel_gated_delta_net_f32[4][2][2] = {};
     cl_kernel kernel_ssm_scan_f32_mamba2_d128 = nullptr;
+    cl_kernel kernel_ssm_scan_f32_mamba2_d128_r4 = nullptr;  // 4 dim rows per WG
     cl_kernel kernel_ssm_scan_f32_mamba2_d256 = nullptr;
 
     cl_kernel kernel_timestep_embedding;
@@ -3207,6 +3208,27 @@ static void load_cl_kernels(ggml_backend_opencl_context *backend_ctx) {
         CL_CHECK((backend_ctx->kernel_ssm_scan_f32_mamba2_d128 = clCreateKernel(prog, "kernel_ssm_scan_f32_mamba2_d128", &err), err));
         CL_CHECK((backend_ctx->kernel_ssm_scan_f32_mamba2_d256 = clCreateKernel(prog, "kernel_ssm_scan_f32_mamba2_d256", &err), err));
         CL_CHECK(clReleaseProgram(prog));
+
+        // SSM_R=4 variant of the d128 scan: same kernel, four dim rows per
+        // workgroup, so the (group, token)-indexed B/C loads are issued once
+        // instead of once per row. Its own program because the row count is a
+        // compile-time constant. Non-fatal: if it does not build we keep the
+        // one-row kernel. Dispatch requires head_dim % 4 == 0.
+        {
+            const std::string opts_r4 = compile_opts +
+                " -DSSM_R=4 -DSSM_KNAME=kernel_ssm_scan_f32_mamba2_d128_r4";
+            cl_int err_r4 = CL_SUCCESS;
+            cl_program prog_r4 = build_program_from_source_ex(
+                backend_ctx->context, backend_ctx->device, kernel_src.c_str(), opts_r4,
+                /*fatal=*/false, "ssm_scan_r4");
+            if (prog_r4) {
+                cl_kernel k = clCreateKernel(prog_r4, "kernel_ssm_scan_f32_mamba2_d128_r4", &err_r4);
+                if (err_r4 == CL_SUCCESS && k) {
+                    backend_ctx->kernel_ssm_scan_f32_mamba2_d128_r4 = k;
+                }
+                CL_CHECK(clReleaseProgram(prog_r4));
+            }
+        }
         GGML_LOG_CONT(".");
     }
 
@@ -12738,9 +12760,28 @@ static void ggml_cl_ssm_scan(ggml_backend_t backend, ggml_tensor * dst) {
     // Mirror CPU ref: s_off = ggml_nelements(src1) * sizeof(float)
     const cl_ulong s_off_bytes = (cl_ulong) ggml_nelements(src1) * sizeof(float);
 
-    cl_kernel kernel = (d_state == 128)
-        ? backend_ctx->kernel_ssm_scan_f32_mamba2_d128
-        : backend_ctx->kernel_ssm_scan_f32_mamba2_d256;
+    // Rows of `dim` per workgroup. B and C are indexed by (group, token) only,
+    // so the one-row kernel has every head_dim * (n_head/n_group) workgroups of
+    // a group re-reading the identical B/C. Folding 4 rows into a workgroup cuts
+    // that traffic 4x. Opt out with GGML_OPENCL_SSM_ROWS=1.
+    static const int ssm_rows_env = []{
+        const char * e = getenv("GGML_OPENCL_SSM_ROWS");
+        return (e && e[0]) ? atoi(e) : 0;
+    }();
+    int ssm_rows = 1;
+    cl_kernel kernel = nullptr;
+    if (d_state == 128) {
+        const bool r4_ok = backend_ctx->kernel_ssm_scan_f32_mamba2_d128_r4 != nullptr &&
+                           (head_dim % 4) == 0 && ssm_rows_env != 1;
+        if (r4_ok) {
+            kernel    = backend_ctx->kernel_ssm_scan_f32_mamba2_d128_r4;
+            ssm_rows  = 4;
+        } else {
+            kernel = backend_ctx->kernel_ssm_scan_f32_mamba2_d128;
+        }
+    } else {
+        kernel = backend_ctx->kernel_ssm_scan_f32_mamba2_d256;
+    }
     GGML_ASSERT(kernel != nullptr);
 
     cl_ulong s0_nb2 = src0->nb[2];
@@ -12788,7 +12829,10 @@ static void ggml_cl_ssm_scan(ggml_backend_t backend, ggml_tensor * dst) {
     CL_CHECK(clSetKernelArg(kernel, 30, sizeof(int),      &n_group));
     CL_CHECK(clSetKernelArg(kernel, 31, sizeof(int),      &n_tokens));
 
-    size_t global_work_size[] = { (size_t)n_head * head_dim * 64, (size_t)n_seqs, 1 };
+    // 64 threads (= Adreno half wave, REQD_SUBGROUP_SIZE_64) per workgroup.
+    // Each thread holds ssm_rows * d_state/64 state elements in private.
+    // Grid: (n_head * head_dim / ssm_rows, n_seqs).
+    size_t global_work_size[] = { (size_t)n_head * (head_dim / ssm_rows) * 64, (size_t)n_seqs, 1 };
     size_t local_work_size[]  = { 64, 1, 1 };
 
     backend_ctx->enqueue_ndrange_kernel(kernel, 3, global_work_size, local_work_size, dst);

--- a/ggml/src/ggml-opencl/kernels/ssm_scan.cl
+++ b/ggml/src/ggml-opencl/kernels/ssm_scan.cl
@@ -24,9 +24,24 @@ inline float softplus_f32(float x) {
 }
 
 // d_state = 128 (most Mamba-2 models, e.g. mamba2-2.7B, Codestral-Mamba).
-// WG = 64 threads, each holds 2 state elements (tid and tid+64).
+// WG = 64 threads, each holds 2 state elements (tid and tid+64) per row.
+//
+// SSM_R = rows of `dim` handled per workgroup (compile-time; default 1 keeps the
+// original one-row kernel bit-identical). B and C are indexed by (group, token)
+// only -- never by dim -- so with one row per workgroup, every head_dim
+// workgroups of a head re-read the identical B/C rows. Handling SSM_R rows per
+// workgroup cuts that traffic by SSM_R, and costs SSM_R state registers per
+// thread plus SSM_R subgroup reductions per token. dt/dA are per-head and stay
+// hoisted out of the row loop. Requires head_dim % SSM_R == 0, enforced at
+// dispatch.
+#ifndef SSM_R
+#define SSM_R 1
+#endif
+#ifndef SSM_KNAME
+#define SSM_KNAME kernel_ssm_scan_f32_mamba2_d128
+#endif
 REQD_SUBGROUP_SIZE_64
-kernel void kernel_ssm_scan_f32_mamba2_d128(
+kernel void SSM_KNAME(
     global const char * src0_base, ulong src0_off,
     global const char * src1_base, ulong src1_off,
     global const char * src2_base, ulong src2_off,
@@ -50,8 +65,11 @@ kernel void kernel_ssm_scan_f32_mamba2_d128(
     const int wg_x    = (int) get_group_id(0);
     const int seq_id  = (int) get_group_id(1);
 
-    const int head_id = wg_x / head_dim;
-    const int dim_id  = wg_x - head_id * head_dim;
+    // Each workgroup owns SSM_R consecutive dim rows of one head, so the B/C
+    // loads below are issued once and reused across all SSM_R rows.
+    const int rows_per_head = head_dim / SSM_R;
+    const int head_id = wg_x / rows_per_head;
+    const int dim_id  = (wg_x - head_id * rows_per_head) * SSM_R;
     const int g       = head_id / (n_head / n_group);
 
     src0_base += src0_off;
@@ -83,34 +101,50 @@ kernel void kernel_ssm_scan_f32_mamba2_d128(
 
     const float A_val = ((global const float *)src3_base)[(ulong)head_id * A_nb1 / sizeof(float)];
 
-    // c_factor = 2: each thread owns 2 state elements (tid and tid+64).
-    float state0 = s0_warp[tid];
-    float state1 = s0_warp[tid + 64];
+    // c_factor = 2: each thread owns 2 state elements (tid and tid+64) per row.
+    float state0[SSM_R];
+    float state1[SSM_R];
+    #pragma unroll
+    for (int r = 0; r < SSM_R; ++r) {
+        state0[r] = s0_warp[(ulong)r * d_state + tid];
+        state1[r] = s0_warp[(ulong)r * d_state + tid + 64];
+    }
 
     for (int t = 0; t < n_tokens; ++t) {
+        // per-head, shared by all SSM_R rows
         const float dt_h        = ((global const float *)(dt_seq + (ulong)t * dt_nb1))[head_id];
         const float dt_softplus = softplus_f32(dt_h);
         const float dA          = exp(dt_softplus * A_val);
-        const float x_val       = ((global const float *)(x_seq + (ulong)t * x_nb2))[(ulong)head_id * head_dim + dim_id];
-        const float x_dt        = x_val * dt_softplus;
 
+        // per-(group, token): loaded ONCE and reused across all SSM_R rows
         const float B0 = ((global const float *)(B_seq + (ulong)t * B_nb2))[tid];
         const float B1 = ((global const float *)(B_seq + (ulong)t * B_nb2))[tid + 64];
         const float C0 = ((global const float *)(C_seq + (ulong)t * C_nb2))[tid];
         const float C1 = ((global const float *)(C_seq + (ulong)t * C_nb2))[tid + 64];
 
-        state0 = state0 * dA + B0 * x_dt;
-        state1 = state1 * dA + B1 * x_dt;
-        const float partial = state0 * C0 + state1 * C1;
+        global const float * x_row = (global const float *)(x_seq + (ulong)t * x_nb2)
+                                     + (ulong)head_id * head_dim + dim_id;
 
-        const float sum = sub_group_reduce_add(partial);
-        if (tid == 0) {
-            y_seq[(ulong)t * y_dim_total + (ulong)head_id * head_dim + dim_id] = sum;
+        #pragma unroll
+        for (int r = 0; r < SSM_R; ++r) {
+            const float x_dt = x_row[r] * dt_softplus;
+
+            state0[r] = state0[r] * dA + B0 * x_dt;
+            state1[r] = state1[r] * dA + B1 * x_dt;
+            const float partial = state0[r] * C0 + state1[r] * C1;
+
+            const float sum = sub_group_reduce_add(partial);
+            if (tid == 0) {
+                y_seq[(ulong)t * y_dim_total + (ulong)head_id * head_dim + dim_id + r] = sum;
+            }
         }
     }
 
-    s_warp[tid]      = state0;
-    s_warp[tid + 64] = state1;
+    #pragma unroll
+    for (int r = 0; r < SSM_R; ++r) {
+        s_warp[(ulong)r * d_state + tid]      = state0[r];
+        s_warp[(ulong)r * d_state + tid + 64] = state1[r];
+    }
 }
 
 // d_state = 256 (Falcon-H1). WG = 64 threads, each holds 4 state elements.

--- a/ggml/src/ggml-opencl/kernels/ssm_scan.cl
+++ b/ggml/src/ggml-opencl/kernels/ssm_scan.cl
@@ -57,7 +57,8 @@ kernel void SSM_KNAME(
     ulong B_nb2,  ulong B_nb3,
     ulong C_nb2,  ulong C_nb3,
     ulong s_off_bytes,
-    int   head_dim, int n_head, int n_group, int n_tokens
+    int   head_dim, int n_head, int n_group, int n_tokens,
+    int   K,        int n_seqs
 ) {
     const int d_state = 128;
 
@@ -138,6 +139,24 @@ kernel void SSM_KNAME(
                 y_seq[(ulong)t * y_dim_total + (ulong)head_id * head_dim + dim_id + r] = sum;
             }
         }
+
+        // Rollback snapshots. Slot 0 is the final state, written after the loop;
+        // slots 1..K-1 hold the state as it stood after each of the last K-1
+        // tokens, so a speculative verify can rewind when a drafted token is
+        // rejected. `slot` counts back from the last token, matching the CUDA
+        // reference. K == 1 (every non-speculative graph) leaves this dead.
+        const int slot = n_tokens - 1 - t;
+        if (slot > 0 && slot < K) {
+            global float * snap = (global float *)(dst_base + s_off_bytes
+                + ((ulong)slot * (ulong)n_seqs + (ulong)seq_id) * s0_nb3
+                + (ulong)head_id * s0_nb2
+                + (ulong)dim_id * d_state * sizeof(float));
+            #pragma unroll
+            for (int r = 0; r < SSM_R; ++r) {
+                snap[(ulong)r * d_state + tid]      = state0[r];
+                snap[(ulong)r * d_state + tid + 64] = state1[r];
+            }
+        }
     }
 
     #pragma unroll
@@ -165,7 +184,8 @@ kernel void kernel_ssm_scan_f32_mamba2_d256(
     ulong B_nb2,  ulong B_nb3,
     ulong C_nb2,  ulong C_nb3,
     ulong s_off_bytes,
-    int   head_dim, int n_head, int n_group, int n_tokens
+    int   head_dim, int n_head, int n_group, int n_tokens,
+    int   K,        int n_seqs
 ) {
     const int d_state = 256;
 
@@ -240,6 +260,19 @@ kernel void kernel_ssm_scan_f32_mamba2_d256(
         const float sum = sub_group_reduce_add(partial);
         if (tid == 0) {
             y_seq[(ulong)t * y_dim_total + (ulong)head_id * head_dim + dim_id] = sum;
+        }
+
+        // Rollback snapshots -- see the d128 kernel above.
+        const int slot = n_tokens - 1 - t;
+        if (slot > 0 && slot < K) {
+            global float * snap = (global float *)(dst_base + s_off_bytes
+                + ((ulong)slot * (ulong)n_seqs + (ulong)seq_id) * s0_nb3
+                + (ulong)head_id * s0_nb2
+                + (ulong)dim_id * d_state * sizeof(float));
+            snap[tid]       = state0;
+            snap[tid + 64]  = state1;
+            snap[tid + 128] = state2;
+            snap[tid + 192] = state3;
         }
     }
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Two changes to the mamba2 `ssm_scan` kernel from #26439.

**Optimization: fewer redundant loads.** B and C are indexed by `(group, token)`, never by `dim`, but the kernel runs one work-group per `(head, dim)` row, so hundreds of work-groups re-read the same values every token. Folding `SSM_R` consecutive rows into one work-group loads them once. `SSM_R` is compile-time so the row loop unrolls and the state stays in registers; `SSM_R=1` is the original kernel unchanged. Used when `d_state == 128` and `head_dim % 4 == 0`, otherwise the one-row kernel. Improve a third of prefill perf on an all-mamba2 model; `GGML_OPENCL_SSM_ROWS=1` opts out.

**Converage: rollback snapshots on the GPU.** The kernel wrote only the final recurrent state, so `supports_op` declined every `K > 1` and each SSM layer of a speculative verify fell to the CPU. It now writes slots `1..K-1` in the token loop. `test-backend-ops -o SSM_SCAN` goes from 6/6 to 7/7 on Adreno 840 and 740.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) Yes
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, used for testing. Code reviewed manually

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
