### PR TITLE
vulkan: fix missing view-alias dependencies in ggml_vk_graph_optimize

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17779,15 +17779,24 @@ static void ggml_vk_graph_optimize(ggml_backend_t backend, struct ggml_cgraph * 
     };
 
     auto const &is_src_of = [](const ggml_tensor *dst, const ggml_tensor *src) -> bool {
+        auto const &base = [](const ggml_tensor * tensor) {
+            return tensor->view_src ? tensor->view_src : tensor;
+        };
         for (uint32_t s = 0; s < GGML_MAX_SRC; ++s) {
             if (dst->src[s] == src) {
                 return true;
             }
+            // A source view of dst may read storage written through a different view by src.
+            if (dst->src[s] && base(dst->src[s]) == base(src)) {
+                return true;
+            }
+            // Moving dst forward may overwrite storage still read through a view by src.
+            if (src->src[s] && base(dst) == base(src->src[s])) {
+                return true;
+            }
         }
         // implicit dependency if they view the same tensor
-        const ggml_tensor *dst2 = dst->view_src ? dst->view_src : dst;
-        const ggml_tensor *src2 = src->view_src ? src->view_src : src;
-        if (dst2 == src2) {
+        if (base(dst) == base(src)) {
             return true;
         }
         return false;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17774,11 +17774,11 @@ static void ggml_vk_graph_optimize(ggml_backend_t backend, struct ggml_cgraph * 
         return;
     }
 
-    auto const &is_empty = [](ggml_tensor * node) -> bool {
+    auto const &is_empty = [](const ggml_tensor * node) -> bool {
         return node->op == GGML_OP_NONE || node->op == GGML_OP_RESHAPE || node->op == GGML_OP_TRANSPOSE || node->op == GGML_OP_VIEW || node->op == GGML_OP_PERMUTE;
     };
 
-    auto const &is_src_of = [](const ggml_tensor *dst, const ggml_tensor *src) -> bool {
+    auto const &is_src_of = [&is_empty](const ggml_tensor *dst, const ggml_tensor *src) -> bool {
         auto const &base = [](const ggml_tensor * tensor) {
             return tensor->view_src ? tensor->view_src : tensor;
         };

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17786,6 +17786,9 @@ static void ggml_vk_graph_optimize(ggml_backend_t backend, struct ggml_cgraph * 
             if (dst->src[s] == src) {
                 return true;
             }
+            if (is_empty(dst) || is_empty(src)) {
+                continue;
+            }
             // A source view of dst may read storage written through a different view by src.
             if (dst->src[s] && base(dst->src[s]) == base(src)) {
                 return true;


### PR DESCRIPTION
## Overview

Fixes #27805

`is_src_of` in `ggml_vk_graph_optimize` checks whether one node depends on another before the optimizer reorders them. It knows two cases: a node depends on its direct inputs, and two views of the same tensor share memory. It **misses a third case**: a node that reads or writes memory through one view depends on a node that writes or reads the same memory through a different view. The optimizer can then run those two nodes in the wrong order.

Result: wrong tokens at temperature 0, a different answer on every server start, and speculative-decoding acceptance numbers that mean nothing. Nothing is written to the log.

Found with the DFlash 2 verify graph from #27342, which does not touch ggml-vulkan.cpp. Any model that keeps state in views is exposed (Qwen3.8's recurrent state where I encountered it). AMD and NVIDIA Vulkan affected; CUDA on the same NVIDIA GPU is not.

**Fix:** compare the underlying tensor (`view_src`) on both sides of the check, in addition to the existing tests.

## Additional information

Verified 12/12 fresh runs match the no-speculation output on RTX 5000 (Vulkan) and RX 7800 XT, where the unpatched build gave 4 distinct outputs and 0/12 matches. Plain and MTP output unchanged.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. The investigation, instrumentation and reproducer scripts were AI-assisted (Claude Fable 5 & GPT 5.6 Sol); the diff was validated by me on my own hardware (NVIDIA and AMD) and I wrote this PR.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->