### PR TITLE
llama : fix out-of-bounds layer split when all devices report zero free memory

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1460,8 +1460,23 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         split_sum += splits[i];
         splits[i] = split_sum;
     }
-    for (size_t i = 0; i < n_devices(); ++i) {
-        splits[i] /= split_sum;
+
+    if (split_sum == 0.0f) {
+        // all devices report zero free memory (e.g. a Vulkan GPU that is already
+        // fully occupied by a previously loaded model, such as an MTP draft model
+        // loaded after the target). normalizing by zero would produce NaN split
+        // points and make std::upper_bound return the end iterator, causing an
+        // out-of-bounds access in devices.at(layer_gpu) below.
+        // fall back to an even split, mirroring the host-memory fallback above.
+        // fixes: https://github.com/ggml-org/llama.cpp/issues/27717
+        LLAMA_LOG_WARN("%s: all devices report zero free memory - falling back to an even layer split\n", __func__);
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] = float(i + 1) / n_devices();
+        }
+    } else {
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] /= split_sum;
+        }
     }
 
     const int i_gpu_start = std::max(n_layer_all + 1 - n_gpu_layers, 0);


### PR DESCRIPTION
## Overview

Fixes a model-load crash (issue #27717): `std::out_of_range` ("invalid vector subscript" on MSVC) thrown from `devices.at(layer_gpu)` inside `get_layer_buft_list` (`src/llama-model.cpp`) when **every device in the model's device list reports 0 bytes of free memory**.

`load_tensors` computes the layer split points from **free** device memory. When all devices report zero free memory (e.g. a Vulkan GPU already fully occupied by a previously loaded model, such as an MTP draft model loaded after a target kept nearly fully on GPU with a low `--n-cpu-moe`), `split_sum == 0` and the normalization `splits[i] /= split_sum` produces **NaN** split points. `std::upper_bound` over NaN values returns the end iterator, so `layer_gpu == n_devices()` and `devices.at(layer_gpu)` throws, aborting the load.

The existing zero-memory fallback (issues #18577) only covers `free == 0 && total == 0`, which is why this case slips through.

**Fix:** fall back to an **even split** (with a warning) when `split_sum == 0.0f`, mirroring the spirit of the host-memory fallback. With a single device this is placement-neutral (split point is 1.0 either way) — it strictly replaces the crash with normal load behavior.

## Additional information

- Reproduced on Windows 11 / Vulkan (RX 7600 XT 16 GB), build b10621: MoE target + `--n-cpu-moe 14` + `--spec-type draft-mtp -md <draft>` → `error loading model: invalid vector subscript` during draft load.
- Config-level confirmation of the trigger: the identical command with `--n-cpu-moe 22` (leaving ~2 GB free) loads the draft and serves with speculative decoding; `-ngl 0` (empty device list → CPU branch) also loads fine.
- Independently confirmed in #27717 by @Stevie-O (also 16 GB AMD/Vulkan), whose patched build works and prints an equivalent "all devices report zero free memory" warning — this PR's fallback emits the same warning.
- The reported `--n-cpu-moe` "threshold" in #27717 is explained by this mechanism: it was never about the layer count, only how much VRAM the target leaves free.
- Happy to add a regression test if maintainers can suggest where it fits best (the split computation is embedded in `load_tensors`, so exercising it would need a device reporting zero free memory — pointers welcome).

Fixes #27717

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
