### PR TITLE
ci : check for missing autoreleasepools

### DIFF
--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -66,7 +66,13 @@ jobs:
             -DGGML_RPC=ON \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3
           time cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
-          leaks -atExit -- ./build/bin/test-thread-safety -hf ggml-org/gemma-3-270m-qat-GGUF -ngl 99 -p "$(printf 'hello %.0s' {1..128})" -n 16 -c 512 -ub 32 -np 2 -t 2 -lv 1
+
+      - name: Check for leaks
+        run: |
+          cmd=(./build/bin/test-thread-safety -hf ggml-org/gemma-3-270m-qat-GGUF -ngl 99 -p "$(printf 'hello %.0s' {1..128})" -n 16 -c 512 -ub 32 -np 2 -t 2 -lv 1)
+          leaks -atExit -- "${cmd[@]}"
+          # AGXG16SDevice is leaked by Metal in Apple code sometimes, so we ignore it
+          OBJC_DEBUG_MISSING_POOLS=YES "${cmd[@]}" 2>&1 | awk '{ print } index($0, "autoreleased with no pool in place") && !index($0, "AGXG16SDevice") { found = 1 } END { exit found }'
 
       - name: Test
         id: cmake_test

--- a/.github/workflows/build-apple.yml
+++ b/.github/workflows/build-apple.yml
@@ -71,8 +71,8 @@ jobs:
         run: |
           cmd=(./build/bin/test-thread-safety -hf ggml-org/gemma-3-270m-qat-GGUF -ngl 99 -p "$(printf 'hello %.0s' {1..128})" -n 16 -c 512 -ub 32 -np 2 -t 2 -lv 1)
           leaks -atExit -- "${cmd[@]}"
-          # AGXG16SDevice is leaked by Metal in Apple code sometimes, so we ignore it
-          OBJC_DEBUG_MISSING_POOLS=YES "${cmd[@]}" 2>&1 | awk '{ print } index($0, "autoreleased with no pool in place") && !index($0, "AGXG16SDevice") { found = 1 } END { exit found }'
+          # Graphics devices are leaked by Metal in Apple code sometimes, so we ignore those leaks
+          OBJC_DEBUG_MISSING_POOLS=YES "${cmd[@]}" 2>&1 | awk '{ print } index($0, "autoreleased with no pool in place") && !/class [a-zA-Z0-9]+Device autoreleased/ { found = 1 } END { exit found }'
 
       - name: Test
         id: cmake_test


### PR DESCRIPTION
## Overview

Adds CI check against missing autorelease pools as discussed in https://github.com/ggml-org/llama.cpp/pull/27758#issuecomment-5434547005.

We exclude graphics device leaks (`AGXG16SDevice` on my Mac, `AppleParavirtDevice` in CI). I've fixed some of them in https://github.com/ggml-org/llama.cpp/pull/27883. There are still some that happen in internal macOS code that I haven't fixed yet. For now, let's exclude those macOS-internal graphics device leaks.

