### PR TITLE
HIP: Fix Flash Attention max_blocks_per_sm assertion crash on RDNA2 (#23310)

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -1111,7 +1111,14 @@ void launch_fattn(
     const dim3 block_dim(warp_size, nwarps, 1);
     int max_blocks_per_sm = 1; // Max. number of active blocks limited by occupancy.
     CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&max_blocks_per_sm, fattn_kernel, block_dim.x * block_dim.y * block_dim.z, nbytes_shared));
-    GGML_ASSERT(max_blocks_per_sm > 0);
+    #if defined(GGML_USE_HIP)
+        if (max_blocks_per_sm <= 0) {
+            GGML_LOG_WARN("cudaOccupancyMaxActiveBlocksPerMultiprocessor returned %d, falling back to 1\n", max_blocks_per_sm);
+            max_blocks_per_sm = 1;
+        }
+    #else
+        GGML_ASSERT(max_blocks_per_sm > 0);
+    #endif
     int parallel_blocks = max_blocks_per_sm;
 
     const int ntiles_KV = (K->ne[1] + nbatch_fa - 1) / nbatch_fa; // Max. number of parallel blocks limited by KV cache length.


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Ok so from what I understand, this bypasses the current limitation in which the V620 is asked to fit in a 256 attention head and allows flash attention to load on RDNA2 cards with qwen 3.8 flash next. 

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
* Used the code from `@Minerest` in Discussion #23310.
* Tested on physical hardware: Dual AMD Radeon Pro V620 (gfx1030) with 64 GB total VRAM. 
* Before the patch, standard attention caused a 3 GB memory spike around 44k tokens, which with my specific quant caused OOM
* With the patch, Flash Attention launched successfully, and I got to 100k+ tokens at Q8_0 kv cache with barely any increase in vram!! YAY!!!
* Ok so long story short I am very very new to this, but was so excited that AI helped me get this workign and thought it would be fun to share! If I did anything wrong in submitting this I am sorry, it was completely unintentional. 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used an AI assistant to help identify the C++ compiler guards for the HIP fix and to organize the structure of this pull request, but I executed all hardware testing manually and wrote this description in my own words.