### PR TITLE
ggml : skip backend supports_op check for GGML_OP_NONE

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -883,9 +883,10 @@ static int ggml_backend_sched_backend_from_buffer(ggml_backend_sched_t sched, co
     }
 
     // find highest prio backend that supports the buffer type and the op
+    const bool skip_op_none = (op->op == GGML_OP_NONE);
     for (int i = 0; i < sched->n_backends; i++) {
         if (ggml_backend_supports_buft(sched->backends[i], buffer->buft) &&
-            ggml_backend_supports_op(sched->backends[i], op)) {
+            (skip_op_none || ggml_backend_supports_op(sched->backends[i], op))) {
             return i;
         }
     }


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
ggml_backend_sched_backend_from_buffer calls supports_op for every tensor, including leaves. Vulkan and Metal backends reject GGML_OP_NONE. Vulkan does it in a tensor size precheck before the op case switch. Metal simply rejects it. Since there's no compute to do, we can safely skip this op check. 

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
The crash happened during model loading of a Dflash2 draft model.
```
[Qwen3.8-27B-SSMFIX-Apostate-Q4_K_M]
hf                    = creekhop/Qwen3.8-27B-SSMFIX-Apostate-GGUF:Q4_K_M
ctx-size              = 50000
spec-draft-hf         = incoai/Qwen3.8-27B-DFlash2-GGUF:Q4_K_M
spec-type             = draft-dflash
spec-draft-n-max      = 7
```

```
[52313] 0.05.482.511 I common_speculative_init_result: loading draft model '/home/woadmull/.config/llm/models/models--incoai--Qwen3.8-27B-DFlash2-GGUF/snapshots/6cb5872e2cee6b4e780a8414922350be8e42d65c/Qwen3.8-27B-DFlash2-Q4_K_M.gguf'
[52313] /home/woadmull/.config/llm/llamacpp/ggml/src/ggml-backend.cpp:932: pre-allocated tensor (token_embd.weight) in a buffer (Vulkan0) that cannot run the operation (NONE)
[52313] 0x00007f3c480a6f12 in __syscall_cancel_arch () from /lib64/libc.so.6
[52313] #0  0x00007f3c480a6f12 in __syscall_cancel_arch () from /lib64/libc.so.6
[52313] #1  0x00007f3c4809a118 in __internal_syscall_cancel () from /lib64/libc.so.6
[52313] #2  0x00007f3c4809a171 in __syscall_cancel () from /lib64/libc.so.6
[52313] #3  0x00007f3c4810c6bb in wait4 () from /lib64/libc.so.6
[52313] #4  0x00007f3c5236fd96 in ggml_print_backtrace () from /home/woadmull/.config/llm/llamacpp/build/bin/libggml-base.so.0
[52313] #5  0x00007f3c52387599 in ggml_abort () from /home/woadmull/.config/llm/llamacpp/build/bin/libggml-base.so.0
[52313] #6  0x00007f3c5239021e in ggml_backend_sched_backend_id_from_cur(ggml_backend_sched*, ggml_tensor*) () from /home/woadmull/.config/llm/llamacpp/build/bin/libggml-base.so.0
[52313] #7  0x00007f3c5238d155 in ggml_backend_sched_split_graph () from /home/woadmull/.config/llm/llamacpp/build/bin/libggml-base.so.0
[52313] #8  0x00007f3c51b58f9b in llama_context::graph_reserve(unsigned int, unsigned int, unsigned int, llama_memory_context_i const*, bool, unsigned long*) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama.so.0
[52313] #9  0x00007f3c51b585c1 in llama_context::resolve_fused_ops(llama_memory_context_i const*, unsigned int)::$_0::operator()(llm_fused_op_probe const&, bool&) const () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama.so.0
[52313] #10 0x00007f3c51b58537 in llama_context::resolve_fused_ops(llama_memory_context_i const*, unsigned int) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama.so.0
[52313] #11 0x00007f3c51b57935 in llama_context::sched_reserve() () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama.so.0
[52313] #12 0x00007f3c51b5642d in llama_context::llama_context(llama_model const&, llama_context_params) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama.so.0
[52313] #13 0x00007f3c51b6133b in llama_init_from_model () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama.so.0
[52313] #14 0x00007f3c52196f6d in common_speculative_init_result::common_speculative_init_result(common_params&, llama_model*, llama_context*) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama-common.so.0
[52313] #15 0x00007f3c521971f3 in common_speculative_init_from_params(common_params&, llama_model*, llama_context*) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama-common.so.0
[52313] #16 0x00007f3c5290047d in server_context_impl::load_model(common_params&) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama-server-impl.so
[52313] #17 0x00007f3c527fa4a1 in llama_server(common_params&, int, char**) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama-server-impl.so
[52313] #18 0x00007f3c527f19f5 in llama_server(int, char**) () from /home/woadmull/.config/llm/llamacpp/build/bin/libllama-server-impl.so
[52313] #19 0x00007f3c4802b4fe in __libc_start_call_main () from /lib64/libc.so.6
[52313] #20 0x00007f3c4802b62b in __libc_start_main_impl () from /lib64/libc.so.6
[52313] #21 0x0000561215d50805 in _start () at ../sysdeps/x86_64/start.S:115
[52313] warning: 115	../sysdeps/x86_64/start.S: No such file or directory
```


./build/bin/test-backend-ops -b Vulkan0:
```
17253/17253 tests passed
  Backend Vulkan0: OK
Backend 4/5: Vulkan1
  Skipping
Backend 5/5: CPU
  Skipping
5/5 backends passed
```

Benchmark before the fix:
```
| model                          |       size |     params | backend    | ngl |  fa | dev          |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ------------ | --------------: | -------------------: |
| qwen35 27B Q4_K - Medium       |  15.65 GiB |    27.32 B | ROCm,Vulkan |  -1 |   1 | Vulkan0      |           pp512 |       1022.92 ± 1.99 |
| qwen35 27B Q4_K - Medium       |  15.65 GiB |    27.32 B | ROCm,Vulkan |  -1 |   1 | Vulkan0      |           tg128 |         30.90 ± 0.14 |
```

After the fix:
```
| model                          |       size |     params | backend    | ngl |  fa | dev          |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --: | ------------ | --------------: | -------------------: |
| qwen35 27B Q4_K - Medium       |  15.65 GiB |    27.32 B | ROCm,Vulkan |  -1 |   1 | Vulkan0      |           pp512 |       1019.97 ± 2.22 |
| qwen35 27B Q4_K - Medium       |  15.65 GiB |    27.32 B | ROCm,Vulkan |  -1 |   1 | Vulkan0      |           tg128 |         31.12 ± 0.10 |
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> YES - used for exploring the code base
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
