### PR TITLE
CUDA : fix divergent FlashAttention barrier

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1535,8 +1535,6 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
             }
         }
 
-        __syncthreads();
-
         // Write back combined meta data:
 #pragma unroll
         for (int imeta = 0; imeta < nmeta; ++imeta) {
@@ -1556,10 +1554,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
             float2 * dstk_fixup_meta = dstk_fixup + (gridDim.x + blockIdx.x)*ncols;
             dstk_fixup_meta[(threadIdx.y/np)*cols_per_warp + threadIdx.x] = make_float2(KQ_cmn, KQ_crs);
         }
-    } else if (np > 1) {
-        // Warps with threadIdx.y % np == 0 execute a __syncthreads() in the if branch.
-        // Therefore, all other warps also need to execute a __syncthreads().
-        // Otherwise the points at which warps synchronize with each other would become misaligned.
+    }
+
+    if constexpr (np > 1) {
         __syncthreads();
     }
 


### PR DESCRIPTION
## Overview
Incorrect use of `__syncthreads()`  created divergent barriers in the FlashAttention code. It produced 1024 synchronization errors reported by NVIDIA Compute Sanitizer:
`compute-sanitizer --tool synccheck`. 
The issue is:
```
.... threads in the same block  ... 
if (thread_type_a) {
    .....
    __syncthreads(); // creates barrier A
} else {
   __syncthreads();  // creates barrier B
}
```
So the threads in the same block are running towards different barriers based on which branch they take.  
This can be fixed by:
```
.... threads in the same block ... 
if (thread_type_a) {
    .....
}

__syncthreads();  // creates common barrier
```
This produces 0 errors.  The numerical tests passed and after benchmarking 100k cached + 1k prompt + 256 generated tokens produced almost no performance change.
Measured change:  improved prompt processing by 0.43% and token generation by 0.15%, so no measurable performance regression.

## Additional information
- https://docs.nvidia.com/cuda/cuda-programming-guide/#thread-block-synchronization-functions
- https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#synccheck-tool

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, GPT-5.6 Sol. I was doing performance optimizations for qwen 3.8 27B and it identified this issue during some FlashAttention work. 

