### PR TITLE
llama: add byte-oriented per-sequence state file API

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -46,7 +46,7 @@
 #define LLAMA_SESSION_VERSION 10
 
 #define LLAMA_STATE_SEQ_MAGIC   LLAMA_FILE_MAGIC_GGSQ
-#define LLAMA_STATE_SEQ_VERSION 3
+#define LLAMA_STATE_SEQ_VERSION 4
 
 #ifdef __cplusplus
 extern "C" {
@@ -902,6 +902,22 @@ extern "C" {
                      llama_token * tokens_out,
                           size_t   n_token_capacity,
                           size_t * n_token_count_out);
+
+    LLAMA_API size_t llama_state_seq_save_file_data(
+            struct llama_context * ctx,
+                      const char * filepath,
+                    llama_seq_id   seq_id,
+                   const uint8_t * data,
+                          size_t   data_size);
+
+    // If data_out is NULL, only the data size is reported through data_size_out and no state is loaded
+    LLAMA_API size_t llama_state_seq_load_file_data(
+            struct llama_context * ctx,
+                      const char * filepath,
+                    llama_seq_id   dest_seq_id,
+                         uint8_t * data_out,
+                          size_t   data_capacity,
+                          size_t * data_size_out);
 
 #define LLAMA_STATE_SEQ_FLAGS_NONE 0
 

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -3197,47 +3197,53 @@ bool llama_context::state_save_file(const char * filepath, const llama_token * t
     return true;
 }
 
-size_t llama_context::state_seq_load_file(llama_seq_id seq_id, const char * filepath, llama_token * tokens_out, size_t n_token_capacity, size_t * n_token_count_out) {
+size_t llama_context::state_seq_load_file(llama_seq_id seq_id, const char * filepath, llama_state_seq_file_type type, uint8_t * data_out, size_t data_capacity, size_t * data_size_out) {
     llama_file file(filepath, "rb");
 
     // version checks
-    {
-        const uint32_t magic   = file.read_u32();
-        const uint32_t version = file.read_u32();
+    const uint32_t magic   = file.read_u32();
+    const uint32_t version = file.read_u32();
 
-        if (magic != LLAMA_STATE_SEQ_MAGIC || version != LLAMA_STATE_SEQ_VERSION) {
-            LLAMA_LOG_ERROR("%s: unknown (magic, version) for sequence state file: %08x, %08x\n", __func__, magic, version);
-            return 0;
-        }
+    if (magic != LLAMA_STATE_SEQ_MAGIC || (version != LLAMA_STATE_SEQ_VERSION && version != 3)) {
+        LLAMA_LOG_ERROR("%s: unknown (magic, version) for sequence state file: %08x, %08x\n", __func__, magic, version);
+        return 0;
     }
 
-    // load the prompt
+    const uint32_t file_type = version == 3 ? LLAMA_STATE_SEQ_FILE_TYPE_TOKENS : file.read_u32();
+    const uint64_t data_size = version == 3 ? (uint64_t) file.read_u32() * sizeof(llama_token) : file.read_u32();
+
+    if ((file_type != LLAMA_STATE_SEQ_FILE_TYPE_TOKENS && file_type != LLAMA_STATE_SEQ_FILE_TYPE_DATA) ||
+        (type == LLAMA_STATE_SEQ_FILE_TYPE_TOKENS && file_type != LLAMA_STATE_SEQ_FILE_TYPE_TOKENS)) {
+        LLAMA_LOG_ERROR("%s: unexpected data type in sequence state file: %u\n", __func__, file_type);
+        return 0;
+    }
+
+    // load the caller data
     {
-        const uint32_t n_token_count = file.read_u32();
+        const size_t data_size_max = file.size() - file.tell();
+        if (data_size > data_size_max) {
+            LLAMA_LOG_ERROR("%s: data size in sequence state file exceeds the file size! %" PRIu64 " > %zu\n", __func__, data_size, data_size_max);
+            return 0;
+        }
 
-        if (tokens_out == nullptr) {
-            const size_t n_token_max = (file.size() - file.tell()) / sizeof(llama_token);
-            if (n_token_count > n_token_max) {
-                LLAMA_LOG_ERROR("%s: token count in sequence state file exceeds the file size! %u > %zu\n", __func__, n_token_count, n_token_max);
-                return 0;
-            }
-
-            *n_token_count_out = n_token_count;
+        if (data_out == nullptr) {
+            *data_size_out = (size_t) data_size;
             return file.tell();
         }
 
-        if (n_token_count > n_token_capacity) {
-            LLAMA_LOG_ERROR("%s: token count in sequence state file exceeded capacity! %u > %zu\n", __func__, n_token_count, n_token_capacity);
+        if (data_size > data_capacity) {
+            LLAMA_LOG_ERROR("%s: data size in sequence state file exceeded capacity! %" PRIu64 " > %zu\n", __func__, data_size, data_capacity);
             return 0;
         }
 
-        file.read_raw(tokens_out, sizeof(llama_token) * n_token_count);
-        *n_token_count_out = n_token_count;
+        file.read_raw(data_out, (size_t) data_size);
+        *data_size_out = (size_t) data_size;
     }
 
     // restore the context state
     {
-        const size_t state_size = file.size() - file.tell();
+        const size_t state_offset = file.tell();
+        const size_t state_size   = file.size() - state_offset;
         llama_io_read_file io(&file);
         const size_t nread = state_seq_read_data(io, seq_id, 0);
         if (!nread) {
@@ -3245,28 +3251,33 @@ size_t llama_context::state_seq_load_file(llama_seq_id seq_id, const char * file
             return 0;
         }
         GGML_ASSERT(nread <= state_size);
-        GGML_ASSERT(nread + sizeof(uint32_t) * 3 + sizeof(llama_token) * *n_token_count_out == file.tell());
+        GGML_ASSERT(state_offset + nread == file.tell());
     }
 
     return file.tell();
 }
 
-size_t llama_context::state_seq_save_file(llama_seq_id seq_id, const char * filepath, const llama_token * tokens, size_t n_token_count) {
+size_t llama_context::state_seq_save_file(llama_seq_id seq_id, const char * filepath, llama_state_seq_file_type type, const uint8_t * data, size_t data_size) {
+    if (data_size > std::numeric_limits<uint32_t>::max()) {
+        throw std::runtime_error("sequence state file data is too large");
+    }
+
     llama_file file(filepath, "wb");
 
     file.write_u32(LLAMA_STATE_SEQ_MAGIC);
     file.write_u32(LLAMA_STATE_SEQ_VERSION);
 
-    // save the prompt
-    file.write_u32((uint32_t) n_token_count);
-    file.write_raw(tokens, sizeof(llama_token) * n_token_count);
+    // save the caller data
+    file.write_u32(type);
+    file.write_u32((uint32_t) data_size);
+    file.write_raw(data, data_size);
 
     // save the context state using stream saving
     llama_io_write_file io(&file);
     state_seq_write_data(io, seq_id, 0);
 
     const size_t res = file.tell();
-    GGML_ASSERT(res == sizeof(uint32_t) * 3 + sizeof(llama_token) * n_token_count + io.n_bytes());
+    GGML_ASSERT(res == sizeof(uint32_t) * 4 + data_size + io.n_bytes());
 
     return res;
 }
@@ -4215,7 +4226,8 @@ size_t llama_state_seq_save_file(llama_context * ctx, const char * filepath, lla
     ctx->synchronize();
 
     try {
-        return ctx->state_seq_save_file(seq_id, filepath, tokens, n_token_count);
+        return ctx->state_seq_save_file(seq_id, filepath, LLAMA_STATE_SEQ_FILE_TYPE_TOKENS,
+            reinterpret_cast<const uint8_t *>(tokens), n_token_count * sizeof(llama_token));
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: error saving sequence state file: %s\n", __func__, err.what());
         return 0;
@@ -4226,7 +4238,35 @@ size_t llama_state_seq_load_file(llama_context * ctx, const char * filepath, lla
     ctx->synchronize();
 
     try {
-        return ctx->state_seq_load_file(dest_seq_id, filepath, tokens_out, n_token_capacity, n_token_count_out);
+        size_t data_size = 0;
+        const size_t res = ctx->state_seq_load_file(dest_seq_id, filepath, LLAMA_STATE_SEQ_FILE_TYPE_TOKENS,
+            reinterpret_cast<uint8_t *>(tokens_out), n_token_capacity * sizeof(llama_token), &data_size);
+        if (res != 0) {
+            *n_token_count_out = data_size / sizeof(llama_token);
+        }
+        return res;
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: error loading sequence state file: %s\n", __func__, err.what());
+        return 0;
+    }
+}
+
+size_t llama_state_seq_save_file_data(llama_context * ctx, const char * filepath, llama_seq_id seq_id, const uint8_t * data, size_t data_size) {
+    ctx->synchronize();
+
+    try {
+        return ctx->state_seq_save_file(seq_id, filepath, LLAMA_STATE_SEQ_FILE_TYPE_DATA, data, data_size);
+    } catch (const std::exception & err) {
+        LLAMA_LOG_ERROR("%s: error saving sequence state file: %s\n", __func__, err.what());
+        return 0;
+    }
+}
+
+size_t llama_state_seq_load_file_data(llama_context * ctx, const char * filepath, llama_seq_id dest_seq_id, uint8_t * data_out, size_t data_capacity, size_t * data_size_out) {
+    ctx->synchronize();
+
+    try {
+        return ctx->state_seq_load_file(dest_seq_id, filepath, LLAMA_STATE_SEQ_FILE_TYPE_DATA, data_out, data_capacity, data_size_out);
     } catch (const std::exception & err) {
         LLAMA_LOG_ERROR("%s: error loading sequence state file: %s\n", __func__, err.what());
         return 0;

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -39,6 +39,11 @@ struct llama_memory_buffer {
 
 using llama_memory_buffers = std::map<ggml_backend_buffer_type_t, llama_memory_buffer>;
 
+enum llama_state_seq_file_type : uint32_t {
+    LLAMA_STATE_SEQ_FILE_TYPE_TOKENS = 0,
+    LLAMA_STATE_SEQ_FILE_TYPE_DATA   = 1,
+};
+
 struct llama_context {
     // init scheduler and compute buffers, reserve worst-case graphs
     llama_context(
@@ -168,17 +173,19 @@ struct llama_context {
                 size_t   n_token_count);
 
     size_t state_seq_load_file(
-          llama_seq_id   seq_id,
-            const char * filepath,
-           llama_token * tokens_out,
-                size_t   n_token_capacity,
-                size_t * n_token_count_out);
+                 llama_seq_id   seq_id,
+                   const char * filepath,
+    llama_state_seq_file_type   type,
+                      uint8_t * data_out,
+                       size_t   data_capacity,
+                       size_t * data_size_out);
 
     size_t state_seq_save_file(
-          llama_seq_id   seq_id,
-            const char * filepath,
-     const llama_token * tokens,
-                size_t   n_token_count);
+                 llama_seq_id   seq_id,
+                   const char * filepath,
+    llama_state_seq_file_type   type,
+                const uint8_t * data,
+                       size_t   data_size);
 
     //
     // perf

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -297,7 +297,7 @@ public:
     template <typename T>
     void write(T value) {
         static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable");
-        const auto * ptr = reinterpret_cast<const char *>(&value);
+        const auto * ptr = reinterpret_cast<const uint8_t *>(&value);
         data.insert(data.end(), ptr, ptr + sizeof(value));
     }
 
@@ -308,7 +308,7 @@ public:
         if (values.empty()) {
             return;
         }
-        const auto * ptr = reinterpret_cast<const char *>(values.data());
+        const auto * ptr = reinterpret_cast<const uint8_t *>(values.data());
         data.insert(data.end(), ptr, ptr + values.size() * sizeof(T));
     }
 
@@ -324,18 +324,17 @@ public:
         write(chunk_data);
     }
 
-    std::vector<char> take() {
-        data.resize((data.size() + sizeof(llama_token) - 1) / sizeof(llama_token) * sizeof(llama_token), 0);
+    raw_buffer take() {
         return std::move(data);
     }
 
 private:
-    std::vector<char> data;
+    raw_buffer data;
 };
 
 class server_tokens_state_reader {
 public:
-    server_tokens_state_reader(const char * data, size_t size) : data(data), size(size) {}
+    server_tokens_state_reader(const uint8_t * data, size_t size) : data(data), size(size) {}
 
     template <typename T>
     T read() {
@@ -370,7 +369,7 @@ public:
     }
 
 private:
-    const char * data;
+    const uint8_t * data;
     size_t size;
     size_t pos = 0;
 };
@@ -567,7 +566,7 @@ const llama_tokens & server_tokens::get_tokens() const {
     return tokens;
 }
 
-std::vector<char> server_tokens::serialize() const {
+raw_buffer server_tokens::serialize() const {
     static_assert(sizeof(llama_token) == sizeof(uint32_t), "unexpected llama_token size");
 
     server_tokens_state_writer writer;
@@ -589,15 +588,27 @@ std::vector<char> server_tokens::serialize() const {
     return writer.take();
 }
 
-server_tokens server_tokens::deserialize(const llama_tokens & packed, bool has_mtmd) {
+server_tokens server_tokens::deserialize(const raw_buffer & packed, bool has_mtmd) {
     static_assert(sizeof(llama_token) == sizeof(uint32_t), "unexpected llama_token size");
 
-    if (packed.empty() || packed[0] != LLAMA_TOKEN_NULL) {
-        // plain token list, as written by older versions
-        return server_tokens(packed, has_mtmd);
+    llama_token marker = 0;
+    if (packed.size() >= sizeof(marker)) {
+        std::memcpy(&marker, packed.data(), sizeof(marker));
     }
 
-    server_tokens_state_reader reader(reinterpret_cast<const char *>(packed.data()), packed.size() * sizeof(llama_token));
+    if (marker != LLAMA_TOKEN_NULL) {
+        // plain token list, as written by older versions
+        if (packed.size() % sizeof(llama_token) != 0) {
+            throw std::runtime_error("Invalid token data size in server tokens state");
+        }
+        llama_tokens tokens(packed.size() / sizeof(llama_token));
+        if (!packed.empty()) {
+            std::memcpy(tokens.data(), packed.data(), packed.size());
+        }
+        return server_tokens(tokens, has_mtmd);
+    }
+
+    server_tokens_state_reader reader(packed.data(), packed.size());
     reader.read<llama_token>(); // format marker
     if (reader.read<uint32_t>() != SERVER_TOKENS_STATE_VERSION) {
         throw std::runtime_error("Unsupported server tokens state version");

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -212,8 +212,8 @@ public:
 
     llama_tokens get_text_tokens() const;
 
-    std::vector<char> serialize() const;
-    static server_tokens deserialize(const llama_tokens & packed, bool has_mtmd);
+    raw_buffer serialize() const;
+    static server_tokens deserialize(const raw_buffer & packed, bool has_mtmd);
 
     // for compatibility with speculative decoding
     void set_token(llama_pos pos, llama_token id);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2562,7 +2562,7 @@ private:
                     std::string filename = task.slot_action.filename;
                     std::string filepath = task.slot_action.filepath;
 
-                    std::vector<char> packed;
+                    raw_buffer packed;
                     try {
                         packed = slot->prompt.tokens.serialize();
                     } catch (const std::exception & err) {
@@ -2570,10 +2570,7 @@ private:
                         break;
                     }
 
-                    GGML_ASSERT(packed.size() % sizeof(llama_token) == 0);
-                    const size_t nwrite = llama_state_seq_save_file(
-                        ctx_tgt, filepath.c_str(), slot->id,
-                        reinterpret_cast<const llama_token *>(packed.data()), packed.size() / sizeof(llama_token));
+                    const size_t nwrite = llama_state_seq_save_file_data(ctx_tgt, filepath.c_str(), slot->id, packed.data(), packed.size());
                     if (nwrite == 0) {
                         send_error(task, "Unable to save slot", ERROR_TYPE_SERVER);
                         break;
@@ -2615,11 +2612,11 @@ private:
                     size_t nread = 0;
                     try {
                         size_t n_packed = 0;
-                        llama_tokens packed;
-                        nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, nullptr, 0, &n_packed);
+                        raw_buffer packed;
+                        nread = llama_state_seq_load_file_data(ctx_tgt, filepath.c_str(), slot->id, nullptr, 0, &n_packed);
                         if (nread != 0) {
                             packed.resize(std::max<size_t>(1, n_packed));
-                            nread = llama_state_seq_load_file(ctx_tgt, filepath.c_str(), slot->id, packed.data(), packed.size(), &n_packed);
+                            nread = llama_state_seq_load_file_data(ctx_tgt, filepath.c_str(), slot->id, packed.data(), packed.size(), &n_packed);
                         }
                         if (nread == 0) {
                             throw std::runtime_error("No available space in KV cache or invalid slot save file");

--- a/tools/server/tests/unit/test_slot_save.py
+++ b/tools/server/tests/unit/test_slot_save.py
@@ -4,8 +4,8 @@ import base64
 import requests
 import struct
 
-# sequence state file: magic(4) version(4) payload_size(4), then payload_size llama_token words
-STATE_FILE_HEADER_SIZE = 12
+# sequence state file: magic(4) version(4) type(4) payload_size(4), then payload_size bytes
+STATE_FILE_HEADER_SIZE = 16
 
 server = ServerPreset.tinyllama2()
 
@@ -93,7 +93,7 @@ def test_slot_restore_legacy_token_list():
     assert res.status_code == 200
     assert res.body["n_saved"] == 84
 
-    # rewrite the token payload into a plain token list, as written by servers that predate the packed server_tokens format
+    # rewrite the file as v3 with a plain token list, as written by llama_state_seq_save_file
     path = os.path.join(server.slot_save_path, "slot_legacy.bin")
     with open(path, "rb") as f:
         data = bytearray(f.read())
@@ -102,13 +102,12 @@ def test_slot_restore_legacy_token_list():
     packed_header_size = 12
 
     payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
-    payload_end = STATE_FILE_HEADER_SIZE + payload_size * 4
+    payload_end = STATE_FILE_HEADER_SIZE + payload_size
     n_tokens = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE + 8)[0]
     assert n_tokens == 84
 
     tokens_start = STATE_FILE_HEADER_SIZE + packed_header_size
-    data = data[:STATE_FILE_HEADER_SIZE] + data[tokens_start:tokens_start + n_tokens * 4] + data[payload_end:]
-    struct.pack_into("=I", data, STATE_FILE_HEADER_SIZE - 4, n_tokens)
+    data = data[:4] + struct.pack("=II", 3, n_tokens) + data[tokens_start:tokens_start + n_tokens * 4] + data[payload_end:]
 
     with open(path, "wb") as f:
         f.write(data)
@@ -466,7 +465,7 @@ def test_slot_save_restore_image_payload_larger_than_context(mmproj_server):
     with open(path, "rb") as f:
         data = bytearray(f.read())
     payload_size = struct.unpack_from("=I", data, STATE_FILE_HEADER_SIZE - 4)[0]
-    assert payload_size > n_ctx_slot  # the scenario under test: the payload does not fit in n_ctx
+    assert payload_size > n_ctx_slot * 4  # the scenario under test: the payload does not fit in n_ctx
 
     # drop the image from the slot, then restore it from the file
     res = server.make_request("POST", "/completion", data={


### PR DESCRIPTION
## Overview

#26640 serializes llama-server slot state into a byte stream, but the per-sequence file API accepts caller-owned data as `llama_token[]`.
This requires llama-server to pad the payload to a multiple of `sizeof(llama_token)` and pass it through the token-oriented API.
This PR adds a byte-oriented per-sequence file API and migrates llama-server to use it directly.

Related issue: #27942

## Additional information

### Changes

* add `llama_state_seq_save_file_data` / `llama_state_seq_load_file_data` for byte-oriented per-sequence state persistence
* introduce sequence-state file format v4 with explicit `TOKENS` and `DATA` payload types and byte-sized payload lengths
* make both save APIs write v4 while retaining v3 read compatibility
* keep the token load API restricted to token payloads, while the byte API can load both token and arbitrary byte payloads
* migrate llama-server slot persistence to the byte-oriented API
* use `raw_buffer` for serialized `server_tokens`
* remove token-width padding and reinterpretation as `llama_token *`

Existing v3 sequence-state files are treated as token payloads and remain readable.

### Tests

Updated the existing `test_slot_save.py` coverage for the v4 framing, legacy v3 token-list compatibility, and the existing multimodal slot case.

Local validation passes: `ctest` 62/62 and `unit/test_slot_save.py` 9/9.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

* I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
* AI usage disclosure: YES

  * **Motivation & Design:** I identified the token-typed caller-payload limitation exposed by #26640. The final v4 typed file framing and v3-read/v4-write compatibility approach follows review feedback on this PR.
  * **Investigation & Code Review (Fable 5 / Opus 5 / GPT-5.6 Sol):** AI agents were used to investigate the sequence-state API, compatibility behavior, and llama-server slot persistence paths, and to assist with code and test review under my instructions.
  * **Implementation (Opus 5 / Fable 5 / GPT-5.6 Sol):** AI assistance was used to draft parts of the implementation and updates to existing tests based on my technical instructions.
  * **Draft Translation (Opus 5 / Fable 5 / GPT-5.6 Sol):** AI was used to assist with English wording for the Issue and PR text based on my Japanese technical notes.
  * **Validation & Responsibility:** I manually reviewed the submitted changes and ran the local build and tests. I take full responsibility for the submitted changes.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->