### PR TITLE
ggml-cpu : conditionally add SpacemiT IME kernel sources

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -453,12 +453,16 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
                 ggml-cpu/spacemit/repack.h
                 ggml-cpu/spacemit/ime_env.cpp
                 ggml-cpu/spacemit/ime_env.h
-                ggml-cpu/spacemit/ime1_kernels.cpp
-                ggml-cpu/spacemit/ime2_kernels.cpp
                 ggml-cpu/spacemit/ime_kernels.h
                 ggml-cpu/spacemit/rvv_kernels.cpp
                 ggml-cpu/spacemit/rvv_kernels.h
             )
+            if ("RISCV64_SPACEMIT_IME1" IN_LIST RISCV64_SPACEMIT_IME_SPEC)
+                list(APPEND GGML_CPU_SOURCES ggml-cpu/spacemit/ime1_kernels.cpp)
+            endif()
+            if ("RISCV64_SPACEMIT_IME2" IN_LIST RISCV64_SPACEMIT_IME_SPEC)
+                list(APPEND GGML_CPU_SOURCES ggml-cpu/spacemit/ime2_kernels.cpp)
+            endif()
         endif()
         if(NOT GGML_CPU_ALL_VARIANTS)
             set(MARCH_STR "rv64gc")


### PR DESCRIPTION
## Overview

When building with gcc < 15, CMakeLists.txt unconditionally adds `ime2_kernels.cpp`, which fails to compile. `FindSMTIME.cmake` only defines `RISCV64_SPACEMIT_IME2` when the IME2 instructions are detected, and gcc 14 only has IME1, so `ime2_kernels.cpp` hits its `#error`.

This PR fixes it by using `IN_LIST` to add each kernel source according to the spec that was actually detected.

## Additional information

Tested on Milk-V Jupiter (SpacemiT X60) with gcc 14.2:
- Before: build fails on `ime2_kernels.cpp`.
- After: clean configure + build; `ime2_kernels.cpp` is excluded, `ime1_kernels.cpp` is kept.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: The code change was produced with the help of an AI coding agent. This PR description and the commit message were written by me.