### PR TITLE
speculative : fix shared-KV detection for draft-mtp contexts

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1371,7 +1371,11 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
         llama_set_embeddings_nextn(ctx_tgt, true, /*masked*/ false);
         llama_set_embeddings_nextn(ctx_dft, true, /*masked*/ true);
 
-        is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
+        // ask the draft memory whether it actually shares the target's KV cells.
+        // llama_get_ctx_other(ctx_dft) == ctx_tgt holds for every MTP context, shared
+        // KV or not, so it mislabeled separate-KV MTP archs (e.g. qwen35) as shared
+        // and skipped both the catch-up decode and the per-step draft positions.
+        is_mem_shared = llama_memory_has_shared_cells(llama_get_memory(ctx_dft));
         chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
 
         if (chain_heads) {

--- a/include/llama.h
+++ b/include/llama.h
@@ -571,6 +571,9 @@ extern "C" {
 
     LLAMA_API const struct llama_model * llama_get_model   (const struct llama_context * ctx);
     LLAMA_API           llama_memory_t   llama_get_memory  (const struct llama_context * ctx);
+
+    // true if this memory shares its KV cells with another context's memory
+    LLAMA_API bool llama_memory_has_shared_cells(llama_memory_t mem);
     LLAMA_API  enum llama_pooling_type   llama_pooling_type(const struct llama_context * ctx); // TODO: rename to llama_get_pooling_type
 
     LLAMA_API const struct llama_vocab * llama_model_get_vocab(const struct llama_model * model);

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3978,6 +3978,10 @@ llama_pos llama_memory_seq_pos_min(
     return mem->seq_pos_min(seq_id);
 }
 
+bool llama_memory_has_shared_cells(llama_memory_t mem) {
+    return mem != nullptr && mem->get_has_shared_cells();
+}
+
 llama_pos llama_memory_seq_pos_max(
         llama_memory_t mem,
           llama_seq_id seq_id) {

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -272,6 +272,10 @@ void llama_kv_cache_iswa::state_read(llama_io_read_i & io, llama_seq_id seq_id, 
     kv_swa->state_read(io, seq_id, flags);
 }
 
+bool llama_kv_cache_iswa::get_has_shared_cells() const {
+    return (kv_base && kv_base->get_has_shared_cells()) || (kv_swa && kv_swa->get_has_shared_cells());
+}
+
 llama_kv_cache * llama_kv_cache_iswa::get_base() const {
     return kv_base.get();
 }

--- a/src/llama-kv-cache-iswa.h
+++ b/src/llama-kv-cache-iswa.h
@@ -65,6 +65,8 @@ public:
 
     bool get_can_shift() const override;
 
+    bool get_has_shared_cells() const override;
+
     void clear(bool data) override;
 
     bool seq_rm  (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1) override;

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -131,6 +131,8 @@ public:
 
     bool get_can_shift() const override;
 
+    bool get_has_shared_cells() const override { return other != nullptr; }
+
     void clear(bool data) override;
 
     bool seq_rm  (llama_seq_id seq_id,                              llama_pos p0, llama_pos p1) override;

--- a/src/llama-memory.h
+++ b/src/llama-memory.h
@@ -100,6 +100,11 @@ struct llama_memory_i {
     // getters
     virtual bool get_can_shift() const = 0;
 
+    // true when this memory views KV cells owned by another context's memory
+    // (e.g. an MTP draft context that reuses the target's cells and never
+    // decodes into cells of its own)
+    virtual bool get_has_shared_cells() const { return false; }
+
     //
     // ops
     //


### PR DESCRIPTION
`common_speculative_impl_draft_mtp` decides at construction whether the draft context shares the target's KV:

```cpp
is_mem_shared = llama_get_ctx_other(ctx_dft) == ctx_tgt;
```

That test is true for every MTP context. `ctx_other` is how an MTP context finds its target. It says nothing about memory. Gemma4-assistant draft contexts really do share the target's cells. The qwen35 family does not, it gets its own `llama_kv_cache` filtered to `il >= n_layer()`. Both answer yes here.

So on separate-KV MTP archs the flag comes up true when it should be false, and two things quietly go wrong. The catch-up decode in `process()` is skipped, so the draft KV never advances past whatever the prompt left there. And the drafting loop takes the shared-memory branch, which places every draft token at `dp.n_past` instead of `dp.n_past + i + 1`. The head drafts from stale state at pinned positions. It still mostly works, because `eh_proj` keeps feeding it fresh hidden rows from the trunk, but acceptance pays for it on any text the head cannot guess from the embedding alone.

The fix asks the memory instead of the context graph. `llama_kv_cache` already knows the answer: it adopts the source cache's `v_cells_impl` exactly when it was constructed over a non-null `mem_other`. This PR exposes that as `llama_memory_has_shared_cells()`. Default false on `llama_memory_i`, `other != nullptr` on `llama_kv_cache`, an OR over base and swa on `llama_kv_cache_iswa`. `speculative.cpp` then reads the property that the branch actually depends on. Gemma4-assistant keeps its shared path, since its iswa cache is built over the target's memory with a share callback. Separate-KV MTP gets its catch-up decode and its real positions back.

Measured on Qwen3.8-27B UD-Q4_K_M with the embedded MTP head, `--spec-type draft-mtp --spec-draft-n-max 2`, CPU backend, 16 threads, warm page cache, single runs:

| | master | this PR |
|---|---|---|
| extraction prompt, acceptance | 1.000 (266/266), mean len 3.00 | 1.000 (266/266), mean len 3.00 |
| prose prompt, acceptance | 0.597 (108/181), mean len 2.19 | 0.675 (114/169), mean len 2.34 |
| prose, decode t/s | 2.93 | 3.23 |

Extraction was already saturated and does not move, which also says the restored catch-up decode costs nothing visible. Prose acceptance rises about eight points. I saw the same shape on a second separate-KV MTP arch running locally, where the prose acceptance floor went from 0.65 to 0.80 with this change and nothing else.

One caveat. I have no Gemma4-assistant pair on this machine, so the shared path is argued from construction rather than re-measured: its cache is built over `mem_other`, the new predicate returns true, the branch behavior is unchanged. A quick run from someone with that setup would be welcome.
