### PR TITLE
(WIP) CUDA/HIP: GPU partial top-k for ROCm (fix full-sort/CPU fallback)

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2572,15 +2572,18 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
 
 #if defined(GGML_USE_HIP)
         // [TAG_TOP_K_HIP_CUDA_GRAPHS]
-        // The ROCm partial top-k path (rocprim::partial_sort_copy) synchronizes the stream, so it
-        // cannot be captured into a HIP graph. k == ncols uses the capture-safe bitonic sort.
-        if (node->op == GGML_OP_TOP_K && node->ne[0] < node->src[0]->ne[0]) {
+        // Multi-row top-k uses hipCUB DeviceSegmentedRadixSort. Instantiating a HIP graph that
+        // contains a large segmented sort overflows the ROCm runtime's graph builder (stack
+        // overflow inside libamdhip64). Single-row top-k (decode) uses DeviceRadixSort and is
+        // graph-safe, so only skip graphs for the nrows>1 case (prefill/batched, which does not
+        // rely on CUDA graphs anyway).
+        if (node->op == GGML_OP_TOP_K && ggml_nrows(node->src[0]) > 1) {
             use_cuda_graph = false;
 #ifndef NDEBUG
-            GGML_LOG_DEBUG("%s: disabling HIP graphs due to ROCm partial top-k\n", __func__);
+            GGML_LOG_DEBUG("%s: disabling CUDA graphs due to multi-row TOP_K on ROCm\n", __func__);
 #endif
         }
-#endif
+#endif // GGML_USE_HIP
 
         if (!use_cuda_graph) {
             break;
@@ -5272,9 +5275,8 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             return ggml_is_contiguous_rows(op->src[0]);
         case GGML_OP_TOP_K:
 #if defined(GGML_USE_HIP)
-            // rocPRIM partial top-k (partial_sort_copy) handles any ncols when k < ncols;
-            // k == ncols uses the bitonic fallback, which is limited to ncols <= 1024.
-            return op->ne[0] < op->src[0]->ne[0] || op->src[0]->ne[0] <= 1024;
+            // capture-safe radix SortPairs handles any ncols / nrows on ROCm
+            return true;
 #elif !defined(GGML_CUDA_USE_CUB)
             return op->src[0]->ne[0] <= 1024;
 #else

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2570,6 +2570,18 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
             }
         }
 
+#if defined(GGML_USE_HIP)
+        // [TAG_TOP_K_HIP_CUDA_GRAPHS]
+        // The ROCm partial top-k path (rocprim::partial_sort_copy) synchronizes the stream, so it
+        // cannot be captured into a HIP graph. k == ncols uses the capture-safe bitonic sort.
+        if (node->op == GGML_OP_TOP_K && node->ne[0] < node->src[0]->ne[0]) {
+            use_cuda_graph = false;
+#ifndef NDEBUG
+            GGML_LOG_DEBUG("%s: disabling HIP graphs due to ROCm partial top-k\n", __func__);
+#endif
+        }
+#endif
+
         if (!use_cuda_graph) {
             break;
         }
@@ -5259,6 +5271,15 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_SUM:
             return ggml_is_contiguous_rows(op->src[0]);
         case GGML_OP_TOP_K:
+#if defined(GGML_USE_HIP)
+            // rocPRIM partial top-k (partial_sort_copy) handles any ncols when k < ncols;
+            // k == ncols uses the bitonic fallback, which is limited to ncols <= 1024.
+            return op->ne[0] < op->src[0]->ne[0] || op->src[0]->ne[0] <= 1024;
+#elif !defined(GGML_CUDA_USE_CUB)
+            return op->src[0]->ne[0] <= 1024;
+#else
+            return true;
+#endif
         case GGML_OP_ARGSORT:
 #ifndef GGML_CUDA_USE_CUB
             return op->src[0]->ne[0] <= 1024;