(The regex `[a-zA-Z0-9]+Device` isn't perfect and would also match classes such as `MTLDevice`, but adding the test with that regex is better than not having a test at all.)

## Additional information

Unfixed `AGXG16SDevice` backtraces (using `breakpoint set -n objc_autoreleaseNoPool` in `lldb`):

<details><summary>Backtrace when loading a model (happens only sometimes, not every time)</summary>
<p>

```
objc[52873]: MISSING POOLS: (0x17048b000) Object 0x828838000 of class AGXG16SDevice autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
Process 52873 stopped
* thread #13, queue = 'com.apple.MTLCompilerConnectionQueue', stop reason = breakpoint 1.1
    frame #0: 0x000000018f848a38 libobjc.A.dylib`_objc_warn_deprecated
libobjc.A.dylib`_objc_warn_deprecated:
->  0x18f848a38 <+0>:  ret    
    0x18f848a3c <+4>:  udf    #0x0
    0x18f848a40 <+8>:  udf    #0x0
    0x18f848a44 <+12>: udf    #0x0
Target 0: (llama-cli) stopped.
(lldb) bt
* thread #13, queue = 'com.apple.MTLCompilerConnectionQueue', stop reason = breakpoint 1.1
  * frame #0: 0x000000018f848a38 libobjc.A.dylib`_objc_warn_deprecated
    frame #1: 0x000000018f83fff8 libobjc.A.dylib`AutoreleasePoolPage::autoreleaseNoPage(objc_object*) + 260
    frame #2: 0x000000018f83fe14 libobjc.A.dylib`objc_autoreleasePoolPush + 76
    frame #3: 0x000000018faf3ea0 libdispatch.dylib`_dispatch_lane_serial_drain + 340
    frame #4: 0x000000018faf4b64 libdispatch.dylib`_dispatch_lane_invoke + 448
    frame #5: 0x000000018fafee34 libdispatch.dylib`_dispatch_root_queue_drain_deferred_wlh + 284
    frame #6: 0x000000018fafe734 libdispatch.dylib`_dispatch_workloop_worker_thread + 720
    frame #7: 0x000000018fca3ec0 libsystem_pthread.dylib`_pthread_wqthread + 292
```

</p>
</details> 

<details><summary>Backtrace while initializing SSL during model download in `test-thread-safety`</summary>
<p>

```
objc[22992]: MISSING POOLS: (0x17048b000) Object 0xbaa854000 of class AGXG16SDevice autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
Process 22992 stopped
* thread #14, queue = 'copy_certificates_from_keychain', stop reason = breakpoint 1.1
    frame #0: 0x000000018f848a38 libobjc.A.dylib`_objc_warn_deprecated
libobjc.A.dylib`_objc_warn_deprecated:
->  0x18f848a38 <+0>:  ret    
    0x18f848a3c <+4>:  udf    #0x0
    0x18f848a40 <+8>:  udf    #0x0
    0x18f848a44 <+12>: udf    #0x0
Target 0: (test-thread-safety) stopped.
(lldb) bt
* thread #14, queue = 'copy_certificates_from_keychain', stop reason = breakpoint 1.1
  * frame #0: 0x000000018f848a38 libobjc.A.dylib`_objc_warn_deprecated
    frame #1: 0x000000018f83fff8 libobjc.A.dylib`AutoreleasePoolPage::autoreleaseNoPage(objc_object*) + 260
    frame #2: 0x000000018f83fe14 libobjc.A.dylib`objc_autoreleasePoolPush + 76
    frame #3: 0x0000000193590950 Security`Security::SecPointerBase::SecPointerBase(Security::SecCFObject*) + 32
    frame #4: 0x00000001935a5068 Security`Security::KeychainCore::StorageManager::keychain(Security::DLDbIdentifier const&) + 736
    frame #5: 0x0000000193880578 Security`Security::KeychainCore::StorageManager::makeKeychain(Security::DLDbIdentifier const&, bool, bool) + 140
    frame #6: 0x00000001938872cc Security`Security::KeychainCore::StorageManager::make(char const*, bool, bool) + 372
    frame #7: 0x000000019387afa8 Security`__SecTrustSettingsCopyCertificates_block_invoke_2 + 300
    frame #8: 0x000000018fafaf04 libdispatch.dylib`_dispatch_block_async_invoke2 + 148
    frame #9: 0x000000018fb054b0 libdispatch.dylib`_dispatch_client_callout + 16
    frame #10: 0x000000018faf4030 libdispatch.dylib`_dispatch_lane_serial_drain + 740
    frame #11: 0x000000018faf4b2c libdispatch.dylib`_dispatch_lane_invoke + 392
    frame #12: 0x000000018fafee34 libdispatch.dylib`_dispatch_root_queue_drain_deferred_wlh + 284
    frame #13: 0x000000018fafe734 libdispatch.dylib`_dispatch_workloop_worker_thread + 720
    frame #14: 0x000000018fca3ec0 libsystem_pthread.dylib`_pthread_wqthread + 292
```

Which is called via this stack:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x000000019387ac70 Security`SecTrustSettingsCopyCertificates
    frame #1: 0x000000010084abf4 libllama-common.0.dylib`httplib::tls::load_system_certs(void*) + 64
    frame #2: 0x000000010084ab1c libllama-common.0.dylib`httplib::detail::load_client_ca_config(void*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, bool, httplib::SystemCAMode, unsigned long long&) + 324
    frame #3: 0x00000001008a89dc libllama-common.0.dylib`void std::__1::__call_once_proxy[abi:nqe210106]<std::__1::tuple<httplib::SSLClient::load_certs()::$_0&&>>(void*) + 92
    frame #4: 0x000000018fbb93b8 libc++.1.dylib`std::__1::__call_once(unsigned long volatile&, void*, void (*)(void*)) + 196
    frame #5: 0x0000000100886ee8 libllama-common.0.dylib`httplib::SSLClient::initialize_ssl(httplib::ClientImpl::Socket&, httplib::Error&) + 124
    frame #6: 0x0000000100887258 libllama-common.0.dylib`httplib::SSLClient::ensure_socket_connection(httplib::ClientImpl::Socket&, httplib::Error&) + 96
    frame #7: 0x000000010086591c libllama-common.0.dylib`httplib::ClientImpl::send_(httplib::Request&, httplib::Response&, httplib::Error&) + 228
    frame #8: 0x0000000100865f78 libllama-common.0.dylib`httplib::ClientImpl::send_(httplib::Request&&) + 172
    frame #9: 0x000000010086ef0c libllama-common.0.dylib`httplib::ClientImpl::Get(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, httplib::detail::insertion_ordered_multimap<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, httplib::detail::case_ignore::equal_to> const&, std::__1::function<bool (unsigned long, unsigned long)>) + 496
    frame #10: 0x000000010087c578 libllama-common.0.dylib`httplib::Client::Get(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, httplib::detail::insertion_ordered_multimap<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, httplib::detail::case_ignore::equal_to> const&, std::__1::function<bool (unsigned long, unsigned long)>) + 148
    frame #11: 0x000000010075b688 libllama-common.0.dylib`hf_cache::api_get(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 4984
    frame #12: 0x0000000100757954 libllama-common.0.dylib`hf_cache::get_repo_files(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 644
    frame #13: 0x00000001007457fc libllama-common.0.dylib`common_download_get_hf_plan(common_params_model const&, common_download_opts const&) + 148
    frame #14: 0x000000010064a1e0 libllama-common.0.dylib`common_models_handler_init(common_params const&, llama_example) + 1136
    frame #15: 0x00000001006751c0 libllama-common.0.dylib`common_params_parse(int, char**, common_params&, llama_example, void (*)(int, char**)) + 4884
    frame #16: 0x0000000100002b60 test-thread-safety`main + 112
    frame #17: 0x000000018f8dc4e4 dyld`start + 6992
```

</p>
</details> 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Had some assistance from GPT-5.6 when writing the CLI commands. Edited them manually afterwards.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
