### PR TITLE
qwen4exp: reduce the generation slowdown as context grows

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -1868,15 +1868,32 @@ void llama_kv_cache::get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, st
 
     for (uint32_t s = 0; s < n_stream; ++s) {
         // p_max inclusive: an embd token looks up cells at its own (shared) position
-        v_cells[s].for_each_token_in(seqs, 0, p_max + 1,
+        v_cells[s].for_each_token_in(seqs, w0, p_max + 1,
             [&](llama_seq_id seq_id, llama_pos pos, llama_token tok) {
-                if (pos >= w0) {
-                    hist[key(seq_id, pos)] = tok;
-                } else if (pos > below[seq_id].first) {
-                    below[seq_id] = { pos, tok };
-                }
+                hist[key(seq_id, pos)] = tok;
             });
     }
+
+    // below[] only answers when an M-RoPE gap leaves the window empty, so it costs a pass of
+    // its own that contiguous positions never pay
+    bool below_ready = false;
+
+    const auto ensure_below = [&]() {
+        if (below_ready) {
+            return;
+        }
+
+        below_ready = true;
+
+        for (uint32_t s = 0; s < n_stream; ++s) {
+            v_cells[s].for_each_token_in(seqs, 0, w0,
+                [&](llama_seq_id seq_id, llama_pos pos, llama_token tok) {
+                    if (pos > below[seq_id].first) {
+                        below[seq_id] = { pos, tok };
+                    }
+                });
+        }
+    };
 
     // the token at pos p, or the nearest earlier one when p falls in an M-RoPE gap
     const auto lookup = [&](llama_seq_id seq_id, llama_pos p) -> llama_token {
@@ -1886,6 +1903,9 @@ void llama_kv_cache::get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, st
                 return it->second;
             }
         }
+
+        ensure_below();
+
         return below[seq_id].second;
     };
 

--- a/src/llama-kv-cells.h
+++ b/src/llama-kv-cells.h
@@ -10,6 +10,10 @@
 #include <set>
 #include <vector>
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 struct llama_kv_cell_ext {
     // 2D spatial positions, typically used for M-RoPE
     llama_pos x = 0;
@@ -29,6 +33,106 @@ struct llama_kv_cell_ext {
 
         *this = llama_kv_cell_ext{};
     }
+};
+
+// index of the lowest set bit, and of the highest; the word is never zero here
+#if defined(_MSC_VER)
+static inline uint32_t llama_kv_ctz64(uint64_t x) {
+    unsigned long r;
+    _BitScanForward64(&r, x);
+    return (uint32_t) r;
+}
+
+static inline uint32_t llama_kv_clz64(uint64_t x) {
+    unsigned long r;
+    _BitScanReverse64(&r, x);
+    return (uint32_t) r;
+}
+#else
+static inline uint32_t llama_kv_ctz64(uint64_t x) {
+    return (uint32_t) __builtin_ctzll(x);
+}
+
+static inline uint32_t llama_kv_clz64(uint64_t x) {
+    return (uint32_t) (63 - __builtin_clzll(x));
+}
+#endif
+
+// a dense set of cell indices, kept as a bitmap so that a full pass reads words instead of
+// chasing tree nodes. the cells it tracks are a large fraction of the cache, so the bitmap is
+// both smaller and faster to walk than a node per index
+class llama_kv_idx_set {
+public:
+    void resize(uint32_t n) {
+        bits.assign((n + 63)/64, 0);
+        n_set = 0;
+    }
+
+    void clear() {
+        std::fill(bits.begin(), bits.end(), 0);
+        n_set = 0;
+    }
+
+    void insert(uint32_t i) {
+        uint64_t & w = bits[i/64];
+        const uint64_t b = 1ull << (i%64);
+
+        n_set += (w & b) == 0;
+        w |= b;
+    }
+
+    void erase(uint32_t i) {
+        uint64_t & w = bits[i/64];
+        const uint64_t b = 1ull << (i%64);
+
+        n_set -= (w & b) != 0;
+        w &= ~b;
+    }
+
+    bool contains(uint32_t i) const {
+        return (bits[i/64] >> (i%64)) & 1;
+    }
+
+    uint32_t size()  const { return n_set; }
+    bool     empty() const { return n_set == 0; }
+
+    uint32_t first() const {
+        for (size_t w = 0; w < bits.size(); ++w) {
+            if (bits[w]) {
+                return 64*w + llama_kv_ctz64(bits[w]);
+            }
+        }
+
+        return 0;
+    }
+
+    uint32_t last() const {
+        for (size_t w = bits.size(); w-- > 0; ) {
+            if (bits[w]) {
+                return 64*w + llama_kv_clz64(bits[w]);
+            }
+        }
+
+        return 0;
+    }
+
+    // visits the indices in ascending order
+    template <class F>
+    void for_each(F && f) const {
+        for (size_t w = 0; w < bits.size(); ++w) {
+            uint64_t m = bits[w];
+
+            while (m) {
+                f((uint32_t) (64*w + llama_kv_ctz64(m)));
+                m &= m - 1;
+            }
+        }
+    }
+
+private:
+    std::vector<uint64_t> bits;
+
+    uint32_t n_set = 0;
 };
 
 // meta information about KV cells that can be part of multiple sequences at the same time
