### PR TITLE
server: clarify remote -hf preset trust boundary

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -677,7 +677,9 @@ void common_models_handler_apply(common_models_handler & handler, common_params 
     if (!plan.preset.local_path.empty()) {
         tasks.emplace_back(plan.preset, opts, [&]() {
             // if HF repo is a preset repo, we simply run server in router mode with the preset.ini file
-            params.models_preset_hf = params.model.hf_repo; // only for showing a warning
+            // mark the preset as remote: shown in the startup warning, and used to
+            // restrict which keys the preset may set (see set_remote_allowed_keys())
+            params.models_preset_hf = params.model.hf_repo;
             params.models_preset    = hf_cache::finalize_file(plan.preset);
             params.model = common_params_model{}; // make sure to clear model, so server starts in router mode
         });

--- a/common/common.h
+++ b/common/common.h
@@ -684,7 +684,8 @@ struct common_params {
     std::string models_preset = "";     // directory containing model presets for the router server
     int models_max = 4;                 // maximum number of models to load simultaneously
     bool models_autoload = true;        // automatically load models when requested via the router server
-    std::string models_preset_hf = "";  // show a warning about remote presets on router loaded (if not empty)
+    std::string models_preset_hf = "";  // set when the models preset was fetched from a remote Hugging Face repo
+                                        // note: also gates the remote-preset key allowlist, see set_remote_allowed_keys()
 
     bool log_json = false;
 

--- a/common/preset.cpp
+++ b/common/preset.cpp
@@ -276,10 +276,56 @@ static std::string parse_bool_arg(const common_arg & arg, const std::string & ke
     return value;
 }
 
+// keys that a remote (untrusted) preset is allowed to set
+// ref: https://github.com/ggml-org/llama.cpp/pull/18520
+static std::set<std::string> get_remote_preset_whitelist(const std::map<std::string, common_arg> & key_to_opt) {
+    static const std::set<std::string> allowed_options = {
+        "model-url",
+        "hf-repo",
+        "hf-repo-draft",
+        "hf-repo-v", // vocoder
+        "hf-file-v", // vocoder
+        "mmproj-url",
+        "pooling",
+        "jinja",
+        "batch-size",
+        "ubatch-size",
+        "cache-reuse",
+        "chat-template-kwargs",
+        "mmap",
+        // note: sampling params are automatically allowed by default
+        // negated args will be added automatically
+    };
+
+    std::set<std::string> allowed_keys;
+
+    for (const auto & it : key_to_opt) {
+        const std::string & key = it.first;
+        const common_arg & opt = it.second;
+        if (allowed_options.find(key) != allowed_options.end() || opt.is_sampling) {
+            allowed_keys.insert(key);
+            // also add variant keys (args without leading dashes and env vars)
+            for (const auto & arg : opt.get_args()) {
+                allowed_keys.insert(rm_leading_dashes(arg));
+            }
+            for (const auto & env : opt.get_env()) {
+                allowed_keys.insert(env);
+            }
+        }
+    }
+
+    return allowed_keys;
+}
+
 common_preset_context::common_preset_context(llama_example ex)
         : ctx_params(common_params_parser_init(default_params, ex)) {
     common_params_add_preset_options(ctx_params.options);
     key_to_opt = get_map_key_opt(ctx_params);
+}
+
+void common_preset_context::set_remote_allowed_keys() {
+    filter_allowed_keys = true;
+    allowed_keys = get_remote_preset_whitelist(key_to_opt);
 }
 
 common_presets common_preset_context::load_from_ini(const std::string & path, common_preset & global) const {

--- a/common/preset.h
+++ b/common/preset.h
@@ -63,8 +63,11 @@ struct common_preset_context {
     // used for config files shared by all binaries, where each binary only knows a subset of options
     bool ignore_unknown_keys = false;
 
-    // if only_remote_allowed is true, only accept whitelisted keys
     common_preset_context(llama_example ex);
+
+    // restrict load_from_ini() to the keys a remote (untrusted) preset may set
+    // must be called before loading a preset that was fetched from a remote repo
+    void set_remote_allowed_keys();
 
     // load presets from INI file
     common_presets load_from_ini(const std::string & path, common_preset & global) const;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -516,6 +516,10 @@ void server_models::load_models() {
     common_preset global = {};
     common_presets custom_presets = {};
     if (!base_params.models_preset.empty()) {
+        if (!base_params.models_preset_hf.empty()) {
+            // preset came from a remote repo, restrict which keys it may set
+            ctx_preset.set_remote_allowed_keys();
+        }
         custom_presets = ctx_preset.load_from_ini(base_params.models_preset, global);
         SRV_INF("Loaded %zu custom model presets from %s\n", custom_presets.size(), base_params.models_preset.c_str());
     }

--- a/tools/server/tests/unit/test_security.py
+++ b/tools/server/tests/unit/test_security.py
@@ -2,6 +2,7 @@ import pytest
 from openai import OpenAI
 from utils import *
 import threading
+import tempfile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 server = ServerPreset.tinyllama2()
@@ -243,3 +244,160 @@ def test_local_media_file(media_path, image_url, success,):
         assert res.status_code == 200
     else:
         assert res.status_code == 400
+
+
+# --- remote preset key allowlist (ref: issue #27857) ---------------------------
+# A preset.ini fetched from a remote repo is untrusted input: it is parsed and
+# rendered into the argv of a child llama-server, so it must only be able to set
+# keys on the allowlist. These tests drive the real -hf flow against a local stub
+# of the HF API, so no network and no remote repository are involved.
+
+REMOTE_PRESET_REPO = "test-user/preset-repo"
+REMOTE_PRESET_COMMIT = "0" * 40
+
+
+def _hf_stub(preset_ini: bytes):
+    repo = REMOTE_PRESET_REPO
+    commit = REMOTE_PRESET_COMMIT
+
+    class HfStubHandler(BaseHTTPRequestHandler):
+        def _body_for(self, path):
+            if path == f"/api/models/{repo}/refs":
+                return json.dumps({"branches": [{"name": "main", "targetCommit": commit}]}).encode()
+            if path == f"/api/models/{repo}/tree/{commit}":
+                return json.dumps([{"type": "file", "path": "preset.ini", "size": len(preset_ini)}]).encode()
+            if path == f"/{repo}/resolve/{commit}/preset.ini":
+                return preset_ini
+            return None
+
+        def _respond(self, body, with_body):
+            if body is None:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Accept-Ranges", "bytes")
+            self.end_headers()
+            if with_body:
+                self.wfile.write(body)
+
+        def do_HEAD(self):
+            self._respond(self._body_for(self.path.split("?")[0]), False)
+
+        def do_GET(self):
+            self._respond(self._body_for(self.path.split("?")[0]), True)
+
+        def log_message(self, format, *args):
+            pass
+
+    hf = ThreadingHTTPServer(("127.0.0.1", 0), HfStubHandler)
+    threading.Thread(target=hf.serve_forever, daemon=True).start()
+    return hf
+
+
+def _run_server_with_remote_preset(preset_ini: bytes, port: int, wait_for_start: bool):
+    """Start llama-server with -hf pointed at the stub. Returns (started, output, models_json)."""
+    hf = _hf_stub(preset_ini)
+    with tempfile.TemporaryDirectory() as cache_dir:
+        env = {
+            **os.environ,
+            "MODEL_ENDPOINT": f"http://127.0.0.1:{hf.server_port}/",
+            "LLAMA_CACHE": cache_dir,
+        }
+        cmd = [
+            "../../../build/bin/llama-server",
+            "-hf", REMOTE_PRESET_REPO,
+            "--host", "127.0.0.1",
+            "--port", str(port),
+        ]
+        if not wait_for_start:
+            try:
+                proc = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=30)
+                return False, proc.stdout + proc.stderr, None
+            except subprocess.TimeoutExpired as e:
+                out = (e.stdout or b"").decode(errors="replace") + (e.stderr or b"").decode(errors="replace")
+                return True, out, None
+            finally:
+                hf.shutdown()
+
+        proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        models = None
+        try:
+            for _ in range(60):
+                if proc.poll() is not None:
+                    break
+                try:
+                    r = requests.get(f"http://127.0.0.1:{port}/v1/models", timeout=2)
+                    if r.status_code == 200:
+                        models = r.json()
+                        break
+                except Exception:
+                    pass
+                time.sleep(1)
+        finally:
+            proc.terminate()
+            try:
+                out = proc.communicate(timeout=15)[0]
+            except Exception:
+                proc.kill()
+                out = proc.communicate()[0]
+            hf.shutdown()
+        return models is not None, out, models
+
+
+# every key below is a real registered llama-server option that the UNFILTERED
+# local preset path accepts; each is outside the remote allowlist, so on the
+# remote path it must be rejected by the allowlist specifically
+@pytest.mark.parametrize("key, value", [
+    ("mcp-servers-json",   '{"mcpServers":{}}'),
+    ("mcp-servers-config", "/dev/null"),
+    ("webui-mcp-proxy",    "false"),
+    ("host",               "127.0.0.1"),
+    ("port",               "8099"),
+])
+def test_remote_preset_rejects_non_allowlisted_key(key, value):
+    preset_ini = f"version = 1\n\n[*]\n{key} = {value}\n".encode()
+    started, output, _ = _run_server_with_remote_preset(preset_ini, 8081, wait_for_start=False)
+    assert not started, (
+        f"server started with a remote preset that sets '{key}'; "
+        "the remote-preset allowlist did not reject it"
+    )
+    assert f"option '{key}' is not allowed in remote presets" in output, output[-2000:]
+
+
+def test_remote_preset_accepts_allowlisted_key():
+    # batch-size is on the remote allowlist: the preset must load and take effect,
+    # proving the allowlist filters keys rather than rejecting remote presets wholesale
+    preset_ini = (
+        b"version = 1\n\n[remote-model]\n"
+        b"batch-size = 128\n"
+    )
+    started, output, models = _run_server_with_remote_preset(preset_ini, 8082, wait_for_start=True)
+    assert started, f"server did not start with an allowlisted remote preset key: {output[-2000:]}"
+    assert models is not None and models["data"], f"no models listed: {output[-2000:]}"
+    args = models["data"][0]["status"]["args"]
+    assert "--batch-size" in args, args
+    assert args[args.index("--batch-size") + 1] == "128", args
+
+
+def test_local_preset_is_not_filtered():
+    # the local path is operator-authored and must stay unfiltered
+    with tempfile.TemporaryDirectory() as d:
+        ini = os.path.join(d, "preset.ini")
+        with open(ini, "w") as f:
+            f.write('version = 1\n\n[local-model]\nmcp-servers-json = {"mcpServers":{}}\n')
+        server = ServerPreset.tinyllama2()
+        server.api_key = None
+        server.model_hf_repo = None
+        server.model_hf_file = None
+        server.model_file = None
+        server.models_preset = ini
+        server.start()
+        try:
+            res = server.make_request("GET", "/v1/models")
+            assert res.status_code == 200
+            args = res.body["data"][0]["status"]["args"]
+            assert "--mcp-servers-json" in args, args
+        finally:
+            server.stop()


### PR DESCRIPTION
## Overview

Addresses #27857.

Remote `preset.ini` files fetched through `-hf` are loaded as router-model presets. Their options are rendered into the child server's argument list, including operator-level options such as:

* `mcp-servers-json`
* `mcp-servers-config`
* `webui-mcp-proxy`

`host` and `port` are also accepted by the preset loader, although `update_args()` overwrites both before spawning the child; rejecting them is defense in depth.

The remote-preset allowlist was introduced in #18520 (`8ece3836b4`) and later removed in `552258c5350d` (#24739). In #24739, the code removal (including the explicit `rm unused get_remote_preset_whitelist()` commit note) and the documentation change happened together. This should be treated as an intentional behavioral/trust-model change rather than an accidental deletion; whether it represents the intended security policy needs maintainer guidance. This PR restores the immediately pre-removal allowlist behavior for presets fetched through `-hf`, while preserving unrestricted local `--models-preset` files.

The implementation is adapted to the current codebase:

* `is_sparam` is now `is_sampling`.
* The old `only_remote_allowed` constructor argument no longer exists, so filtering is enabled with `set_remote_allowed_keys()` at the remote call site.

## Additional information

### Compatibility and design question

This patch restores the immediately pre-removal, narrow allowlist, including the `mmap` and `chat-template-kwargs` additions from #18728. It still rejects options shown in the current Hugging Face preset example in `docs/preset.md`, including `ctx-size`, `kv-unified`, `parallel`, and `spec-default`.

The trust warning and the `mcp-servers-json` command-spawn path are in tension. Before merging, maintainer guidance is needed on the intended policy:

1. Narrowly block the two MCP server configuration options;
2. Restore a corrected allowlist that preserves supported remote-preset options; or
3. Keep the current trust-warning-only behavior.

This PR deliberately does not expand the historical allowlist until that choice is made.

### Testing

Added coverage to `unit/test_security.py` for the remote/local boundary.

Remote presets reject the following registered options:

```text
mcp-servers-json
mcp-servers-config
webui-mcp-proxy
host
port
```

The patched build reports:

```text
failed to initialize router models: option 'mcp-servers-json' is not allowed in remote presets
failed to initialize router models: option 'mcp-servers-config' is not allowed in remote presets
failed to initialize router models: option 'webui-mcp-proxy' is not allowed in remote presets
failed to initialize router models: option 'host' is not allowed in remote presets
failed to initialize router models: option 'port' is not allowed in remote presets
```

A remote preset containing `batch-size = 128` is accepted and applied; the resolved child arguments contain `--batch-size 128`.

A local `--models-preset` containing `mcp-servers-json` remains accepted.

The remote tests exercise the actual `-hf` preset-loading path using a local HTTP stub for the Hugging Face API, without an external repository.

### Results

The new tests pass on the patched build:

```text
unit/test_security.py::test_remote_preset_rejects_non_allowlisted_key[mcp-servers-json-{\"mcpServers\":{}}] PASSED
unit/test_security.py::test_remote_preset_rejects_non_allowlisted_key[mcp-servers-config-/dev/null] PASSED
unit/test_security.py::test_remote_preset_rejects_non_allowlisted_key[webui-mcp-proxy-false] PASSED
unit/test_security.py::test_remote_preset_rejects_non_allowlisted_key[host-127.0.0.1] PASSED
unit/test_security.py::test_remote_preset_rejects_non_allowlisted_key[port-8099] PASSED
unit/test_security.py::test_remote_preset_accepts_allowlisted_key PASSED
unit/test_security.py::test_local_preset_is_not_filtered PASSED

7 passed in 10.21s
```

Full `unit/test_security.py`:

```text
18 failed, 18 passed in 7.38s
```

The 18 failures are pre-existing environment failures caused by unavailable test models. Comparing the baseline and patched failure sets shows no new failures.

On unpatched master, the remote `host` and `port` cases are accepted instead of being rejected by the remote-preset allowlist.

The test verifies the configuration boundary and does not execute an external command or require a hosted malicious repository.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I authored all code changes and made the final technical decisions. AI assistance was used for testing and validation, and I independently verified the implementation and results.
