### PR TITLE
fix assertion DFlash2 with `--split-mode tensor` on CUDA

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1319,6 +1319,17 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
         }
         cparams_dft.n_rs_seq = 0;
 
+        // keep the fit estimate in sync with common_speculative_init_result (see there)
+        const bool has_block_draft = std::any_of(
+            params.speculative.types.begin(), params.speculative.types.end(),
+            [](common_speculative_type t) {
+                return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
+            });
+        if (has_block_draft) {
+            cparams_dft.n_ubatch = std::min(cparams_dft.n_ubatch,
+                    params_dft.n_parallel * (uint32_t) std::max(1, params_dft.speculative.draft.n_max + 1));
+        }
+
         const common_fit_extra_model extra = {
             /*.path_model   =*/ params_dft.model.path.c_str(),
             /*.mparams      =*/ &mparams_dft,

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1292,12 +1292,12 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
     auto mparams = common_model_params_to_llama(params);
     auto cparams = common_context_params_to_llama(params);
 
-    // DFlash2/DSpark drafters rank their full draft vocabulary inside the graph (top_k / argmax
-    // on the lm_head output), which needs the lm_head (the target's when the draft has none)
-    // replicated on every device. The flag must be set before the model is loaded, since the
-    // tensor split state is fixed during load.
+    // DSpark's markov head reads the lm_head output in-graph (argmax over the full vocabulary),
+    // so it keeps the lm_head replicated on every device; DFlash2 ranks the vocabulary on the
+    // CPU instead and can use a split lm_head. The flag must be set before the model is loaded,
+    // since the tensor split state is fixed during load.
     if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && !params.speculative.draft.mparams.path.empty() &&
-            common_speculative_draft_ranks_full_output(params.speculative.draft.mparams.path)) {
+            common_speculative_draft_replicated_lm_head(params.speculative.draft.mparams.path)) {
         mparams.output_replicated = true;
     }
 

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1327,7 +1327,7 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
             });
         if (has_block_draft) {
             cparams_dft.n_ubatch = std::min(cparams_dft.n_ubatch,
-                    params_dft.n_parallel * (uint32_t) std::max(1, params_dft.speculative.draft.n_max + 1));
+                    std::max<uint32_t>(params_dft.n_parallel * (uint32_t) std::max(1, params_dft.speculative.draft.n_max + 1), 64));
         }
 
         const common_fit_extra_model extra = {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1292,6 +1292,15 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
     auto mparams = common_model_params_to_llama(params);
     auto cparams = common_context_params_to_llama(params);
 
+    // DFlash2/DSpark drafters rank their full draft vocabulary inside the graph (top_k / argmax
+    // on the lm_head output), which needs the lm_head (the target's when the draft has none)
+    // replicated on every device. The flag must be set before the model is loaded, since the
+    // tensor split state is fixed during load.
+    if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && !params.speculative.draft.mparams.path.empty() &&
+            common_speculative_draft_ranks_full_output(params.speculative.draft.mparams.path)) {
+        mparams.output_replicated = true;
+    }
+
     if (params.fit_params) {
         COM_TRC("%s", "fitting params to device memory ...\n");
         COM_TRC("%s", "(for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)\n");

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1311,12 +1311,7 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
         cparams_dft.n_rs_seq = 0;
 
         // keep the fit estimate in sync with common_speculative_init_result (see there)
-        const bool has_block_draft = std::any_of(
-            params.speculative.types.begin(), params.speculative.types.end(),
-            [](common_speculative_type t) {
-                return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
-            });
-        if (has_block_draft) {
+        if (common_speculative_is_block_draft(params.speculative.types)) {
             cparams_dft.n_ubatch = std::min(cparams_dft.n_ubatch,
                     common_speculative_block_draft_n_ubatch(params_dft.n_parallel, params_dft.speculative.draft.n_max));
         }

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1327,7 +1327,7 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
             });
         if (has_block_draft) {
             cparams_dft.n_ubatch = std::min(cparams_dft.n_ubatch,
-                    std::max<uint32_t>(params_dft.n_parallel * (uint32_t) std::max(1, params_dft.speculative.draft.n_max + 1), 64));
+                    common_speculative_block_draft_n_ubatch(params_dft.n_parallel, params_dft.speculative.draft.n_max));
         }
 
         const common_fit_extra_model extra = {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1292,15 +1292,6 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
     auto mparams = common_model_params_to_llama(params);
     auto cparams = common_context_params_to_llama(params);
 
-    // DSpark's markov head reads the lm_head output in-graph (argmax over the full vocabulary),
-    // so it keeps the lm_head replicated on every device; DFlash2 ranks the vocabulary on the
-    // CPU instead and can use a split lm_head. The flag must be set before the model is loaded,
-    // since the tensor split state is fixed during load.
-    if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && !params.speculative.draft.mparams.path.empty() &&
-            common_speculative_draft_replicated_lm_head(params.speculative.draft.mparams.path)) {
-        mparams.output_replicated = true;
-    }
-
     if (params.fit_params) {
         COM_TRC("%s", "fitting params to device memory ...\n");
         COM_TRC("%s", "(for bugs during this step try to reproduce them with -fit off, or provide --verbose logs if the bug only occurs with -fit on)\n");

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2573,24 +2573,6 @@ std::vector<common_speculative_type> common_speculative_types_from_gguf(const st
     return { type };
 }
 
-bool common_speculative_draft_replicated_lm_head(const std::string & path) {
-    struct gguf_init_params gguf_params = {
-        /* .no_alloc = */ true,
-        /* .ctx      = */ nullptr,
-    };
-
-    gguf_context_ptr gguf_ctx(gguf_init_from_file(path.c_str(), gguf_params));
-    if (!gguf_ctx) {
-        return false;
-    }
-
-    // the target lm_head is replicated only when a DSpark draft consumes its output in-graph
-    // (the markov head argmax) and ships no lm_head of its own to run the head on; DFlash2
-    // ranks the vocabulary on the CPU instead and can use a split lm_head
-    return gguf_find_tensor(gguf_ctx.get(), "markov_w1.weight") >= 0 &&
-           gguf_find_tensor(gguf_ctx.get(), "output.weight") < 0;
-}
-
 static uint32_t common_get_enabled_speculative_configs(const std::vector<common_speculative_type> & configs) {
     uint32_t result = 0;
     for (size_t i = 0; i < configs.size(); i++) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2741,12 +2741,7 @@ common_params common_base_params_to_speculative(const common_params & params) {
     // dflash/dspark decode the whole noise block in a single pass and sample every block position on the backend
     // TODO: refactor such properties to be announced by the speculative types
     //       something like `struct common_speculative_type_props common_speculative_type_get_props(...);`
-    const bool has_block_draft = std::any_of(
-        params.speculative.types.begin(), params.speculative.types.end(),
-        [](common_speculative_type t) {
-            return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
-        });
-    if (has_block_draft) {
+    if (common_speculative_is_block_draft(params.speculative.types)) {
         // per-seq output positions: DFlash decodes anchor + n_max masks (n_max + 1); DSpark n_max -> +1 covers both
         const int32_t per_seq = std::max(1, params_spec.n_max + 1);
         result.n_outputs_max = params.n_parallel * per_seq;
@@ -2795,12 +2790,7 @@ common_speculative_init_result::common_speculative_init_result(
     // DFlash2/DSpark rank the full target vocabulary (in-graph or on the CPU after the
     // decode), so the reserved lm_head output grows with the draft ubatch; see
     // common_speculative_block_draft_n_ubatch for the cap rationale
-    const bool has_block_draft = std::any_of(
-        params.speculative.types.begin(), params.speculative.types.end(),
-        [](common_speculative_type t) {
-            return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
-        });
-    if (has_block_draft) {
+    if (common_speculative_is_block_draft(params.speculative.types)) {
         const uint32_t n_ubatch_dft = common_speculative_block_draft_n_ubatch(params.n_parallel, params.speculative.draft.n_max);
         if (cparams.n_ubatch > n_ubatch_dft) {
             LOG_INF("%s: capping draft context ubatch from %u to %u (block draft)\n", __func__, cparams.n_ubatch, n_ubatch_dft);

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1063,12 +1063,13 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             llama_set_embeddings_layer_inp(ctx_tgt, (uint32_t) target_layer_ids[k], true);
         }
 
-        // DFlash2 reads its selector lattice from h_nextn and never consumes raw logits.
+        // DFlash2's CPU selector reads the decoder hidden states of every block position from
+        // h_nextn, so the output stays dense; DFlash1/DSpark carry only their output rows there
         llama_set_embeddings_nextn(ctx_dft, true, /*masked*/ !is_dflash2);
         llama_set_causal_attn(ctx_dft, causal_attn); // DFlash needs non-causal attention unless the model says otherwise
     }
 
-    // read the DFlash2 selector weights straight from the draft GGUF file (they are i8)
+    // read the DFlash2 selector weights straight from the draft GGUF file
     void load_dflash2_selector() {
         struct gguf_init_params gguf_params = {
             /* .no_alloc = */ true,
@@ -1076,45 +1077,73 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         };
 
         gguf_context_ptr gguf_ctx(gguf_init_from_file(params.mparams.path.c_str(), gguf_params));
-        GGML_ASSERT(gguf_ctx && "failed to open the draft GGUF for the DFlash2 selector");
+        if (!gguf_ctx) {
+            throw std::runtime_error("failed to open the draft GGUF for the DFlash2 selector");
+        }
 
-        FILE * file = ggml_fopen(params.mparams.path.c_str(), "rb");
-        GGML_ASSERT(file && "failed to open the draft GGUF for the DFlash2 selector");
+        // RAII: close the file even when a load step below throws
+        struct file_closer {
+            void operator()(FILE * file) const {
+                fclose(file);
+            }
+        };
+        std::unique_ptr<FILE, file_closer> file(ggml_fopen(params.mparams.path.c_str(), "rb"));
+        if (!file) {
+            throw std::runtime_error("failed to open the draft GGUF for the DFlash2 selector");
+        }
 
         const int64_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(llama_get_model(params.ctx_dft)));
 
-        auto load_i8 = [&](const char * name, std::vector<float> & dst) {
+        // read and dequantize one selector tensor, validating its shape against the loader
+        // expectation; returns the row count (ne[0]) so the first table can fix the rank
+        auto load_i8 = [&](const char * name, std::vector<float> & dst, int64_t ne0_expect, int64_t ne1_expect) -> int64_t {
             const int64_t id = gguf_find_tensor(gguf_ctx.get(), name);
-            GGML_ASSERT(id >= 0 && "DFlash2 selector tensor missing");
+            if (id < 0) {
+                throw std::runtime_error(std::string("DFlash2 selector tensor '") + name + "' is missing from the draft GGUF");
+            }
+
+            const int64_t * ne = gguf_get_tensor_ne(gguf_ctx.get(), id);
+            if ((ne0_expect > 0 && ne[0] != ne0_expect) || ne[1] != ne1_expect) {
+                throw std::runtime_error(std::string("DFlash2 selector tensor '") + name +
+                        "' has an unexpected shape in the draft GGUF");
+            }
+
             const enum ggml_type t = gguf_get_tensor_type(gguf_ctx.get(), id);
             const struct ggml_type_traits * tt = ggml_get_type_traits(t);
-            GGML_ASSERT(tt && tt->to_float && "unsupported DFlash2 selector tensor type");
+            if (tt == nullptr || tt->to_float == nullptr) {
+                throw std::runtime_error(std::string("DFlash2 selector tensor '") + name + "' uses an unsupported type");
+            }
 
             const size_t size = gguf_get_tensor_size(gguf_ctx.get(), id);
             std::vector<uint8_t> raw(size);
 
             const int64_t offset = gguf_get_data_offset(gguf_ctx.get()) + gguf_get_tensor_offset(gguf_ctx.get(), id);
 #ifdef _WIN32
-            const int rc = _fseeki64(file, offset, SEEK_SET);
+            const int rc = _fseeki64(file.get(), offset, SEEK_SET);
 #else
-            const int rc = fseeko(file, (off_t) offset, SEEK_SET);
+            const int rc = fseeko(file.get(), (off_t) offset, SEEK_SET);
 #endif
-            GGML_ASSERT(rc == 0 && "failed to seek to the DFlash2 selector tensor");
-            GGML_ASSERT(fread(raw.data(), 1, size, file) == size && "failed to read the DFlash2 selector tensor");
+            if (rc != 0) {
+                throw std::runtime_error(std::string("failed to seek to the DFlash2 selector tensor '") + name + "'");
+            }
+            if (fread(raw.data(), 1, size, file.get()) != size) {
+                throw std::runtime_error(std::string("failed to read the DFlash2 selector tensor '") + name + "'");
+            }
 
             // dequantize with the same conversion the GPU get_rows uses
             const size_t n_elts = size / tt->type_size * tt->blck_size;
             dst.resize(n_elts);
             tt->to_float(raw.data(), dst.data(), (int64_t) n_elts);
+
+            return ne[0];
         };
 
-        load_i8("selector_successor.weight",  sel_next);
-        load_i8("selector_predecessor.weight", sel_prev);
-        load_i8("selector_hidden.weight",      sel_hidden);
+        // the successor table fixes the rank; the other two tables are checked against it
+        const int64_t rank = load_i8("selector_successor.weight",   sel_next,   -1,        n_vocab);
+        load_i8("selector_predecessor.weight", sel_prev,   rank,      n_vocab);
+        load_i8("selector_hidden.weight",      sel_hidden, n_embd_dec, rank);
 
-        fclose(file);
-
-        selector_rank = (int32_t) (sel_next.size() / n_vocab);
+        selector_rank = (int32_t) rank;
         GGML_ASSERT((size_t) selector_rank * n_vocab == sel_next.size());
         GGML_ASSERT((size_t) selector_rank * n_vocab == sel_prev.size());
         GGML_ASSERT((size_t) n_embd_dec * selector_rank == sel_hidden.size());
@@ -2519,9 +2548,11 @@ bool common_speculative_draft_replicated_lm_head(const std::string & path) {
         return false;
     }
 
-    // DSpark's markov head reads the lm_head output in-graph; DFlash2 ranks the
-    // vocabulary on the CPU instead and can use a split lm_head
-    return gguf_find_tensor(gguf_ctx.get(), "markov_w1.weight") >= 0;
+    // the target lm_head is replicated only when a DSpark draft consumes its output in-graph
+    // (the markov head argmax) and ships no lm_head of its own to run the head on; DFlash2
+    // ranks the vocabulary on the CPU instead and can use a split lm_head
+    return gguf_find_tensor(gguf_ctx.get(), "markov_w1.weight") >= 0 &&
+           gguf_find_tensor(gguf_ctx.get(), "output.weight") < 0;
 }
 
 static uint32_t common_get_enabled_speculative_configs(const std::vector<common_speculative_type> & configs) {
@@ -2743,19 +2774,16 @@ common_speculative_init_result::common_speculative_init_result(
     cparams.n_rs_seq  = 0;
     cparams.ctx_other = ctx_tgt;
 
-    // DFlash2/DSpark rank the full target vocabulary (in-graph or on the CPU after the decode),
-    // so the lm_head output for every block position grows with n_ubatch * n_vocab.
-    // Their largest decode batch is one noise block per sequence (n_max + 1 tokens), but the
-    // target-feature prefill (encoder + KV injection) is chunked by the same ubatch, so keep a
-    // floor: anything below ~64 tokens per chunk is launch-bound and degrades prompt processing.
+    // DFlash2/DSpark rank the full target vocabulary (in-graph or on the CPU after the
+    // decode), so the reserved lm_head output grows with the draft ubatch; see
+    // common_speculative_block_draft_n_ubatch for the cap rationale
     const bool has_block_draft = std::any_of(
         params.speculative.types.begin(), params.speculative.types.end(),
         [](common_speculative_type t) {
             return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
         });
     if (has_block_draft) {
-        const uint32_t n_ubatch_dft = std::max<uint32_t>(
-            params.n_parallel * (uint32_t) std::max(1, params.speculative.draft.n_max + 1), 64);
+        const uint32_t n_ubatch_dft = common_speculative_block_draft_n_ubatch(params.n_parallel, params.speculative.draft.n_max);
         if (cparams.n_ubatch > n_ubatch_dft) {
             LOG_INF("%s: capping draft context ubatch from %u to %u (block draft)\n", __func__, cparams.n_ubatch, n_ubatch_dft);
             cparams.n_ubatch = n_ubatch_dft;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2358,6 +2358,44 @@ std::vector<common_speculative_type> common_speculative_types_from_gguf(const st
     return { type };
 }
 
+bool common_speculative_draft_ranks_full_output(const std::string & path) {
+    struct gguf_init_params gguf_params = {
+        /* .no_alloc = */ true,
+        /* .ctx      = */ nullptr,
+    };
+
+    gguf_context_ptr gguf_ctx(gguf_init_from_file(path.c_str(), gguf_params));
+    if (!gguf_ctx) {
+        return false;
+    }
+
+    const int64_t arch_id = gguf_find_key(gguf_ctx.get(), "general.architecture");
+    if (arch_id < 0 || gguf_get_kv_type(gguf_ctx.get(), arch_id) != GGUF_TYPE_STRING) {
+        return false;
+    }
+
+    const std::string arch = gguf_get_val_str(gguf_ctx.get(), arch_id);
+    if (arch != "dflash") {
+        return false;
+    }
+
+    // DFlash2's candidate selector and DSpark's markov head rank the full draft
+    // vocabulary in-graph (top_k / argmax on the lm_head output)
+    bool ranks_full_output = false;
+    if (gguf_find_tensor(gguf_ctx.get(), "selector_hidden.weight") >= 0) {
+        ranks_full_output = true; // DFlash2
+    }
+    if (gguf_find_tensor(gguf_ctx.get(), "markov_w1.weight") >= 0) {
+        ranks_full_output = true; // DSpark
+    }
+    if (!ranks_full_output) {
+        return false;
+    }
+
+    // a draft with its own lm_head replicates it itself; only the shared target lm_head needs the flag
+    return gguf_find_tensor(gguf_ctx.get(), "output.weight") < 0;
+}
+
 static uint32_t common_get_enabled_speculative_configs(const std::vector<common_speculative_type> & configs) {
     uint32_t result = 0;
     for (size_t i = 0; i < configs.size(); i++) {

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1096,7 +1096,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
         // read and dequantize one selector tensor, validating its shape against the loader
         // expectation; returns the row count (ne[0]) so the first table can fix the rank
-        auto load_i8 = [&](const char * name, std::vector<float> & dst, int64_t ne0_expect, int64_t ne1_expect) -> int64_t {
+        auto load_selector_tensor = [&](const char * name, std::vector<float> & dst, int64_t ne0_expect, int64_t ne1_expect) -> int64_t {
             const int64_t id = gguf_find_tensor(gguf_ctx.get(), name);
             if (id < 0) {
                 throw std::runtime_error(std::string("DFlash2 selector tensor '") + name + "' is missing from the draft GGUF");
@@ -1139,9 +1139,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         };
 
         // the successor table fixes the rank; the other two tables are checked against it
-        const int64_t rank = load_i8("selector_successor.weight",   sel_next,   -1,        n_vocab);
-        load_i8("selector_predecessor.weight", sel_prev,   rank,      n_vocab);
-        load_i8("selector_hidden.weight",      sel_hidden, n_embd_dec, rank);
+        const int64_t rank = load_selector_tensor("selector_successor.weight",   sel_next,   -1,        n_vocab);
+        load_selector_tensor("selector_predecessor.weight", sel_prev,   rank,      n_vocab);
+        load_selector_tensor("selector_hidden.weight",      sel_hidden, n_embd_dec, rank);
 
         selector_rank = (int32_t) rank;
         GGML_ASSERT((size_t) selector_rank * n_vocab == sel_next.size());

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2741,15 +2741,17 @@ common_speculative_init_result::common_speculative_init_result(
 
     // DFlash2/DSpark rank the full target vocabulary (in-graph or on the CPU after the decode),
     // so the lm_head output for every block position grows with n_ubatch * n_vocab.
-    // Their largest decode batch is one noise block per sequence (n_max + 1 tokens), so cap the
-    // ubatch to that; anything larger only inflates the reserved compute buffer.
+    // Their largest decode batch is one noise block per sequence (n_max + 1 tokens), but the
+    // target-feature prefill (encoder + KV injection) is chunked by the same ubatch, so keep a
+    // floor: anything below ~64 tokens per chunk is launch-bound and degrades prompt processing.
     const bool has_block_draft = std::any_of(
         params.speculative.types.begin(), params.speculative.types.end(),
         [](common_speculative_type t) {
             return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
         });
     if (has_block_draft) {
-        const uint32_t n_ubatch_dft = params.n_parallel * (uint32_t) std::max(1, params.speculative.draft.n_max + 1);
+        const uint32_t n_ubatch_dft = std::max<uint32_t>(
+            params.n_parallel * (uint32_t) std::max(1, params.speculative.draft.n_max + 1), 64);
         if (cparams.n_ubatch > n_ubatch_dft) {
             LOG_INF("%s: capping draft context ubatch from %u to %u (block draft)\n", __func__, cparams.n_ubatch, n_ubatch_dft);
             cparams.n_ubatch = n_ubatch_dft;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1078,6 +1078,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         gguf_context_ptr gguf_ctx(gguf_init_from_file(params.mparams.path.c_str(), gguf_params));
         GGML_ASSERT(gguf_ctx && "failed to open the draft GGUF for the DFlash2 selector");
 
+        FILE * file = ggml_fopen(params.mparams.path.c_str(), "rb");
+        GGML_ASSERT(file && "failed to open the draft GGUF for the DFlash2 selector");
+
         const int64_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(llama_get_model(params.ctx_dft)));
 
         auto load_i8 = [&](const char * name, std::vector<float> & dst) {
@@ -1090,15 +1093,14 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             const size_t size = gguf_get_tensor_size(gguf_ctx.get(), id);
             std::vector<uint8_t> raw(size);
 
-            std::unique_ptr<FILE, decltype(&fclose)> f(ggml_fopen(params.mparams.path.c_str(), "rb"), fclose);
-            GGML_ASSERT(f && "failed to open the draft GGUF for the DFlash2 selector");
+            const int64_t offset = gguf_get_data_offset(gguf_ctx.get()) + gguf_get_tensor_offset(gguf_ctx.get(), id);
 #ifdef _WIN32
-            const int rc = _fseeki64(f.get(), (int64_t) (gguf_get_data_offset(gguf_ctx.get()) + gguf_get_tensor_offset(gguf_ctx.get(), id)), SEEK_SET);
+            const int rc = _fseeki64(file, offset, SEEK_SET);
 #else
-            const int rc = fseeko(f.get(), (off_t) (gguf_get_data_offset(gguf_ctx.get()) + gguf_get_tensor_offset(gguf_ctx.get(), id)), SEEK_SET);
+            const int rc = fseeko(file, (off_t) offset, SEEK_SET);
 #endif
             GGML_ASSERT(rc == 0 && "failed to seek to the DFlash2 selector tensor");
-            GGML_ASSERT(fread(raw.data(), 1, size, f.get()) == size && "failed to read the DFlash2 selector tensor");
+            GGML_ASSERT(fread(raw.data(), 1, size, file) == size && "failed to read the DFlash2 selector tensor");
 
             // dequantize with the same conversion the GPU get_rows uses
             const size_t n_elts = size / tt->type_size * tt->blck_size;
@@ -1109,6 +1111,8 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         load_i8("selector_successor.weight",  sel_next);
         load_i8("selector_predecessor.weight", sel_prev);
         load_i8("selector_hidden.weight",      sel_hidden);
+
+        fclose(file);
 
         selector_rank = (int32_t) (sel_next.size() / n_vocab);
         GGML_ASSERT((size_t) selector_rank * n_vocab == sel_next.size());

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -928,6 +928,13 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     bool    is_dflash2     = false;
     bool    is_mrope       = false;
     int32_t selector_top_k = 0;
+    int32_t selector_rank  = 0;
+
+    // DFlash2 CPU-side selector: the lm_head output may be split across devices, so the
+    // candidate lattice is built on the host from the gathered logits
+    std::vector<float> sel_next;     // [selector_rank, n_vocab]
+    std::vector<float> sel_prev;     // [selector_rank, n_vocab]
+    std::vector<float> sel_hidden;   // [n_embd_dec, selector_rank]
 
     // draft-dspark: the draft carries a Markov head and uses an anchor-first block layout
     const bool is_dspark;
@@ -983,6 +990,12 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         selector_top_k = llama_model_dflash_selector_top_k(model_dft);
         is_dflash2     = selector_top_k > 0;
         mask_token_id = llama_vocab_mask(llama_model_get_vocab(model_dft));
+
+        if (is_dflash2) {
+            // the candidate lattice is built on the CPU, so the raw lm_head output must be
+            // available after the decode; the hidden states ride the nextn output
+            load_dflash2_selector();
+        }
 
         if (is_dspark && this->params.p_min > 0.0f) {
             char buf[16] = {};
@@ -1053,6 +1066,112 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         // DFlash2 reads its selector lattice from h_nextn and never consumes raw logits.
         llama_set_embeddings_nextn(ctx_dft, true, /*masked*/ !is_dflash2);
         llama_set_causal_attn(ctx_dft, causal_attn); // DFlash needs non-causal attention unless the model says otherwise
+    }
+
+    // read the DFlash2 selector weights straight from the draft GGUF file (they are i8)
+    void load_dflash2_selector() {
+        struct gguf_init_params gguf_params = {
+            /* .no_alloc = */ true,
+            /* .ctx      = */ nullptr,
+        };
+
+        gguf_context_ptr gguf_ctx(gguf_init_from_file(params.mparams.path.c_str(), gguf_params));
+        GGML_ASSERT(gguf_ctx && "failed to open the draft GGUF for the DFlash2 selector");
+
+        const int64_t n_vocab = llama_vocab_n_tokens(llama_model_get_vocab(llama_get_model(params.ctx_dft)));
+
+        auto load_i8 = [&](const char * name, std::vector<float> & dst) {
+            const int64_t id = gguf_find_tensor(gguf_ctx.get(), name);
+            GGML_ASSERT(id >= 0 && "DFlash2 selector tensor missing");
+            const enum ggml_type t = gguf_get_tensor_type(gguf_ctx.get(), id);
+            const struct ggml_type_traits * tt = ggml_get_type_traits(t);
+            GGML_ASSERT(tt && tt->to_float && "unsupported DFlash2 selector tensor type");
+
+            const size_t size = gguf_get_tensor_size(gguf_ctx.get(), id);
+            std::vector<uint8_t> raw(size);
+
+            std::unique_ptr<FILE, decltype(&fclose)> f(ggml_fopen(params.mparams.path.c_str(), "rb"), fclose);
+            GGML_ASSERT(f && "failed to open the draft GGUF for the DFlash2 selector");
+#ifdef _WIN32
+            const int rc = _fseeki64(f.get(), (int64_t) (gguf_get_data_offset(gguf_ctx.get()) + gguf_get_tensor_offset(gguf_ctx.get(), id)), SEEK_SET);
+#else
+            const int rc = fseeko(f.get(), (off_t) (gguf_get_data_offset(gguf_ctx.get()) + gguf_get_tensor_offset(gguf_ctx.get(), id)), SEEK_SET);
+#endif
+            GGML_ASSERT(rc == 0 && "failed to seek to the DFlash2 selector tensor");
+            GGML_ASSERT(fread(raw.data(), 1, size, f.get()) == size && "failed to read the DFlash2 selector tensor");
+
+            // dequantize with the same conversion the GPU get_rows uses
+            const size_t n_elts = size / tt->type_size * tt->blck_size;
+            dst.resize(n_elts);
+            tt->to_float(raw.data(), dst.data(), (int64_t) n_elts);
+        };
+
+        load_i8("selector_successor.weight",  sel_next);
+        load_i8("selector_predecessor.weight", sel_prev);
+        load_i8("selector_hidden.weight",      sel_hidden);
+
+        selector_rank = (int32_t) (sel_next.size() / n_vocab);
+        GGML_ASSERT((size_t) selector_rank * n_vocab == sel_next.size());
+        GGML_ASSERT((size_t) selector_rank * n_vocab == sel_prev.size());
+        GGML_ASSERT((size_t) n_embd_dec * selector_rank == sel_hidden.size());
+    }
+
+    // DFlash2 CPU-side selector: rank the (possibly split) lm_head output once per batch and
+    // return the per-position top-k candidate ids, unary scores and the selector gate
+    void build_dflash2_selector_cpu(std::vector<int32_t> & cand, std::vector<float> & unary, std::vector<float> & gate) {
+        auto & ctx_dft = params.ctx_dft;
+
+        const int64_t n_vocab  = llama_vocab_n_tokens(llama_model_get_vocab(llama_get_model(ctx_dft)));
+        const int32_t n_tokens = batch.n_tokens;
+        const int32_t top_k    = selector_top_k;
+        const int32_t rank     = selector_rank;
+
+        cand.resize((size_t) n_tokens * top_k);
+        unary.resize((size_t) n_tokens * top_k);
+        gate.resize((size_t) n_tokens * rank);
+
+        const float * embd_all = llama_get_embeddings_nextn(ctx_dft);
+        GGML_ASSERT(embd_all && "DFlash2 CPU selector requires the decoder hidden states");
+        for (int32_t i = 0; i < n_tokens; ++i) {
+            const float * logits = llama_get_logits_ith(ctx_dft, i);
+            const float * embd   = embd_all + (size_t) i * n_embd_dec;
+            GGML_ASSERT(logits && "DFlash2 CPU selector requires the lm_head output");
+
+            int32_t * ci = cand.data()  + (size_t) i * top_k;
+            float   * ui = unary.data() + (size_t) i * top_k;
+
+            // top-k scan keeping the largest values in descending order
+            std::vector<int32_t> ids(top_k, 0);
+            std::vector<float>   vals(top_k, -INFINITY);
+            for (int64_t t = 0; t < n_vocab; ++t) {
+                const float v = logits[t];
+                if (v <= vals[top_k - 1]) {
+                    continue;
+                }
+                int32_t pos = top_k - 1;
+                while (pos > 0 && v > vals[pos - 1]) {
+                    vals[pos] = vals[pos - 1];
+                    ids[pos]  = ids[pos - 1];
+                    pos--;
+                }
+                vals[pos] = v;
+                ids[pos]  = (int32_t) t;
+            }
+            for (int32_t k = 0; k < top_k; ++k) {
+                ci[k] = ids[k];
+                ui[k] = vals[k];
+            }
+
+            // gate = selector_hidden^T x hidden_state
+            float * gi = gate.data() + (size_t) i * rank;
+            for (int32_t k = 0; k < rank; ++k) {
+                float s = 0.0f;
+                for (int32_t d = 0; d < n_embd_dec; ++d) {
+                    s += sel_hidden[(size_t) k * n_embd_dec + d] * embd[d];
+                }
+                gi[k] = s;
+            }
+        }
     }
 
     ~common_speculative_impl_draft_dflash() override {
@@ -1239,7 +1358,8 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             i_block_beg[seq_id] = batch.n_tokens;
             n_block    [seq_id] = n_block_tokens;
             for (int32_t i = 0; i < n_block_tokens; ++i) {
-                common_batch_add(batch, i == 0 ? dp.id_last : mask_token_id, n + i, { seq_id }, !is_dflash2);
+                // DFlash2 ranks the lm_head output on the CPU, so its block positions emit logits
+                common_batch_add(batch, i == 0 ? dp.id_last : mask_token_id, n + i, { seq_id }, true);
             }
         }
 
@@ -1252,6 +1372,14 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         if (ret != 0) {
             LOG_WRN("%s: llama_decode returned %d\n", __func__, ret);
             return;
+        }
+
+        // DFlash2 ranks the (possibly split) lm_head output on the CPU once for the whole batch
+        std::vector<int32_t> cand;
+        std::vector<float>   unary;
+        std::vector<float>   gate;
+        if (is_dflash2) {
+            build_dflash2_selector_cpu(cand, unary, gate);
         }
 
         for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
@@ -1268,16 +1396,34 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             auto & result = *dp.result;
 
             if (is_dflash2) {
-                const float * lattice = llama_get_embeddings_nextn(ctx_dft);
-                GGML_ASSERT(lattice && "DFlash2 selector produced no lattice");
-
+                // block walk over the CPU-computed candidates: the transition scores for the
+                // current predecessor are evaluated on the fly
                 int32_t predecessor = 0;
                 for (int32_t i = 1; i < n_block_tokens; ++i) {
-                    const float * row = lattice + (size_t) (beg + i) * n_embd_dec;
-                    const float * scores = row + selector_top_k + (size_t) predecessor * selector_top_k;
+                    const int32_t pos = beg + i;
 
-                    predecessor = (int32_t) std::distance(scores,
-                            std::max_element(scores, scores + selector_top_k));
+                    const int32_t * ci = cand.data()  + (size_t) pos * selector_top_k;
+                    const float   * ui = unary.data() + (size_t) pos * selector_top_k;
+                    const float   * gi = gate.data()  + (size_t) pos * selector_rank;
+
+                    // the predecessor candidate id: the anchor for block position 1, else the
+                    // previously chosen candidate
+                    const int32_t pred_id = i == 1
+                        ? batch.token[beg]
+                        : cand[(size_t) (pos - 1) * selector_top_k + predecessor];
+
+                    std::vector<float> scores(selector_top_k);
+                    for (int32_t j = 0; j < selector_top_k; ++j) {
+                        float s = ui[j];
+                        const int32_t cj = ci[j];
+                        for (int32_t k = 0; k < selector_rank; ++k) {
+                            s += sel_next[(size_t) cj * selector_rank + k] * sel_prev[(size_t) pred_id * selector_rank + k] * gi[k];
+                        }
+                        scores[j] = s;
+                    }
+
+                    predecessor = (int32_t) std::distance(scores.begin(),
+                            std::max_element(scores.begin(), scores.end()));
                     if (params.p_min > 0.0f) {
                         // softmax(scores) at the argmax, i.e. 1 / sum(exp(s_k - s_max))
                         float sum = 0.0f;
@@ -1288,7 +1434,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
                             break;
                         }
                     }
-                    result.push_back((llama_token) row[predecessor]);
+                    result.push_back((llama_token) ci[predecessor]);
                 }
 
                 if (result.size() < (size_t) params.n_min) {
@@ -2358,7 +2504,7 @@ std::vector<common_speculative_type> common_speculative_types_from_gguf(const st
     return { type };
 }
 
-bool common_speculative_draft_ranks_full_output(const std::string & path) {
+bool common_speculative_draft_replicated_lm_head(const std::string & path) {
     struct gguf_init_params gguf_params = {
         /* .no_alloc = */ true,
         /* .ctx      = */ nullptr,
@@ -2369,31 +2515,9 @@ bool common_speculative_draft_ranks_full_output(const std::string & path) {
         return false;
     }
 
-    const int64_t arch_id = gguf_find_key(gguf_ctx.get(), "general.architecture");
-    if (arch_id < 0 || gguf_get_kv_type(gguf_ctx.get(), arch_id) != GGUF_TYPE_STRING) {
-        return false;
-    }
-
-    const std::string arch = gguf_get_val_str(gguf_ctx.get(), arch_id);
-    if (arch != "dflash") {
-        return false;
-    }
-
-    // DFlash2's candidate selector and DSpark's markov head rank the full draft
-    // vocabulary in-graph (top_k / argmax on the lm_head output)
-    bool ranks_full_output = false;
-    if (gguf_find_tensor(gguf_ctx.get(), "selector_hidden.weight") >= 0) {
-        ranks_full_output = true; // DFlash2
-    }
-    if (gguf_find_tensor(gguf_ctx.get(), "markov_w1.weight") >= 0) {
-        ranks_full_output = true; // DSpark
-    }
-    if (!ranks_full_output) {
-        return false;
-    }
-
-    // a draft with its own lm_head replicates it itself; only the shared target lm_head needs the flag
-    return gguf_find_tensor(gguf_ctx.get(), "output.weight") < 0;
+    // DSpark's markov head reads the lm_head output in-graph; DFlash2 ranks the
+    // vocabulary on the CPU instead and can use a split lm_head
+    return gguf_find_tensor(gguf_ctx.get(), "markov_w1.weight") >= 0;
 }
 
 static uint32_t common_get_enabled_speculative_configs(const std::vector<common_speculative_type> & configs) {
@@ -2615,8 +2739,8 @@ common_speculative_init_result::common_speculative_init_result(
     cparams.n_rs_seq  = 0;
     cparams.ctx_other = ctx_tgt;
 
-    // DFlash2/DSpark rank the full target vocabulary inside the draft graph (top_k / argmax
-    // on the lm_head output), so the worst-case compute buffer grows with n_ubatch * n_vocab.
+    // DFlash2/DSpark rank the full target vocabulary (in-graph or on the CPU after the decode),
+    // so the lm_head output for every block position grows with n_ubatch * n_vocab.
     // Their largest decode batch is one noise block per sequence (n_max + 1 tokens), so cap the
     // ubatch to that; anything larger only inflates the reserved compute buffer.
     const bool has_block_draft = std::any_of(

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2615,6 +2615,23 @@ common_speculative_init_result::common_speculative_init_result(
     cparams.n_rs_seq  = 0;
     cparams.ctx_other = ctx_tgt;
 
+    // DFlash2/DSpark rank the full target vocabulary inside the draft graph (top_k / argmax
+    // on the lm_head output), so the worst-case compute buffer grows with n_ubatch * n_vocab.
+    // Their largest decode batch is one noise block per sequence (n_max + 1 tokens), so cap the
+    // ubatch to that; anything larger only inflates the reserved compute buffer.
+    const bool has_block_draft = std::any_of(
+        params.speculative.types.begin(), params.speculative.types.end(),
+        [](common_speculative_type t) {
+            return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
+        });
+    if (has_block_draft) {
+        const uint32_t n_ubatch_dft = params.n_parallel * (uint32_t) std::max(1, params.speculative.draft.n_max + 1);
+        if (cparams.n_ubatch > n_ubatch_dft) {
+            LOG_INF("%s: capping draft context ubatch from %u to %u (block draft)\n", __func__, cparams.n_ubatch, n_ubatch_dft);
+            cparams.n_ubatch = n_ubatch_dft;
+        }
+    }
+
     std::string model_path;
     if (has_draft) {
         model_path = params.speculative.draft.mparams.path;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -926,6 +926,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     llama_token mask_token_id = 0;
 
     bool    is_dflash2     = false;
+    bool    is_dflash2_cpu = false;  // ranks the lm_head output on the host when it is split (tensor parallelism)
     bool    is_mrope       = false;
     int32_t selector_top_k = 0;
     int32_t selector_rank  = 0;
@@ -989,9 +990,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
         selector_top_k = llama_model_dflash_selector_top_k(model_dft);
         is_dflash2     = selector_top_k > 0;
+        // under tensor parallelism the lm_head is split and the in-graph selector cannot run
+        is_dflash2_cpu = is_dflash2 && llama_model_get_split_mode(model_dft) == LLAMA_SPLIT_MODE_TENSOR;
         mask_token_id = llama_vocab_mask(llama_model_get_vocab(model_dft));
 
-        if (is_dflash2) {
+        if (is_dflash2_cpu) {
             // the candidate lattice is built on the CPU, so the raw lm_head output must be
             // available after the decode; the hidden states ride the nextn output
             load_dflash2_selector();
@@ -1063,13 +1066,17 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             llama_set_embeddings_layer_inp(ctx_tgt, (uint32_t) target_layer_ids[k], true);
         }
 
-        // DFlash2's CPU selector reads the decoder hidden states of every block position from
-        // h_nextn, so the output stays dense; DFlash1/DSpark carry only their output rows there
+        // DFlash2 reads its selector data from h_nextn for every block position (the decoder
+        // hidden states on the CPU path, the packed lattice in-graph), so the output stays
+        // dense; DFlash1/DSpark carry only their output rows there
         llama_set_embeddings_nextn(ctx_dft, true, /*masked*/ !is_dflash2);
         llama_set_causal_attn(ctx_dft, causal_attn); // DFlash needs non-causal attention unless the model says otherwise
     }
 
-    // read the DFlash2 selector weights straight from the draft GGUF file
+    // read the DFlash2 selector weights straight from the draft GGUF file (tensor-parallel
+    // mode only: the lm_head is split, so the in-graph build_dflash2_selector() in
+    // src/models/dflash.cpp cannot run and these tables are not loaded into device memory);
+    // keep the candidate math in sync with that in-graph implementation
     void load_dflash2_selector() {
         struct gguf_init_params gguf_params = {
             /* .no_alloc = */ true,
@@ -1150,7 +1157,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
     }
 
     // DFlash2 CPU-side selector: rank the (possibly split) lm_head output once per batch and
-    // return the per-position top-k candidate ids, unary scores and the selector gate
+    // return the per-position top-k candidate ids, unary scores and the selector gate.
+    // In-graph counterpart: build_dflash2_selector() in src/models/dflash.cpp (runs when the
+    // lm_head is not split); keep the candidate math in sync.
     void build_dflash2_selector_cpu(std::vector<int32_t> & cand, std::vector<float> & unary, std::vector<float> & gate) {
         auto & ctx_dft = params.ctx_dft;
 
@@ -1391,8 +1400,9 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             i_block_beg[seq_id] = batch.n_tokens;
             n_block    [seq_id] = n_block_tokens;
             for (int32_t i = 0; i < n_block_tokens; ++i) {
-                // DFlash2 ranks the lm_head output on the CPU, so its block positions emit logits
-                common_batch_add(batch, i == 0 ? dp.id_last : mask_token_id, n + i, { seq_id }, true);
+                // the CPU-side DFlash2 selector needs the gathered lm_head output for every block
+                // position; the in-graph selector consumes it inside the graph instead
+                common_batch_add(batch, i == 0 ? dp.id_last : mask_token_id, n + i, { seq_id }, !is_dflash2 || is_dflash2_cpu);
             }
         }
 
@@ -1411,7 +1421,7 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
         std::vector<int32_t> cand;
         std::vector<float>   unary;
         std::vector<float>   gate;
-        if (is_dflash2) {
+        if (is_dflash2_cpu) {
             build_dflash2_selector_cpu(cand, unary, gate);
         }
 
@@ -1429,45 +1439,71 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             auto & result = *dp.result;
 
             if (is_dflash2) {
-                // block walk over the CPU-computed candidates: the transition scores for the
-                // current predecessor are evaluated on the fly
-                int32_t predecessor = 0;
-                for (int32_t i = 1; i < n_block_tokens; ++i) {
-                    const int32_t pos = beg + i;
+                if (is_dflash2_cpu) {
+                    // block walk over the CPU-computed candidates: the transition scores for the
+                    // current predecessor are evaluated on the fly
+                    int32_t predecessor = 0;
+                    for (int32_t i = 1; i < n_block_tokens; ++i) {
+                        const int32_t pos = beg + i;
 
-                    const int32_t * ci = cand.data()  + (size_t) pos * selector_top_k;
-                    const float   * ui = unary.data() + (size_t) pos * selector_top_k;
-                    const float   * gi = gate.data()  + (size_t) pos * selector_rank;
+                        const int32_t * ci = cand.data()  + (size_t) pos * selector_top_k;
+                        const float   * ui = unary.data() + (size_t) pos * selector_top_k;
+                        const float   * gi = gate.data()  + (size_t) pos * selector_rank;
 
-                    // the predecessor candidate id: the anchor for block position 1, else the
-                    // previously chosen candidate
-                    const int32_t pred_id = i == 1
-                        ? batch.token[beg]
-                        : cand[(size_t) (pos - 1) * selector_top_k + predecessor];
+                        // the predecessor candidate id: the anchor for block position 1, else the
+                        // previously chosen candidate
+                        const int32_t pred_id = i == 1
+                            ? batch.token[beg]
+                            : cand[(size_t) (pos - 1) * selector_top_k + predecessor];
 
-                    std::vector<float> scores(selector_top_k);
-                    for (int32_t j = 0; j < selector_top_k; ++j) {
-                        float s = ui[j];
-                        const int32_t cj = ci[j];
-                        for (int32_t k = 0; k < selector_rank; ++k) {
-                            s += sel_next[(size_t) cj * selector_rank + k] * sel_prev[(size_t) pred_id * selector_rank + k] * gi[k];
+                        std::vector<float> scores(selector_top_k);
+                        for (int32_t j = 0; j < selector_top_k; ++j) {
+                            float s = ui[j];
+                            const int32_t cj = ci[j];
+                            for (int32_t k = 0; k < selector_rank; ++k) {
+                                s += sel_next[(size_t) cj * selector_rank + k] * sel_prev[(size_t) pred_id * selector_rank + k] * gi[k];
+                            }
+                            scores[j] = s;
                         }
-                        scores[j] = s;
+
+                        predecessor = (int32_t) std::distance(scores.begin(),
+                                std::max_element(scores.begin(), scores.end()));
+                        if (params.p_min > 0.0f) {
+                            // softmax(scores) at the argmax, i.e. 1 / sum(exp(s_k - s_max))
+                            float sum = 0.0f;
+                            for (int32_t k = 0; k < selector_top_k; ++k) {
+                                sum += std::exp(scores[k] - scores[predecessor]);
+                            }
+                            if (1.0f / sum < params.p_min) {
+                                break;
+                            }
+                        }
+                        result.push_back((llama_token) ci[predecessor]);
                     }
+                } else {
+                    // block walk over the lattice packed by the in-graph selector
+                    const float * lattice = llama_get_embeddings_nextn(ctx_dft);
+                    GGML_ASSERT(lattice && "DFlash2 selector produced no lattice");
 
-                    predecessor = (int32_t) std::distance(scores.begin(),
-                            std::max_element(scores.begin(), scores.end()));
-                    if (params.p_min > 0.0f) {
-                        // softmax(scores) at the argmax, i.e. 1 / sum(exp(s_k - s_max))
-                        float sum = 0.0f;
-                        for (int32_t k = 0; k < selector_top_k; ++k) {
-                            sum += std::exp(scores[k] - scores[predecessor]);
+                    int32_t predecessor = 0;
+                    for (int32_t i = 1; i < n_block_tokens; ++i) {
+                        const float * row = lattice + (size_t) (beg + i) * n_embd_dec;
+                        const float * scores = row + selector_top_k + (size_t) predecessor * selector_top_k;
+
+                        predecessor = (int32_t) std::distance(scores,
+                                std::max_element(scores, scores + selector_top_k));
+                        if (params.p_min > 0.0f) {
+                            // softmax(scores) at the argmax, i.e. 1 / sum(exp(s_k - s_max))
+                            float sum = 0.0f;
+                            for (int32_t k = 0; k < selector_top_k; ++k) {
+                                sum += std::exp(scores[k] - scores[predecessor]);
+                            }
+                            if (1.0f / sum < params.p_min) {
+                                break;
+                            }
                         }
-                        if (1.0f / sum < params.p_min) {
-                            break;
-                        }
+                        result.push_back((llama_token) row[predecessor]);
                     }
-                    result.push_back((llama_token) ci[predecessor]);
                 }
 
                 if (result.size() < (size_t) params.n_min) {

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -17,6 +17,11 @@ std::vector<enum common_speculative_type> common_speculative_types_from_names(co
 // infer the spec types from the GGUF metadata of a draft model; empty if unknown
 std::vector<enum common_speculative_type> common_speculative_types_from_gguf(const std::string & path);
 
+// returns true when the draft model ranks its full vocabulary inside the graph (DFlash2
+// candidate selector, DSpark markov head) and has no lm_head of its own, so the target's
+// lm_head must be replicated on every device under tensor parallelism
+bool common_speculative_draft_ranks_full_output(const std::string & path);
+
 // convert string to type
 enum common_speculative_type common_speculative_type_from_name(const std::string & name);
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -17,10 +17,9 @@ std::vector<enum common_speculative_type> common_speculative_types_from_names(co
 // infer the spec types from the GGUF metadata of a draft model; empty if unknown
 std::vector<enum common_speculative_type> common_speculative_types_from_gguf(const std::string & path);
 
-// returns true when the draft model ranks its full vocabulary inside the graph (DFlash2
-// candidate selector, DSpark markov head) and has no lm_head of its own, so the target's
-// lm_head must be replicated on every device under tensor parallelism
-bool common_speculative_draft_ranks_full_output(const std::string & path);
+// returns true when the draft's in-graph logits consumer (DSpark markov head) requires the
+// lm_head replicated on every device under tensor parallelism
+bool common_speculative_draft_replicated_lm_head(const std::string & path);
 
 // convert string to type
 enum common_speculative_type common_speculative_type_from_name(const std::string & name);

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -19,11 +19,6 @@ std::vector<enum common_speculative_type> common_speculative_types_from_names(co
 // infer the spec types from the GGUF metadata of a draft model; empty if unknown
 std::vector<enum common_speculative_type> common_speculative_types_from_gguf(const std::string & path);
 
-// returns true when the target lm_head must be replicated on every device under tensor
-// parallelism: a DSpark draft with no lm_head of its own consumes the target lm_head output
-// in-graph (markov head argmax over the full vocabulary)
-bool common_speculative_draft_replicated_lm_head(const std::string & path);
-
 // convert string to type
 enum common_speculative_type common_speculative_type_from_name(const std::string & name);
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -3,6 +3,8 @@
 #include "llama.h"
 #include "common.h"
 
+#include <algorithm>
+
 struct common_speculative;
 
 // comma separated list the provided types
@@ -17,8 +19,9 @@ std::vector<enum common_speculative_type> common_speculative_types_from_names(co
 // infer the spec types from the GGUF metadata of a draft model; empty if unknown
 std::vector<enum common_speculative_type> common_speculative_types_from_gguf(const std::string & path);
 
-// returns true when the draft's in-graph logits consumer (DSpark markov head) requires the
-// lm_head replicated on every device under tensor parallelism
+// returns true when the target lm_head must be replicated on every device under tensor
+// parallelism: a DSpark draft with no lm_head of its own consumes the target lm_head output
+// in-graph (markov head argmax over the full vocabulary)
 bool common_speculative_draft_replicated_lm_head(const std::string & path);
 
 // convert string to type
@@ -49,6 +52,13 @@ struct common_speculative_output_limits {
 // return the output limits needed for speculative decoding
 common_speculative_output_limits common_speculative_get_output_limits(
         int32_t n_batch, int32_t n_parallel, int32_t n_draft);
+
+// max draft-context ubatch for block drafts (DFlash/DSpark): their largest decode batch is
+// one noise block per sequence (n_max + 1 tokens), but the target-feature prefill (encoder +
+// KV injection) is chunked by the same ubatch, so keep a floor to avoid launch-bound chunks
+inline uint32_t common_speculative_block_draft_n_ubatch(uint32_t n_parallel, int32_t n_max) {
+    return std::max<uint32_t>(n_parallel * (uint32_t) std::max(1, n_max + 1), 64);
+}
 
 common_speculative * common_speculative_init(common_params_speculative & params, uint32_t n_seq);
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -48,6 +48,13 @@ struct common_speculative_output_limits {
 common_speculative_output_limits common_speculative_get_output_limits(
         int32_t n_batch, int32_t n_parallel, int32_t n_draft);
 
+// true when any enabled type is a block draft (DFlash/DSpark)
+inline bool common_speculative_is_block_draft(const std::vector<common_speculative_type> & types) {
+    return std::any_of(types.begin(), types.end(), [](common_speculative_type t) {
+        return t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH || t == COMMON_SPECULATIVE_TYPE_DRAFT_DSPARK;
+    });
+}
+
 // max draft-context ubatch for block drafts (DFlash/DSpark): their largest decode batch is
 // one noise block per sequence (n_max + 1 tokens), but the target-feature prefill (encoder +
 // KV injection) is chunked by the same ubatch, so keep a floor to avoid launch-bound chunks

--- a/include/llama.h
+++ b/include/llama.h
@@ -348,7 +348,9 @@ extern "C" {
         bool no_alloc;        // only load metadata and simulate memory allocations
         bool load_mtp;        // whether to load MTP layers
         bool output_replicated; // replicate the output projection (lm_head) in full on every device
-                               // (tensor parallelism); required by drafters that rank the vocabulary in-graph
+                               // (tensor parallelism). Set by the common code when a DSpark draft
+                               // consumes the lm_head output in-graph; do not set it manually, it
+                               // multiplies the lm_head VRAM per device
     };
 
     struct llama_sampler_seq_config {

--- a/include/llama.h
+++ b/include/llama.h
@@ -347,10 +347,6 @@ extern "C" {
         bool no_host;         // bypass host buffer allowing extra buffers to be used
         bool no_alloc;        // only load metadata and simulate memory allocations
         bool load_mtp;        // whether to load MTP layers
-        bool output_replicated; // replicate the output projection (lm_head) in full on every device
-                               // (tensor parallelism). Set internally when a draft model consumes
-                               // the lm_head output in-graph (e.g. DSpark); do not set it manually,
-                               // it multiplies the lm_head VRAM per device
     };
 
     struct llama_sampler_seq_config {

--- a/include/llama.h
+++ b/include/llama.h
@@ -348,9 +348,9 @@ extern "C" {
         bool no_alloc;        // only load metadata and simulate memory allocations
         bool load_mtp;        // whether to load MTP layers
         bool output_replicated; // replicate the output projection (lm_head) in full on every device
-                               // (tensor parallelism). Set by the common code when a DSpark draft
-                               // consumes the lm_head output in-graph; do not set it manually, it
-                               // multiplies the lm_head VRAM per device
+                               // (tensor parallelism). Set internally when a draft model consumes
+                               // the lm_head output in-graph (e.g. DSpark); do not set it manually,
+                               // it multiplies the lm_head VRAM per device
     };
 
     struct llama_sampler_seq_config {

--- a/include/llama.h
+++ b/include/llama.h
@@ -347,6 +347,8 @@ extern "C" {
         bool no_host;         // bypass host buffer allowing extra buffers to be used
         bool no_alloc;        // only load metadata and simulate memory allocations
         bool load_mtp;        // whether to load MTP layers
+        bool output_replicated; // replicate the output projection (lm_head) in full on every device
+                               // (tensor parallelism); required by drafters that rank the vocabulary in-graph
     };
 
     struct llama_sampler_seq_config {

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -122,6 +122,9 @@ LLAMA_API llama_context * llama_get_ctx_other(struct llama_context * ctx);
 
 LLAMA_API int32_t llama_model_dflash_selector_top_k(const struct llama_model * model);
 
+// returns how the model is split across devices
+LLAMA_API enum llama_split_mode llama_model_get_split_mode(const struct llama_model * model);
+
 // returns pointer to the target-model layer indices
 LLAMA_API const int32_t * llama_model_target_layer_ids  (const struct llama_model * model);
 // returns the number of extracted layers from target model

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -575,7 +575,7 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
 
         // output
         if (std::regex_match(tensor_name, pattern_output_weight)) {
-            if (is_dsv4) {
+            if (is_dsv4 || ud->model->output_replicated) {
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED);
             }
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1);
@@ -583,6 +583,11 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         if (std::regex_match(tensor_name, pattern_output_bias)) {
             const ggml_tensor * output_weight = ud->model->get_tensor("output.weight");
             GGML_ASSERT(output_weight != nullptr);
+            // bias must follow the lm_head: when the weight is replicated the bias is too,
+            // otherwise the ADD of (MIRRORED logits + axis-0 bias) is invalid in the meta backend
+            if (is_dsv4 || ud->model->output_replicated) {
+                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED);
+            }
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0);
         }
 
@@ -1180,6 +1185,8 @@ llama_model::llama_model(const llama_model_params & params) : params(params), pi
         this->params.tensor_split = pimpl->tensor_split_owned.data();
     }
     pimpl->has_tensor_overrides = params.tensor_buft_overrides && params.tensor_buft_overrides[0].pattern;
+
+    output_replicated = params.output_replicated;
 }
 
 llama_model::~llama_model() {
@@ -2693,6 +2700,7 @@ llama_model_params llama_model_default_params() {
         /*.no_host                     =*/ false,
         /*.no_alloc                    =*/ false,
         /*.load_mtp                    =*/ false,
+        /*.output_replicated           =*/ false,
     };
 
     return result;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -575,7 +575,7 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
 
         // output
         if (std::regex_match(tensor_name, pattern_output_weight)) {
-            if (is_dsv4 || ud->model->output_replicated) {
+            if (is_dsv4) {
                 return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED);
             }
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_1);
@@ -583,11 +583,6 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         if (std::regex_match(tensor_name, pattern_output_bias)) {
             const ggml_tensor * output_weight = ud->model->get_tensor("output.weight");
             GGML_ASSERT(output_weight != nullptr);
-            // bias must follow the lm_head: when the weight is replicated the bias is too,
-            // otherwise the ADD of (MIRRORED logits + axis-0 bias) is invalid in the meta backend
-            if (is_dsv4 || ud->model->output_replicated) {
-                return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_MIRRORED);
-            }
             return get_tensor_config_impl(GGML_BACKEND_SPLIT_AXIS_0);
         }
 
@@ -1185,8 +1180,6 @@ llama_model::llama_model(const llama_model_params & params) : params(params), pi
         this->params.tensor_split = pimpl->tensor_split_owned.data();
     }
     pimpl->has_tensor_overrides = params.tensor_buft_overrides && params.tensor_buft_overrides[0].pattern;
-
-    output_replicated = params.output_replicated;
 }
 
 llama_model::~llama_model() {
@@ -2700,7 +2693,6 @@ llama_model_params llama_model_default_params() {
         /*.no_host                     =*/ false,
         /*.no_alloc                    =*/ false,
         /*.load_mtp                    =*/ false,
-        /*.output_replicated           =*/ false,
     };
 
     return result;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -2746,6 +2746,10 @@ int32_t llama_model_dflash_selector_top_k(const llama_model * model) {
     return model->hparams.dflash_selector_top_k;
 }
 
+llama_split_mode llama_model_get_split_mode(const llama_model * model) {
+    return model->split_mode();
+}
+
 int32_t llama_model_n_head(const llama_model * model) {
     return model->hparams.n_head();
 }

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -676,8 +676,6 @@ struct llama_model {
     struct ggml_tensor * dspark_conf_proj   = nullptr;
     struct ggml_tensor * dspark_conf_proj_b = nullptr;
 
-    struct ggml_tensor * dflash_selector_prev   = nullptr;
-    struct ggml_tensor * dflash_selector_next   = nullptr;
     struct ggml_tensor * dflash_selector_hidden = nullptr;
 
     // unified vector to store target-model extracted layer ids in eagle3, dflash, etc.
@@ -707,8 +705,9 @@ struct llama_model {
     // statically allocated context for assigning
     struct llama_meta_device_get_split_state_userdata get_split_state_ud;
 
-    // when set, the output projection (lm_head) is replicated in full on every device.
-    // required by DFlash2/DSpark drafters that rank the vocabulary inside the graph.
+    // when set, the output projection (lm_head) is replicated in full on every device under
+    // tensor parallelism; set by the model loader for the in-graph DSpark markov head / d2t
+    // scatter, or by common code for the target model when a DSpark draft consumes its lm_head
     bool output_replicated = false;
 
     int64_t t_load_us  = 0;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -676,6 +676,10 @@ struct llama_model {
     struct ggml_tensor * dspark_conf_proj   = nullptr;
     struct ggml_tensor * dspark_conf_proj_b = nullptr;
 
+    // DFlash2 selector: the tables feed either the in-graph selector (no tensor parallelism)
+    // or the CPU-side selector that reads them straight from the GGUF file (tensor parallelism)
+    struct ggml_tensor * dflash_selector_prev   = nullptr;
+    struct ggml_tensor * dflash_selector_next   = nullptr;
     struct ggml_tensor * dflash_selector_hidden = nullptr;
 
     // unified vector to store target-model extracted layer ids in eagle3, dflash, etc.

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -709,11 +709,6 @@ struct llama_model {
     // statically allocated context for assigning
     struct llama_meta_device_get_split_state_userdata get_split_state_ud;
 
-    // when set, the output projection (lm_head) is replicated in full on every device under
-    // tensor parallelism; set by the model loader for the in-graph DSpark markov head / d2t
-    // scatter, or by common code for the target model when a DSpark draft consumes its lm_head
-    bool output_replicated = false;
-
     int64_t t_load_us  = 0;
     int64_t t_start_us = 0;
 

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -707,6 +707,10 @@ struct llama_model {
     // statically allocated context for assigning
     struct llama_meta_device_get_split_state_userdata get_split_state_ud;
 
+    // when set, the output projection (lm_head) is replicated in full on every device.
+    // required by DFlash2/DSpark drafters that rank the vocabulary inside the graph.
+    bool output_replicated = false;
+
     int64_t t_load_us  = 0;
     int64_t t_start_us = 0;
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -148,6 +148,12 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
                 hparams.dflash_selector_rank, hparams.dflash_selector_top_k);
     }
 
+    // DFlash2/DSpark rank the full draft vocabulary in-graph (top_k/argmax on the lm_head
+    // output), which requires the lm_head to be replicated on every device
+    if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && (selector_meta || markov_meta)) {
+        output_replicated = true;
+    }
+
     fc              = create_tensor(tn(LLM_TENSOR_FC,              "weight"), { n_embd_inp, n_embd }, 0);
     fc_s            = create_tensor(tn(LLM_TENSOR_FC,              "scale"),  { 1 }, TENSOR_NOT_REQUIRED);
     output_norm_enc = create_tensor(tn(LLM_TENSOR_ENC_OUTPUT_NORM, "weight"), { n_embd }, 0); // encoder hidden_norm (after fc)

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -139,10 +139,12 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
             throw std::runtime_error("DFlash2 hidden size is too small for the selector lattice");
         }
 
-        // the successor/predecessor tables are consumed by the CPU-side selector straight
-        // from the GGUF file, so they are not loaded into device memory
-        create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_PREV,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
-        create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_NEXT,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
+        // Under tensor parallelism the lm_head is split along the vocabulary, which the
+        // in-graph selector cannot consume, so DFlash2 ranks on the CPU and reads these tables
+        // straight from the GGUF file; otherwise the in-graph selector uses them in the model
+        const bool use_cpu_selector = params.split_mode == LLAMA_SPLIT_MODE_TENSOR;
+        dflash_selector_prev   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_PREV,   "weight"), { rank, n_vocab }, use_cpu_selector ? TENSOR_SKIP : 0);
+        dflash_selector_next   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_NEXT,   "weight"), { rank, n_vocab }, use_cpu_selector ? TENSOR_SKIP : 0);
         dflash_selector_hidden = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_HIDDEN, "weight"), { n_embd, rank }, 0);
 
         LLAMA_LOG_INFO("%s: DFlash2 conv kernel = %u, group = %u, selector rank = %u, top-k = %u\n", __func__,
@@ -479,6 +481,102 @@ static ggml_tensor * build_dflash2_conv(
     return result;
 }
 
+// DFlash2 selector (no tensor parallelism): top-k candidates per block position plus the
+// pairwise transition scores, packed into the nextn output slot for the CPU-side walk.
+// Under tensor parallelism the lm_head is split, so the same candidate math runs on the host
+// via load_dflash2_selector()/build_dflash2_selector_cpu() in common/speculative.cpp;
+// keep the two implementations in sync.
+static void build_dflash2_selector(llm_graph_context & g, const llama_model & model, ggml_tensor * tokens) {
+    ggml_context * ctx0 = g.ctx0;
+    auto         & res  = g.res;
+
+    const auto & hparams = g.hparams;
+    const int64_t n_tokens = g.n_tokens;
+    const int64_t n_embd   = g.n_embd;
+
+    const int64_t top_k    = hparams.dflash_selector_top_k;
+    const int64_t rank     = hparams.dflash_selector_rank;
+    const int64_t n_blocks = g.ubatch.n_seqs_unq;
+    GGML_ASSERT(n_blocks > 0 && n_tokens % n_blocks == 0);
+    GGML_ASSERT(res->t_logits->ne[1] == n_tokens);
+    if (!tokens) {
+        return;
+    }
+
+    const int64_t tokens_per_block = n_tokens / n_blocks;
+    const int64_t block_size = std::min<int64_t>(tokens_per_block, hparams.dflash_block_size);
+    const int64_t row_used   = top_k + top_k * top_k;
+
+    ggml_tensor * candidates  = ggml_top_k(ctx0, res->t_logits, top_k);
+    ggml_tensor * logits_rows = ggml_reshape_3d(ctx0, res->t_logits, 1, res->t_logits->ne[0], n_tokens);
+    ggml_tensor * unary       = ggml_reshape_2d(ctx0,
+            ggml_get_rows(ctx0, logits_rows, candidates), top_k, n_tokens);
+    ggml_tensor * gate        = g.build_lora_mm(model.dflash_selector_hidden, res->t_embd);
+
+    // Everything below indexes [.., tokens_per_block, n_blocks]: the block
+    // position varies fastest, sequences are the outer dimension.
+    ggml_tensor * cand_blk  = ggml_reshape_3d(ctx0, candidates, top_k, tokens_per_block, n_blocks);
+    ggml_tensor * unary_blk = ggml_reshape_3d(ctx0, unary,      top_k, tokens_per_block, n_blocks);
+    ggml_tensor * gate_blk  = ggml_reshape_3d(ctx0, gate,       rank,  tokens_per_block, n_blocks);
+
+    // a position's score reads only the candidate sets at pos-1 and pos, so a run
+    // of positions has no internal dependency and scores in one batched matmul
+    auto score_run = [&](int64_t beg_pos, int64_t n_pos, ggml_tensor * pred_ids) {
+        ggml_tensor * cand_run = ggml_cont(ctx0, ggml_view_3d(ctx0, cand_blk, top_k, n_pos, n_blocks,
+                    cand_blk->nb[1], cand_blk->nb[2], beg_pos * cand_blk->nb[1]));
+        ggml_tensor * unary_run = ggml_cont(ctx0, ggml_view_3d(ctx0, unary_blk, top_k, n_pos, n_blocks,
+                    unary_blk->nb[1], unary_blk->nb[2], beg_pos * unary_blk->nb[1]));
+        ggml_tensor * gate_run = ggml_cont(ctx0, ggml_view_3d(ctx0, gate_blk, rank, n_pos, n_blocks,
+                    gate_blk->nb[1], gate_blk->nb[2], beg_pos * gate_blk->nb[1]));
+
+        const int64_t n_pred = pred_ids->ne[0] / (n_pos * n_blocks);
+
+        ggml_tensor * successor = ggml_reshape_4d(ctx0,
+                ggml_get_rows(ctx0, model.dflash_selector_next, ggml_reshape_1d(ctx0, cand_run, top_k * n_pos * n_blocks)),
+                rank, top_k, n_pos, n_blocks);
+        ggml_tensor * predecessor = ggml_reshape_4d(ctx0,
+                ggml_get_rows(ctx0, model.dflash_selector_prev, pred_ids),
+                rank, n_pred, n_pos, n_blocks);
+
+        ggml_tensor * gate_bcast = ggml_reshape_4d(ctx0, gate_run, rank, 1, n_pos, n_blocks);
+        ggml_tensor * cond  = ggml_mul(ctx0, predecessor, ggml_repeat(ctx0, gate_bcast, predecessor));
+        ggml_tensor * score = ggml_mul_mat(ctx0, successor, cond);
+        if (n_pred == 1) {
+            score = ggml_repeat_4d(ctx0, score, top_k, top_k, n_pos, n_blocks);
+        }
+        ggml_tensor * unary_bcast = ggml_reshape_4d(ctx0, unary_run, top_k, 1, n_pos, n_blocks);
+        score = ggml_add(ctx0, score, ggml_repeat(ctx0, unary_bcast, score));
+
+        ggml_tensor * row = ggml_concat(ctx0,
+                ggml_cast(ctx0, cand_run, GGML_TYPE_F32),
+                ggml_reshape_3d(ctx0, score, top_k * top_k, n_pos, n_blocks), 0);
+        return ggml_pad(ctx0, row, n_embd - row_used, 0, 0, 0);
+    };
+
+    ggml_tensor * packed = ggml_fill(ctx0,
+            ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, n_embd, 1, n_blocks), 0.0f);
+
+    if (block_size > 1) {
+        // Position 1 alone: its predecessor is the anchor token, one id per
+        // sequence rather than a candidate set.
+        ggml_tensor * anchor_ids = ggml_cont_1d(ctx0,
+                ggml_view_2d(ctx0, tokens, 1, n_blocks, tokens_per_block * tokens->nb[0], 0), n_blocks);
+        packed = ggml_concat(ctx0, packed, score_run(1, 1, anchor_ids), 1);
+    }
+    if (block_size > 2) {
+        ggml_tensor * prev_ids = ggml_reshape_1d(ctx0,
+                ggml_cont(ctx0, ggml_view_3d(ctx0, cand_blk, top_k, block_size - 2, n_blocks,
+                        cand_blk->nb[1], cand_blk->nb[2], cand_blk->nb[1])),
+                top_k * (block_size - 2) * n_blocks);
+        packed = ggml_concat(ctx0, packed, score_run(2, block_size - 2, prev_ids), 1);
+    }
+
+    packed = ggml_reshape_2d(ctx0, packed, n_embd, block_size * n_blocks);
+    g.cb(packed, "dflash2_lattice", -1);
+    res->t_h_nextn = packed;
+    ggml_build_forward_expand(g.gf, packed);
+}
+
 // DFlash decoder, dual-mode by batch type:
 //   * embd batch  -> fused target features: project + inject K/V into the cache.
 //   * token batch -> noise-block diffusion: attend over [committed, MASK...] to generate draft tokens
@@ -679,10 +777,10 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 
     res->t_embd = cur;
 
-    // DFlash2's candidate lattice is built on the CPU by the speculative implementation from
-    // the lm_head output (which may be split across devices), so expose the decoder hidden
-    // states through the nextn slot that the implementation already reads
-    if (model.dflash_selector_hidden) {
+    // DFlash2 under tensor parallelism ranks on the CPU from the gathered lm_head output, so
+    // the decoder hidden states ride the nextn slot; without tensor parallelism the in-graph
+    // selector packs its lattice there instead (see below)
+    if (model.dflash_selector_hidden && model.split_mode() == LLAMA_SPLIT_MODE_TENSOR) {
         res->t_h_nextn = cur;
     }
 
@@ -699,8 +797,9 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 
     cur = build_lora_mm(output, cur, output_s);
 
-    // DFlash2 feeds these logits to the CPU-side selector, so they need the target's
-    // output transforms; DFlash1 and DSpark read them through the sampler instead
+    // DFlash2 feeds these logits to its candidate selector (in-graph or on the CPU after
+    // gathering), so they need the target's output transforms; DFlash1 and DSpark read them
+    // through the sampler instead
     if (model.dflash_selector_hidden) {
         if (hparams.f_logit_scale != 0.0f) {
             cur = ggml_scale(ctx0, cur, hparams.f_logit_scale);
@@ -735,6 +834,11 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
     // DSpark: bias the draft logits with the Markov head
     if (model.dspark_markov_w1) {
         build_dspark_markov_head(*this, model, inp_tokens);
+    }
+
+    // DFlash2 ranks its candidates in-graph when the lm_head is not split along the vocabulary
+    if (model.dflash_selector_hidden && model.split_mode() != LLAMA_SPLIT_MODE_TENSOR) {
+        build_dflash2_selector(*this, model, inp_tokens);
     }
 }
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -152,14 +152,6 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
                 hparams.dflash_selector_rank, hparams.dflash_selector_top_k);
     }
 
-    // The DSpark markov head ranks its lm_head output in-graph (argmax over the full
-    // vocabulary) and the reduced-vocab d2t scatter consumes the lm_head rows on a full
-    // vocab-sized tensor, so a draft lm_head stays replicated in full on every device under
-    // tensor parallelism; plain DFlash2 ranks on the CPU instead and keeps the lm_head split.
-    if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && (markov_meta || d2t_meta)) {
-        output_replicated = true;
-    }
-
     fc              = create_tensor(tn(LLM_TENSOR_FC,              "weight"), { n_embd_inp, n_embd }, 0);
     fc_s            = create_tensor(tn(LLM_TENSOR_FC,              "scale"),  { 1 }, TENSOR_NOT_REQUIRED);
     output_norm_enc = create_tensor(tn(LLM_TENSOR_ENC_OUTPUT_NORM, "weight"), { n_embd }, 0); // encoder hidden_norm (after fc)

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -141,8 +141,8 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
 
         // the successor/predecessor tables are consumed by the CPU-side selector straight
         // from the GGUF file, so they are not loaded into device memory
-        dflash_selector_prev   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_PREV,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
-        dflash_selector_next   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_NEXT,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
+        create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_PREV,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
+        create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_NEXT,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
         dflash_selector_hidden = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_HIDDEN, "weight"), { n_embd, rank }, 0);
 
         LLAMA_LOG_INFO("%s: DFlash2 conv kernel = %u, group = %u, selector rank = %u, top-k = %u\n", __func__,
@@ -150,9 +150,11 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
                 hparams.dflash_selector_rank, hparams.dflash_selector_top_k);
     }
 
-    // a draft with its own lm_head keeps it replicated under tensor parallelism, so the
-    // in-graph DSpark markov head sees the full vocabulary
-    if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && (selector_meta || markov_meta)) {
+    // The DSpark markov head ranks its lm_head output in-graph (argmax over the full
+    // vocabulary) and the reduced-vocab d2t scatter consumes the lm_head rows on a full
+    // vocab-sized tensor, so a draft lm_head stays replicated in full on every device under
+    // tensor parallelism; plain DFlash2 ranks on the CPU instead and keeps the lm_head split.
+    if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && (markov_meta || d2t_meta)) {
         output_replicated = true;
     }
 

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -139,8 +139,10 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
             throw std::runtime_error("DFlash2 hidden size is too small for the selector lattice");
         }
 
-        dflash_selector_prev   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_PREV,   "weight"), { rank, n_vocab }, 0);
-        dflash_selector_next   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_NEXT,   "weight"), { rank, n_vocab }, 0);
+        // the successor/predecessor tables are consumed by the CPU-side selector straight
+        // from the GGUF file, so they are not loaded into device memory
+        dflash_selector_prev   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_PREV,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
+        dflash_selector_next   = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_NEXT,   "weight"), { rank, n_vocab }, TENSOR_SKIP);
         dflash_selector_hidden = create_tensor(tn(LLM_TENSOR_DFLASH_SELECTOR_HIDDEN, "weight"), { n_embd, rank }, 0);
 
         LLAMA_LOG_INFO("%s: DFlash2 conv kernel = %u, group = %u, selector rank = %u, top-k = %u\n", __func__,
@@ -148,8 +150,8 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader &) {
                 hparams.dflash_selector_rank, hparams.dflash_selector_top_k);
     }
 
-    // DFlash2/DSpark rank the full draft vocabulary in-graph (top_k/argmax on the lm_head
-    // output), which requires the lm_head to be replicated on every device
+    // a draft with its own lm_head keeps it replicated under tensor parallelism, so the
+    // in-graph DSpark markov head sees the full vocabulary
     if (params.split_mode == LLAMA_SPLIT_MODE_TENSOR && (selector_meta || markov_meta)) {
         output_replicated = true;
     }
@@ -475,99 +477,6 @@ static ggml_tensor * build_dflash2_conv(
     return result;
 }
 
-// DFlash2 selector: top-k candidates per block position plus the pairwise
-// transition scores, packed into the nextn output slot for the CPU-side walk.
-static void build_dflash2_selector(llm_graph_context & g, const llama_model & model, ggml_tensor * tokens) {
-    ggml_context * ctx0 = g.ctx0;
-    auto         & res  = g.res;
-
-    const auto & hparams = g.hparams;
-    const int64_t n_tokens = g.n_tokens;
-    const int64_t n_embd   = g.n_embd;
-
-    const int64_t top_k    = hparams.dflash_selector_top_k;
-    const int64_t rank     = hparams.dflash_selector_rank;
-    const int64_t n_blocks = g.ubatch.n_seqs_unq;
-    GGML_ASSERT(n_blocks > 0 && n_tokens % n_blocks == 0);
-    GGML_ASSERT(res->t_logits->ne[1] == n_tokens);
-    if (!tokens) {
-        return;
-    }
-
-    const int64_t tokens_per_block = n_tokens / n_blocks;
-    const int64_t block_size = std::min<int64_t>(tokens_per_block, hparams.dflash_block_size);
-    const int64_t row_used   = top_k + top_k * top_k;
-
-    ggml_tensor * candidates  = ggml_top_k(ctx0, res->t_logits, top_k);
-    ggml_tensor * logits_rows = ggml_reshape_3d(ctx0, res->t_logits, 1, res->t_logits->ne[0], n_tokens);
-    ggml_tensor * unary       = ggml_reshape_2d(ctx0,
-            ggml_get_rows(ctx0, logits_rows, candidates), top_k, n_tokens);
-    ggml_tensor * gate        = g.build_lora_mm(model.dflash_selector_hidden, res->t_embd);
-
-    // Everything below indexes [.., tokens_per_block, n_blocks]: the block
-    // position varies fastest, sequences are the outer dimension.
-    ggml_tensor * cand_blk  = ggml_reshape_3d(ctx0, candidates, top_k, tokens_per_block, n_blocks);
-    ggml_tensor * unary_blk = ggml_reshape_3d(ctx0, unary,      top_k, tokens_per_block, n_blocks);
-    ggml_tensor * gate_blk  = ggml_reshape_3d(ctx0, gate,       rank,  tokens_per_block, n_blocks);
-
-    // a position's score reads only the candidate sets at pos-1 and pos, so a run
-    // of positions has no internal dependency and scores in one batched matmul
-    auto score_run = [&](int64_t beg_pos, int64_t n_pos, ggml_tensor * pred_ids) {
-        ggml_tensor * cand_run = ggml_cont(ctx0, ggml_view_3d(ctx0, cand_blk, top_k, n_pos, n_blocks,
-                    cand_blk->nb[1], cand_blk->nb[2], beg_pos * cand_blk->nb[1]));
-        ggml_tensor * unary_run = ggml_cont(ctx0, ggml_view_3d(ctx0, unary_blk, top_k, n_pos, n_blocks,
-                    unary_blk->nb[1], unary_blk->nb[2], beg_pos * unary_blk->nb[1]));
-        ggml_tensor * gate_run = ggml_cont(ctx0, ggml_view_3d(ctx0, gate_blk, rank, n_pos, n_blocks,
-                    gate_blk->nb[1], gate_blk->nb[2], beg_pos * gate_blk->nb[1]));
-
-        const int64_t n_pred = pred_ids->ne[0] / (n_pos * n_blocks);
-
-        ggml_tensor * successor = ggml_reshape_4d(ctx0,
-                ggml_get_rows(ctx0, model.dflash_selector_next, ggml_reshape_1d(ctx0, cand_run, top_k * n_pos * n_blocks)),
-                rank, top_k, n_pos, n_blocks);
-        ggml_tensor * predecessor = ggml_reshape_4d(ctx0,
-                ggml_get_rows(ctx0, model.dflash_selector_prev, pred_ids),
-                rank, n_pred, n_pos, n_blocks);
-
-        ggml_tensor * gate_bcast = ggml_reshape_4d(ctx0, gate_run, rank, 1, n_pos, n_blocks);
-        ggml_tensor * cond  = ggml_mul(ctx0, predecessor, ggml_repeat(ctx0, gate_bcast, predecessor));
-        ggml_tensor * score = ggml_mul_mat(ctx0, successor, cond);
-        if (n_pred == 1) {
-            score = ggml_repeat_4d(ctx0, score, top_k, top_k, n_pos, n_blocks);
-        }
-        ggml_tensor * unary_bcast = ggml_reshape_4d(ctx0, unary_run, top_k, 1, n_pos, n_blocks);
-        score = ggml_add(ctx0, score, ggml_repeat(ctx0, unary_bcast, score));
-
-        ggml_tensor * row = ggml_concat(ctx0,
-                ggml_cast(ctx0, cand_run, GGML_TYPE_F32),
-                ggml_reshape_3d(ctx0, score, top_k * top_k, n_pos, n_blocks), 0);
-        return ggml_pad(ctx0, row, n_embd - row_used, 0, 0, 0);
-    };
-
-    ggml_tensor * packed = ggml_fill(ctx0,
-            ggml_new_tensor_3d(ctx0, GGML_TYPE_F32, n_embd, 1, n_blocks), 0.0f);
-
-    if (block_size > 1) {
-        // Position 1 alone: its predecessor is the anchor token, one id per
-        // sequence rather than a candidate set.
-        ggml_tensor * anchor_ids = ggml_cont_1d(ctx0,
-                ggml_view_2d(ctx0, tokens, 1, n_blocks, tokens_per_block * tokens->nb[0], 0), n_blocks);
-        packed = ggml_concat(ctx0, packed, score_run(1, 1, anchor_ids), 1);
-    }
-    if (block_size > 2) {
-        ggml_tensor * prev_ids = ggml_reshape_1d(ctx0,
-                ggml_cont(ctx0, ggml_view_3d(ctx0, cand_blk, top_k, block_size - 2, n_blocks,
-                        cand_blk->nb[1], cand_blk->nb[2], cand_blk->nb[1])),
-                top_k * (block_size - 2) * n_blocks);
-        packed = ggml_concat(ctx0, packed, score_run(2, block_size - 2, prev_ids), 1);
-    }
-
-    packed = ggml_reshape_2d(ctx0, packed, n_embd, block_size * n_blocks);
-    g.cb(packed, "dflash2_lattice", -1);
-    res->t_h_nextn = packed;
-    ggml_build_forward_expand(g.gf, packed);
-}
-
 // DFlash decoder, dual-mode by batch type:
 //   * embd batch  -> fused target features: project + inject K/V into the cache.
 //   * token batch -> noise-block diffusion: attend over [committed, MASK...] to generate draft tokens
@@ -768,6 +677,13 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 
     res->t_embd = cur;
 
+    // DFlash2's candidate lattice is built on the CPU by the speculative implementation from
+    // the lm_head output (which may be split across devices), so expose the decoder hidden
+    // states through the nextn slot that the implementation already reads
+    if (model.dflash_selector_hidden) {
+        res->t_h_nextn = cur;
+    }
+
     // lm_head from the target model (shared via ctx_other)
     auto * output   = model.output;
     auto * output_s = model.output_s;
@@ -781,8 +697,8 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 
     cur = build_lora_mm(output, cur, output_s);
 
-    // DFlash2 feeds these logits to the selector, so they need the target's output
-    // transforms; DFlash1 and DSpark read them through the sampler instead
+    // DFlash2 feeds these logits to the CPU-side selector, so they need the target's
+    // output transforms; DFlash1 and DSpark read them through the sampler instead
     if (model.dflash_selector_hidden) {
         if (hparams.f_logit_scale != 0.0f) {
             cur = ggml_scale(ctx0, cur, hparams.f_logit_scale);
@@ -817,10 +733,6 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
     // DSpark: bias the draft logits with the Markov head
     if (model.dspark_markov_w1) {
         build_dspark_markov_head(*this, model, inp_tokens);
-    }
-
-    if (model.dflash_selector_hidden) {
-        build_dflash2_selector(*this, model, inp_tokens);
     }
 }
 


### PR DESCRIPTION
## Overview

Assertion is failed on llama-server startup if using dflash2 draft model and `--split-mode tensor` flag:

```
ggml\src\ggml-backend-meta.cpp:543: GGML_ASSERT(src_ss[0].axis != GGML_BACKEND_SPLIT_AXIS_0) failed
```

The changes in this PR address two issues:
- Crash in GGML_ASSERT (root cause)
- Reducing the VRAM footprint of the DFlash2 model for **`--split-mode tensor`**

## Additional information

Issue for this case: https://github.com/ggml-org/llama.cpp/issues/27819

### Root cause

The DFlash2 candidate selector runs `ggml_top_k()` on the lm_head output (`t_logits`) inside the graph. Under tensor parallelism `output.weight` is split along the vocab axis, so `t_logits` is split along axis 0, which `GGML_OP_TOP_K` (a per-row op) cannot handle in the meta backend.

**Fix:** When a DFlash2 draft is used with tensor parallelism, the lm_head must be replicated in full on every device (`GGML_BACKEND_SPLIT_AXIS_MIRRORED`) so the whole vocabulary is available in-graph. 

### Reducing the VRAM footprint

DFlash2's in-graph selector (`ggml_top_k` over the lm_head output) cannot run on a vocab-split lm_head under `--split-mode tensor`. Rather than replicating the lm_head on every device (MIRRORED, ~+500 MiB/device), the **selector now runs on the CPU from the gathered logits** + decoder hidden states, so the lm_head stays split.

VRAM savings for `https://huggingface.co/z-lab/Qwen3.8-27B-DFlash2-GGUF/blob/main/Qwen3.8-27B-DFlash2-Q4_K_M.gguf`:
- lm_head stays vocab-split instead of replicated: ~-500 MiB/device.
- Selector codebook tables are `TENSOR_SKIP`'d under tensor parallelism and read from the GGUF at init: ~-68 MiB/device.
- Draft ubatch is capped (floor 64) so the reserved `[vocab x ubatch]` compute buffer drops from ~539 MiB to ~67 MiB/device.

Without these modifications, the amount of occupied VRAM was x4.4 of the gguf file size.

NOTE: **No `ggml/` changes; the non-tensor path (single GPU / layer split) keeps the original in-graph selector.**

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  YES, Deepseek 4 Flash was used for investigation, fixing and reviewing <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
