### PR TITLE
mtmd : add optional Hailo NPU vision encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Instructions for adding support for new models: [HOWTO-add-model.md](docs/develo
 | [RPC](https://github.com/ggml-org/llama.cpp/tree/master/tools/rpc) | All |
 | [Hexagon [In Progress]](docs/backend/snapdragon/README.md) | Snapdragon |
 | [VirtGPU](docs/backend/VirtGPU.md) | VirtGPU APIR |
+| [Hailo NPU (vision encoder)](docs/multimodal-hailo.md) | Hailo-8 |
 
 ## Obtaining and quantizing models
 

--- a/docs/multimodal-hailo.md
+++ b/docs/multimodal-hailo.md
@@ -1,0 +1,54 @@
+# Hailo NPU vision backend
+
+This backend offloads the multimodal vision encoder (CLIP/ViT) to a Hailo NPU.
+Everything else — text decode, sampling, server — keeps running on CPU exactly as upstream.
+Currently only Qwen3-VL is supported.
+
+## Prerequisites
+
+- HailoRT installed.
+  See the [HailoRT install guide](https://hailo.ai/developer-zone/documentation/).
+- An `hef` file for your VLM, produced by Hailo's Dataflow Compiler.
+
+## Build
+
+```bash
+cmake -B build -DLLAMA_HAILO=ON -DGGML_NATIVE=ON
+cmake --build build -j$(nproc)
+```
+
+`LLAMA_HAILO` defaults to `OFF`; with it off, no Hailo code is compiled and behavior is unchanged from upstream.
+
+## Usage
+
+Across every interface, the integration point is the same: pass the `.hef` wherever you would normally pass the mmproj GGUF.
+
+### Command line
+
+```bash
+./build/bin/llama-mtmd-cli \
+    -m model.gguf \
+    --mmproj /path/to/encoder.hef \
+    --image photo.jpg \
+    -p "Describe this image"
+```
+
+### Server
+
+```bash
+./build/bin/llama-server \
+    -m model.gguf \
+    --mmproj /path/to/encoder.hef \
+    --host 127.0.0.1 --port 8080
+```
+
+### C++
+
+```cpp
+#include "mtmd.h"
+
+mtmd_context_params params = mtmd_context_params_default();
+mtmd_context * ctx = mtmd_init_from_file("/path/to/encoder.hef", llama_model, params);
+```
+
+See `tools/mtmd/mtmd-cli.cpp` for a full embedding example.

--- a/tools/mtmd/CMakeLists.txt
+++ b/tools/mtmd/CMakeLists.txt
@@ -2,6 +2,19 @@
 
 find_package(Threads REQUIRED)
 
+# Optional Hailo-NPU vision backend.
+# When enabled, links against HailoRT and compiles tools/mtmd/hailo/.
+# Set via -DLLAMA_HAILO=ON.
+option(LLAMA_HAILO "build mtmd with optional Hailo NPU vision backend" OFF)
+set(MTMD_HAILO_SOURCES "")
+if (LLAMA_HAILO)
+    find_package(HailoRT REQUIRED)
+    message(STATUS "mtmd: Hailo backend enabled (HailoRT ${HailoRT_VERSION})")
+    set(MTMD_HAILO_SOURCES
+        hailo/hailo_encoder.hpp
+        hailo/hailo_encoder.cpp)
+endif()
+
 add_library(mtmd
             mtmd.cpp
             mtmd-audio.cpp
@@ -41,6 +54,7 @@ add_library(mtmd
             models/mobilenetv5.cpp
             models/youtuvl.cpp
             models/yasa2.cpp
+            ${MTMD_HAILO_SOURCES}
             )
 
 set_target_properties(mtmd PROPERTIES
@@ -55,6 +69,11 @@ target_include_directories(mtmd PUBLIC  .)
 target_include_directories(mtmd PRIVATE ../..)
 target_include_directories(mtmd PRIVATE ../../vendor)
 target_compile_features   (mtmd PRIVATE cxx_std_17)
+
+if (LLAMA_HAILO)
+    target_compile_definitions(mtmd PRIVATE LLAMA_USE_HAILO)
+    target_link_libraries     (mtmd PRIVATE HailoRT::libhailort)
+endif()
 
 if (BUILD_SHARED_LIBS)
     set_target_properties     (mtmd PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/tools/mtmd/README.md
+++ b/tools/mtmd/README.md
@@ -2,6 +2,14 @@
 
 This directory provides multimodal capabilities for `llama.cpp`. Initially intended as a showcase for running LLaVA models, its scope has expanded significantly over time to include various other vision-capable models. As a result, LLaVA is no longer the only multimodal architecture supported.
 
+> **Optional Hailo NPU vision backend:** if you have a Hailo accelerator
+> (e.g. Hailo-8 on Raspberry Pi 5) and a compiled HEF for your VLM, you can
+> off-load the vision encoder for faster image encode. Build with
+> `cmake -DLLAMA_HAILO=ON` and pass the `.hef` directly as `--mmproj`
+> (the existing flag accepts both GGUF and HEF). See
+> [docs/multimodal-hailo.md](../../docs/multimodal-hailo.md). Disabled by
+> default — non-Hailo users see no change.
+
 > [!IMPORTANT]
 >
 > Multimodal support can be viewed as a sub-project within `llama.cpp`. It is under **very heavy development**, and **breaking changes are expected**.

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -362,6 +362,19 @@ static projector_type clip_projector_type_from_string(const std::string & str) {
     return PROJECTOR_TYPE_UNKNOWN;
 }
 
+#ifdef LLAMA_USE_HAILO
+// Minimal clip_ctx for the Hailo path: no GGUF loaded, no tensors populated.
+struct clip_ctx * clip_init_hailo(
+    enum projector_type proj_type,
+    int32_t             max_image_edge,
+    int32_t             patch_size,
+    int32_t             spatial_merge_size,
+    int32_t             n_embd_per_stream,
+    int32_t             n_deepstack_layers,
+    const float         image_mean[3],
+    const float         image_std[3]);
+#endif
+
 // RGB uint8 image
 struct clip_image_u8 {
     int nx;

--- a/tools/mtmd/clip-model.h
+++ b/tools/mtmd/clip-model.h
@@ -293,6 +293,9 @@ struct clip_model {
     clip_modality modality = CLIP_MODALITY_VISION;
     projector_type proj_type = PROJECTOR_TYPE_MLP;
     clip_hparams hparams;
+#ifdef LLAMA_USE_HAILO
+    bool hailo_backend = false;
+#endif
 
     // embeddings
     ggml_tensor * class_embedding = nullptr;

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2831,6 +2831,46 @@ void clip_free(clip_ctx * ctx) {
     delete ctx;
 }
 
+#ifdef LLAMA_USE_HAILO
+struct clip_ctx * clip_init_hailo(
+    enum projector_type proj_type,
+    int32_t             max_image_edge,
+    int32_t             patch_size,
+    int32_t             spatial_merge_size,
+    int32_t             n_embd_per_stream,
+    int32_t             n_deepstack_layers,
+    const float         image_mean[3],
+    const float         image_std[3]) {
+
+    clip_context_params ctx_params{};
+    auto * ctx = new clip_ctx(ctx_params);
+
+    if (proj_type != PROJECTOR_TYPE_QWEN3VL) {
+        LOG_ERR("%s: only PROJECTOR_TYPE_QWEN3VL is supported, got %d\n", __func__, static_cast<int>(proj_type));
+        clip_free(ctx);
+        return nullptr;
+    }
+
+    ctx->model.proj_type          = proj_type;
+    ctx->model.modality           = CLIP_MODALITY_VISION;
+    ctx->model.n_deepstack_layers = n_deepstack_layers;
+    ctx->model.hailo_backend      = true;
+
+    auto & hp = ctx->model.hparams;
+    hp.image_size         = max_image_edge;
+    hp.patch_size         = patch_size;
+    hp.n_embd             = n_embd_per_stream;
+    hp.projection_dim     = n_embd_per_stream;
+    hp.n_merge            = spatial_merge_size;
+    hp.image_resize_algo  = RESIZE_ALGO_BILINEAR;
+    hp.warmup_image_size  = max_image_edge;
+    hp.image_mean[0] = image_mean[0]; hp.image_mean[1] = image_mean[1]; hp.image_mean[2] = image_mean[2];
+    hp.image_std[0]  = image_std[0];  hp.image_std[1]  = image_std[1];  hp.image_std[2]  = image_std[2];
+
+    return ctx;
+}
+#endif
+
 // deprecated
 size_t clip_embd_nbytes(const struct clip_ctx * ctx) {
     const int32_t nx = ctx->model.hparams.image_size;
@@ -3806,6 +3846,13 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
             return ctx->model.mm_1_b->ne[0];
         case PROJECTOR_TYPE_QWEN3VL:
             // main path + deepstack paths
+#ifdef LLAMA_USE_HAILO
+            // Hailo HEF replaces ViT + projector, so mm_* tensors are not loaded.
+            // Read the dim from hparams.n_embd (saved from HEF metadata at init).
+            if (ctx->model.hailo_backend) {
+                return ctx->model.hparams.n_embd * (1 + ctx->model.n_deepstack_layers);
+            }
+#endif
             return ctx->model.mm_1_b->ne[0] * (1 + ctx->model.n_deepstack_layers);
         case PROJECTOR_TYPE_STEP3VL:
             return ctx->model.mm_model_proj->ne[1];

--- a/tools/mtmd/hailo/hailo_encoder.cpp
+++ b/tools/mtmd/hailo/hailo_encoder.cpp
@@ -1,0 +1,488 @@
+#include "hailo_encoder.hpp"
+#include "clip-impl.h"
+
+#include <hailo/vdevice.hpp>
+#include <hailo/infer_model.hpp>
+#include <hailo/buffer.hpp>
+#include <hailo/expected.hpp>
+#include <hailo/hef.hpp>
+#include <hailo/hailort.h>
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#define HAILO_CONFIG_RESOURCE        "hailo-config.json"
+#define HAILO_OUTPUT_LAYERS_KEY      "encoder_output_layers_names_suffixes"
+#define HAILO_PATCH_SIZE_KEY         "patch_size"
+#define HAILO_SPATIAL_MERGE_SIZE_KEY "spatial_merge_size"
+// inner-dict keys under HAILO_OUTPUT_LAYERS_KEY
+#define HAILO_LAYER_IMAGE_EMBEDDINGS "image_embeddings"
+#define HAILO_LAYER_DEEPSTACK_PREFIX "deepstack_layer_"
+
+namespace hailo_mtmd {
+
+static constexpr auto HAILO_ENCODE_TIMEOUT = std::chrono::seconds(10);
+// one slot per prefetch plus one kept clear for a needed-now encode. fewer slots lowers the
+// prefetch depth too, and at depth 1 nothing overlaps
+static constexpr uint32_t HAILO_SLOTS = 3;
+static constexpr uint32_t HAILO_PREFETCH_DEPTH = 2;
+
+// a queued job only starts once those ahead of it finish, so a wait covers the whole queue
+static constexpr auto HAILO_WAIT_TIMEOUT = HAILO_ENCODE_TIMEOUT * (HAILO_PREFETCH_DEPTH + 1);
+
+static std::atomic<uint64_t> g_next_request_id{NO_REQUEST_ID + 1};
+
+// Async inference callback result
+struct SlotSync {
+    std::atomic<bool> done{false};
+    hailo_status      status = HAILO_SUCCESS;   // only meaningful once done is set
+};
+
+struct EncodeSlot {
+    hailort::ConfiguredInferModel::Bindings bindings;
+    hailort::Buffer                         input;
+    std::vector<hailort::Buffer>            outputs;   // by stream slot [main, ds_1 .. ds_3]
+    hailort::AsyncInferJob                  job;
+
+    uint64_t                   id = NO_REQUEST_ID;
+    std::shared_ptr<SlotSync>  sync;
+
+    // only a device that stops signalling entirely gets here; ordinary errors complete with a bad
+    // status instead. the device may still write these buffers, so never reused
+    bool stuck = false;
+
+    bool occupied() const { return stuck || id != NO_REQUEST_ID; }
+    bool running()  const { return !stuck && id != NO_REQUEST_ID && !sync->done.load(std::memory_order_acquire); }
+    bool finished() const { return !stuck && id != NO_REQUEST_ID &&  sync->done.load(std::memory_order_acquire); }
+};
+
+struct HailoVisionEncoder::Impl {
+    // declared first so it is destroyed last: the device has to be gone before these DMA buffers are
+    // freed, or a transfer still in flight would land in memory the allocator has handed on
+    std::vector<EncodeSlot> slots;
+
+    std::unique_ptr<hailort::VDevice> vdevice;
+    std::shared_ptr<hailort::InferModel> infer_model;
+    hailort::ConfiguredInferModel configured;
+
+    // only for terminal failure: run_async shuts the model down internally, leaving nothing to retry against
+    bool failed_already = false;
+
+    uint32_t input_w = 0;
+    uint32_t input_h = 0;
+    size_t input_frame_size = 0;
+    uint32_t n_image_tokens = 0;
+    uint32_t n_embd_per_stream = 0;
+    uint32_t n_streams = 0;
+    uint32_t patch_size = 0;
+    uint32_t spatial_merge_size = 0;
+
+    uint32_t prefetch_depth = 0;
+    size_t   n_stuck = 0;
+
+    bool model_configured = false;
+
+    Impl() = default;
+
+    // submitted and not yet complete, i.e. how much the device already has to chew on
+    uint32_t n_running() const {
+        uint32_t n = 0;
+        for (const auto & s : slots) {
+            n += s.running() ? 1 : 0;
+        }
+        return n;
+    }
+
+    EncodeSlot * pick_free() {
+        for (auto & s : slots) {
+            if (!s.occupied()) {
+                return &s;
+            }
+        }
+        return nullptr;
+    }
+
+    EncodeSlot * pick_oldest(bool (EncodeSlot::*state)() const) {
+        EncodeSlot * oldest = nullptr;
+        for (auto & s : slots) {
+            // ids are handed out in submission order
+            if ((s.*state)() && (oldest == nullptr || s.id < oldest->id)) {
+                oldest = &s;
+            }
+        }
+        return oldest;
+    }
+
+    EncodeSlot * pick_newest(bool (EncodeSlot::*state)() const) {
+        EncodeSlot * newest = nullptr;
+        for (auto & s : slots) {
+            if ((s.*state)() && (newest == nullptr || s.id > newest->id)) {
+                newest = &s;
+            }
+        }
+        return newest;
+    }
+
+    void mark_stuck(EncodeSlot & slot) {
+        slot.stuck = true;
+        slot.id    = NO_REQUEST_ID;
+        if (++n_stuck == slots.size()) {
+            LOG_ERR("HailoVisionEncoder: all %zu encode slots are stuck; no further encodes are possible\n",
+                    slots.size());
+        }
+    }
+
+    EncodeSlot * find_by_request_id(uint64_t id) {
+        if (id == NO_REQUEST_ID) {
+            return nullptr;
+        }
+        for (auto & s : slots) {
+            if (s.id == id) {
+                return &s;
+            }
+        }
+        return nullptr;
+    }
+
+    // `slot` already hold its frame
+    bool start_encode(EncodeSlot & slot, std::chrono::milliseconds ready_timeout) {
+        if (configured.wait_for_async_ready(ready_timeout, 1) != HAILO_SUCCESS) {
+            return false;
+        }
+        slot.sync->done.store(false, std::memory_order_relaxed);
+        slot.id = g_next_request_id.fetch_add(1, std::memory_order_relaxed);
+        auto job = configured.run_async(slot.bindings,
+            [sync = slot.sync](const hailort::AsyncInferCompletionInfo & info) {
+                sync->status = info.status;
+                sync->done.store(true, std::memory_order_release);
+            });
+        if (!job) {
+            slot.id = NO_REQUEST_ID;
+            failed_already = true;
+            LOG_ERR("HailoVisionEncoder: run_async failed; encoder is now unusable\n");
+            return false;
+        }
+        slot.job = job.release();
+        return true;
+    }
+
+    ~Impl() {
+        // detach() is non-blocking; shutdown() below is what stops the device touching our buffers
+        for (auto & s : slots) {
+            if (s.occupied()) {
+                s.job.detach();
+            }
+        }
+        if (!model_configured) {
+            return;
+        }
+        const auto status = configured.shutdown();
+        if (status != HAILO_SUCCESS) {
+            // the slots outlive every member below, so the buffers survive until the device is gone
+            LOG_ERR("HailoVisionEncoder: shutdown failed (%d)\n", static_cast<int>(status));
+        }
+    }
+};
+
+// strips the "<network_name>/" prefix from a HEF output stream name and looks
+// up its slot in the config-derived map. throws if the suffix isn't present.
+static int slot_for_output_name(const std::string & name,
+                                const std::unordered_map<std::string, int> & suffix_to_slot)
+{
+    const auto slash = name.find('/');
+    const std::string suffix = (slash == std::string::npos) ? name : name.substr(slash + 1);
+    auto found = suffix_to_slot.find(suffix);
+    if (found == suffix_to_slot.end()) {
+        throw std::runtime_error("HailoVisionEncoder: HEF output stream '" + name
+            + "' has no entry in " HAILO_CONFIG_RESOURCE);
+    }
+    return found->second;
+}
+
+static void validate_output_shapes(const std::shared_ptr<hailort::InferModel> & model)
+{
+    const auto names = model->get_output_names();
+    const auto first_shape = model->output(names[0]).expect("HailoVisionEncoder: output() failed").shape();
+    for (const auto & name : names) {
+        const auto shape = model->output(name).expect("HailoVisionEncoder: output() failed").shape();
+        if (shape.height   != first_shape.height
+         || shape.width    != first_shape.width
+         || shape.features != first_shape.features) {
+            throw std::runtime_error("HailoVisionEncoder: output shape mismatch at '" + name + "'");
+        }
+    }
+}
+
+// transposes per-stream output buffers into the token-major [main | ds0 | ds1 | ...]
+// layout the decoder expects. `streams` is indexed by slot (assignment happens at init).
+static void transpose_to_token_major(const std::vector<hailort::Buffer> & streams,
+                                     float * output_buffer,
+                                     uint32_t n_tokens,
+                                     uint32_t n_embd_per_stream)
+{
+    const uint32_t n_embd_inp = n_embd_per_stream * static_cast<uint32_t>(streams.size());
+    for (size_t slot = 0; slot < streams.size(); ++slot) {
+        const float * src = reinterpret_cast<const float *>(streams[slot].data());   // [n_tokens * n_embd]
+        for (uint32_t t = 0; t < n_tokens; ++t) {
+            float * dst = output_buffer + t * n_embd_inp + slot * n_embd_per_stream;
+            std::memcpy(dst, src + t * n_embd_per_stream, n_embd_per_stream * sizeof(float));
+        }
+    }
+}
+
+static hailort::Buffer load_hef_to_buffer(const std::string & hef_path)
+{
+    std::ifstream hef_file(hef_path, std::ios::binary | std::ios::ate);
+    if (!hef_file) {
+        throw std::runtime_error("HailoVisionEncoder: cannot open HEF '" + hef_path + "'");
+    }
+    const std::streamsize hef_size = hef_file.tellg();
+    hef_file.seekg(0, std::ios::beg);
+    auto blob = hailort::Buffer::create(static_cast<size_t>(hef_size))
+        .expect("HailoVisionEncoder: hef Buffer::create failed");
+    if (!hef_file.read(reinterpret_cast<char *>(blob.data()), hef_size)) {
+        throw std::runtime_error("HailoVisionEncoder: failed to read HEF '" + hef_path + "'");
+    }
+    return blob;
+}
+
+// reads the hailo-config.json blob embedded in the HEF and parses it.
+static nlohmann::json read_hailo_config(const std::shared_ptr<hailort::InferModel> & model)
+{
+    auto view = model->hef().get_external_resources(HAILO_CONFIG_RESOURCE)
+        .expect("HailoVisionEncoder: HEF is missing required external resource '" HAILO_CONFIG_RESOURCE "'");
+    try {
+        return nlohmann::json::parse(reinterpret_cast<const char *>(view.data()),
+                                     reinterpret_cast<const char *>(view.data()) + view.size());
+    } catch (const std::exception & e) {
+        throw std::runtime_error(
+            std::string("HailoVisionEncoder: failed to parse ") + HAILO_CONFIG_RESOURCE + ": " + e.what());
+    }
+}
+
+HailoVisionEncoder::HailoVisionEncoder(const std::string & hef_path)
+    : pimpl(new Impl())
+{
+    pimpl->vdevice = hailort::VDevice::create().expect("HailoVisionEncoder: VDevice::create failed");
+
+    // reads the HEF file into a buffer in order to read the external resources
+    const auto hef_blob = load_hef_to_buffer(hef_path);
+    pimpl->infer_model = pimpl->vdevice->create_infer_model(
+        hailort::MemoryView::create_const(hef_blob.data(), hef_blob.size())
+    ).expect("HailoVisionEncoder: create_infer_model failed for '" + hef_path + "'");
+
+    const auto output_names = pimpl->infer_model->get_output_names();
+    if (output_names.size() != 4) {
+        throw std::runtime_error("HailoVisionEncoder: HEF must have exactly 4 outputs, but got " + std::to_string(output_names.size()));
+    }
+
+    auto input = pimpl->infer_model->input().expect("HailoVisionEncoder: input() failed");
+    const auto in_shape = input.shape();
+    pimpl->input_h = in_shape.height;
+    pimpl->input_w = in_shape.width;
+    pimpl->input_frame_size = input.get_frame_size();
+
+    validate_output_shapes(pimpl->infer_model);
+    const auto output_shape = pimpl->infer_model->output(output_names[0]).expect("HailoVisionEncoder: output(" + output_names[0] + ") failed").shape();
+    pimpl->n_image_tokens = output_shape.height * output_shape.width;
+    pimpl->n_embd_per_stream = output_shape.features;
+    pimpl->n_streams = static_cast<uint32_t>(output_names.size());
+
+    const auto hailo_config = read_hailo_config(pimpl->infer_model);
+    pimpl->patch_size = hailo_config.at(HAILO_PATCH_SIZE_KEY).get<uint32_t>();
+    pimpl->spatial_merge_size = hailo_config.at(HAILO_SPATIAL_MERGE_SIZE_KEY).get<uint32_t>();
+
+    // slot order is fixed by the decoder: [image_embeddings, deepstack_1, deepstack_2, deepstack_3].
+    const auto & layers = hailo_config.at(HAILO_OUTPUT_LAYERS_KEY);
+    const std::pair<const char *, int> layer_slots[] = {
+        { HAILO_LAYER_IMAGE_EMBEDDINGS,     0 },
+        { HAILO_LAYER_DEEPSTACK_PREFIX "1", 1 },
+        { HAILO_LAYER_DEEPSTACK_PREFIX "2", 2 },
+        { HAILO_LAYER_DEEPSTACK_PREFIX "3", 3 },
+    };
+    std::unordered_map<std::string, int> suffix_to_slot;
+    for (const auto & [key, slot] : layer_slots) {
+        const auto suffix = layers.at(key).get<std::string>();
+        // a repeat would collapse two layers onto one slot, leaving slot.outputs short of its indices
+        if (!suffix_to_slot.emplace(suffix, slot).second) {
+            throw std::runtime_error(std::string("HailoVisionEncoder: ") + key + " suffix '" + suffix
+                + "' is already used by another layer in " HAILO_CONFIG_RESOURCE);
+        }
+    }
+
+    for (const auto & name : output_names) {
+        pimpl->infer_model->output(name).expect("HailoVisionEncoder: output(" + name + ") failed")
+            .set_format_type(HAILO_FORMAT_TYPE_FLOAT32);
+    }
+
+    pimpl->configured = pimpl->infer_model->configure().expect("HailoVisionEncoder: configure failed");
+    pimpl->model_configured = true;
+
+    // the device queue is the hard ceiling: run_async past it shuts the model down for good
+    const auto queue_size = pimpl->configured.get_async_queue_size();
+    const uint32_t n_slots = queue_size
+        ? std::max<uint32_t>(1, std::min<uint32_t>(HAILO_SLOTS, static_cast<uint32_t>(queue_size.value())))
+        : 1;
+    pimpl->prefetch_depth = std::min(HAILO_PREFETCH_DEPTH, n_slots - 1);
+    LOG_INF("HailoVisionEncoder: %u encode slot(s), prefetch depth %u, device async queue %s\n",
+            n_slots, pimpl->prefetch_depth,
+            queue_size ? std::to_string(queue_size.value()).c_str() : "unknown");
+
+    // bound once, so no buffer is ever rebound while the device may be reading it
+    pimpl->slots.resize(n_slots);
+    for (auto & slot : pimpl->slots) {
+        slot.sync = std::make_shared<SlotSync>();
+        slot.bindings = pimpl->configured.create_bindings().expect("HailoVisionEncoder: create_bindings failed");
+
+        slot.input = hailort::Buffer::create(pimpl->input_frame_size, hailort::BufferStorageParams::create_dma())
+            .expect("HailoVisionEncoder: input Buffer::create failed");
+        auto input_bind = slot.bindings.input().expect("HailoVisionEncoder: bindings.input failed");
+        const auto in_st = input_bind.set_buffer(hailort::MemoryView(slot.input.data(), slot.input.size()));
+        if (HAILO_SUCCESS != in_st) {
+            throw std::runtime_error("HailoVisionEncoder: input set_buffer failed (" + std::to_string(in_st) + ")");
+        }
+
+        // per-slot outputs
+        slot.outputs.resize(suffix_to_slot.size());
+        for (const auto & output : pimpl->infer_model->outputs()) {
+            const std::string name = output.name();
+            const int out_slot = slot_for_output_name(name, suffix_to_slot);
+
+            auto buffer = hailort::Buffer::create(output.get_frame_size(), hailort::BufferStorageParams::create_dma()).expect("HailoVisionEncoder: Buffer::create failed");
+            auto output_bind = slot.bindings.output(name).expect("HailoVisionEncoder: bindings.output failed");
+            auto out_st = output_bind.set_buffer(hailort::MemoryView(buffer.data(), buffer.size()));
+            if (HAILO_SUCCESS != out_st) {
+                throw std::runtime_error("HailoVisionEncoder: output set_buffer failed (" + std::to_string(out_st) + ")");
+            }
+            slot.outputs[out_slot] = std::move(buffer);
+        }
+    }
+}
+
+HailoVisionEncoder::SubmitStatus HailoVisionEncoder::try_submit(uint64_t & req_id, const uint8_t * input_img,
+                                                                size_t n_bytes)
+{
+    req_id = NO_REQUEST_ID;
+    // checked before failed_already so a bad frame is reported as such even on a dead encoder
+    if (input_img == nullptr || n_bytes != pimpl->input_frame_size) {
+        return SubmitStatus::unsupported;
+    }
+    if (pimpl->failed_already) {
+        return SubmitStatus::busy;
+    }
+    if (pimpl->n_running() >= pimpl->prefetch_depth) {
+        return SubmitStatus::busy;   // more depth than a one-frame-at-a-time device can use
+    }
+
+    // free slots only - recycling a finished result would discard work its owner is about to collect
+    EncodeSlot * slot = pimpl->pick_free();
+    if (slot == nullptr) {
+        return SubmitStatus::busy;
+    }
+
+    // the frame must outlive this call and the chunk it came from need not - a released server slot frees
+    // it while the device is still reading, so the encode gets its own slot-owned copy
+    std::memcpy(slot->input.data(), input_img, pimpl->input_frame_size);
+    // zero timeout keeps this speculative call non-blocking; a busy pipeline just declines
+    if (!pimpl->start_encode(*slot, std::chrono::milliseconds(0))) {
+        return SubmitStatus::busy;
+    }
+    req_id = slot->id;
+    return SubmitStatus::started;
+}
+
+bool HailoVisionEncoder::submit(uint64_t & req_id, const uint8_t * input_img, size_t n_bytes)
+{
+    req_id = NO_REQUEST_ID;
+    if (pimpl->failed_already || input_img == nullptr || n_bytes != pimpl->input_frame_size) {
+        return false;
+    }
+
+    EncodeSlot * slot = pimpl->pick_free();
+    if (slot == nullptr) {
+        // taking over a slot costs its owner a re-encode either way, so pick the cheapest: a finished one
+        // needs no wait, newest first since it is wanted last. else wait on the job nearest the queue head
+        slot = pimpl->pick_newest(&EncodeSlot::finished);
+        if (slot == nullptr) {
+            slot = pimpl->pick_oldest(&EncodeSlot::running);
+            if (slot == nullptr) {
+                return false;   // every slot is stuck
+            }
+            if (slot->job.wait(HAILO_WAIT_TIMEOUT) != HAILO_SUCCESS) {
+                LOG_ERR("HailoVisionEncoder: encode slot did not free up\n");
+                pimpl->mark_stuck(*slot);
+                return false;
+            }
+        }
+    }
+
+    // the frame must outlive this call and the chunk it came from need not - a released server slot frees
+    // it while the device is still reading, so the encode gets its own slot-owned copy
+    std::memcpy(slot->input.data(), input_img, pimpl->input_frame_size);
+    if (!pimpl->start_encode(*slot, HAILO_ENCODE_TIMEOUT)) {
+        LOG_ERR("HailoVisionEncoder: pipeline did not free up for a new encode\n");
+        return false;
+    }
+    req_id = slot->id;
+    return true;
+}
+
+bool HailoVisionEncoder::wait(uint64_t & req_id, float * output_buffer)
+{
+    if (output_buffer == nullptr) {
+        LOG_ERR("HailoVisionEncoder: wait() called with no output buffer\n");
+        return false;   // the request is untouched and still collectable
+    }
+    EncodeSlot * slot = pimpl->find_by_request_id(req_id);
+    if (slot == nullptr) {
+        req_id = NO_REQUEST_ID;   // no slot honours this id, so its owner has to submit again
+        return false;
+    }
+    if (slot->job.wait(HAILO_WAIT_TIMEOUT) != HAILO_SUCCESS) {
+        // poison the slot, not the encoder: killing it here would turn a retry into endless failures
+        LOG_ERR("HailoVisionEncoder: encode did not complete within %lld s; slot taken out of service\n",
+                static_cast<long long>(
+                    std::chrono::duration_cast<std::chrono::seconds>(HAILO_WAIT_TIMEOUT).count()));
+        pimpl->mark_stuck(*slot);
+        req_id = NO_REQUEST_ID;
+        return false;
+    }
+    const auto status = slot->sync->status;
+    slot->id = NO_REQUEST_ID;
+    req_id = NO_REQUEST_ID;
+    if (status != HAILO_SUCCESS) {
+        LOG_ERR("HailoVisionEncoder: encode ended with status %d\n", static_cast<int>(status));
+        return false;
+    }
+    transpose_to_token_major(slot->outputs, output_buffer,
+                             pimpl->n_image_tokens, pimpl->n_embd_per_stream);
+    return true;
+}
+
+bool HailoVisionEncoder::owns(uint64_t req_id) const
+{
+    return pimpl->find_by_request_id(req_id) != nullptr;
+}
+
+
+uint32_t HailoVisionEncoder::input_w() const { return pimpl->input_w; }
+uint32_t HailoVisionEncoder::input_h() const { return pimpl->input_h; }
+uint32_t HailoVisionEncoder::n_image_tokens() const { return pimpl->n_image_tokens; }
+uint32_t HailoVisionEncoder::n_embd_per_stream() const { return pimpl->n_embd_per_stream; }
+uint32_t HailoVisionEncoder::n_streams() const { return pimpl->n_streams; }
+uint32_t HailoVisionEncoder::n_embd_inp() const { return pimpl->n_embd_per_stream * pimpl->n_streams; }
+uint32_t HailoVisionEncoder::patch_size() const { return pimpl->patch_size; }
+uint32_t HailoVisionEncoder::spatial_merge_size() const { return pimpl->spatial_merge_size; }
+HailoVisionEncoder::~HailoVisionEncoder() = default;
+
+} // namespace hailo_mtmd

--- a/tools/mtmd/hailo/hailo_encoder.hpp
+++ b/tools/mtmd/hailo/hailo_encoder.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace hailo_mtmd {
+
+constexpr uint64_t NO_REQUEST_ID = 0;
+
+class HailoVisionEncoder {
+public:
+    explicit HailoVisionEncoder(const std::string & hef_path);
+    ~HailoVisionEncoder();
+
+    HailoVisionEncoder(const HailoVisionEncoder &) = delete;
+    HailoVisionEncoder & operator=(const HailoVisionEncoder &) = delete;
+
+    enum class SubmitStatus { started, busy, unsupported };
+
+    // start encoding a frame; `req_id` receives the id that later collects the result.
+    // input_img must hold exactly one HEF input frame and is copied, so it need not outlive the call
+    // try_submit() is speculative: never blocks, and declines rather than disturb a pending result
+    // submit() is for a result needed now: may recycle a finished slot, or wait for one
+    SubmitStatus try_submit(uint64_t & req_id, const uint8_t * input_img, size_t n_bytes);
+    bool         submit    (uint64_t & req_id, const uint8_t * input_img, size_t n_bytes);
+
+    // wait for the encode, transpose into output_buffer, free the slot and clear `req_id`
+    // only valid for an id the encoder still owns - check owns() first, the slot may have been recycled
+    bool wait(uint64_t & req_id, float * output_buffer);
+
+    bool owns(uint64_t req_id) const;
+
+    uint32_t input_w() const;
+    uint32_t input_h() const;
+    uint32_t n_image_tokens() const;
+    uint32_t n_embd_per_stream() const;
+    uint32_t n_streams() const;
+    uint32_t n_embd_inp() const;
+    uint32_t patch_size() const;
+    uint32_t spatial_merge_size() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl;
+};
+
+} // namespace hailo_mtmd

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -401,6 +401,26 @@ int32_t mtmd_helper_eval_chunks(mtmd_context * ctx,
         return 0;
     }
 
+    // images in eval order; re-passing a decoded one would re-submit it, so the window only advances
+    std::vector<mtmd_input_chunk *> prefetch_images;
+    size_t prefetch_next = 0;
+    if (mtmd_supports_prefetch(ctx)) {
+        for (size_t i = 0; i < n_chunks; i++) {
+            auto * c = mtmd_input_chunks_get(chunks, i);
+            if (mtmd_input_chunk_get_type(c) == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+                // the chunks are not const - only this accessor's return type is
+                prefetch_images.push_back(const_cast<mtmd_input_chunk *>(c));
+            }
+        }
+    }
+    auto prefetch_top_up = [&]() {
+        if (prefetch_next < prefetch_images.size()) {
+            mtmd_encode_prefetch(ctx, prefetch_images.data() + prefetch_next,
+                                 prefetch_images.size() - prefetch_next);
+        }
+    };
+    prefetch_top_up();
+
     for (size_t i = 0; i < n_chunks; i++) {
         bool chunk_logits_last = (i == n_chunks - 1) && logits_last;
         auto chunk = mtmd_input_chunks_get(chunks, i);
@@ -411,6 +431,12 @@ int32_t mtmd_helper_eval_chunks(mtmd_context * ctx,
             return res;
         }
         *new_n_past = n_past;
+
+        // topping up right after an image frees a slot is what lets the next one run during its decode
+        if (prefetch_next < prefetch_images.size() && prefetch_images[prefetch_next] == chunk) {
+            ++prefetch_next;
+            prefetch_top_up();
+        }
     }
 
     return 0;

--- a/tools/mtmd/mtmd-image.cpp
+++ b/tools/mtmd/mtmd-image.cpp
@@ -560,6 +560,10 @@ private:
     }
 };
 
+void mtmd_resize_image_u8(const clip_image_u8 & src, clip_image_u8 & dst, int target_width, int target_height) {
+    img_tool::resize(src, dst, {target_width, target_height}, RESIZE_ALGO_BILINEAR, /*add_padding=*/false);
+}
+
 
 //
 // mtmd_image_preprocessor_llava_uhd

--- a/tools/mtmd/mtmd-image.h
+++ b/tools/mtmd/mtmd-image.h
@@ -8,6 +8,8 @@
 
 #define MTMD_INTERNAL_HEADER
 
+void mtmd_resize_image_u8(const clip_image_u8 & src, clip_image_u8 & dst, int target_width, int target_height);
+
 // base class, models must inherit from this class
 struct mtmd_image_preprocessor {
     const clip_hparams & hparams;

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -7,6 +7,10 @@
 
 #include "llama.h"
 
+#ifdef LLAMA_USE_HAILO
+#include "hailo/hailo_encoder.hpp"
+#endif
+
 // fix problem with std::min and std::max
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
@@ -21,7 +25,39 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <fstream>
 #include <vector>
+
+#ifdef LLAMA_USE_HAILO
+// returns true if `path` looks like a Hailo .hef file — by suffix or, failing
+// that, by the 4-byte HEF magic (0x01 'H' 'E' 'F'). suffix check first to avoid
+// opening every non-HEF mmproj.
+static bool mtmd_is_path_hef(const char * path) {
+    if (path == nullptr) {
+        return false;
+    }
+
+    static constexpr char HEF_SUFFIX[] = ".hef";
+    static constexpr char HEF_MAGIC[]  = "\x01HEF";
+    constexpr size_t HEF_SUFFIX_LEN = sizeof(HEF_SUFFIX) - 1;  // exclude null terminator
+    constexpr size_t HEF_MAGIC_LEN  = sizeof(HEF_MAGIC)  - 1;
+
+    const std::string s = path;
+    if (s.size() >= HEF_SUFFIX_LEN
+            && s.compare(s.size() - HEF_SUFFIX_LEN, HEF_SUFFIX_LEN, HEF_SUFFIX) == 0) {
+        return true;
+    }
+
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        return false;
+    }
+    char buf[HEF_MAGIC_LEN] = {};
+    f.read(buf, HEF_MAGIC_LEN);
+    return (f.gcount() == static_cast<std::streamsize>(HEF_MAGIC_LEN))
+        && (std::memcmp(buf, HEF_MAGIC, HEF_MAGIC_LEN) == 0);
+}
+#endif
 
 // represents raw image data, layout is RGBRGBRGB...
 // length of data must be nx * ny * 3
@@ -55,6 +91,13 @@ struct mtmd_image_tokens {
     clip_image_f32_batch batch_f32; // preprocessed image patches
     std::string id; // optional user-defined ID, useful for KV cache tracking
 
+#ifdef LLAMA_USE_HAILO
+    std::vector<unsigned char> hailo_input;   // raw RGB bytes at HEF input dims
+
+    // collects this image's encode; not copied by clone(), or two chunks would share one id
+    uint64_t hailo_encode_request_id = hailo_mtmd::NO_REQUEST_ID;
+#endif
+
     mtmd_image_tokens clone() {
         return mtmd_image_tokens{
             nx,
@@ -62,7 +105,11 @@ struct mtmd_image_tokens {
             pos,
             image_idx,
             batch_f32.clone(),
-            id
+            id,
+#ifdef LLAMA_USE_HAILO
+            hailo_input,
+            hailo_mtmd::NO_REQUEST_ID,   // not cloned; see the member
+#endif
         };
     }
 };
@@ -137,8 +184,8 @@ mtmd_context_params mtmd_context_params_default() {
 }
 
 struct mtmd_context {
-    struct clip_ctx * ctx_v; // vision
-    struct clip_ctx * ctx_a; // audio
+    struct clip_ctx * ctx_v = nullptr; // vision
+    struct clip_ctx * ctx_a = nullptr; // audio
     const struct llama_model * text_model;
     std::vector<float> image_embd_v; // image embedding vector
 
@@ -173,6 +220,10 @@ struct mtmd_context {
 
     std::unique_ptr<mtmd_audio_preprocessor> audio_preproc;
     std::unique_ptr<mtmd_image_preprocessor> image_preproc;
+
+#ifdef LLAMA_USE_HAILO
+    std::unique_ptr<hailo_mtmd::HailoVisionEncoder> hailo;  // set when --mmproj is a .hef
+#endif
 
     // TODO @ngxson : add timings
 
@@ -209,6 +260,14 @@ struct mtmd_context {
             default:
                 throw std::runtime_error(string_format("unsupported decoder rope type: %d\n", decoder_rope_type));
         }
+
+#ifdef LLAMA_USE_HAILO
+        // .hef as --mmproj: HEF-only path, no GGUF loaded
+        if (mtmd_is_path_hef(mmproj_fname)) {
+            init_from_hef(mmproj_fname);
+            return;
+        }
+#endif
 
         clip_context_params ctx_clip_params {
             /* use_gpu           */ ctx_params.use_gpu,
@@ -254,6 +313,42 @@ struct mtmd_context {
             init_audio();
         }
     }
+
+#ifdef LLAMA_USE_HAILO
+    // open the Hailo encoder and pair it with a stub clip_ctx
+    void init_from_hef(const char * hef_path) {
+        hailo = std::make_unique<hailo_mtmd::HailoVisionEncoder>(hef_path);
+        LOG_INF("%s: Hailo encoder loaded from %s\n", __func__, hef_path);
+
+        // no-op normalization; HEF self-quantizes on-chip (values unused on the Hailo path but required by clip_ctx)
+        static const float qwen3_vl_image_mean[3] = {0.0f, 0.0f, 0.0f};
+        static const float qwen3_vl_image_std [3] = {1.0f, 1.0f, 1.0f};
+
+        ctx_v = clip_init_hailo(
+            /* proj_type          */ PROJECTOR_TYPE_QWEN3VL,
+            /* max_image_edge     */ static_cast<int32_t>(std::max(hailo->input_w(), hailo->input_h())),
+            /* patch_size         */ static_cast<int32_t>(hailo->patch_size()),
+            /* spatial_merge_size */ static_cast<int32_t>(hailo->spatial_merge_size()),
+            /* n_embd_per_stream  */ static_cast<int32_t>(hailo->n_embd_per_stream()),
+            /* n_deepstack_layers */ static_cast<int32_t>(hailo->n_streams()) - 1,
+            qwen3_vl_image_mean,
+            qwen3_vl_image_std);
+        if (ctx_v == nullptr) {
+            throw std::runtime_error("clip_init_hailo failed");
+        }
+
+        // same n_embd validation the GGUF path performs
+        const int n_embd_clip = clip_n_mmproj_embd(ctx_v);
+        if (n_embd_text != n_embd_clip) {
+            throw std::runtime_error(string_format(
+                "mismatch between text model (n_embd_inp = %d) and HEF (n_embd_inp = %d).\n",
+                n_embd_text, n_embd_clip));
+        }
+
+        init_vision();
+        image_embd_v.reserve(static_cast<size_t>(hailo->n_image_tokens()) * hailo->n_embd_inp());
+    }
+#endif
 
     void init_vision() {
         GGML_ASSERT(ctx_v != nullptr);
@@ -743,6 +838,38 @@ struct mtmd_tokenizer {
             img_u8->buf.resize(bitmap->data.size());
             std::memcpy(img_u8->buf.data(), bitmap->data.data(), img_u8->nx * img_u8->ny * 3);
 
+#ifdef LLAMA_USE_HAILO
+            if (ctx->hailo) {
+                // Hailo path: the HEF accepts raw uint8 input, so the resize and
+                // token-grid derivation are performed locally rather than via image_preproc.
+                const int in_w = static_cast<int>(ctx->hailo->input_w());
+                const int in_h = static_cast<int>(ctx->hailo->input_h());
+                if ((img_u8->nx != in_w) || (img_u8->ny != in_h)) {
+                    clip_image_u8_ptr resized(clip_image_u8_init());
+                    mtmd_resize_image_u8(*img_u8, *resized, in_w, in_h);
+                    img_u8 = std::move(resized);
+                }
+
+                auto image_tokens = std::make_unique<mtmd_image_tokens>();
+                const uint32_t stride = ctx->hailo->patch_size() * ctx->hailo->spatial_merge_size();
+                image_tokens->nx          = ctx->hailo->input_w() / stride;
+                image_tokens->ny          = ctx->hailo->input_h() / stride;
+                image_tokens->pos         = ctx->pos_type;
+                image_tokens->image_idx   = n_images_added;
+                image_tokens->id          = bitmap->id;
+                image_tokens->hailo_input = std::move(img_u8->buf);
+
+                mtmd_input_chunk chunk{
+                    MTMD_INPUT_CHUNK_TYPE_IMAGE,
+                    {},
+                    std::move(image_tokens),
+                    nullptr,
+                };
+                cur.entries.emplace_back(std::move(chunk));
+            } else
+#endif
+            {
+
             // preprocess image
             clip_image_f32_batch batch_f32;
             bool ok = ctx->image_preproc->preprocess(*img_u8, batch_f32);
@@ -854,6 +981,8 @@ struct mtmd_tokenizer {
                 };
                 cur.entries.emplace_back(std::move(chunk));
             }
+
+            } // end of CPU image-tokenize path
 
             if (!ctx->img_end.empty()) {
                 add_text(ctx->img_end, true); // add image end token
@@ -995,6 +1124,19 @@ struct mtmd_tokenizer {
     }
 };
 
+#ifdef LLAMA_USE_HAILO
+static bool hailo_can_encode(const mtmd_input_chunk * c) {
+    return c && c->type == MTMD_INPUT_CHUNK_TYPE_IMAGE && c->tokens_image
+        && !c->tokens_image->hailo_input.empty();
+}
+
+// the HEF is fixed at load time, so a mismatch means the wrong model, not a bad image
+static bool hailo_dims_check(mtmd_context * ctx, const mtmd_image_tokens & img) {
+    return static_cast<int>(img.n_tokens()) == static_cast<int>(ctx->hailo->n_image_tokens())
+        && ctx->n_embd_text == static_cast<int>(ctx->hailo->n_embd_inp());
+}
+#endif
+
 int32_t mtmd_tokenize(mtmd_context * ctx,
             mtmd_input_chunks * output,
             const mtmd_input_text * text,
@@ -1013,6 +1155,33 @@ int32_t mtmd_encode_chunk(mtmd_context * ctx, const mtmd_input_chunk * chunk) {
             LOG_ERR("%s: model does not support vision input\n", __func__);
             return 1;
         }
+#ifdef LLAMA_USE_HAILO
+        if (ctx->hailo && hailo_can_encode(chunk)) {
+            // non-const through the unique_ptr: this chunk's encode id is consumed here
+            auto * img = chunk->tokens_image.get();
+
+            if (!hailo_dims_check(ctx, *img)) {
+                LOG_ERR("%s: HEF/model mismatch (n_tokens=%d/%u, n_embd_inp=%d/%u)\n",
+                        __func__, static_cast<int>(img->n_tokens()), ctx->hailo->n_image_tokens(),
+                        ctx->n_embd_text, ctx->hailo->n_embd_inp());
+                return 1;
+            }
+            ctx->image_embd_v.resize(static_cast<size_t>(img->n_tokens()) * ctx->n_embd_text);
+
+            // nothing prefetched it, or its slot was recycled since; either way, encode it now
+            if (!ctx->hailo->owns(img->hailo_encode_request_id)
+                && !ctx->hailo->submit(img->hailo_encode_request_id,
+                                       img->hailo_input.data(), img->hailo_input.size())) {
+                LOG_ERR("%s: Hailo submit failed\n", __func__);
+                return 1;
+            }
+            if (!ctx->hailo->wait(img->hailo_encode_request_id, ctx->image_embd_v.data())) {
+                LOG_ERR("%s: Hailo encode failed\n", __func__);
+                return 1;
+            }
+            return 0;
+        }
+#endif
         return mtmd_encode(ctx, chunk->tokens_image.get());
     } else if (chunk->type == MTMD_INPUT_CHUNK_TYPE_AUDIO) {
         if (!ctx->ctx_a) {
@@ -1071,6 +1240,48 @@ int32_t mtmd_encode(mtmd_context * ctx, const mtmd_image_tokens * image_tokens) 
 
 float * mtmd_get_output_embd(mtmd_context * ctx) {
     return ctx->image_embd_v.data();
+}
+
+bool mtmd_supports_prefetch(const mtmd_context * ctx) {
+#ifdef LLAMA_USE_HAILO
+    return ctx && ctx->hailo != nullptr;
+#else
+    (void) ctx;
+    return false;
+#endif
+}
+
+void mtmd_encode_prefetch(mtmd_context * ctx, mtmd_input_chunk ** chunks, size_t n_chunks) {
+#ifdef LLAMA_USE_HAILO
+    if (!ctx || !ctx->hailo || !chunks) {
+        return;
+    }
+
+    // nothing is remembered between calls, so interleaving callers cannot disturb each other
+    for (size_t i = 0; i < n_chunks; ++i) {
+        auto * c = chunks[i];
+        if (!hailo_can_encode(c)) {
+            continue;
+        }
+        auto * img = c->tokens_image.get();
+        if (ctx->hailo->owns(img->hailo_encode_request_id)) {
+            continue;   // already in flight or waiting to be collected
+        }
+        // try_submit() clears the id first, so a stale one cannot keep this image out of the pipeline
+        const auto st = ctx->hailo->try_submit(img->hailo_encode_request_id,
+                                               img->hailo_input.data(), img->hailo_input.size());
+        if (st == hailo_mtmd::HailoVisionEncoder::SubmitStatus::unsupported) {
+            LOG_ERR("%s: image does not fit the HEF input (%zu bytes, expected %ux%u); not prefetched\n",
+                    __func__, img->hailo_input.size(), ctx->hailo->input_w(), ctx->hailo->input_h());
+            continue;
+        }
+        if (st != hailo_mtmd::HailoVisionEncoder::SubmitStatus::started) {
+            break;      // nothing more can start right now, so nothing behind it can either
+        }
+    }
+#else
+    (void) ctx; (void) chunks; (void) n_chunks;
+#endif
 }
 
 bool mtmd_decode_use_non_causal(const mtmd_context * ctx, const mtmd_input_chunk * chunk) {

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -235,6 +235,21 @@ MTMD_API int32_t mtmd_encode(mtmd_context * ctx,
 MTMD_API int32_t mtmd_encode_chunk(mtmd_context * ctx,
                                    const mtmd_input_chunk * chunk);
 
+// whether prefetching does anything for this context, so a caller can skip
+// gathering the chunk list when it would be a no-op
+MTMD_API bool mtmd_supports_prefetch(const mtmd_context * ctx);
+
+// hint that these chunks are about to be encoded, so a backend that encodes
+// asynchronously can start ahead and overlap the caller's decode
+// safe to call repeatedly with the not-yet-encoded chunks; anything already
+// being encoded is ignored, as are non-image chunks
+// each chunk records the encode started for it, so this must run on the thread
+// that will encode them
+// mtmd_helper_eval_chunks() already does this
+MTMD_API void mtmd_encode_prefetch(mtmd_context * ctx,
+                                   mtmd_input_chunk ** chunks,
+                                   size_t n_chunks);
+
 // get output embeddings from the last encode pass
 // the reading size (in bytes) is equal to:
 // llama_model_n_embd_inp(model) * mtmd_input_chunk_get_n_tokens(chunk) * sizeof(float)

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2607,6 +2607,22 @@ private:
 
                     bool has_mtmd = false;
 
+                    if (mtmd_supports_prefetch(mctx)) {
+                        std::vector<mtmd_input_chunk *> media;
+                        const size_t end = (size_t) slot.task->n_tokens();
+                        for (size_t p = slot.prompt.n_tokens(); p < end; ) {
+                            if (input_tokens[p] == LLAMA_TOKEN_NULL) {
+                                const auto & ch = input_tokens.find_chunk(p);
+                                media.push_back(ch.get());
+                                // n_tokens, not n_pos - p is a token index, and the two differ under mrope
+                                p += mtmd_input_chunk_get_n_tokens(ch.get());
+                            } else { ++p; }
+                        }
+                        if (!media.empty()) {
+                            mtmd_encode_prefetch(mctx, media.data(), media.size());
+                        }
+                    }
+
                     // check if we should process the image
                     while (slot.prompt.n_tokens() < slot.task->n_tokens() && input_tokens[slot.prompt.n_tokens()] == LLAMA_TOKEN_NULL) {
                         // process the image


### PR DESCRIPTION
Adds an optional Hailo NPU backend for the mtmd vision encoder. Off by default (-DLLAMA_HAILO=ON to enable). Qwen3-VL only for now, tested on Hailo-8 with Raspberry Pi 5.

The .hef replaces the mmproj GGUF - pass it to --mmproj and the dims are read from HEF metadata. Adds mtmd_encode_prefetch() so image encode on the NPU overlaps CPU decode.