### PR TITLE
cuda: enable GGML_CUDA_FA_ALL_QUANTS by default

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -205,7 +205,7 @@ set   (GGML_CUDA_PEER_MAX_BATCH_SIZE "128" CACHE STRING
 option(GGML_CUDA_NO_PEER_COPY               "ggml: do not use peer to peer copies"            OFF)
 option(GGML_CUDA_NO_VMM                     "ggml: do not try to use CUDA VMM"                OFF)
 option(GGML_CUDA_FA                         "ggml: compile ggml FlashAttention CUDA kernels"  ON)
-option(GGML_CUDA_FA_ALL_QUANTS              "ggml: compile all quants for FlashAttention"     OFF)
+option(GGML_CUDA_FA_ALL_QUANTS              "ggml: compile all quants for FlashAttention"     ON)
 option(GGML_CUDA_GRAPHS                     "ggml: use CUDA graphs (llama.cpp only)"          ${GGML_CUDA_GRAPHS_DEFAULT})
 option(GGML_CUDA_NCCL                       "ggml: use NVIDIA Collective Comm. Library"       ON)
 set   (GGML_CUDA_COMPRESSION_MODE "size" CACHE STRING


### PR DESCRIPTION
## Overview

This change fixes a big drawback in performance when GGML_CUDA_FA_ALL_QUANTS is off by default. 
Stock builds only compile FlashAttention instances for f16, q4_0, q8_0 and bf16. Any other KV quant (q4_0, q4_1, q5_0, q5_1, ...) silently falls back to the generic dequant path. On my RTX 3090 that drops prefill from ~1147 t/s to ~34 t/s with flash attention on, and nothing in the logs hints at what is going on. The change is one line in ggml/CMakeLists.txt, just compiles the remaining template instances. -DGGML_CUDA_FA_ALL_QUANTS=OFF still gives the old behavior.

## Additional information

- Fixes #27109 (4-bit KV cache collapses prefill on RTX 3090). I originally suspected an MMQ regression in #26285, but a runtime probe ruled that out and pointed at the missing FA-vec instances.
- #27140 fixes the same regression a different way (dedicated half2-vectorized dequant kernels). If that one is preferred, this PR can be closed.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - analysis and measurements are mine, AI helped with wording only