### PR TITLE
On ggml-cpu: tweak ARM_NATIVE_FLAG native baseline arch when extensions need it

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -140,6 +140,26 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
                     message(STATUS "ARM detected flags: ${ARM_NATIVE_FLAG}")
                 endif()
 
+                # The detected flags can list an extension (dotprod, i8mm, sve, sme)
+                # on an -march=armv8-a/armv8.1-a base, older than the architecture
+                # version that extension needs. GCC then refuses to inline the
+                # matching ACLE intrinsics ("target specific option mismatch"),
+                # so compilation fails. Raise the base version to match.
+                if ("${ARM_NATIVE_FLAG}" MATCHES "^-march=armv8(\\.[01])?-a")
+                    set(ARM_NATIVE_MIN_ARCH "armv8-a")
+                    if ("${ARM_NATIVE_FLAG}" MATCHES "\\+sme")
+                        set(ARM_NATIVE_MIN_ARCH "armv9.2-a")
+                    elseif ("${ARM_NATIVE_FLAG}" MATCHES "\\+(i8mm|sve2)")
+                        set(ARM_NATIVE_MIN_ARCH "armv8.6-a")
+                    elseif ("${ARM_NATIVE_FLAG}" MATCHES "\\+(dotprod|fp16fml|sve)")
+                        set(ARM_NATIVE_MIN_ARCH "armv8.2-a")
+                    endif()
+                    if (NOT ARM_NATIVE_MIN_ARCH STREQUAL "armv8-a")
+                        string(REGEX REPLACE "^-march=armv8(\\.[01])?-a" "-march=${ARM_NATIVE_MIN_ARCH}" ARM_NATIVE_FLAG "${ARM_NATIVE_FLAG}")
+                        message(STATUS "ARM detected flags need a newer base architecture, using: ${ARM_NATIVE_FLAG}")
+                    endif()
+                endif()
+
                 include(CheckCXXSourceRuns)
 
                 macro(check_arm_feature tag feature code)


### PR DESCRIPTION
## Overview 

When I tried to compile llama.cpp c841aeeb8bb2fe417038dadfa9b007cf1a9ef950 on my slightly rare situation,
which is Debian 12 (GCC 12.2.2) running under the Apple Virtualization.framework (under Orbstack tool), it fails to compile.
Issue #27982  contains full version info, and build failure log

In CMakeFile.txt, this raises the base version of ARM_NATIVE_MIN_ARCH given the extensions to work better on GCC 12.x, based upon ARM extension: (dotprod, i8mm, sve, sme)

So, for my hardware I have built and tested: dotprod(8.2-a) and i8mm(8.6-a)
 
I haven't personally verified these branches: sve2 and sme, but the should be fine given the GGML_CPU_ALL_VARIANTS block in the CMakefile

I tested on GCC 12.2.0 on Debian 12 under an Apple M5 Cpu under the Apple Virtualization.framework






## Additional information

This code was provided by Claude Code, under my direction

<details>
<summary>Claude Code explanation</summary>

GGML_NATIVE detects extensions like dotprod/i8mm/sve/sme on the detected CPU and appends them to an -march=armv8-a (or 8.1-a) base. GCC's ACLE intrinsics for these extensions are declared always_inline against a minimum architecture version (e.g. dotprod needs armv8.2-a), so inlining fails with 'target specific option mismatch' when the translation unit's own baseline stays at armv8-a.

Raise the base version token to the minimum the detected extensions require, matching the version thresholds already used by the GGML_CPU_ALL_VARIANTS path in this same file.
</details>
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used to diagnose the issue, and propose this fix.

This was authored by Cameron Elliott, human. 
