### PR TITLE
server : support input_image in Responses API tool call output

### DIFF
--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -202,14 +202,37 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
                     });
                 } else {
                     json chatcmpl_outputs = item.at("output");
+                    json tool_content     = json::array();
+
                     for (json & chatcmpl_output : chatcmpl_outputs) {
-                        if (!chatcmpl_output.contains("type") || chatcmpl_output.at("type") != "input_text") {
-                            throw std::invalid_argument("Output of tool call should be 'Input text'");
+                        const std::string output_type = json_value(chatcmpl_output, "type", std::string());
+
+                        if (output_type == "input_text") {
+                            chatcmpl_output["type"] = "text";
+                            tool_content.push_back(chatcmpl_output);
+                        } else if (output_type == "input_image") {
+                            // Mirrors the "Input image" branch of input messages above.
+                            // Some clients (e.g. Codex) return screenshots as the output
+                            // of a tool call. The image stays in the tool message: media
+                            // is extracted later by oaicompat_chat_params_parse(), which
+                            // rewrites image_url into a media marker for every role, so
+                            // the chat template never sees the media itself.
+                            if (!chatcmpl_output.contains("image_url")) {
+                                throw std::invalid_argument("'image_url' is required");
+                            }
+                            tool_content.push_back(json {
+                                {"image_url", json {
+                                    {"url", chatcmpl_output.at("image_url")}
+                                }},
+                                {"type", "image_url"},
+                            });
+                        } else {
+                            throw std::invalid_argument("Output of tool call should be 'Input text' or 'Input image'");
                         }
-                        chatcmpl_output["type"] = "text";
                     }
+
                     chatcmpl_messages.push_back(json {
-                        {"content",      chatcmpl_outputs},
+                        {"content",      tool_content},
                         {"role",         "tool"},
                         {"tool_call_id", item.at("call_id")},
                     });


### PR DESCRIPTION
The Responses API's `function_call_output` only accepts `input_text`, so returning an image from a tool gives a 400:

```
400 {"error":{"message":"Output of tool call should be 'Input text'","type":"invalid_request_error"}}
```

This breaks Codex when it uses the vision capability of a local model - every screenshot step fails. Input messages already accept `input_image` a few lines above in the same file, so it is only the tool output path that is missing it.

The fix is to convert `input_image` to `image_url` and keep it inside the tool message.

This works because `oaicompat_chat_params_parse()` handles `image_url` the same way for every message role - it extracts the media into `out_files` and replaces it with a media marker, so the chat template never sees the media itself. This is the same approach as #22536, which already does this for the Anthropic -> OpenAI path.

## Testing

Local CUDA build, Qwen3.8-27B-Q8_0 + mmproj-model-bf16, sending a real 50 KB JPEG screenshot as `input_image` inside `function_call_output`.

| case | result |
|---|---|
| text + image in the tool output | 200 |
| image only, no text part | 200 |
| text-only tool output | 200, unchanged |
| `output` as a plain string | 200, unchanged |
| unsupported output type | 400, `should be 'Input text' or 'Input image'` |

In the two image cases the model describes what is actually in the picture ("a pixel-art game scene, rocky pillars, a signpost, a Poke Ball near the water"), so the image reaches the vision encoder rather than only passing validation.

The converted request keeps 3 messages (user / assistant / tool) with the image inside the tool message content array, no extra user message:

```
roles: ['user', 'assistant', 'tool']
tool message content: [ {"type":"text",...}, {"type":"image_url",...} ]
```

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: the code change and the test runs were produced with Claude Code under my direction, and I reviewed the change before submitting.
