### PR TITLE
Blackwell IQ Failures issue Fixes

### DIFF
--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -7,21 +7,26 @@
 static __device__ __forceinline__ int get_int_b1(const void * x, const int & i32) {
     const uint8_t * x8 = (const uint8_t *) x;
 
-    int x32  = x8[4*i32 + 0] <<  0;
-    x32     |= x8[4*i32 + 1] <<  8;
-    x32     |= x8[4*i32 + 2] << 16;
-    x32     |= x8[4*i32 + 3] << 24;
+    uint32_t x32  = uint32_t(x8[4*i32 + 0]) <<  0;
+    x32          |= uint32_t(x8[4*i32 + 1]) <<  8;
+    x32          |= uint32_t(x8[4*i32 + 2]) << 16;
+    x32          |= uint32_t(x8[4*i32 + 3]) << 24;
 
-    return x32;
+    return static_cast<int>(x32);
 }
 
 static __device__ __forceinline__ int get_int_b2(const void * x, const int & i32) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000 && __CUDA_ARCH__ < GGML_CUDA_CC_RUBIN
+    // 2-byte loads produce incorrect IQ{1,2,3}_S MMQ/MMVQ results on Blackwell.
+    return get_int_b1(x, i32);
+#else
     const uint16_t * x16 = (const uint16_t *) x; // assume at least 2 byte alignment
 
-    int x32  = x16[2*i32 + 0] <<  0;
-    x32     |= x16[2*i32 + 1] << 16;
+    uint32_t x32  = uint32_t(x16[2*i32 + 0]) <<  0;
+    x32          |= uint32_t(x16[2*i32 + 1]) << 16;
 
-    return x32;
+    return static_cast<int>(x32);
+#endif
 }
 
 static __device__ __forceinline__ int get_int_b4(const void * x, const int & i32) {


### PR DESCRIPTION
## Overview

  Base commit:
  6fe749801 (b10678)

  Diffstat:
  1 file changed, 13 insertions(+), 8 deletions(-)
  ggml/src/ggml-cuda/vecdotq.cuh

  ## Hardware:
  NVIDIA RTX PRO 6000 Blackwell Workstation Edition
  Compute capability 12.0
  Driver 610.57.04
  CUDA 13.2

  ## Root cause:
  The 2-byte-aligned packed-load path in get_int_b2 produces incorrect
  IQ1_S, IQ2_S, and IQ3_S MMQ/MMVQ results on Blackwell. Using byte-safe
  loads for Blackwell corrects the native kernels. Packed reconstruction
  was also changed to unsigned arithmetic to avoid signed-shift undefined
  behavior. Other CUDA architectures and non-CUDA backends retain the
  existing path.

## Additional information

  ### Before:
  IQ3_S MUL_MAT_ID: 0/3 passed
  IQ3_S MUL_MAT: 0/11 passed
  Full-GPU Qwen3.8-Flash-Next generated corrupt output above the partial
  offload threshold.

 ### After:
  Targeted IQ1_S/IQ2_S/IQ3_S plus IQ3_XXS/IQ4_XS controls: 70/70 passed
  Complete CUDA MUL_MAT_ID suite: 869/869 passed
  Complete CUDA MUL_MAT suite: 1193/1193 passed

### Model validation:
  unsloth/Qwen3.8-Flash-Next-GGUF UD-IQ4_XS
  All layers GPU-offloaded; no --cpu-moe workaround
  Correct deterministic responses at 98.6–104.2 generation tok/s
  Five simultaneous server slots all returned correct distinct responses
  at 47.7–58.4 tok/s per request.

### Performance comparison:
  CPU-MoE workaround: ~23.3 tok/s
  Correctness fallback: ~44.2 tok/s
  Native packed-load fix: ~99–104 tok/s

  Relevant links: Qwen3.8 Blackwell issue #27763, earlier Blackwell IQ failures #21289.  Related prior Blackwell IQ failures: #21289 #27763 
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->  


