### PR TITLE
vulkan : fix target-env for non-_cm2-named shaders needing vulkan1.3

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -12,6 +12,7 @@
 #include <queue>
 #include <condition_variable>
 #include <atomic>
+#include <set>
 #include <cstdio>
 #include <cstring>
 #include <cstdlib>
@@ -255,6 +256,11 @@ std::string basename(const std::string &path) {
     return path.substr(path.find_last_of("/\\") + 1);
 }
 
+std::string get_path_dirname(const std::string &path) {
+    size_t pos = path.find_last_of("/\\");
+    return pos == std::string::npos ? std::string(".") : path.substr(0, pos);
+}
+
 std::stringstream make_generic_stringstream() {
     std::stringstream ss;
     ss.imbue(c_locale);
@@ -335,8 +341,51 @@ compile_count_guard acquire_compile_slot() {
     return compile_count_guard(&compile_count, &decrement_compile_count);
 }
 
+// Shaders with a specialization-constant local size (local_size_*_id) lower to the
+// LocalSizeId execution mode, which the Vulkan environment rules only allow from
+// target-env vulkan1.3 onward (without it, the SPIR-V is technically invalid, even
+// though some older glslc/spirv-opt versions failed to catch it). The declaration can
+// live in an #include'd file, so this follows local (same-directory) includes.
+bool shader_needs_localsizeid(const std::string& path, std::set<std::string>& visited) {
+    if (!visited.insert(path).second) {
+        return false;
+    }
+
+    std::string source = read_binary_file(path, true);
+    if (source.find("local_size_x_id") != std::string::npos ||
+        source.find("local_size_y_id") != std::string::npos ||
+        source.find("local_size_z_id") != std::string::npos) {
+        return true;
+    }
+
+    const std::string dir = get_path_dirname(path);
+    size_t pos = 0;
+    while ((pos = source.find("#include", pos)) != std::string::npos) {
+        size_t quote_start = source.find('"', pos);
+        size_t newline = source.find('\n', pos);
+        if (quote_start == std::string::npos || (newline != std::string::npos && quote_start > newline)) {
+            pos += 8;
+            continue;
+        }
+        size_t quote_end = source.find('"', quote_start + 1);
+        if (quote_end == std::string::npos) {
+            pos = quote_start + 1;
+            continue;
+        }
+        std::string included = source.substr(quote_start + 1, quote_end - quote_start - 1);
+        if (shader_needs_localsizeid(dir + "/" + included, visited)) {
+            return true;
+        }
+        pos = quote_end + 1;
+    }
+
+    return false;
+}
+
 void string_to_spv_func(std::string name, std::string in_path, std::string out_path, std::map<std::string, std::string> defines, bool coopmat, bool dep_file, compile_count_guard slot) {
-    std::string target_env = (name.find("_cm2") != std::string::npos) ? "--target-env=vulkan1.3" : "--target-env=vulkan1.2";
+    std::set<std::string> visited;
+    bool needs_vulkan13 = name.find("_cm2") != std::string::npos || shader_needs_localsizeid(in_path, visited);
+    std::string target_env = needs_vulkan13 ? "--target-env=vulkan1.3" : "--target-env=vulkan1.2";
 
     #ifdef _WIN32
         std::vector<std::string> cmd = {GLSLC, "-fshader-stage=compute", target_env, "\"" + in_path + "\"", "-o", "\"" + out_path + "\""};


### PR DESCRIPTION
## Overview

string_to_spv_func hardcodes `target-env=vulkan1.2` for every shader but those with `_cm2` in the name. A large portion of shaders don't have `_cm2` (`mul_mm`, `mul_mat_vec`, `flash_attn`, `conv`, `argsort`, `cumsum`, etc) but declare `local_size_*_id` that lowers to SPIR-V's `LocalSizeId` execution mode which is invalid under vulkan1.2 environment ruleset without `maintenance4`. Ubuntu 24.04 bundled glslc doesn't enforce the Vulkan-env rule, so it "magically" worked; a current glslc refuses to compile the shaders and Vulkan backend fails to build.

fix: after local #include, detect which shaders actually declare `local_size_*_id` and only bump them to `--target-env=vulkan1.3` leaving everything else vulkan1.2. Chose this over the current existing precedent of disabling `-O` for `shader-compiler-bug` shaders (see #16860 workaround) because that would not optimize the hottest kernels (`mul_mat_vec`, `mul_mm`, `flash_attn`) we want on this hardware.

verification: test-backend-ops 17251/17251 pass on Vulkan0 (full suite). No known duplicate PR/issue found (searched LocalSizeId, maintenance4, target-env=vulkan1.2 / vulkan1.3).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Claude Code assisted in investigating the root cause and drafting the shader_needs_localsizeid detection logic, which I then reviewed, tested, and understand.