### PR TITLE
context : disable non-fused GDN and LID ops

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -231,10 +231,10 @@ llama_context::llama_context(
 
     cparams.fused_gdn_ar = true;
     cparams.fused_gdn_ch = true;
-    cparams.auto_fgdn    = true;
+    cparams.auto_fgdn    = false;
 
-    cparams.fused_lid    = true;
-    cparams.auto_flid    = true;
+    cparams.fused_lid = true;
+    cparams.auto_flid = false;
 
     cparams.fused_dsv4_hc_pre  = true;
     cparams.fused_dsv4_hc_comb = true;


### PR DESCRIPTION
## Overview

Disable non-fused paths for the Gated Delta Net and Lightning Indexer ops. These ops have good backend coverage now (Metal, CUDA, Vulkan, SYCL) and no need to keep resolving the fusion logic all the time. For backends that don't yet support these ops, there is CPU fallback.

Fixes: https://github.com/ggml-org/llama.cpp/actions/runs/33149014284/job/98776418532#step:5:12665

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