@@ -69,6 +173,7 @@ public:
         ext.resize(n);
         shift.resize(n);
         seq.resize(n);
+        used.resize(n);
 
         reset();
     }
@@ -87,13 +192,13 @@ public:
     // the index of the first cell that is used
     // return 0 if no cells are used
     uint32_t used_min() const {
-        return used.empty() ? 0 : *used.begin();
+        return used.empty() ? 0 : used.first();
     }
 
     // the index of the last cell that is used + 1
     // return 0 if no cells are used
     uint32_t used_max_p1() const {
-        return used.empty() ? 0 : *used.rbegin() + 1;
+        return used.empty() ? 0 : used.last() + 1;
     }
 
     bool get_has_shift() const {
@@ -314,9 +419,9 @@ public:
     // note: used by n-gram input embeddings to recover the tokens preceding a ubatch
     template<typename F>
     void for_each_token_in(const std::bitset<LLAMA_MAX_SEQ> & seqs, llama_pos p0, llama_pos p1, F && f) const {
-        for (const auto & i : used) {
+        used.for_each([&](uint32_t i) {
             if (pos[i] < p0 || pos[i] >= p1) {
-                continue;
+                return;
             }
 
             const auto m = seq[i] & seqs;
@@ -331,7 +436,7 @@ public:
                     --left;
                 }
             }
-        }
+        });
     }
 
     // note: call only if the cell is not empty and the seq_id is not in the cell
@@ -488,7 +593,7 @@ private:
     bool has_shift = false;
 
     // set of indices of used cells (i.e. pos[i] != -1, allowed to not have any seq_id)
-    std::set<uint32_t> used;
+    llama_kv_idx_set used;
 
     std::vector<llama_pos> pos;
 

--- a/src/llama-kv-cells.h
+++ b/src/llama-kv-cells.h
@@ -320,13 +320,15 @@ public:
             }
 
             const auto m = seq[i] & seqs;
-            if (m.none()) {
-                continue;
-            }
 
-            for (llama_seq_id s = 0; s < LLAMA_MAX_SEQ; ++s) {
+            // a cell carries a handful of sequences at most, so stop once they are all seen
+            // instead of walking the whole LLAMA_MAX_SEQ width
+            size_t left = m.count();
+
+            for (llama_seq_id s = 0; left > 0 && s < (llama_seq_id) LLAMA_MAX_SEQ; ++s) {
                 if (m.test(s)) {
                     f(s, pos[i], ext[i].tok);
+                    --left;
                 }
             }
         }

--- a/src/llama-kv-cells.h
+++ b/src/llama-kv-cells.h
@@ -58,9 +58,8 @@ static inline uint32_t llama_kv_clz64(uint64_t x) {
 }
 #endif
 
