### PR TITLE
ggml : add ggml_backend_op_alloc_size_may_expand, use it in RPC

### DIFF
--- a/ggml/include/ggml-backend.h
+++ b/ggml/include/ggml-backend.h
@@ -424,6 +424,10 @@ extern "C" {
     // Compare the output of two backends
     GGML_API bool ggml_backend_compare_graph_backend(ggml_backend_t backend1, ggml_backend_t backend2, struct ggml_cgraph * graph, ggml_backend_eval_callback callback, void * user_data, struct ggml_tensor const * const * test_nodes, size_t num_test_nodes);
 
+    // returns true for ops that may require additional memory for fleeting data on some backends,
+    // i.e. the backend's get_alloc_size may return more than ggml_nbytes for the output tensor
+    GGML_API bool ggml_backend_op_alloc_size_may_expand(enum ggml_op op);
+
     // Tensor initialization
     GGML_API enum ggml_status ggml_backend_tensor_alloc(ggml_backend_buffer_t buffer, struct ggml_tensor * tensor, void * addr);
     GGML_API enum ggml_status ggml_backend_view_init(struct ggml_tensor * tensor);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -64,6 +64,13 @@ size_t ggml_backend_buft_get_alloc_size(ggml_backend_buffer_type_t buft, const s
     if (buft->iface.get_alloc_size) {
         size_t size = buft->iface.get_alloc_size(buft, tensor);
         assert(size >= ggml_nbytes(tensor));
+
+        // [TAG_ALLOC_SIZE_EXPAND]
+        // if you hit this assert, update ggml_backend_op_alloc_size_may_expand() accordingly
+        GGML_ASSERT(size <= ggml_nbytes(tensor) ||
+                    ggml_op_is_empty(tensor->op) ||
+                    ggml_backend_op_alloc_size_may_expand(tensor->op));
+
         return size;
     }
     return ggml_nbytes(tensor);
@@ -2050,6 +2057,22 @@ ggml_backend_t ggml_backend_sched_get_tensor_backend(ggml_backend_sched_t sched,
 }
 
 // utils
+
+// [TAG_ALLOC_SIZE_EXPAND]
+// returns true for ops that may require additional memory for fleeting data on some backends,
+// i.e. the backend's get_alloc_size may return more than ggml_nbytes for the output tensor
+bool ggml_backend_op_alloc_size_may_expand(enum ggml_op op) {
+    switch (op) {
+        case GGML_OP_FLASH_ATTN_EXT:
+        case GGML_OP_MUL_MAT_ID:
+        case GGML_OP_CUMSUM:
+        case GGML_OP_ARGSORT:
+        case GGML_OP_TOP_K:
+            return true;
+        default:
+            return false;
+    }
+}
 
 enum ggml_status ggml_backend_view_init(struct ggml_tensor * tensor) {
     GGML_ASSERT(tensor);

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -826,10 +826,10 @@ static size_t ggml_backend_rpc_buffer_type_get_alloc_size(ggml_backend_buffer_ty
     // See comments in init_tensor.
     rpc_get |= ggml_is_quantized(tensor->type) && (tensor->ne[0] % 512 != 0) && (tensor->view_src == nullptr);
 
-    // ops that require additional memory for fleeting data on certain backends
+    // [TAG_ALLOC_SIZE_EXPAND]
+    // ops that may require additional memory for fleeting data on certain backends
     // ref: https://github.com/ggml-org/llama.cpp/pull/15966
-    rpc_get |= tensor->op == GGML_OP_FLASH_ATTN_EXT;
-    rpc_get |= tensor->op == GGML_OP_MUL_MAT_ID;
+    rpc_get |= ggml_backend_op_alloc_size_may_expand(tensor->op);
 
     if (rpc_get) {
         ggml_backend_rpc_buffer_type_context * buft_ctx = (ggml_backend_rpc_buffer_type_context *)buft->context;


### PR DESCRIPTION
## Overview

Some backends (Metal, SYCL, WebGPU) require additional memory for fleeting data for certain ops, which is reflected in their `get_alloc_size` implementations. The RPC backend had a hardcoded list of such ops (`FLASH_ATTN_EXT`, `MUL_MAT_ID`): if a backend started expanding the alloc size of another op and the list was not updated, the RPC client would under-allocate.

- add `ggml_backend_op_alloc_size_may_expand()` to the backend utils, returning `true` for the ops that expand the alloc size in any backend (`FLASH_ATTN_EXT`, `MUL_MAT_ID`, `CUMSUM`, `ARGSORT`, `TOP_K`)
- add a `GGML_ASSERT` in `ggml_backend_buft_get_alloc_size()` catching a backend that expands the alloc size of a compute op that is not listed in the helper
- use the helper in the RPC backend instead of the hardcoded list, which also fixes the previously missing `CUMSUM`/`ARGSORT`/`TOP_K` for e.g. a Metal server

## Additional information

The op list was derived by auditing all `get_alloc_size` implementations in the tree. All relevant sites are marked with a `[TAG_ALLOC_SIZE_EXPAND]` comment so that they can be found easily when adding a new op.

The assert exempts non-compute tensors (`ggml_op_is_empty`), since type-dependent expansions (e.g. quantized weight padding) apply to weights regardless of op.

ref: https://github.com/ggml-org/llama.cpp/pull/15966

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/Qwen3.8-27B