--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -49,24 +49,21 @@ static int next_power_of_2(int x) {
 #endif                            // CUB_TOP_K_AVAILABLE
 
 #if defined(GGML_USE_HIP)
-#include <rocprim/rocprim.hpp>
-// rocPRIM has no DeviceTopK equivalent; partial_sort_copy is nth_element(O(ncols)) + a sort of only
-// the first k, i.e. the same algorithmic class as cub::DeviceTopK and far cheaper than the generic
-// full-sort fallback when k << ncols. It is keys-only, so pack (order-preserving float bits, index)
-// into one u64 key to carry the index through the sort.
-static __global__ void ggml_cuda_topk_pack_kv(const float * x, uint64_t * packed, const int ncols) {
-    const int col = blockIdx.x * blockDim.x + threadIdx.x;
-    if (col >= ncols) {
-        return;
+#include <hipcub/hipcub.hpp>
+// hipCUB has no DeviceTopK, so on ROCm top-k is implemented by sorting (score, index) pairs in
+// descending order with DeviceRadixSort (single row) / DeviceSegmentedRadixSort (multi-row) and
+// keeping the first k of each row. These radix sorts are stream-capture-safe. The helpers below
+// fill the per-element value (original column index) and the per-row segment offsets.
+static __global__ void ggml_cuda_topk_iota_rows(int * idx, const int ncols, const int64_t n) {
+    const int64_t i = (int64_t) blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        idx[i] = (int) (i % ncols);
     }
-    uint32_t u = __float_as_uint(x[col]);
-    u ^= (u & 0x80000000u) ? 0xFFFFFFFFu : 0x80000000u; // order-preserving float -> u32
-    packed[col] = ((uint64_t) (~u) << 32) | (uint32_t) col; // hi = ~score (ascending == descending), lo = index
 }
-static __global__ void ggml_cuda_topk_unpack_idx(const uint64_t * packed, int * dst, const int k) {
-    const int j = blockIdx.x * blockDim.x + threadIdx.x;
-    if (j < k) {
-        dst[j] = (int) (uint32_t) (packed[j] & 0xFFFFFFFFu);
+static __global__ void ggml_cuda_topk_init_offsets(int * off, const int ncols, const int n1) {
+    const int s = blockIdx.x * blockDim.x + threadIdx.x;
+    if (s < n1) {
+        off[s] = s * ncols;
     }
 }
 #endif // GGML_USE_HIP
@@ -94,33 +91,39 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
     }
 #elif defined(GGML_USE_HIP)  // CUB_TOP_K_AVAILABLE
-    // ROCm partial top-k (see doc/PLAN_hip_partial_topk.md). rocprim::partial_sort_copy requires
-    // middle < size, so k == ncols falls back to a full descending sort.
-    if (k < ncols) {
-        const int block = 256;
-        ggml_cuda_pool_alloc<uint64_t> packed_in_alloc(pool, ncols);
-        ggml_cuda_pool_alloc<uint64_t> packed_out_alloc(pool, ncols + 1);
-        uint64_t * packed_in  = packed_in_alloc.get();
-        uint64_t * packed_out = packed_out_alloc.get();
-        for (int64_t r = 0; r < nrows; ++r) {
-            const dim3 grid((ncols + block - 1) / block);
-            ggml_cuda_topk_pack_kv<<<grid, block, 0, stream>>>(src0_d + r * ncols, packed_in, (int) ncols);
+    // ROCm top-k via capture-safe radix sort-pairs (see doc/PLAN_hip_partial_topk.md).
+    {
+        const int     block = 256;
+        const int64_t n     = ncols * nrows;
+        ggml_cuda_pool_alloc<float> keys_alloc(pool, n);
+        ggml_cuda_pool_alloc<int>   vals_in_alloc(pool, n);
+        ggml_cuda_pool_alloc<int>   vals_out_alloc(pool, n);
+        float * keys     = keys_alloc.get();
+        int   * vals_in  = vals_in_alloc.get();
+        int   * vals_out = vals_out_alloc.get();
 
-            size_t tmp_bytes = 0;
-            CUDA_CHECK(rocprim::partial_sort_copy(nullptr, tmp_bytes, packed_in, packed_out,
-                                                  (size_t) k, (size_t) ncols, rocprim::less<uint64_t>(), stream));
+        CUDA_CHECK(cudaMemcpyAsync(keys, src0_d, n * sizeof(float), cudaMemcpyDeviceToDevice, stream));
+        ggml_cuda_topk_iota_rows<<<(n + block - 1) / block, block, 0, stream>>>(vals_in, (int) ncols, n);
+
+        size_t tmp_bytes = 0;
+        if (nrows == 1) {
+            CUDA_CHECK(hipcub::DeviceRadixSort::SortPairsDescending(nullptr, tmp_bytes, keys, keys,
+                vals_in, vals_out, (int) ncols, 0, (int) sizeof(float) * 8, stream));
             ggml_cuda_pool_alloc<uint8_t> tmp_alloc(pool, tmp_bytes);
-            CUDA_CHECK(rocprim::partial_sort_copy(tmp_alloc.get(), tmp_bytes, packed_in, packed_out,
-                                                  (size_t) k, (size_t) ncols, rocprim::less<uint64_t>(), stream));
-
-            const dim3 ugrid((k + block - 1) / block);
-            ggml_cuda_topk_unpack_idx<<<ugrid, block, 0, stream>>>(packed_out, dst_d + r * k, (int) k);
+            CUDA_CHECK(hipcub::DeviceRadixSort::SortPairsDescending(tmp_alloc.get(), tmp_bytes, keys, keys,
+                vals_in, vals_out, (int) ncols, 0, (int) sizeof(float) * 8, stream));
+        } else {
+            ggml_cuda_pool_alloc<int> off_alloc(pool, nrows + 1);
+            int * off = off_alloc.get();
+            ggml_cuda_topk_init_offsets<<<(nrows + 1 + block - 1) / block, block, 0, stream>>>(off, (int) ncols, (int) (nrows + 1));
+            CUDA_CHECK(hipcub::DeviceSegmentedRadixSort::SortPairsDescending(nullptr, tmp_bytes, keys, keys,
+                vals_in, vals_out, (int) n, (int) nrows, off, off + 1, 0, (int) sizeof(float) * 8, stream));
+            ggml_cuda_pool_alloc<uint8_t> tmp_alloc(pool, tmp_bytes);
+            CUDA_CHECK(hipcub::DeviceSegmentedRadixSort::SortPairsDescending(tmp_alloc.get(), tmp_bytes, keys, keys,
+                vals_in, vals_out, (int) n, (int) nrows, off, off + 1, 0, (int) sizeof(float) * 8, stream));
         }
-    } else {
-        ggml_cuda_pool_alloc<int> temp_dst_alloc(pool, ncols * nrows);
-        int * tmp_dst = temp_dst_alloc.get();
-        argsort_f32_i32_cuda_bitonic(src0_d, tmp_dst, ncols, nrows, GGML_SORT_ORDER_DESC, stream);
-        CUDA_CHECK(cudaMemcpy2DAsync(dst_d, k * sizeof(int), tmp_dst, ncols * sizeof(int),
+        // keep the first k sorted indices of each row
+        CUDA_CHECK(cudaMemcpy2DAsync(dst_d, k * sizeof(int), vals_out, ncols * sizeof(int),
                                      k * sizeof(int), nrows, cudaMemcpyDeviceToDevice, stream));
     }
 #elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE

--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -48,6 +48,29 @@ static int next_power_of_2(int x) {
 
 #endif                            // CUB_TOP_K_AVAILABLE
 
+#if defined(GGML_USE_HIP)
+#include <rocprim/rocprim.hpp>
+// rocPRIM has no DeviceTopK equivalent; partial_sort_copy is nth_element(O(ncols)) + a sort of only
+// the first k, i.e. the same algorithmic class as cub::DeviceTopK and far cheaper than the generic
+// full-sort fallback when k << ncols. It is keys-only, so pack (order-preserving float bits, index)
+// into one u64 key to carry the index through the sort.
+static __global__ void ggml_cuda_topk_pack_kv(const float * x, uint64_t * packed, const int ncols) {
+    const int col = blockIdx.x * blockDim.x + threadIdx.x;
+    if (col >= ncols) {
+        return;
+    }
+    uint32_t u = __float_as_uint(x[col]);
+    u ^= (u & 0x80000000u) ? 0xFFFFFFFFu : 0x80000000u; // order-preserving float -> u32
+    packed[col] = ((uint64_t) (~u) << 32) | (uint32_t) col; // hi = ~score (ascending == descending), lo = index
+}
+static __global__ void ggml_cuda_topk_unpack_idx(const uint64_t * packed, int * dst, const int k) {
+    const int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j < k) {
+        dst[j] = (int) (uint32_t) (packed[j] & 0xFFFFFFFFu);
+    }
+}
+#endif // GGML_USE_HIP
+
 void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0   = dst->src[0];
     const float *       src0_d = (const float *) src0->data;
@@ -69,6 +92,36 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     // TODO: investigate if there exists a point where parallelized argsort is faster than sequential top-k
     for (int i = 0; i < nrows; i++) {
         top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+    }
+#elif defined(GGML_USE_HIP)  // CUB_TOP_K_AVAILABLE
+    // ROCm partial top-k (see doc/PLAN_hip_partial_topk.md). rocprim::partial_sort_copy requires
+    // middle < size, so k == ncols falls back to a full descending sort.
+    if (k < ncols) {
+        const int block = 256;
+        ggml_cuda_pool_alloc<uint64_t> packed_in_alloc(pool, ncols);
+        ggml_cuda_pool_alloc<uint64_t> packed_out_alloc(pool, ncols + 1);
+        uint64_t * packed_in  = packed_in_alloc.get();
+        uint64_t * packed_out = packed_out_alloc.get();
+        for (int64_t r = 0; r < nrows; ++r) {
+            const dim3 grid((ncols + block - 1) / block);
+            ggml_cuda_topk_pack_kv<<<grid, block, 0, stream>>>(src0_d + r * ncols, packed_in, (int) ncols);
+
+            size_t tmp_bytes = 0;
+            CUDA_CHECK(rocprim::partial_sort_copy(nullptr, tmp_bytes, packed_in, packed_out,
+                                                  (size_t) k, (size_t) ncols, rocprim::less<uint64_t>(), stream));
+            ggml_cuda_pool_alloc<uint8_t> tmp_alloc(pool, tmp_bytes);
+            CUDA_CHECK(rocprim::partial_sort_copy(tmp_alloc.get(), tmp_bytes, packed_in, packed_out,
+                                                  (size_t) k, (size_t) ncols, rocprim::less<uint64_t>(), stream));
+
+            const dim3 ugrid((k + block - 1) / block);
+            ggml_cuda_topk_unpack_idx<<<ugrid, block, 0, stream>>>(packed_out, dst_d + r * k, (int) k);
+        }
+    } else {
+        ggml_cuda_pool_alloc<int> temp_dst_alloc(pool, ncols * nrows);
+        int * tmp_dst = temp_dst_alloc.get();
+        argsort_f32_i32_cuda_bitonic(src0_d, tmp_dst, ncols, nrows, GGML_SORT_ORDER_DESC, stream);
+        CUDA_CHECK(cudaMemcpy2DAsync(dst_d, k * sizeof(int), tmp_dst, ncols * sizeof(int),
+                                     k * sizeof(int), nrows, cudaMemcpyDeviceToDevice, stream));
     }
 #elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
     // Fall back to argsort + copy


### PR DESCRIPTION
ggml_cuda_op_top_k had a fast partial-top-k path only under CUB_TOP_K_AVAILABLE (NVIDIA CCCL >= 3.2 DeviceTopK). On ROCm/HIP that is never defined, so:
  - supports_op reported TOP_K unsupported for ne[0] > 1024, pushing it to the CPU backend (a per-token GPU<->CPU roundtrip + CPU sort), and
  - where it did run, it full-sorted every row. This collapses Qwen3-Next/qwen4exp QSA long-context decode on Strix Halo, while a same-bandwidth NVIDIA GB10 (DeviceTopK) stays flat.

- top-k.cu: add a HIP branch using rocPRIM partial_sort_copy on packed (score,index) keys (nth_element + sort of the first k). k == ncols falls back to bitonic (rocPRIM requires middle < size).
- ggml-cuda.cu: enable TOP_K in supports_op on HIP when k < ncols (or ncols <= 1024), and disable graph capture for graphs whose TOP_K uses the partial path (it syncs the stream), mirroring the MUL_MAT_ID guard.

Validation on gfx1151 / ROCm 7.2.1:
- test-backend-ops -o TOP_K: 517/517 OK (incl. ncols up to 16384).
- qwen4exp UD-IQ4_XS single-stream, graphs ON: S_TG at N_KV 640/2176/8320 = 21.5/20.7/19.3 t/s (was 21.5/8.8/8.1) -> long-context collapse eliminated.

The following is speed testing result of `Qwen3.8-Flash-Next-GGUF` on AMD Strix Halo 395 Chip:
N_KV | before (tok/s)| after (tok/s)
-- | -- | --
640 | 21.5 | 21.47
2176 | 8.8 | 20.72
8320 | 8.1 | 19.25


cc @zhangnju
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
