### PR TITLE
CUDA/HIP: use hipCUB DeviceReduce for SUM and MEAN on ROCm

### DIFF
--- a/ggml/src/ggml-cuda/mean.cu
+++ b/ggml/src/ggml-cuda/mean.cu
@@ -4,6 +4,9 @@
 #ifdef GGML_CUDA_USE_CUB
 #include <cub/cub.cuh>
 using namespace cub;
+#elif defined(GGML_USE_HIP)
+#include <hipcub/hipcub.hpp>
+using namespace hipcub;
 #endif  // GGML_CUDA_USE_CUB
 
 template <typename T> __global__ void divide_by_count(T * result, size_t count) {
@@ -24,13 +27,13 @@ void ggml_cuda_op_mean(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const int64_t nrows = ggml_nrows(src0);
 
 // Special case for reducing vectors
-#ifdef GGML_CUDA_USE_CUB
-#ifdef USE_CUDA_GRAPH
+#if defined(GGML_CUDA_USE_CUB) || defined(GGML_USE_HIP)
+#if defined(USE_CUDA_GRAPH) && !defined(GGML_USE_HIP)
     cudaStreamCaptureStatus iscapturing;
     CUDA_CHECK(cudaStreamIsCapturing(stream, &iscapturing));
 #endif // USE_CUDA_GRAPH
     if ((nrows == 1) &&
-#ifdef USE_CUDA_GRAPH
+#if defined(USE_CUDA_GRAPH) && !defined(GGML_USE_HIP)
             // Determine if CUDA graphs are effectively disabled for this context
             // (no graph instance exists and we're not capturing, OR graphs are explicitly enabled)
             (((ncols > 65536) &&
@@ -47,10 +50,10 @@ void ggml_cuda_op_mean(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         size_t           tmp_size = 0;
         ggml_cuda_pool & pool     = ctx.pool();
 
-        DeviceReduce::Sum(nullptr, tmp_size, src0_d, dst_d, ncols, stream);
+        CUDA_CHECK(DeviceReduce::Sum(nullptr, tmp_size, src0_d, dst_d, ncols, stream));
 
         ggml_cuda_pool_alloc<uint8_t> tmp_alloc(pool, tmp_size);
-        DeviceReduce::Sum(tmp_alloc.ptr, tmp_size, src0_d, dst_d, ncols, stream);
+        CUDA_CHECK(DeviceReduce::Sum(tmp_alloc.ptr, tmp_size, src0_d, dst_d, ncols, stream));
 
         // Divide by ncols
         divide_by_count<float><<<1, 1, 0, stream>>>(dst_d, ncols);

--- a/ggml/src/ggml-cuda/sum.cu
+++ b/ggml/src/ggml-cuda/sum.cu
@@ -4,19 +4,22 @@
 #ifdef GGML_CUDA_USE_CUB
 #include <cub/cub.cuh>
 using namespace cub;
+#elif defined(GGML_USE_HIP)
+#include <hipcub/hipcub.hpp>
+using namespace hipcub;
 #endif  // GGML_CUDA_USE_CUB
 
 #include <cstdint>
 
 void sum_f32_cuda(ggml_cuda_pool & pool, const float * x, float * dst, const int64_t ne, cudaStream_t stream) {
-#ifdef GGML_CUDA_USE_CUB
+#if defined(GGML_CUDA_USE_CUB) || defined(GGML_USE_HIP)
     size_t tmp_size = 0;
-    DeviceReduce::Sum(nullptr,       tmp_size, x, dst, ne, stream);
+    CUDA_CHECK(DeviceReduce::Sum(nullptr,       tmp_size, x, dst, ne, stream));
     ggml_cuda_pool_alloc<uint8_t> tmp_alloc(pool, tmp_size);
-    DeviceReduce::Sum(tmp_alloc.ptr, tmp_size, x, dst, ne, stream);
+    CUDA_CHECK(DeviceReduce::Sum(tmp_alloc.ptr, tmp_size, x, dst, ne, stream));
 #else
-    // Use (inefficient) sum_rows implementation as a fallback.
-    // For AMD there is rocPRIM which could be used as a drop-in replacement via hipcub but this would require C++11 -> C++14.
+    // Fallback for backends without a device-wide reduction (e.g. MUSA):
+    // use the (inefficient) sum_rows implementation.
     sum_rows_f32_cuda(x, dst, ne, 1, stream);
     GGML_UNUSED(pool);
 #endif // GGML_CUDA_USE_CUB


### PR DESCRIPTION
On ROCm, GGML_OP_SUM used an inefficient sum_rows fallback (the whole tensor reduced as a single row) and GGML_OP_MEAN's single-row device-wide reduction was NVIDIA-only, because DeviceReduce comes from CUB (GGML_CUDA_USE_CUB is defined only for NVIDIA). hipCUB provides DeviceReduce, so wire it in for HIP - the note in sum.cu claiming this needs C++11 -> C++14 is stale (ggml is C++17).

- sum.cu / mean.cu: include hipcub and use hipcub::DeviceReduce::Sum on HIP via the existing NVIDIA CUB code path.
- mean.cu: HIP uses the plain ncols > 65536 threshold for the device-wide path; the CUDA-graph capture-status heuristic stays NVIDIA-only (it uses cuda* capture symbols not aliased on HIP). hipCUB DeviceReduce is stream-capture-safe (verified under HIP graph capture at up to 4M elements).
- wrap DeviceReduce::Sum in CUDA_CHECK (hipCUB marks it [[nodiscard]]).

test-backend-ops -o SUM -o MEAN: all pass. perf -o SUM on gfx1151 (RDNA3.5):
 - `ne=[8192,8192] 9723 -> 1107 us/run` (**8.8x**, 26 -> 228 GB/s)
 - `ne=[128,8192]   98.6 -> 9.5 us/run` (**10.4x**)

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->YES 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