-// a dense set of cell indices, kept as a bitmap so that a full pass reads words instead of
-// chasing tree nodes. the cells it tracks are a large fraction of the cache, so the bitmap is
-// both smaller and faster to walk than a node per index
+// the cells tracked are a large fraction of the cache, so a bitmap is both smaller and faster
+// to walk than a tree node per index
 class llama_kv_idx_set {
 public:
     void resize(uint32_t n) {
@@ -116,7 +115,7 @@ public:
         return 0;
     }
 
-    // visits the indices in ascending order
+    // ascending order, as the set it replaces guaranteed
     template <class F>
     void for_each(F && f) const {
         for (size_t w = 0; w < bits.size(); ++w) {

--- a/src/models/models.h
+++ b/src/models/models.h
@@ -2320,6 +2320,22 @@ struct llama_model_qwen4exp : public llama_model_base {
                           float   kq_scale,
                             int   il);
 
+        // attention over the whole window, masked down to the selection
+        ggml_tensor * build_qsa_scan(
+        llm_graph_input_attn_kv * inp,
+                    ggml_tensor * q_cur,
+                    ggml_tensor * top_k,
+                          float   kq_scale,
+                            int   il);
+
+        // attention over the selected cells alone, gathered into a window per query
+        ggml_tensor * build_qsa_gather(
+        llm_graph_input_attn_kv * inp,
+                    ggml_tensor * q_cur,
+                    ggml_tensor * top_k,
+                          float   kq_scale,
+                            int   il);
+
         // the QSA cache layout inputs do not depend on the layer, only on its compress ratio,
         // so the layers sharing a ratio share one input set
         std::map<uint32_t, llm_graph_input_qsa *> qsa_inps;

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -666,10 +666,8 @@ ggml_tensor * llama_model_qwen4exp::graph::build_attn_qsa(
     const int64_t n_tps = top_k->ne[1];
     const int64_t n_kv  = mctx_cur->get_n_kv();
 
-    // the scan reads the window once for all the queries of a stream, the gather moves the
-    // selected cells twice, so the two meet at 2*n_tps*width == n_kv. the margin below keeps
-    // the win clear and the windows small enough to stay in the compute buffer of a decode
-    // graph. flash attention keeps the value side as rows, which is what the gather reads
+    // the two costs meet at 2*n_tps*width == n_kv; the margin keeps the windows small enough
+    // for the compute buffer of a decode graph. flash attention is what keeps the values as rows
     ggml_tensor * cur = cparams.flash_attn && 4*n_tps*width < n_kv
         ? build_qsa_gather(inp, q_cur, top_k, kq_scale, il)
         : build_qsa_scan  (inp, q_cur, top_k, kq_scale, il);
@@ -728,9 +726,8 @@ ggml_tensor * llama_model_qwen4exp::graph::build_qsa_scan(
     return build_attn_mha(q, k, v, nullptr, kq_mask_top_k, nullptr, nullptr, kq_scale, il);
 }
 
-// The selected cells are gathered into a window of their own, one per query, so the key and
-// value traffic follows the budget instead of the whole cache. The queries then ride the stream
-// axis of the attention: each one carries the window its own selection named.
+// Key and value traffic follows the budget instead of the whole cache. The queries ride the
+// stream axis of the attention, each carrying the window its own selection named.
 ggml_tensor * llama_model_qwen4exp::graph::build_qsa_gather(
         llm_graph_input_attn_kv * inp,
         ggml_tensor *             q_cur,

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -662,6 +662,37 @@ ggml_tensor * llama_model_qwen4exp::graph::build_attn_qsa(
         ggml_build_forward_expand(gf, mctx_cur->cpy_v(ctx0, v_cur, v_idxs, il));
     }
 
+    const int64_t width = top_k->ne[0];
+    const int64_t n_tps = top_k->ne[1];
+    const int64_t n_kv  = mctx_cur->get_n_kv();
+
+    // the scan reads the window once for all the queries of a stream, the gather moves the
+    // selected cells twice, so the two meet at 2*n_tps*width == n_kv. the margin below keeps
+    // the win clear and the windows small enough to stay in the compute buffer of a decode
+    // graph. flash attention keeps the value side as rows, which is what the gather reads
+    ggml_tensor * cur = cparams.flash_attn && 4*n_tps*width < n_kv
+        ? build_qsa_gather(inp, q_cur, top_k, kq_scale, il)
+        : build_qsa_scan  (inp, q_cur, top_k, kq_scale, il);
+    cb(cur, "kqv_out", il);
+
+    // the rotation is its own inverse, so undo it on the value side of the output
+    if (inp->self_v_rot) {
+        cur = llama_mul_mat_hadamard(ctx0, cur, inp->self_v_rot);
+    }
+
+    return cur;
+}
+
+// The window stays whole and the mask hides every cell the selection leaves out.
+// The mask build below copies the MLA sparse path in llm_graph_context::build_attn.
+ggml_tensor * llama_model_qwen4exp::graph::build_qsa_scan(
+        llm_graph_input_attn_kv * inp,
+        ggml_tensor *             q_cur,
+        ggml_tensor *             top_k,
+        float                     kq_scale,
+        int                       il) {
+    const auto * mctx_cur = inp->mctx;
+
     ggml_tensor * kq_mask = inp->get_kq_mask();
 
     // prepare new kq mask - starts filled with -INFINITY
@@ -694,15 +725,65 @@ ggml_tensor * llama_model_qwen4exp::graph::build_attn_qsa(
     ggml_tensor * k = mctx_cur->get_k(ctx0, il);
     ggml_tensor * v = mctx_cur->get_v(ctx0, il);
 
-    ggml_tensor * cur = build_attn_mha(q, k, v, nullptr, kq_mask_top_k, nullptr, nullptr, kq_scale, il);
-    cb(cur, "kqv_out", il);
+    return build_attn_mha(q, k, v, nullptr, kq_mask_top_k, nullptr, nullptr, kq_scale, il);
+}
 
-    // the rotation is its own inverse, so undo it on the value side of the output
-    if (inp->self_v_rot) {
-        cur = llama_mul_mat_hadamard(ctx0, cur, inp->self_v_rot);
-    }
+// The selected cells are gathered into a window of their own, one per query, so the key and
+// value traffic follows the budget instead of the whole cache. The queries then ride the stream
+// axis of the attention: each one carries the window its own selection named.
+ggml_tensor * llama_model_qwen4exp::graph::build_qsa_gather(
+        llm_graph_input_attn_kv * inp,
+        ggml_tensor *             q_cur,
+        ggml_tensor *             top_k,
+        float                     kq_scale,
+        int                       il) {
+    const auto * mctx_cur = inp->mctx;
 
-    return cur;
+    const int64_t width    = top_k->ne[0];
+    const int64_t n_tps    = top_k->ne[1];
+    const int64_t n_stream = top_k->ne[3];
+    const int64_t n_q      = n_tps*n_stream;
+
+    ggml_tensor * k_all = mctx_cur->get_k(ctx0, il);
+    ggml_tensor * v_all = mctx_cur->get_v(ctx0, il);
+
+    const int64_t n_kv = k_all->ne[2];
+
+    // a cell holds its heads back to back, so one row of the gather is one whole cell
+    ggml_tensor * k_cells = ggml_view_3d(ctx0, k_all, k_all->ne[0]*k_all->ne[1], n_kv, n_stream,
+            k_all->nb[2], k_all->nb[3], 0);
+    ggml_tensor * v_cells = ggml_view_3d(ctx0, v_all, v_all->ne[0]*v_all->ne[1], n_kv, n_stream,
+            v_all->nb[2], v_all->nb[3], 0);
+
+    // a cell index names a cell of its own stream, and the ubatch lays the queries of a stream
+    // out contiguously, so the flat index of a window is the index of its query
+    ggml_tensor * idx_stream = ggml_reshape_2d(ctx0, top_k, width*n_tps, n_stream);
+
+    ggml_tensor * k_sel = ggml_get_rows(ctx0, k_cells, idx_stream);
+    ggml_tensor * v_sel = ggml_get_rows(ctx0, v_cells, idx_stream);
+
+    k_sel = ggml_reshape_4d(ctx0, k_sel, k_all->ne[0], k_all->ne[1], width, n_q);
+    v_sel = ggml_reshape_4d(ctx0, v_sel, v_all->ne[0], v_all->ne[1], width, n_q);
+    cb(k_sel, "qsa_k_sel", il);
+    cb(v_sel, "qsa_v_sel", il);
+
+    // gathering the attention mask at the selected cells leaves the same values the scan path
+    // would put there, so the window carries the reach of its query
+    ggml_tensor * kq_mask = inp->get_kq_mask();
+
+    GGML_ASSERT(kq_mask->nb[3] == kq_mask->nb[1]*n_tps);
+
+    ggml_tensor * mask_cells = ggml_view_3d(ctx0, kq_mask, 1, n_kv, n_q,
+            kq_mask->nb[0], kq_mask->nb[1], 0);
+
+    ggml_tensor * idx_query = ggml_reshape_3d(ctx0, top_k, width, n_q, 1);
+
+    ggml_tensor * mask = ggml_get_rows(ctx0, mask_cells, idx_query);
+
+    mask = ggml_cast(ctx0, ggml_reshape_4d(ctx0, mask, width, 1, 1, n_q), GGML_TYPE_F16);
+    cb(mask, "qsa_mask_sel", il);
+
+    return build_attn_mha(q_cur, k_sel, v_sel, nullptr, mask, nullptr, nullptr, kq_scale, il);
 }
 
 ggml_tensor * llama_model_qwen4exp::graph::build_layer_attn(

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -579,9 +579,17 @@ ggml_tensor * llama_model_qwen4exp::graph::build_qsa_top_k(
             ggml_reshape_3d(ctx0, ggml_cont(ctx0, q), idx_dim, n_idx_h*n_tps, n_stream));
     score = ggml_reshape_4d(ctx0, score, n_blocks, n_idx_h, n_tps, n_stream);
     score = ggml_relu(ctx0, score);
-    score = ggml_cont(ctx0, ggml_permute(ctx0, score, 1, 0, 2, 3));
-    score = ggml_sum_rows(ctx0, score);
-    score = ggml_reshape_3d(ctx0, score, n_blocks, n_tps, n_stream);
+
+    // the heads sit side by side on ne[1] and there are few of them, so summing slices beats a
+    // transpose that would carry the whole block by token surface twice over
+    ggml_tensor * summed = nullptr;
+    for (int64_t h = 0; h < n_idx_h; ++h) {
+        ggml_tensor * slice = ggml_view_3d(ctx0, score, n_blocks, n_tps, n_stream,
+                score->nb[2], score->nb[3], h*score->nb[1]);
+        summed = summed ? ggml_add(ctx0, summed, slice) : ggml_cont(ctx0, slice);
+    }
+
+    score = summed;
     cb(score, "indexer_score", il);
 
     // one value per block, so it is cheaper to bias here than after the cells are expanded


### PR DESCRIPTION
## Overview

qwen4exp: reduce the generation slowdown as context grows

<img width="863" height="731" alt="qwen4exp-optimize" src="https://github.com/user-attachments/assets/c09c6ce5-ae60-4f03-901e-d8a434decacd" />

<img width="857" height="929" alt="qwen4exp-optimize-reverse" src="https://github.com/user-attachments/assets/6f781466-81c0-46e8-96fd-ba7bee1137af" />

## Additional information

Five things I found while profiling the long context slowdown on this model.

The big one is the n-gram predecessor lookup. It was walking every cell of the cache and checking all 256 possible sequences, when a cell basically always belongs to one. At 88k that's 20 million iterations per token just to find three positions. Now it stops as soon as it has seen the sequences the cell actually holds. Generation went from 44 to 63 t/s and the GPU from 62% to 91% busy, which is what put me on the trail in the first place: the card was drawing 315W instead of 570W during generation.

Then the attention. QSA picks around 2000 cells per query, but that selection was only used to build a mask, and the whole cache was still handed to flash attention. On the CUDA side the only thing that gets skipped is a trailing cut, and the selection always keeps the tail of the context, so it never skipped anything. The sparsity was doing nothing. The selected cells now get gathered into their own window per query. Generation only, prefill still scans because gathering 2048 windows costs more than reading everything. Worth 6.7% at 132k, nothing at 55k, and it grows with depth.

Third one is in the indexer. Summing the four heads went through a transpose plus a sum_rows with ne0 = 4, which is about the worst shape for that kernel, and the transpose was copying a 671 MB surface twice for nothing. Three adds over strided views do the same thing.

Fourth is the same kind of thing somewhere else. The predecessor scan started at position 0 when we only care about the last few positions. The full range was only there for a fallback that fires on position gaps, which never happens on text, so it only runs when it's actually needed now.

And a small one: the set of used cells was a std::set, so one tree node per cell with no locality at all. It's a bitmap now, walked 64 bits at a time.

Tested on a real 149k agentic conversation, applying and removing the patches both ways to be sure: generation 30 to 56 t/s, prefill 1617 to 2148 t/s.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
