### PR TITLE
speculative: fix combined draft-mtp + external draft (-md) init crash

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -336,6 +336,10 @@ struct common_params_speculative_draft {
     llama_context * ctx_tgt = nullptr;
     llama_context * ctx_dft = nullptr;
 
+    // combined spec-types: when an external draft model is combined with draft-mtp,
+    // ctx_dft belongs to the external draft model and ctx_mtp is the MTP context on the target model
+    llama_context * ctx_mtp = nullptr;
+
     int32_t n_gpu_layers = -1; // number of layers to store in VRAM for the draft model (-1 - use default)
 
     ggml_type cache_type_k = GGML_TYPE_F16; // KV cache data type for the K

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2590,7 +2590,7 @@ common_speculative_init_result::common_speculative_init_result(
         model_path = params.speculative.draft.mparams.path;
         LOG_INF("%s: loading draft model '%s'\n", __func__, model_path.c_str());
 
-        llama_model * model_dft = llama_model_load_from_file(params.model.path.c_str(), mparams);
+        llama_model * model_dft = llama_model_load_from_file(model_path.c_str(), mparams);
         if (model_dft == NULL) {
             LOG_ERR("%s: failed to load draft model, '%s'\n", __func__, model_path.c_str());
             return;
@@ -2611,11 +2611,14 @@ common_speculative_init_result::common_speculative_init_result(
 
             llama_context * ctx_mtp = llama_init_from_model(model_tgt, cparams_mtp);
             if (ctx_mtp == nullptr) {
-                LOG_ERR("%s: failed to create MTP context\n", __func__);
-                return;
+                LOG_WRN("%s: target model has no MTP layers, skipping draft-mtp\n", __func__);
+                params.speculative.types.erase(
+                        std::remove(params.speculative.types.begin(), params.speculative.types.end(),
+                                    COMMON_SPECULATIVE_TYPE_DRAFT_MTP),
+                        params.speculative.types.end());
+            } else {
+                pimpl->context_mtp.reset(ctx_mtp);
             }
-
-            pimpl->context_mtp.reset(ctx_mtp);
         }
     } else if (spec_mtp) {
         model_path = params.model.path;

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1403,6 +1403,10 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
     {
         auto * ctx_tgt = this->params.ctx_tgt;
         auto * ctx_dft = this->params.ctx_dft;
+        if (this->params.ctx_mtp) {
+            // combined spec-types: ctx_dft belongs to an external draft model here
+            ctx_dft = this->params.ctx_mtp;
+        }
         GGML_ASSERT(ctx_tgt && ctx_dft && "MTP requires ctx_tgt and ctx_dft to be set");
 
         n_embd = llama_model_n_embd_out(llama_get_model(ctx_dft));
@@ -2550,6 +2554,7 @@ struct common_speculative_init_result::impl {
     // note: the order in which model, context, etc. are declared matters because their destructors will be called bottom-to-top
     llama_model_ptr   model;
     llama_context_ptr context;
+    llama_context_ptr context_mtp;
 };
 
 common_speculative_init_result::common_speculative_init_result(
@@ -2565,12 +2570,15 @@ common_speculative_init_result::common_speculative_init_result(
     auto mparams = common_model_params_to_llama(params);
     auto cparams = common_context_params_to_llama(params);
 
-    if (spec_mtp) {
-        cparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
-    }
-
     // the draft context holds as many tokens per sequence as the target context
     cparams.n_ctx = llama_n_ctx(ctx_tgt);
+
+    // MTP layers only exist in the target model, so an MTP-typed context can only be
+    // created against the target — never against an external draft model
+    auto cparams_mtp = cparams;
+    if (spec_mtp) {
+        cparams_mtp.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+    }
 
     // note: for small models maybe we can set this to the maximum possible draft from all speculative types
     //       the extra memory for small models is likely negligible?
@@ -2592,17 +2600,29 @@ common_speculative_init_result::common_speculative_init_result(
 
         llama_context * ctx_dft = llama_init_from_model(model_dft, cparams);
         if (ctx_dft == nullptr) {
-            LOG_ERR("%s: failed to create MTP context\n", __func__);
+            LOG_ERR("%s: failed to create draft context\n", __func__);
             return;
         }
 
         pimpl->context.reset(ctx_dft);
+
+        if (spec_mtp) {
+            LOG_INF("%s: creating MTP draft context against the target model '%s'\n", __func__, params.model.path.c_str());
+
+            llama_context * ctx_mtp = llama_init_from_model(model_tgt, cparams_mtp);
+            if (ctx_mtp == nullptr) {
+                LOG_ERR("%s: failed to create MTP context\n", __func__);
+                return;
+            }
+
+            pimpl->context_mtp.reset(ctx_mtp);
+        }
     } else if (spec_mtp) {
         model_path = params.model.path;
 
         LOG_INF("%s: creating MTP draft context against the target model '%s'\n", __func__, model_path.c_str());
 
-        llama_context * ctx_dft = llama_init_from_model(model_tgt, cparams);
+        llama_context * ctx_dft = llama_init_from_model(model_tgt, cparams_mtp);
         if (ctx_dft == nullptr) {
             LOG_ERR("%s: failed to create MTP context\n", __func__);
             return;
@@ -2620,6 +2640,10 @@ llama_model * common_speculative_init_result::model() {
 
 llama_context * common_speculative_init_result::context() {
     return pimpl->context.get();
+}
+
+llama_context * common_speculative_init_result::context_mtp() {
+    return pimpl->context_mtp.get();
 }
 
 common_speculative_init_result_ptr common_speculative_init_from_params(common_params & params, llama_model * model_tgt, llama_context * ctx_tgt) {

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -104,6 +104,7 @@ struct common_speculative_init_result {
 
     llama_model   * model();
     llama_context * context();
+    llama_context * context_mtp();
 
 private:
     struct impl;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1146,6 +1146,18 @@ private:
                 params_base.speculative.draft.ctx_tgt = ctx_tgt;
                 params_base.speculative.draft.ctx_dft = ctx_dft;
                 params_base.speculative.draft.ctx_mtp = spec_init->context_mtp();
+
+                // combined spec lists: when the target has no MTP layers the draft-mtp
+                // component is skipped during init — mirror that here so the runtime
+                // chain never sees a null MTP context under an active draft-mtp type
+                if (params_base.speculative.draft.ctx_mtp == nullptr) {
+                    auto & types = params_base.speculative.types;
+                    auto it = std::find(types.begin(), types.end(), COMMON_SPECULATIVE_TYPE_DRAFT_MTP);
+                    if (it != types.end()) {
+                        SRV_WRN("%s", "target model has no MTP layers, disabling draft-mtp\n");
+                        types.erase(it);
+                    }
+                }
             }
 
             load_progress_callback(1.0f, &load_progress_spec);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1139,12 +1139,13 @@ private:
                 }
 
                 if (ctx_dft == nullptr) {
-                    SRV_ERR("%s", "failed to create MTP context\n");
+                    SRV_ERR("%s", "failed to create draft context\n");
                     return false;
                 }
 
                 params_base.speculative.draft.ctx_tgt = ctx_tgt;
                 params_base.speculative.draft.ctx_dft = ctx_dft;
+                params_base.speculative.draft.ctx_mtp = spec_init->context_mtp();
             }
 
             load_progress_callback(1.0f, &load_progress_spec);

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -203,3 +203,34 @@ def test_multi_requests_parallel(n_slots: int, n_requests: int):
     for res in results:
         assert res.status_code == 200
         assert match_regex("(wise|kind|owl|answer)+", res.body["content"])
+
+
+def test_combined_draft_and_mtp_graceful():
+    # regression: https://github.com/ggml-org/llama.cpp/issues/27839
+    # a combined spec list (external draft + draft-mtp) with a target that has
+    # no MTP layers must not force an MTP context type onto the external draft
+    # model (pre-fix: server dies at load), and must degrade to plain external
+    # drafting (post-fix: combined == draft-only outputs)
+    server.spec_type = "draft-simple,draft-mtp"
+    server.start()
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "I believe the meaning of life is",
+        "temperature": 0.0,
+        "top_k": 1,
+        "n_predict": 16,
+    })
+    assert res.status_code == 200, res.body
+    assert len(res.body["content"]) > 0
+    tokens_combined = res.body["tokens"]
+    server.stop()
+
+    create_server()  # plain draft-simple baseline
+    server.start()
+    res = server.make_request("POST", "/completion", data={
+        "prompt": "I believe the meaning of life is",
+        "temperature": 0.0,
+        "top_k": 1,
+        "n_predict": 16,
+    })
+    assert res.status_code == 200, res.body
+    assert tokens_combined == res.body["tokens"]


### PR DESCRIPTION
**Problem**

`--spec-type` lists that combine `draft-mtp` with an external draft-model type (`draft-dflash`/`draft-dspark`/`draft`) while `-md` is passed crash at server startup:

```
common_speculative_init_result: failed to create MTP context
llama_server: exiting due to model loading error
```

Reported in #27839.

**Root cause**

The spec-init block in `tools/server/server-context.cpp` applies `LLAMA_CONTEXT_TYPE_MTP` through a single shared `cparams` object, so the external draft model's context is also created with the MTP type. MTP layers only exist in the target model, so `llama_init_from_model` returns `nullptr` for the draft and the server dies with a misleading error.

**Fix**

Keep the MTP context type on a separate `cparams` copy and apply it only to a context created against the target model; route `ctx_dft` (external draft) and `ctx_mtp` distinctly when the spec-type list mixes both. Two follow-ups found while writing the regression test: the external draft model was loaded from the *target's* path (now the draft path), and when the target has no MTP layers a combined list left a null MTP context wired into the runtime chain, failing completions — `draft-mtp` is now skipped with a warning and the remaining draft types serve unchanged.

**Testing**

- Regression test added (`tools/server/tests/unit/test_speculative.py::test_combined_draft_and_mtp_graceful`): combined list on a target without MTP layers must boot and produce token-identical output to the external-draft-only configuration. Fails on master (server exits at load); passes with this patch (verified locally, CPU build, stories15M_MOE + stories15M-q4_0 fixtures).
- Original repro config (Qwen3.8-27B target + DFlash draft, spec list `draft-dflash,draft-mtp,ngram-mod`): crashes at load on master, boots and serves with this patch (gfx1151/ROCm).
- Small-scale control (2.6B target + DSpark draft + `draft-mtp` in list): boots and serves clean with the patch, now with the correct draft model loaded.

Note for maintainers: the new-contributor PR-limit flag on this PR is stale — this is currently my only open PR in the repo.

**AI usage disclosure**: the code changes were developed with AI assistance and are human-reviewed; I can explain every line. The description is assembled from measured logs and diffs, with wording I have reviewed and take responsibility for.