### PR TITLE
cuda: always use MMVQ for MUL_MAT_ID on sm_60

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -254,9 +254,9 @@ static constexpr __host__ __device__ int get_mmvq_mmid_max_batch_rdna4(ggml_type
 
 // Host function: returns the max batch size for the current arch+type at runtime.
 int get_mmvq_mmid_max_batch(ggml_type type, int cc) {
-    // NVIDIA: Volta, Ada Lovelace, and Blackwell always use MMVQ for MUL_MAT_ID.
+    // NVIDIA: P100, Volta, Ada Lovelace, and Blackwell always use MMVQ for MUL_MAT_ID.
     if (GGML_CUDA_CC_IS_NVIDIA(cc)) {
-        if (cc == GGML_CUDA_CC_VOLTA || cc >= GGML_CUDA_CC_ADA_LOVELACE) {
+        if (cc == GGML_CUDA_CC_PASCAL || cc == GGML_CUDA_CC_VOLTA || cc >= GGML_CUDA_CC_ADA_LOVELACE) {
             return MMVQ_MAX_BATCH_SIZE;
         }
         if (cc >= GGML_CUDA_CC_TURING) {
@@ -385,7 +385,7 @@ static constexpr __device__ int get_mmvq_mmid_max_batch_for_device() {
     return get_mmvq_mmid_max_batch_cdna(type);
 #elif defined(GCN)
     return get_mmvq_mmid_max_batch_gcn(type);
-#elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == GGML_CUDA_CC_VOLTA || __CUDA_ARCH__ >= GGML_CUDA_CC_ADA_LOVELACE)
+#elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == GGML_CUDA_CC_PASCAL || __CUDA_ARCH__ == GGML_CUDA_CC_VOLTA || __CUDA_ARCH__ >= GGML_CUDA_CC_ADA_LOVELACE)
     return MMVQ_MAX_BATCH_SIZE;
 #elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_TURING
     return get_mmvq_mmid_max_batch_turing_plus(type);


### PR DESCRIPTION
## Overview

On the P100, MMVQ is faster than the alternative for MUL_MAT_ID on all batch sizes up to 8, so include it in the list of architectures that always use MMVQ.

~~I believe some of the quantization types will also run faster with fewer warps active (`calc_nwarps`), but not all of them benefited from halving the number of warps. I'll follow up on that, either in this PR or a next one.  See below, there are some speedups to be had from tuning the number of warps and enabling `small_k` for more quantization types.~~  Tuning seems benefitial, but my first attempts ended in regressions on larger models and will have to wait.

## Additional information

All tests were done on a single P100, powerlimited to 150 W, CUDA 12.9.2, driver 575.64.05.

<details>
<summary>scripts used for testing</summary>

```sh
_quants=(
  Q1_0 Q2_0 Q4_0 Q4_1 Q5_0 Q5_1 Q8_0
  IQ1_S IQ1_M IQ2_XXS IQ2_XS IQ2_S IQ3_XXS IQ3_S IQ4_XS IQ4_NL
  Q2_K Q3_K Q4_K Q5_K Q6_K
)

for q in "${_quants[@]}"
do
  llama-quantize --tensor-type "exps=$q" --tensor-type "embd|blk|out=q8_0" \
    --imatrix "Ling-3.0-Tiny-128x1.0B-imatrix.gguf" "Ling-3.0-Tiny-128x1.0B-BF16.gguf" "bailingmoe3-$q.gguf" "$q"
done

for q in MXFP4 NVFP4
do
  llama-quantize --tensor-type "exps=$q" --tensor-type "embd|blk|out=q8_0" \
    --imatrix "Ling-3.0-Tiny-128x1.0B-imatrix.gguf" "Ling-3.0-Tiny-128x1.0B-BF16.gguf" "bailingmoe3-$q.gguf" "Q8_0"
done
```

```sh
export CUDA_VISIBLE_DEVICES=0

_quants=(
  Q1_0 Q2_0 Q4_0 Q4_1 Q5_0 Q5_1 Q8_0
  IQ1_S IQ1_M IQ2_XXS IQ2_XS IQ2_S IQ3_XXS IQ3_S IQ4_XS IQ4_NL
  Q2_K Q3_K Q4_K Q5_K Q6_K
  MXFP4 NVFP4
)

for q in "${_quants[@]}"
do
  echo "### $q"
  llama-batched-bench -lm dio -fa on -m "bailingmoe3-$q.gguf" -ub 2048 -npp 2048 -ntg 128 -npl 1,2,3,4,5,6,7,8
  sleep 2
done
```
</details>
<details>
<summary>results for Ling 3.0 Tiny</summary>

Bolded values previously exceeded `get_mmvq_mmid_max_batch_pascal_older`.

### Q1_0

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  93.57 | 160.74 | 205.60 | 232.63 | 251.32 | 272.34 | 289.34 | 302.14 |
|   PR   |  93.47 | 160.68 | 205.57 | 232.42 | 251.22 | 272.34 | 289.34 | 302.13 |

### Q2_0

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  93.92 | 160.94 | 205.42 | 232.12 | 250.87 | 271.14 | 287.89 | 300.47 |
|   PR   |  93.68 | 160.64 | 205.16 | 231.97 | 250.55 | 270.75 | 287.41 | 300.15 |

### Q4_0

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  94.92 | 166.06 | 215.03 | 243.58 | 264.47 | 287.69 | 232.84 | 248.23 |
|   PR   |  95.09 | 166.43 | 215.32 | 243.88 | 264.73 | 287.98 | **307.24** | **321.34** |

### Q4_1

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  95.93 | 168.95 | 219.08 | 248.75 | 270.51 | 294.04 | 232.38 | 247.79 |
|   PR   |  95.68 | 168.41 | 218.47 | 248.47 | 270.28 | 293.73 | **314.21** | **328.45** |

### Q5_0

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  90.78 | 157.85 | 200.10 | 225.35 | 242.93 | 263.05 | 212.67 | 228.17 |
|   PR   |  90.93 | 158.10 | 200.44 | 225.47 | 243.01 | 263.30 | **278.20** | **288.57** |

### Q5_1

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  92.18 | 159.46 | 203.87 | 230.44 | 248.07 | 268.15 | 218.11 | 233.08 |
|   PR   |  91.98 | 159.10 | 203.36 | 230.05 | 247.78 | 267.89 | **285.19** | **295.42** |

### Q8_0

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  90.51 | 154.42 | 196.01 | 220.32 | 183.60 | 203.84 | 223.53 | 238.01 |
|   PR   |  90.45 | 154.47 | 196.11 | 220.17 | **237.81** | **257.10** | **271.11** | **282.74** |

### IQ1_S

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  87.03 | 157.85 | 202.83 | 228.34 | 246.51 | 265.94 | 229.18 | 245.03 |
|   PR   |  87.04 | 157.80 | 202.56 | 228.13 | 246.63 | 265.99 | **282.86** | **294.16** |

### IQ1_M

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  83.14 | 152.28 | 193.60 | 217.04 | 233.22 | 250.47 | 161.82 | 170.68 |
|   PR   |  83.23 | 152.25 | 193.68 | 217.51 | 233.93 | 251.70 | **265.30** | **272.28** |

### IQ2_XXS

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  82.22 | 147.15 | 183.75 | 205.72 | 220.32 | 206.62 | 225.94 | 241.61 |
|   PR   |  82.12 | 147.01 | 183.53 | 205.70 | 220.26 | **235.35** | **248.34** | **257.06** |

### IQ2_XS

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  81.14 | 146.00 | 182.00 | 203.15 | 216.85 | 207.52 | 226.43 | 241.97 |
|   PR   |  81.02 | 145.92 | 181.93 | 203.03 | 216.98 | **230.94** | **244.01** | **251.22** |

### IQ2_S

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  81.62 | 145.31 | 181.90 | 203.43 | 186.42 | 206.96 | 225.19 | 240.86 |
|   PR   |  81.83 | 145.49 | 181.95 | 203.48 | **217.35** | **231.38** | **244.35** | **251.41** |

### IQ3_XXS

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  81.56 | 143.36 | 178.54 | 199.32 | 181.87 | 202.11 | 220.87 | 235.85 |
|   PR   |  81.45 | 143.22 | 178.26 | 199.16 | **212.32** | **227.38** | **237.38** | **246.68** |

### IQ3_S

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  80.29 | 139.91 | 174.38 | 193.65 | 179.12 | 199.16 | 217.60 | 232.86 |
|   PR   |  80.39 | 140.03 | 174.45 | 193.41 | **206.19** | **218.42** | **230.00** | **234.84** |

### IQ4_XS

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  84.74 | 156.83 | 200.13 | 225.09 | 242.13 | 205.94 | 225.42 | 240.94 |
|   PR   |  84.97 | 157.07 | 200.41 | 225.24 | 242.51 | **262.11** | **277.13** | **288.76** |

### IQ4_NL

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  94.36 | 164.40 | 212.20 | 239.51 | 259.43 | 281.13 | 225.51 | 241.07 |
|   PR   |  94.15 | 164.16 | 212.03 | 239.31 | 258.94 | 281.01 | **298.99** | **310.75** |

### Q2_K

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  83.55 | 160.36 | 205.09 | 231.39 | 183.61 | 203.56 | 223.00 | 237.68 |
|   PR   |  83.53 | 160.24 | 204.99 | 231.61 | **249.85** | **269.22** | **286.38** | **296.63** |

### Q3_K

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  78.32 | 146.33 | 182.99 | 203.44 | 178.61 | 198.68 | 217.05 | 232.70 |
|   PR   |  78.32 | 145.94 | 182.51 | 202.75 | **215.48** | **230.24** | **237.35** | **247.43** |

### Q4_K

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  91.66 | 155.20 | 197.12 | 222.25 | 239.32 | 209.13 | 228.94 | 243.89 |
|   PR   |  91.59 | 155.01 | 196.93 | 222.07 | 239.18 | **257.11** | **272.16** | **282.56** |

### Q5_K

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  89.61 | 155.65 | 197.70 | 223.57 | 241.00 | 205.08 | 223.57 | 239.11 |
|   PR   |  89.51 | 154.62 | 196.01 | 221.78 | 238.49 | **257.36** | **271.31** | **281.66** |

### Q6_K

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  84.31 | 145.79 | 182.96 | 204.37 | 179.61 | 199.24 | 217.53 | 232.61 |
|   PR   |  84.41 | 145.90 | 183.04 | 204.49 | **219.04** | **235.56** | **246.90** | **256.60** |

### MXFP4

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  92.89 | 159.02 | 202.61 | 228.59 | 182.89 | 202.55 | 221.60 | 237.72 |
|   PR   |  92.77 | 159.09 | 202.85 | 228.46 | **246.78** | **267.12** | **282.25** | **294.00** |

### NVFP4

|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|--------|---|---|---|---|---|---|---|---|
| master |  84.30 | 147.62 | 185.73 | 206.83 | 183.66 | 204.28 | 222.62 | 238.58 |
|   PR   |  83.99 | 147.16 | 185.28 | 206.37 | **221.12** | **238.18** | **250.95** | **260.36** |

</details>

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
