### PR TITLE
mtmd: reject zero granite4-vision downsample sides

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1973,6 +1973,14 @@ struct clip_model_loader {
 
                         get_u32(KEY_PROJ_SAMPLE_QUERY_SIDE,  hparams.downsample_query_side);
                         get_u32(KEY_PROJ_SAMPLE_WINDOW_SIDE, hparams.downsample_window_side);
+
+                        if (hparams.downsample_window_side == 0) {
+                            throw std::runtime_error(string_format("%s: downsample_window_side must be non-zero\n", __func__));
+                        }
+                        if (hparams.downsample_query_side == 0) {
+                            throw std::runtime_error(string_format("%s: downsample_query_side must be non-zero\n", __func__));
+                        }
+
                         hparams.warmup_image_size = hparams.image_size;
                     } break;
                 default:


### PR DESCRIPTION
Add validation in the granite4-vision load_hparams path so downsample_window_side or downsample_query_side of zero fails before warmup graph construction with a descriptive error. Add a CPU regression test using an in-repo generated minimal GGUF: zero window/query side is rejected, while a window_side=8 control loads and encodes on CPU.