### PR TITLE
ggml: avoid KleidiAI init mutex on dispatch (#27078)

### DIFF
--- a/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
+++ b/ggml/src/ggml-cpu/kleidiai/kleidiai.cpp
@@ -1800,7 +1800,7 @@ class extra_buffer_type : ggml::cpu::extra_buffer_type {
         const bool src0_is_kleidiai =
             op->src[0]->buffer &&
             (ggml_n_dims(op->src[0]) == 2) &&
-            op->src[0]->buffer->buft == ggml_backend_cpu_kleidiai_buffer_type() &&
+            op->src[0]->buffer->buft->context == this &&
             slot_total > 0;
 
         if ((op->op == GGML_OP_MUL_MAT || op->op == GGML_OP_GET_ROWS) &&
@@ -1839,7 +1839,7 @@ class extra_buffer_type : ggml::cpu::extra_buffer_type {
 
     ggml::cpu::tensor_traits * get_tensor_traits(const struct ggml_tensor * op) override {
         if (op->op == GGML_OP_MUL_MAT || op->op == GGML_OP_GET_ROWS) {
-            if (op->src[0]->buffer && op->src[0]->buffer->buft == ggml_backend_cpu_kleidiai_buffer_type()) {
+            if (op->src[0]->buffer && op->src[0]->buffer->buft->context == this) {
                 return (ggml::cpu::tensor_traits *) op->src[0]->extra;
             } else {
                 // KleidiAI only has kernels for Q4_0 and Q8_0. For a quantized weight of any


### PR DESCRIPTION
## Overview

Avoid calling `ggml_backend_cpu_kleidiai_buffer_type()` from the KleidiAI dispatch path.

The function enters a critical section for initialization, but it was also being called by the `supports_op()` and `get_tensor_traits()` buffer checks during inference. This caused repeated mutex contention.

Use `buft->context` for the existing buffer type check instead. This keeps the initialization path unchanged and avoids the mutex on dispatch.

Fixes #27078.

## Additional information

The change is limited to two lines in `ggml/src/ggml-cpu/kleidiai/kleidiai.cpp`.

The mutex wait seen in the profiler is eliminated after the change, and generated output remains unchanged.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Cursor was used during investigation and testing. I reviewed the change and verified it with benchmarks and tests.