### PR TITLE
ggml-cuda: add bounded, opt-in retry for CUDA device detection at init

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -225,8 +225,8 @@ static ggml_cuda_device_info ggml_cuda_init() {
         // on some systems (e.g. a systemd service started at boot) the GPU driver stack
         // (e.g. nvidia-uvm) can still be initializing when we get here; GGML_CUDA_INIT_RETRY_MS
         // lets the caller opt into a bounded retry instead of a one-shot failure
-        int retry_budget_ms = 0;
-        const char * retry_env = getenv("GGML_CUDA_INIT_RETRY_MS");
+        int          retry_budget_ms = 0;
+        const char * retry_env       = getenv("GGML_CUDA_INIT_RETRY_MS");
         if (retry_env != nullptr) {
             retry_budget_ms = atoi(retry_env);
             if (retry_budget_ms < 0) {
@@ -237,12 +237,13 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
         if (retry_budget_ms > 0) {
             constexpr int retry_delay_ms = 200;
-            GGML_LOG_WARN("%s: failed to initialize " GGML_CUDA_NAME " (%s), retrying for up to %d ms "
+            GGML_LOG_WARN("%s: failed to initialize " GGML_CUDA_NAME
+                          " (%s), retrying for up to %d ms "
                           "in case the driver is still initializing\n",
                           __func__, cudaGetErrorString(err), retry_budget_ms);
             const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(retry_budget_ms);
             do {
-                (void) cudaGetLastError(); // clear the sticky error before retrying
+                (void) cudaGetLastError();  // clear the sticky error before retrying
                 std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
                 err = cudaGetDeviceCount(&info.physical_device_count);
             } while (err != cudaSuccess && std::chrono::steady_clock::now() < deadline);

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -74,6 +74,7 @@
 #include <array>
 #include <atomic>
 #include <charconv>
+#include <chrono>
 #include <cinttypes>
 #include <condition_variable>
 #include <cstddef>
@@ -88,6 +89,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <thread>
 #include <vector>
 
 static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
@@ -220,8 +222,39 @@ static ggml_cuda_device_info ggml_cuda_init() {
 
     cudaError_t err = cudaGetDeviceCount(&info.physical_device_count);
     if (err != cudaSuccess) {
-        GGML_LOG_ERROR("%s: failed to initialize " GGML_CUDA_NAME ": %s\n", __func__, cudaGetErrorString(err));
-        return info;
+        // on some systems (e.g. a systemd service started at boot) the GPU driver stack
+        // (e.g. nvidia-uvm) can still be initializing when we get here; GGML_CUDA_INIT_RETRY_MS
+        // lets the caller opt into a bounded retry instead of a one-shot failure
+        int retry_budget_ms = 0;
+        const char * retry_env = getenv("GGML_CUDA_INIT_RETRY_MS");
+        if (retry_env != nullptr) {
+            retry_budget_ms = atoi(retry_env);
+            if (retry_budget_ms < 0) {
+                GGML_LOG_WARN("%s: ignoring invalid GGML_CUDA_INIT_RETRY_MS=\"%s\"\n", __func__, retry_env);
+                retry_budget_ms = 0;
+            }
+        }
+
+        if (retry_budget_ms > 0) {
+            constexpr int retry_delay_ms = 200;
+            GGML_LOG_WARN("%s: failed to initialize " GGML_CUDA_NAME " (%s), retrying for up to %d ms "
+                          "in case the driver is still initializing\n",
+                          __func__, cudaGetErrorString(err), retry_budget_ms);
+            const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(retry_budget_ms);
+            do {
+                (void) cudaGetLastError(); // clear the sticky error before retrying
+                std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
+                err = cudaGetDeviceCount(&info.physical_device_count);
+            } while (err != cudaSuccess && std::chrono::steady_clock::now() < deadline);
+            if (err == cudaSuccess) {
+                GGML_LOG_INFO("%s: " GGML_CUDA_NAME " became available after retrying\n", __func__);
+            }
+        }
+
+        if (err != cudaSuccess) {
+            GGML_LOG_ERROR("%s: failed to initialize " GGML_CUDA_NAME ": %s\n", __func__, cudaGetErrorString(err));
+            return info;
+        }
     }
 
     GGML_ASSERT(info.physical_device_count <= GGML_CUDA_MAX_DEVICES);


### PR DESCRIPTION
## Summary
Fixes #27923.

`ggml_cuda_init()` calls `cudaGetDeviceCount()` exactly once. When `llama-server` starts as a `systemd --user` service at cold boot, this can race the `nvidia-uvm` kernel module still initializing (reporter measured a ~3s gap between service start and `nvidia-uvm` readiness). The one-shot call fails with `no CUDA-capable device is detected`, and since the driver genuinely has no way to distinguish "no GPU present" from "GPU driver stack not ready yet," the process silently falls back to CPU inference — `/health` still returns 200, and only the startup log or `nvidia-smi --query-compute-apps` reveals it.

- The failure path already logs at `GGML_LOG_ERROR` (not `WARN` as the issue's log excerpt showed — this may have changed since the reporter's commit), so I left that as-is.
- This PR implements the issue's first suggested fix: a bounded retry with backoff on device-detection failure.
- It's **opt-in** via a new `GGML_CUDA_INIT_RETRY_MS` environment variable (total retry budget in ms; default unset = 0 = today's exact one-shot behavior). `ggml_cuda_init()` runs unconditionally for every CUDA-enabled build at process start, including intentional CPU-only runs (e.g. CI, containers without a GPU) — making the retry opt-in avoids adding multi-second startup latency to that common case, while still letting affected systemd deployments set e.g. `Environment=GGML_CUDA_INIT_RETRY_MS=5000` in their unit file to bridge the boot race, without needing an external `ExecStartPre` polling script.
- On retry, the sticky CUDA error is cleared via `cudaGetLastError()` before each re-attempt (matching the existing retry pattern in the CUDA pool allocator a few hundred lines down in the same file).

## Why this isn't a duplicate
Checked `gh issue view 27923 --comments` (0 comments, no linked PR) and searched open PRs for `27923`, `ggml_cuda_init`, `cudaGetDeviceCount`, `cuda init race`, and `cuda fallback` — nothing addresses this init-time retry.

## Test plan
Originally submitted from an environment with no CUDA hardware; since then, validated end-to-end on real CUDA hardware (NVIDIA A10, driver 580.126.20, CUDA 13.0):

- `cmake -DGGML_CUDA=ON -DCMAKE_BUILD_TYPE=Release` configures cleanly (`CMAKE_CUDA_ARCHITECTURES=86-real`), and `ggml-cuda` builds with zero warnings on the changed file.
- To exercise the actual retry path (not just unit-test the control flow), used an `LD_PRELOAD` shim that intercepts `cudaGetDeviceCount()` so the boot-time race from #27923 could be reproduced deterministically:
  - Baseline (env var unset, real GPU): device detected normally in ~120ms — default path unchanged.
  - Opt-in flag set but device available on the first call (real GPU): ~117ms, no added latency — retry adds zero cost on the happy path.
  - **Transient failure that clears mid-retry** (shim fails for 1200ms, then the real call succeeds; budget=5000ms): recovered at ~1317ms, polling every ~200ms as coded. This is the actual #27923 scenario, and it resolves as intended.
  - Permanent failure (shim always fails; budget=1500ms): loop terminates at ~1717ms (bounded to budget + one retry interval, does not hang) and reports the original error.
  - Invalid env values: `-100` → warns and disables retry; non-numeric (`banana`) → `atoi` yields 0, silently disables retry; neither crashes.
- Ran `clang-format` 22.1.8 (matching the version pinned in `.github/workflows/build-webgpu.yml`) via `git-clang-format` scoped to this diff and fixed the 3 style nits it flagged (declaration alignment, a line-wrap in the `GGML_LOG_WARN` call, comment spacing) in a follow-up commit.

## AI assistance disclosure
This change was drafted with AI assistance (Claude), including the hardware validation above (performed with Claude Code on a CUDA-capable dev box, using the fault-injection shim described in the test plan). I (the submitter) reviewed every changed line and the validation methodology before pushing.
