### PR TITLE
server: persist -fit result across sleep/wake cycles

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1317,13 +1317,17 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
             /*.shares_model =*/ !has_draft, // an MTP context runs on the weights of the main model
         };
 
-        common_fit_params(params.model.path.c_str(), &mparams, &cparams,
+        const common_params_fit_status fit_status = common_fit_params(
+            params.model.path.c_str(), &mparams, &cparams,
             params.tensor_split,
             params.tensor_buft_overrides.data(),
             params.fit_params_target.data(),
             params.fit_params_min_ctx,
             has_draft || spec_mtp ? &extra : nullptr,
             params.verbosity >= LOG_LEVEL_DEBUG ? GGML_LOG_LEVEL_DEBUG : GGML_LOG_LEVEL_ERROR);
+        if (fit_status == COMMON_PARAMS_FIT_STATUS_SUCCESS) {
+            params.n_gpu_layers = mparams.n_gpu_layers; // persist fit's placement decision across sleep/wake
+        }
     }
 
     llama_model * model = llama_model_load_from_file(params.model.path.c_str(), mparams);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -829,6 +829,7 @@ private:
     // use server_context methods instead
 
     common_params params_base;
+    uint32_t fitted_n_ctx = 0; // saved ctx-size after -fit on first load
 
     // note: keep these alive - they determine the lifetime of the model, context, etc.
     common_init_result_ptr llama_init;
@@ -914,6 +915,11 @@ private:
             destroy();
         } else {
             SRV_INF("%s", "server is exiting sleeping state\n");
+            // on wake-up, skip -fit (already fitted on first load) and reuse the fitted ctx-size
+            if (fitted_n_ctx > 0) {
+                params_base.n_ctx = fitted_n_ctx;
+                params_base.fit_params = false;
+            }
             if (!load_model(params_base)) {
                 GGML_ABORT("failed to reload model after sleeping");
             }
@@ -1061,6 +1067,13 @@ private:
         if (ctx_tgt == nullptr) {
             SRV_ERR("failed to create_context with model '%s'\n", params_base.model.path.c_str());
             return false;
+        }
+
+        // save the actual ctx-size used (may be reduced by -fit) for reuse on wake-up
+        if (!is_resume && params_base.fit_params) {
+            fitted_n_ctx = llama_n_ctx(ctx_tgt);
+            // keep params_base.n_ctx in sync so wake and derived params start from the fitted size, not 0
+            params_base.n_ctx = fitted_n_ctx;
         }
 
         vocab = llama_model_get_vocab(model_tgt);


### PR DESCRIPTION
## Overview

 Fit re-runs on every wake and shifts layer placement.

With fit-ctx=131072 the first load offloads 65/66 layers, but after sleep/wake the re-fit lands on 64/66 and throughput drops ~20% silently (n_part=0 keeps the guard quiet).

 With fit-ctx=262144 placement stays 48/66 but every wake pays ~2.4 s of re-fitting for nothing.

 This PR makes fit's decision persistent across sleep/wake by capturing the common_fit_params() status (currently ignored in common.cpp) and on success, writing mparams.n_gpu_layers back to params so the fitted count survives instead of being discarded on wake.

 Then the fitted ctx size is remembered on sleep, then on wake server-context.cpp reuses it and skips the re-fitting.

## Additional information

Fixes #24684

Tested on RTX 3090 24GB, Qwen3.6-27B-MTP-Q4_K_M, A/B testing on the same commit, machine and config (vanilla vs fixed). Here are some numbers:

 With `fit-ctx=131072`: vanilla wake drifts to 64/66 @ 36-40 t/s; fixed stays 65/66, tg flat ~39.5 t/s, no fit re-run, wake reload 0.46 s (vs 3.18 s)

 With `fit-ctx=262144`: vanilla re-fits every wake (2.38 s); fixed stays 48/66, no OOM, no fit re-run, wake reload ~1.2 s

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — local LLM agent assisted with development; every line manually reviewed and tested by me.
