### PR TITLE
hip : enable GGML_CUDA_USE_CUB via hipCUB (fixes TOP_K CPU-fallback cliff / RPC abort on ROCm)

### DIFF
--- a/ggml/src/ggml-cuda/argsort.cu
+++ b/ggml/src/ggml-cuda/argsort.cu
@@ -1,12 +1,17 @@
 #include "argsort.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
-#    include <cub/cub.cuh>
-#    if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 1)
-#        define STRIDED_ITERATOR_AVAILABLE
-#        include <cuda/iterator>
+#    if defined(GGML_USE_HIP)
+#        include <hipcub/hipcub.hpp>
+         using namespace hipcub;
+#    else
+#        include <cub/cub.cuh>
+#        if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 1)
+#            define STRIDED_ITERATOR_AVAILABLE
+#            include <cuda/iterator>
+#        endif
+         using namespace cub;
 #    endif
-using namespace cub;
 #endif  // GGML_CUDA_USE_CUB
 
 static __global__ void init_indices(int * indices, const int ncols, const int nrows) {
@@ -74,14 +79,19 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
     size_t temp_storage_bytes = 0;
 
     bool is_capturing = false;
-#ifdef USE_CUDA_GRAPH
+#if defined(USE_CUDA_GRAPH) && !defined(GGML_USE_HIP)
     // Currently (confirmed for CCCL <= 3.2) DeviceSegmentedSort does not support stream capture, while DeviceSegmentedRadixSort does.
     // See https://github.com/NVIDIA/cccl/issues/5661#issuecomment-3229037149
     // TODO: constrain this to the CCCL versions that have this issue once it's resolved in a future CCCL release.
     cudaStreamCaptureStatus capture_status;
     CUDA_CHECK(cudaStreamIsCapturing(stream, &capture_status));
     is_capturing = (capture_status != cudaStreamCaptureStatusNone);
-#endif  // USE_CUDA_GRAPH
+#endif  // USE_CUDA_GRAPH && !GGML_USE_HIP
+#ifdef GGML_USE_HIP
+    // hipCUB (rocPRIM) has no DeviceSegmentedSort; use DeviceSegmentedRadixSort
+    // unconditionally (works inside and outside stream capture).
+    is_capturing = true;
+#endif
 
     if (order == GGML_SORT_ORDER_ASC) {
         if (nrows == 1) {

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1674,3 +1674,16 @@ static __inline__ void ggml_cuda_kernel_launch(Kernel kernel, const ggml_cuda_ke
     CUDA_CHECK(cudaGetLastError());
 }
 
+
+// HIP compat: the CUDA capture-status API is not aliased by the HIP runtime;
+// map it for GGML_CUDA_USE_CUB code paths (argsort/top-k/mean/sum/...).
+#if defined(GGML_USE_HIP) && defined(GGML_CUDA_USE_CUB)
+#ifndef cudaStreamCaptureStatus
+#define cudaStreamCaptureStatus hipStreamCaptureStatus
+#define cudaStreamIsCapturing hipStreamIsCapturing
+#define cudaStreamCaptureStatusNone hipStreamCaptureStatusNone
+#define cudaStreamCaptureStatusActive hipStreamCaptureStatusActive
+#define cudaStreamCaptureStatusGlobal hipStreamCaptureStatusGlobal
+#define cudaStreamCaptureStatusRelaxed hipStreamCaptureStatusRelaxed
+#endif
+#endif

--- a/ggml/src/ggml-cuda/cumsum.cu
+++ b/ggml/src/ggml-cuda/cumsum.cu
@@ -5,7 +5,12 @@
 #include "ggml.h"
 
 #ifdef GGML_CUDA_USE_CUB
-#   include <cub/cub.cuh>
+#   if defined(GGML_USE_HIP)
+#       include <hipcub/hipcub.hpp>
+        namespace cub = hipcub;
+#   else
+#       include <cub/cub.cuh>
+#   endif
 #endif // GGML_CUDA_USE_CUB
 
 template<typename T, int BLOCK_SIZE>

--- a/ggml/src/ggml-cuda/mean.cu
+++ b/ggml/src/ggml-cuda/mean.cu
@@ -2,8 +2,13 @@
 #include "reduce_rows.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
-#include <cub/cub.cuh>
-using namespace cub;
+#   if defined(GGML_USE_HIP)
+#       include <hipcub/hipcub.hpp>
+        using namespace hipcub;
+#   else
+#       include <cub/cub.cuh>
+        using namespace cub;
+#   endif
 #endif  // GGML_CUDA_USE_CUB
 
 template <typename T> __global__ void divide_by_count(T * result, size_t count) {

--- a/ggml/src/ggml-cuda/sum.cu
+++ b/ggml/src/ggml-cuda/sum.cu
@@ -2,8 +2,13 @@
 #include "sumrows.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
-#include <cub/cub.cuh>
-using namespace cub;
+#   if defined(GGML_USE_HIP)
+#       include <hipcub/hipcub.hpp>
+        using namespace hipcub;
+#   else
+#       include <cub/cub.cuh>
+        using namespace cub;
+#   endif
 #endif  // GGML_CUDA_USE_CUB
 
 #include <cstdint>

--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -2,12 +2,17 @@
 #include "top-k.cuh"
 
 #ifdef GGML_CUDA_USE_CUB
-#    include <cub/cub.cuh>
-#    if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2)
-#        define CUB_TOP_K_AVAILABLE
-#        include <cuda/iterator>
-using namespace cub;
-#    endif  // CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2
+#    if defined(GGML_USE_HIP)
+#        include <hipcub/hipcub.hpp>
+         using namespace hipcub;
+#    else
+#        include <cub/cub.cuh>
+#        if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2)
+#            define CUB_TOP_K_AVAILABLE
+#            include <cuda/iterator>
+             using namespace cub;
+#        endif  // CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2
+#    endif
 #endif      // GGML_CUDA_USE_CUB
 
 #ifdef CUB_TOP_K_AVAILABLE

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -47,6 +47,11 @@ find_package(hip     REQUIRED)
 find_package(hipblas REQUIRED)
 find_package(rocblas REQUIRED)
 
+option(GGML_CUDA_USE_CUB "Use hipCUB-based CUB code paths on HIP (argsort/top-k/mean/sum/cumsum)" OFF)
+if (GGML_CUDA_USE_CUB)
+    add_compile_definitions(GGML_CUDA_USE_CUB)
+endif()
+
 if (GGML_HIP_RCCL)
     find_package(rccl REQUIRED)
 endif()


### PR DESCRIPTION
## Summary

Enables the existing `GGML_CUDA_USE_CUB` code paths on HIP via **hipCUB** (rocPRIM), which provides CUB-compatible APIs (`DeviceRadixSort`, `DeviceSegmentedRadixSort`, `DeviceScan`, `BlockScan/Load/Store`).

This fixes a severe decode cliff and a hard abort on ROCm for `qwen4exp` (Qwen3.8-Flash-Next):

- **#27856** — decode collapses 19.6 → ~6 t/s once `n_kv` crosses ~1024 tokens on HIP (Strix Halo)
- **#27865** — over RPC, the worker aborts with `TOP_K failed: invalid configuration argument` once `n_kv` crosses 2048 columns

## Mechanism

Without `GGML_CUDA_USE_CUB`, the HIP backend reports `TOP_K`/`ARGSORT` as unsupported beyond **1024 columns** (`ggml/src/ggml-cuda/ggml-cuda.cu`, `supports_op`: `return op->src[0]->ne[0] <= 1024;`), because the no-CUB fallback (`argsort_f32_i32_cuda_bitonic`) exceeds launch limits past that (threads = `ncols_pad/2` > 1024, shared memory `ncols_pad * sizeof(int)` > 64 KiB smpb).

For `qwen4exp`, the QSA lightning indexer runs `ggml_top_k()` over a `[n_kv, n_tps]` tensor (`ne[0] == n_kv`) in **all 12 QSA layers on every decode token**. Past the 1024-column threshold the op moves to CPU — with a device→host copy of the scores, a CPU top-k, a host→device copy of the indices and a sync **per layer per token** → the observed 3–4× decode cliff. Over RPC the crash occurs because `ggml_backend_rpc_device_supports_op()` currently reports unconditional support, so the op is dispatched to a worker whose real backend cannot launch it.

With the CUB paths enabled, `top_k`/`argsort` use `DeviceRadixSort`/`DeviceSegmentedRadixSort` on the GPU for arbitrary column counts, and `supports_op` legitimately reports support.

## Changes

- `argsort.cu`, `top-k.cu`, `mean.cu`, `sum.cu`, `cumsum.cu`: include `<hipcub/hipcub.hpp>` instead of `<cub/cub.cuh>` under `GGML_USE_HIP` (using-declaration or `namespace cub = hipcub;` for the qualified usages in `cumsum.cu`)
- `argsort.cu`: skip the `DeviceSegmentedSort` capture-check on HIP and always use `DeviceSegmentedRadixSort` — rocPRIM has no `DeviceSegmentedSort`, and radix sort works both inside and outside stream capture
- `common.cuh`: alias the stream-capture-status API (`cudaStreamCaptureStatus`, `cudaStreamIsCapturing`, …) — the HIP runtime does not provide these aliases; guarded by `GGML_USE_HIP && GGML_CUDA_USE_CUB`
- `ggml-hip/CMakeLists.txt`: expose `GGML_CUDA_USE_CUB` as a CMake option (previously this define was not reachable from any build system on HIP)

**CUDA builds are unaffected:** every source change is guarded by `GGML_USE_HIP`; `ssm-scan.cu` already excludes itself on HIP and needs no change.

## Validation

2× AMD Strix Halo (gfx1151, ROCm 7.2.1, Thunderbolt RPC cluster), `Qwen3.8-Flash-Next` UD-IQ4_XS (93.7 GB, 3 shards), 262144 ctx, `llama-server` + `ggml-rpc-server` (master):

- No TOP_K abort at large `n_kv` (previously a hard worker crash past 2048 columns, #27865)
- Decode: **20.2 t/s** at <1K context, **20.1 t/s** at 18K, 11.7 t/s at 52K — the 1K cliff from #27856 is gone; the remaining degradation is linear (~1 µs per KV token) and comes from the QSA attention being implemented as a mask over the full KV rather than gathering the top-k selection (separate, kernel-level optimization opportunity)
- Prefill: 282 t/s at 18K tokens (`-ub 512`)
- Output quality verified on long generations (800+ tokens, German and English)

Build: `cmake -DGGML_HIP=ON -DGGML_RPC=ON -DAMDGPU_TARGETS=gfx1151 -DGGML_CUDA_USE_CUB=ON …` with ROCm 7.2.1 (clang from ROCm, `CMAKE_HIP_COMPILER=<rocm>/bin/amdclang++`).
