### PR TITLE
grammar : expand \d/\w/\s regex class escapes in GBNF conversion

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -281,6 +281,12 @@ static const int MAX_PATTERN_DEPTH = 100;
 
 static std::unordered_set<char> NON_LITERAL_SET = {'|', '.', '(', ')', '[', ']', '{', '}', '*', '+', '?', '^', '$'};
 static std::unordered_set<char> ESCAPED_IN_REGEXPS_BUT_NOT_IN_LITERALS = {'^', '$', '.', '[', ']', '(', ')', '|', '{', '}', '*', '+', '?'};
+// regex class escapes (\d etc.) as GBNF char classes
+static std::unordered_map<char, std::string> REGEXP_CLASS_ESCAPES = {
+    {'d', "[0-9]"},          {'D', "[^0-9]"},
+    {'w', "[0-9A-Za-z_]"},   {'W', "[^0-9A-Za-z_]"},
+    {'s', "[ \\t\\n\\r]"},   {'S', "[^ \\t\\n\\r]"},
+};
 
 static std::string replacePattern(const std::string & input, const std::regex & regex, const std::function<std::string(const std::smatch  &)> & replacement) {
     std::smatch match;
@@ -495,12 +501,25 @@ private:
                     i++;
                     while (i < length && sub_pattern[i] != ']') {
                         if (sub_pattern[i] == '\\') {
-                            auto escape_length = gbnf_escape_length(sub_pattern, i);
-                            if (escape_length == 0) {
-                                throw unsupported_pattern("unsupported escape in character class: " + sub_pattern.substr(i, 2));
+                            // expand \d/\w/\s; GBNF has no such escapes
+                            char next = i + 1 < length ? sub_pattern[i + 1] : '\0';
+                            if (next == 'd') {
+                                square_brackets += "0-9";
+                                i += 2;
+                            } else if (next == 'w') {
+                                square_brackets += "0-9A-Za-z_";
+                                i += 2;
+                            } else if (next == 's') {
+                                square_brackets += " \\t\\n\\r";
+                                i += 2;
+                            } else {
+                                auto escape_length = gbnf_escape_length(sub_pattern, i);
+                                if (escape_length == 0) {
+                                    throw unsupported_pattern("unsupported escape in character class: " + sub_pattern.substr(i, 2));
+                                }
+                                square_brackets += sub_pattern.substr(i, escape_length);
+                                i += escape_length;
                             }
-                            square_brackets += sub_pattern.substr(i, escape_length);
-                            i += escape_length;
                         } else {
                             square_brackets += sub_pattern[i];
                             i++;
@@ -574,6 +593,10 @@ private:
                         ""
                     );
                     seq.back().second = false;
+                } else if (c == '\\' && i + 1 < length &&
+                        REGEXP_CLASS_ESCAPES.find(sub_pattern[i + 1]) != REGEXP_CLASS_ESCAPES.end()) {
+                    seq.emplace_back(REGEXP_CLASS_ESCAPES.at(sub_pattern[i + 1]), false);
+                    i += 2;
                 } else {
                     std::string literal;
                     auto is_non_literal = [&](char c) {
@@ -585,6 +608,9 @@ private:
                                 throw invalid_pattern("trailing backslash");
                             }
                             char next = sub_pattern[i + 1];
+                            if (REGEXP_CLASS_ESCAPES.find(next) != REGEXP_CLASS_ESCAPES.end()) {
+                                break; // class escape, handled by outer loop
+                            }
                             if (ESCAPED_IN_REGEXPS_BUT_NOT_IN_LITERALS.find(next) != ESCAPED_IN_REGEXPS_BUT_NOT_IN_LITERALS.end()) {
                                 i++;
                                 literal += sub_pattern[i];

--- a/tests/test-json-schema-to-grammar.cpp
+++ b/tests/test-json-schema-to-grammar.cpp
@@ -1580,19 +1580,44 @@ int main() {
             )""",
         });
 
-        // the rules of the partial conversion (here "root-0") must not leak into the grammar
+        // \d, \w, \s class escapes are expanded to GBNF char classes
         run({
             SUCCESS,
-            "regexp with unsupported shorthand",
+            "regexp with class shorthand",
             R"""({
                 "type": "string",
                 "pattern": "^[0-9]{3}\\w$"
             })""",
             R"""(
-                char ::= [^"\\\x7F\x00-\x1F] | [\\] (["\\bfnrt] | "u" [0-9a-fA-F]{4})
-                root ::= string
+                root ::= "\"" (root-1{3,3} [0-9A-Za-z_]) "\""
+                root-1 ::= [0-9]
                 space ::= | " " | "\n"{1,2} [ \t]{0,20}
-                string ::= "\"" char* "\""
+            )""",
+        });
+
+        run({
+            SUCCESS,
+            "regexp with all class shorthands",
+            R"""({
+                "type": "string",
+                "pattern": "^\\d\\D\\w\\W\\s\\S$"
+            })""",
+            R"""(
+                root ::= "\"" ([0-9] [^0-9] [0-9A-Za-z_] [^0-9A-Za-z_] [ \t\n\r] [^ \t\n\r]) "\""
+                space ::= | " " | "\n"{1,2} [ \t]{0,20}
+            )""",
+        });
+
+        run({
+            SUCCESS,
+            "regexp with class shorthands inside brackets",
+            R"""({
+                "type": "string",
+                "pattern": "^[\\d_][\\w-]+[\\s.]?$"
+            })""",
+            R"""(
+                root ::= "\"" ([0-9_] [0-9A-Za-z_-]+ [ \t\n\r.]?) "\""
+                space ::= | " " | "\n"{1,2} [ \t]{0,20}
             )""",
         });
 


### PR DESCRIPTION
JSON-schema patterns using Perl-style class escapes (\d, \D, \w, \W, \s, \S) were either passed through literally or rejected, since GBNF has no such escapes. This aborted grammar generation for tool-call schemas that use them (e.g. Claude Code tool schemas).

Expand them into explicit GBNF character classes, both at top level and inside [...] classes, and add tests.

## Overview

Fix the GBNF so properly handles Perl/JS escaped characters


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) YES
- AI usage disclosure: YES, Claude Code interactive debug

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
