### PR TITLE
sycl: split long rows in TOP_K instead of one workgroup per row

### DIFF
--- a/ggml/src/ggml-sycl/ggml-sycl.cpp
+++ b/ggml/src/ggml-sycl/ggml-sycl.cpp
@@ -2399,7 +2399,138 @@ static void argsort_f32_i32_sycl(const float *x, int *dst, const int ncols,
     }
 }
 
+// Scan and block merge, shared by every launch shape below so a partitioned row uses the
+// same insertion order as an unpartitioned one.
+//
+// src_map  != nullptr: report src_map[col] instead of col, so a merge pass can carry the
+//                      original column index through.
+// out_vals != nullptr: also emit the k winning values, for a later merge pass.
+// swap01:              emit in the output order the single-pass path uses.
+static void top_k_scan_merge_f32(
+    const float *   src_vals,
+    const int32_t * src_map,
+    const int       begin,
+    const int       end,
+    const int       k,
+    const int       block_size,
+    float *         shared_vals,
+    int *           shared_idx,
+    float *         out_vals,
+    int32_t *       out_idx,
+    const bool      swap01,
+    const sycl::nd_item<1> & item_ct1
+) {
+    const int tid = item_ct1.get_local_id(0);
+
+    // The running top-k lives in SLM (shared local memory) rather than a private array:
+    // an array indexed by a runtime position cannot be register-allocated, so a private
+    // one lands in scratch, i.e. device memory, and insertion is this kernel's dominant
+    // cost.
+    //
+    // Lane-strided (lv[i * block_size]) rather than lane-blocked (lv[i]) so a given i is
+    // contiguous across lanes; a k-strided layout would put every lane of a shift step in
+    // the same SLM bank.
+    float * lv = shared_vals + tid;
+    int * li = shared_idx + tid;
+
+    for (int i = 0; i < k; i++) {
+        lv[i * block_size] = -FLT_MAX;
+        li[i * block_size] = -1;
+    }
+
+    // The k-th best, cached in a register. The reject test is taken for the large
+    // majority of elements scanned, and in that case touches no memory.
+    float kth = -FLT_MAX;
+
+    for (int col = begin + tid; col < end; col += block_size) {
+        float val = src_vals[col];
+
+        if (val > kth) {
+            int pos = k - 1;
+            while (pos > 0 && val > lv[(pos - 1) * block_size]) {
+                pos--;
+            }
+
+            for (int i = k - 1; i > pos; i--) {
+                lv[i * block_size] = lv[(i - 1) * block_size];
+                li[i * block_size] = li[(i - 1) * block_size];
+            }
+            lv[pos * block_size] = val;
+            li[pos * block_size] = src_map ? src_map[col] : col;
+
+            kth = lv[(k - 1) * block_size];
+        }
+    }
+
+    item_ct1.barrier(sycl::access::fence_space::local_space);
+
+    if (tid != 0) {
+        return;
+    }
+
+    // Same treatment for the merge accumulator, past the per-lane region.
+    float * fv = shared_vals + (size_t) k * block_size;
+    int * fi = shared_idx + (size_t) k * block_size;
+
+    for (int i = 0; i < k; i++) {
+        fv[i] = -FLT_MAX;
+        fi[i] = -1;
+    }
+
+    float fkth = -FLT_MAX;
+
+    // Candidates are visited in the same (t, i) order as before, so tie-breaking is
+    // unchanged.
+    for (int t = 0; t < block_size; t++) {
+        for (int i = 0; i < k; i++) {
+            float val = shared_vals[i * block_size + t];
+
+            if (val <= fkth) {
+                // Lane t's list is sorted descending, so once one of its entries loses
+                // to the k-th best, every later entry loses too. fkth only rises, so
+                // that stays true for the rest of the merge. This turns the merge from
+                // block_size*k steps into roughly block_size plus the candidates
+                // accepted.
+                break;
+            }
+
+            int idx = shared_idx[i * block_size + t];
+
+            int pos = k - 1;
+            while (pos > 0 && val > fv[pos - 1]) {
+                pos--;
+            }
+
+            for (int j = k - 1; j > pos; j--) {
+                fv[j] = fv[j - 1];
+                fi[j] = fi[j - 1];
+            }
+            fv[pos] = val;
+            fi[pos] = idx;
+
+            fkth = fv[k - 1];
+        }
+    }
+
+    if (out_vals) {
+        for (int i = 0; i < k; i++) {
+            out_vals[i] = fv[i];
+        }
+    }
+
+    for (int i = 0; i < k; i++) {
+        out_idx[i] = fi[i];
+    }
+
+    if (swap01 && k > 1) {
+        int32_t temp = out_idx[0];
+        out_idx[0] = out_idx[1];
+        out_idx[1] = temp;
+    }
+}
+
 static void top_k_f32_sycl(
+    ggml_backend_sycl_context & ctx,
     const float * src,
     int32_t * dst_indices,
     const int64_t ncols,
@@ -2407,98 +2538,107 @@ static void top_k_f32_sycl(
     const int k,
     dpct::queue_ptr main_stream
 ) {
+    // A row is scanned by exactly one work-group, so a vocabulary-sized row leaves the
+    // rest of the device idle. What the scan is short of is memory requests in flight,
+    // not bandwidth or per-request latency, so lanes in flight is the lever: split the
+    // row across independent work-groups, have each emit its partition's top-k, and
+    // merge those nsplit*k candidates in a second launch.
+    //
+    // split_block trades parallelism against SLM residency. Its cost is
+    // (split_block + 1) * k * 8 bytes of SLM per group, so at the k <= 32 ceiling 128
+    // lanes need about 33 KB, which leaves a single resident group per Xe-core. Revisit
+    // if the supported k ever grows.
+    constexpr int split_block = 128;
+    constexpr int max_splits  = 128;
+    constexpr int min_cols    = 8192;
+
+    int nsplit = 1;
+    if (ncols >= min_cols) {
+        // A partition is then always >= split_block = 128 columns, hence always more than
+        // the k <= 32 ceiling, so no pass is ever padded with -FLT_MAX sentinels.
+        const int64_t want = ncols / split_block;
+        nsplit = (int) (want > max_splits ? max_splits : want);
+    }
+
+    if (nsplit > 1) {
+        const int nchunk = (int) ((ncols + nsplit - 1) / nsplit);
+        const size_t ncand = (size_t) nrows * nsplit * k;
+
+        ggml_sycl_pool_alloc<float>   part_vals(ctx.pool(), ncand);
+        ggml_sycl_pool_alloc<int32_t> part_idx(ctx.pool(), ncand);
+
+        float *   pv = part_vals.get();
+        int32_t * pi = part_idx.get();
+
+        const sycl::range<1> block_dims(split_block);
+
+        main_stream->submit([&](sycl::handler &cgh) {
+            sycl::local_accessor<float, 1> shared_vals(sycl::range<1>((split_block + 1) * k), cgh);
+            sycl::local_accessor<int, 1> shared_idx(sycl::range<1>((split_block + 1) * k), cgh);
+
+            cgh.parallel_for(
+                sycl::nd_range<1>(sycl::range<1>(nrows * nsplit) * block_dims, block_dims),
+                [=](sycl::nd_item<1> item_ct1) {
+                    const int grp = item_ct1.get_group(0);
+                    const int row = grp / nsplit;
+                    const int part = grp % nsplit;
+
+                    const int begin = part * nchunk;
+                    int end = begin + nchunk;
+                    if (end > (int) ncols) {
+                        end = (int) ncols;
+                    }
+
+                    top_k_scan_merge_f32(
+                        src + (int64_t) row * ncols, nullptr, begin, end, k, split_block,
+                        shared_vals.get_multi_ptr<sycl::access::decorated::no>().get(),
+                        shared_idx.get_multi_ptr<sycl::access::decorated::no>().get(),
+                        pv + (size_t) grp * k, pi + (size_t) grp * k, false, item_ct1);
+                });
+        });
+
+        main_stream->submit([&](sycl::handler &cgh) {
+            sycl::local_accessor<float, 1> shared_vals(sycl::range<1>((split_block + 1) * k), cgh);
+            sycl::local_accessor<int, 1> shared_idx(sycl::range<1>((split_block + 1) * k), cgh);
+
+            cgh.parallel_for(
+                sycl::nd_range<1>(sycl::range<1>(nrows) * block_dims, block_dims),
+                [=](sycl::nd_item<1> item_ct1) {
+                    const int row = item_ct1.get_group(0);
+                    const size_t off = (size_t) row * nsplit * k;
+
+                    top_k_scan_merge_f32(
+                        pv + off, pi + off, 0, nsplit * k, k, split_block,
+                        shared_vals.get_multi_ptr<sycl::access::decorated::no>().get(),
+                        shared_idx.get_multi_ptr<sycl::access::decorated::no>().get(),
+                        nullptr, dst_indices + (int64_t) row * k, true, item_ct1);
+                });
+        });
+
+        return;
+    }
+
     const int block_size = 128;
 
     const sycl::range<1> block_dims(block_size);
     const sycl::range<1> grid_dims(nrows);
 
     main_stream->submit([&](sycl::handler &cgh) {
-        sycl::local_accessor<float, 1> shared_vals(sycl::range<1>(block_size * k), cgh);
-        sycl::local_accessor<int, 1> shared_idx(sycl::range<1>(block_size * k), cgh);
+        sycl::local_accessor<float, 1> shared_vals(sycl::range<1>((block_size + 1) * k), cgh);
+        sycl::local_accessor<int, 1> shared_idx(sycl::range<1>((block_size + 1) * k), cgh);
 
         cgh.parallel_for(
             sycl::nd_range<1>(grid_dims * block_dims, block_dims),
             [=](sycl::nd_item<1> item_ct1) {
                 const int row = item_ct1.get_group(0);
-                const int tid = item_ct1.get_local_id(0);
 
                 if (row >= nrows) return;
 
-                const float * src_row = src + row * ncols;
-                int32_t * dst_idx_row = dst_indices + row * k;
-
-                float local_vals[32];
-                int local_idx[32];
-
-                for (int i = 0; i < k; i++) {
-                    local_vals[i] = -FLT_MAX;
-                    local_idx[i] = -1;
-                }
-
-                for (int col = tid; col < ncols; col += block_size) {
-                    float val = src_row[col];
-
-                    if (val > local_vals[k-1]) {
-                        int pos = k - 1;
-                        while (pos > 0 && val > local_vals[pos - 1]) {
-                            pos--;
-                        }
-
-                        for (int i = k - 1; i > pos; i--) {
-                            local_vals[i] = local_vals[i - 1];
-                            local_idx[i] = local_idx[i - 1];
-                        }
-                        local_vals[pos] = val;
-                        local_idx[pos] = col;
-                    }
-                }
-
-                for (int i = 0; i < k; i++) {
-                    shared_vals[tid * k + i] = local_vals[i];
-                    shared_idx[tid * k + i] = local_idx[i];
-                }
-                item_ct1.barrier(sycl::access::fence_space::local_space);
-
-                if (tid == 0) {
-                    float final_vals[32];
-                    int final_idx[32];
-
-                    for (int i = 0; i < k; i++) {
-                        final_vals[i] = -FLT_MAX;
-                        final_idx[i] = -1;
-                    }
-
-                    for (int t = 0; t < block_size; t++) {
-                        for (int i = 0; i < k; i++) {
-                            float val = shared_vals[t * k + i];
-                            int idx = shared_idx[t * k + i];
-
-                            if (val > final_vals[k-1]) {
-                                int pos = k - 1;
-                                while (pos > 0 && val > final_vals[pos - 1]) {
-                                    pos--;
-                                }
-
-                                for (int j = k - 1; j > pos; j--) {
-                                    final_vals[j] = final_vals[j - 1];
-                                    final_idx[j] = final_idx[j - 1];
-                                }
-                                final_vals[pos] = val;
-                                final_idx[pos] = idx;
-                            }
-                        }
-                    }
-
-                    for (int i = 0; i < k; i++) {
-                        dst_idx_row[i] = final_idx[i];
-                    }
-
-                    if (k > 1) {
-                        int32_t temp = dst_idx_row[0];
-                        dst_idx_row[0] = dst_idx_row[1];
-                        dst_idx_row[1] = temp;
-                    }
-                }
+                top_k_scan_merge_f32(
+                    src + (int64_t) row * ncols, nullptr, 0, (int) ncols, k, block_size,
+                    shared_vals.get_multi_ptr<sycl::access::decorated::no>().get(),
+                    shared_idx.get_multi_ptr<sycl::access::decorated::no>().get(),
+                    nullptr, dst_indices + (int64_t) row * k, true, item_ct1);
             });
     });
 }
@@ -2899,7 +3039,7 @@ static void ggml_sycl_op_top_k(ggml_backend_sycl_context & ctx, ggml_tensor * ds
     GGML_ASSERT(k > 0 && k <= 32);
     GGML_ASSERT(k <= ncols);
 
-    top_k_f32_sycl(src0_dd, dst_dd, ncols, nrows, k, main_stream);
+    top_k_f32_sycl(ctx, src0_dd, dst_dd, ncols, nrows, k, main_stream);
 }
 
 inline void ggml_sycl_op_argmax(ggml_backend_sycl_context & ctx, ggml_tensor * dst) {


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

This is sort-of a follow up to my previous PRs in terms of spawning the appropriate # of workgroups for a specific task

Performance figures for the TOP_K operation:
```
   ncols  nrows    k   base us   new us  speedup
  ------  -----  ---  --------  -------  ------- 
  200000      1    1    243.53    16.91   14.40x
   65000      1    1     91.55    15.50    5.91x
  200000     16    1    248.42    44.75    5.55x
      10      1   10     96.28    17.73    5.43x
  200000      1   10    664.65   123.07    5.40x
      10     16   10     96.63    18.62    5.19x
   65000      1   10    400.15   104.80    3.82x
    1000      1   10    125.89    48.77    2.58x
    1000     16   10    133.88    59.60    2.25x
   65000     16    1     94.10    42.47    2.22x
    1000      1    1     13.87     8.26    1.68x
       1      1    1     11.70     7.00    1.67x
       2      1    1     11.74     7.03    1.67x
    1000     16    1     14.04     8.41    1.67x
       1     16    1     11.73     7.03    1.67x
  200000     16   10    674.64   462.85    1.46x
   65000     16   10    407.35   370.00    1.10x
```

## Additional information



Command output:

### Before:
```
~ ❱ /nix/store/yaz23lir1kvmlpskr57mm59yd3ijdv7m-test-backend-ops-sycl-0.0.0/bin/test-backend-ops perf -o TOP_K
Testing 2 devices

Build with Macros:
  GGML_SYCL_DNNL: yes
  GGML_SYCL_F16: yes
  GGML_SYCL_FORCE_MMQ: no
  GGML_SYCL_GRAPH: yes
  GGML_SYCL_SUPPORT_LEVEL_ZERO_API: yes
  GGML_SYCL_SUPPORT_VMM: yes
Running with Environment Variables:
  GGML_SYCL_DEBUG: 0
  GGML_SYCL_DEV2DEV_MEMCPY: 0 (SYCL API)
  GGML_SYCL_ENABLE_DNN: 1
  GGML_SYCL_FA_ONEDNN: 1
  GGML_SYCL_FA_ONEDNN_MAX_KV: 0
  GGML_SYCL_ENABLE_FLASH_ATTN: 1
  GGML_SYCL_ENABLE_GRAPH: 0
  GGML_SYCL_ENABLE_OPT: 1
  GGML_SYCL_ENABLE_VMM: 1
  GGML_SYCL_ENABLE_FUSION: 1
  GGML_SYCL_ENABLE_ESIMD: 1
  GGML_SYCL_PRIORITIZE_DMMV: 0
  GGML_SYCL_USE_ASYNC_MEM_OP: 1
  GGML_SYCL_USE_LEVEL_ZERO_API: 1
  GGML_SYCL_USM_SYSTEM: 0
  GGML_SYCL_ENABLE_HOST_PINNED_MEM: 1
Found 1 SYCL devices:
|  |                   |                                       |       |Max    |        |Max  |Global |                     |
|  |                   |                                       |       |compute|Max work|sub  |mem    |                     |
|ID|        Device Type|                                   Name|Version|units  |group   |group|size   |       Driver version|
|--|-------------------|---------------------------------------|-------|-------|--------|-----|-------|---------------------|
| 0| [level_zero:gpu:0]|             Intel Arc Pro B70 Graphics|   20.2|    256|    1024|   32| 34242M|           1.15.38308|
SYCL Optimization Feature:
|ID|        Device Type|Reorder|
|--|-------------------|-------|
| 0| [level_zero:gpu:0]|      Y|
Backend 1/2: SYCL0
  Device description: Intel(R) Arc(TM) Pro B70 Graphics
  Device memory: 32656 MB (32575 MB free)

  TOP_K(type=f32,ne=[2,1,1,1],k=1,ties=0):             90112 runs -    11.86 us/run -        0 kB/run -    0.00 GB/s
  TOP_K(type=f32,ne=[1,1,1,1],k=1,ties=0):             90112 runs -    11.70 us/run -        0 kB/run -    0.00 GB/s
  TOP_K(type=f32,ne=[1000,1,1,1],k=1,ties=0):                  73728 runs -    13.88 us/run -        3 kB/run -    0.27 GB/s
  TOP_K(type=f32,ne=[65000,1,1,1],k=1,ties=0):                 16384 runs -    90.86 us/run -      253 kB/run -    2.67 GB/s
  TOP_K(type=f32,ne=[200000,1,1,1],k=1,ties=0):                 8192 runs -   242.87 us/run -      781 kB/run -    3.07 GB/s
  TOP_K(type=f32,ne=[1,16,1,1],k=1,ties=0):                    90112 runs -    11.73 us/run -        0 kB/run -    0.01 GB/s
  TOP_K(type=f32,ne=[1000,16,1,1],k=1,ties=0):                 73728 runs -    13.95 us/run -       62 kB/run -    4.28 GB/s
  TOP_K(type=f32,ne=[65000,16,1,1],k=1,ties=0):                16384 runs -    93.82 us/run -     4062 kB/run -   41.30 GB/s
  TOP_K(type=f32,ne=[200000,16,1,1],k=1,ties=0):                5370 runs -   248.68 us/run -    12500 kB/run -   47.94 GB/s
  TOP_K(type=f32,ne=[10,1,1,1],k=10,ties=0):                   16384 runs -    94.98 us/run -        0 kB/run -    0.00 GB/s
  TOP_K(type=f32,ne=[1000,1,1,1],k=10,ties=0):                  8192 runs -   129.06 us/run -        3 kB/run -    0.03 GB/s
  TOP_K(type=f32,ne=[65000,1,1,1],k=10,ties=0):                 8192 runs -   401.78 us/run -      253 kB/run -    0.60 GB/s
  TOP_K(type=f32,ne=[200000,1,1,1],k=10,ties=0):                8192 runs -   655.69 us/run -      781 kB/run -    1.14 GB/s
  TOP_K(type=f32,ne=[10,16,1,1],k=10,ties=0):                  16384 runs -    96.61 us/run -        1 kB/run -    0.01 GB/s
  TOP_K(type=f32,ne=[1000,16,1,1],k=10,ties=0):                 8192 runs -   133.92 us/run -       63 kB/run -    0.45 GB/s
  TOP_K(type=f32,ne=[65000,16,1,1],k=10,ties=0):                8192 runs -   413.34 us/run -     4063 kB/run -    9.37 GB/s
  TOP_K(type=f32,ne=[200000,16,1,1],k=10,ties=0):               2685 runs -   660.76 us/run -    12500 kB/run -   18.04 GB/s
  TOP_K(type=f32,ne=[40,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[1000,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[65000,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[200000,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[40,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[1000,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[65000,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[200000,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[400,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[1000,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[65000,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[200000,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[400,16,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[1000,16,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[65000,16,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[200000,16,1,1],k=400,ties=0): not supported
  Backend SYCL0: OK
Backend 2/2: CPU
  Skipping CPU backend
2/2 backends passed
OK
```

### After:
```
~ 35.5s ❱ /nix/store/0rgqaspvn8khabsi0ach7dx8j6cxanyi-test-backend-ops-sycl-0.0.0/bin/test-backend-ops perf -o TOP_K
Testing 2 devices

Build with Macros:
  GGML_SYCL_DNNL: yes
  GGML_SYCL_F16: yes
  GGML_SYCL_FORCE_MMQ: no
  GGML_SYCL_GRAPH: yes
  GGML_SYCL_SUPPORT_LEVEL_ZERO_API: yes
  GGML_SYCL_SUPPORT_VMM: yes
Running with Environment Variables:
  GGML_SYCL_DEBUG: 0
  GGML_SYCL_DEV2DEV_MEMCPY: 0 (SYCL API)
  GGML_SYCL_ENABLE_DNN: 1
  GGML_SYCL_FA_ONEDNN: 1
  GGML_SYCL_FA_ONEDNN_MAX_KV: 0
  GGML_SYCL_ENABLE_FLASH_ATTN: 1
  GGML_SYCL_ENABLE_GRAPH: 0
  GGML_SYCL_ENABLE_OPT: 1
  GGML_SYCL_ENABLE_VMM: 1
  GGML_SYCL_ENABLE_FUSION: 1
  GGML_SYCL_ENABLE_ESIMD: 1
  GGML_SYCL_PRIORITIZE_DMMV: 0
  GGML_SYCL_USE_ASYNC_MEM_OP: 1
  GGML_SYCL_USE_LEVEL_ZERO_API: 1
  GGML_SYCL_USM_SYSTEM: 0
  GGML_SYCL_ENABLE_HOST_PINNED_MEM: 1
Found 1 SYCL devices:
|  |                   |                                       |       |Max    |        |Max  |Global |                     |
|  |                   |                                       |       |compute|Max work|sub  |mem    |                     |
|ID|        Device Type|                                   Name|Version|units  |group   |group|size   |       Driver version|
|--|-------------------|---------------------------------------|-------|-------|--------|-----|-------|---------------------|
| 0| [level_zero:gpu:0]|             Intel Arc Pro B70 Graphics|   20.2|    256|    1024|   32| 34242M|           1.15.38308|
SYCL Optimization Feature:
|ID|        Device Type|Reorder|
|--|-------------------|-------|
| 0| [level_zero:gpu:0]|      Y|
Backend 1/2: SYCL0
  Device description: Intel(R) Arc(TM) Pro B70 Graphics
  Device memory: 32656 MB (32575 MB free)

  TOP_K(type=f32,ne=[2,1,1,1],k=1,ties=0):            147456 runs -     7.16 us/run -        0 kB/run -    0.00 GB/s
  TOP_K(type=f32,ne=[1,1,1,1],k=1,ties=0):            147456 runs -     7.01 us/run -        0 kB/run -    0.00 GB/s
  TOP_K(type=f32,ne=[1000,1,1,1],k=1,ties=0):                 122880 runs -     8.30 us/run -        3 kB/run -    0.45 GB/s
  TOP_K(type=f32,ne=[65000,1,1,1],k=1,ties=0):                 65536 runs -    15.53 us/run -      253 kB/run -   15.60 GB/s
  TOP_K(type=f32,ne=[200000,1,1,1],k=1,ties=0):                65536 runs -    16.82 us/run -      781 kB/run -   44.30 GB/s
  TOP_K(type=f32,ne=[1,16,1,1],k=1,ties=0):                   147456 runs -     7.03 us/run -        0 kB/run -    0.02 GB/s
  TOP_K(type=f32,ne=[1000,16,1,1],k=1,ties=0):                122880 runs -     8.41 us/run -       62 kB/run -    7.09 GB/s
  TOP_K(type=f32,ne=[65000,16,1,1],k=1,ties=0):                24576 runs -    41.89 us/run -     4062 kB/run -   92.49 GB/s
  TOP_K(type=f32,ne=[200000,16,1,1],k=1,ties=0):               24165 runs -    44.83 us/run -    12500 kB/run -  265.94 GB/s
  TOP_K(type=f32,ne=[10,1,1,1],k=10,ties=0):                   57344 runs -    18.57 us/run -        0 kB/run -    0.00 GB/s
  TOP_K(type=f32,ne=[1000,1,1,1],k=10,ties=0):                 24576 runs -    56.73 us/run -        3 kB/run -    0.07 GB/s
  TOP_K(type=f32,ne=[65000,1,1,1],k=10,ties=0):                16384 runs -   115.64 us/run -      253 kB/run -    2.09 GB/s
  TOP_K(type=f32,ne=[200000,1,1,1],k=10,ties=0):               16384 runs -   116.18 us/run -      781 kB/run -    6.41 GB/s
  TOP_K(type=f32,ne=[10,16,1,1],k=10,ties=0):                  57344 runs -    19.12 us/run -        1 kB/run -    0.06 GB/s
  TOP_K(type=f32,ne=[1000,16,1,1],k=10,ties=0):                24576 runs -    58.08 us/run -       63 kB/run -    1.04 GB/s
  TOP_K(type=f32,ne=[65000,16,1,1],k=10,ties=0):                8192 runs -   371.57 us/run -     4063 kB/run -   10.43 GB/s
  TOP_K(type=f32,ne=[200000,16,1,1],k=10,ties=0):               2685 runs -   462.49 us/run -    12500 kB/run -   25.78 GB/s
  TOP_K(type=f32,ne=[40,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[1000,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[65000,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[200000,1,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[40,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[1000,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[65000,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[200000,16,1,1],k=40,ties=0): not supported
  TOP_K(type=f32,ne=[400,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[1000,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[65000,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[200000,1,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[400,16,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[1000,16,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[65000,16,1,1],k=400,ties=0): not supported
  TOP_K(type=f32,ne=[200000,16,1,1],k=400,ties=0): not supported
  Backend SYCL0: OK
Backend 2/2: CPU
  Skipping CPU backend
2/2 backends passed
OK
```

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Claude Fable 5 autonomously found this potential optimization and wrote an initial patch. Then I went in manually and edited it to my liking and terseness.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
