### PR TITLE
clamp video fps to the value of new --video-max-tokens cli flag

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2660,6 +2660,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples(mmproj_examples).set_env("LLAMA_ARG_VIDEO_FPS"));
     add_opt(common_arg(
+        {"--video-max-tokens"}, "N",
+        "maximum number of tokens each video can take (default: disabled)",
+        [](common_params & params, const std::string & value) {
+            params.video_max_tokens = std::stof(value);
+        }
+    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_VIDEO_MAX_TOKENS"));
+    add_opt(common_arg(
         {"--video-timestamp-interval"}, "N",
         string_format("interval in milliseconds between text timestamps (default: %" PRId64 ")", params.video_timestamp_interval_ms),
         [](common_params & params, int value) {

--- a/common/common.h
+++ b/common/common.h
@@ -603,6 +603,7 @@ struct common_params {
     float       video_fps                   = 4.0f;
     int64_t     video_timestamp_interval_ms = 5000;
     std::string video_ffmpeg_bin_dir        = "";
+    float       video_max_tokens            = 0.0f;
 
     // finetune
     struct lr_opt lr;

--- a/tools/mtmd/mtmd-helper.cpp
+++ b/tools/mtmd/mtmd-helper.cpp
@@ -599,6 +599,8 @@ struct mtmd_helper_video {
     std::string prompt_start         = "Video:";
     int32_t     timestamp_interval_ms = 5000; // emit a timestamp text every N ms (0 = disabled)
     float       next_timestamp_ms     = 0.0f; // next elapsed-ms threshold at which to emit
+    float       tokens_per_frame      = 0.0f;
+    float       max_tokens            = 0.0f;
 
     std::vector<uint8_t> frame_buf;
     std::string pending_text; // text queued to be returned before the next frame
@@ -678,7 +680,17 @@ struct mtmd_helper_video {
             duration = (float)n_frames_orig / orig_fps;
         }
 
-        fps_target = fps_target_arg > 0.0f ? fps_target_arg : orig_fps;
+        // clamp video to the given token amount
+        // no fps_target_arg <= 0.0f && because max_tokens should have more priority
+        if (max_tokens > 0.0f && tokens_per_frame > 0.0f && duration > 0.0f) {
+            float computed_fps = max_tokens / (duration * tokens_per_frame);
+            float base_fps     = fps_target_arg > 0.0f ? fps_target_arg : orig_fps;
+
+            fps_target = std::min(base_fps, computed_fps);
+        } else {
+            fps_target = fps_target_arg > 0.0f ? fps_target_arg : orig_fps;
+        }
+
         info.width    = width;
         info.height   = height;
         info.fps      = fps_target;
@@ -856,6 +868,8 @@ mtmd_helper_video_init_params mtmd_helper_video_init_params_default() {
         /* fps_target             */ 4.0f,
         /* ffmpeg_bin_dir         */ nullptr,
         /* timestamp_interval_ms  */ 5000,
+        /* tokens_per_frame       */ 0.0f,
+        /* max_tokens             */ 0.0f
     };
 }
 
@@ -924,6 +938,8 @@ mtmd_helper_video * mtmd_helper_video_init(
     ctx->ffmpeg_bin           = video_resolve_bin(params.ffmpeg_bin_dir, "ffmpeg");
     ctx->ffprobe_bin          = video_resolve_bin(params.ffmpeg_bin_dir, "ffprobe");
     ctx->timestamp_interval_ms = params.timestamp_interval_ms;
+    ctx->tokens_per_frame     = params.tokens_per_frame;
+    ctx->max_tokens           = params.max_tokens;
 
     if (!ctx->probe(params.fps_target)) {
         LOG_ERR("%s: ffprobe failed for '%s' (is ffprobe in PATH?)\n", __func__, path);
@@ -959,6 +975,8 @@ mtmd_helper_video * mtmd_helper_video_init_from_buf(
     ctx->ffmpeg_bin            = video_resolve_bin(params.ffmpeg_bin_dir, "ffmpeg");
     ctx->ffprobe_bin           = video_resolve_bin(params.ffmpeg_bin_dir, "ffprobe");
     ctx->timestamp_interval_ms = params.timestamp_interval_ms;
+    ctx->tokens_per_frame = params.tokens_per_frame;
+    ctx->max_tokens       = params.max_tokens;
 
     if (!ctx->probe(params.fps_target)) {
         LOG_ERR("%s: ffprobe failed on buffer (is ffprobe in PATH?)\n", __func__);

--- a/tools/mtmd/mtmd-helper.h
+++ b/tools/mtmd/mtmd-helper.h
@@ -27,6 +27,8 @@ struct mtmd_helper_video_init_params {
     float fps_target;            // desired output fps; <= 0 means use the video's native fps, defaulted to 4.0f
     const char * ffmpeg_bin_dir; // directory containing ffmpeg/ffprobe binaries; NULL means search PATH
     int64_t timestamp_interval_ms; // interval for adding timestamp as text chunk (example: "[10m50.5s]"); <= 0 means no timestamp, defaulted to 5000ms
+    float tokens_per_frame;
+    float max_tokens;
     // TODO @ngxson : allow "placeholder" bitmap output for counting tokens
 };
 

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -2127,6 +2127,17 @@ bool mtmd_support_vision(const mtmd_context * ctx) {
     return ctx->ctx_v != nullptr;
 }
 
+uint32_t mtmd_get_image_num_tokens(const mtmd_context * ctx) {
+    if (!ctx->ctx_v) {
+        return 0;
+    }
+
+    const clip_hparams * hp = clip_get_hparams(ctx->ctx_v);
+    // tokens per image = (image_size / (patch_size * n_merge))^2
+    const int tpi = hp->image_size / (hp->patch_size * hp->n_merge);
+    return (uint32_t)(tpi * tpi);
+}
+
 bool mtmd_support_audio(const mtmd_context * ctx) {
     return ctx->ctx_a != nullptr;
 }

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -149,6 +149,9 @@ MTMD_API int mtmd_get_audio_sample_rate(const mtmd_context * ctx);
 // get the current marker string
 MTMD_API const char * mtmd_get_marker(const mtmd_context * ctx);
 
+// get the current number of max tokens per image
+MTMD_API uint32_t mtmd_get_image_num_tokens(const mtmd_context * ctx);
+
 // mtmd_bitmap
 //
 // if bitmap is image:

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1167,6 +1167,8 @@ private:
             SRV_INF("loaded multimodal model, '%s'\n", mmproj_path.c_str());
 
             init_opt.video_params.fps_target = params_base.video_fps;
+            init_opt.video_params.max_tokens = params_base.video_max_tokens;
+            init_opt.video_params.tokens_per_frame = mtmd_get_image_num_tokens(mctx);
             init_opt.video_params.timestamp_interval_ms = params_base.video_timestamp_interval_ms;
             init_opt.video_params.ffmpeg_bin_dir = params_base.video_ffmpeg_bin_dir.empty()
                                 ? nullptr : params_base.video_ffmpeg_bin_dir.c_str();


### PR DESCRIPTION
## Overview

This PR adds a new flag --video-max-tokens N by analogy with the flag --image-max-tokens N.
The flag lowers the fps so the video fits within the given token limit. When unset, behavior is unchanged.

### Future work
Dynamically adjust the video fps to fit the remaining free context (ctx_size - used tokens) when that is smaller than the fixed --video-max-tokens limit.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES - AI was used for code navigation and locating relevant code; implementation is my own.