### PR TITLE
webui: Use toLocaleString() format consistently across chat message statistics

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageStatistics/ChatMessageStatistics.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageStatistics/ChatMessageStatistics.svelte
@@ -124,6 +124,8 @@
 	);
 
 	let formattedAgenticTotalTime = $derived(formatPerformanceTime(agenticTotalTimeMs));
+
+	const fixedFormatter = new Intl.NumberFormat(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2})
 </script>
 
 {#snippet viewButton(opts: {
@@ -223,14 +225,14 @@
 				class="bg-transparent"
 				icon={Gauge}
 				tooltipLabel="Generation speed"
-				value="{tokensPerSecond.toFixed(2)} t/s"
+				value="{fixedFormatter.format(tokensPerSecond)} t/s"
 			/>
 		{:else if activeView === ChatMessageStatsView.TOOLS && hasAgenticStats}
 			<ChatMessageStatisticsBadge
 				class="bg-transparent"
 				icon={Wrench}
 				tooltipLabel="Tool calls executed"
-				value="{agenticTimings!.toolCallsCount} calls"
+				value="{agenticTimings!.toolCallsCount.toLocaleString()} calls"
 			/>
 
 			<ChatMessageStatisticsBadge
@@ -244,14 +246,14 @@
 				class="bg-transparent"
 				icon={Gauge}
 				tooltipLabel="Tool execution rate"
-				value="{agenticToolsPerSecond.toFixed(2)} calls/s"
+				value="{fixedFormatter.format(agenticToolsPerSecond)} calls/s"
 			/>
 		{:else if activeView === ChatMessageStatsView.SUMMARY && hasAgenticStats}
 			<ChatMessageStatisticsBadge
 				class="bg-transparent"
 				icon={Layers}
 				tooltipLabel="Agentic turns (LLM calls)"
-				value="{agenticTimings!.turns} turns"
+				value="{agenticTimings!.turns.toLocaleString()} turns"
 			/>
 
 			<ChatMessageStatisticsBadge
@@ -272,7 +274,7 @@
 				class="bg-transparent"
 				icon={WholeWord}
 				tooltipLabel="Prompt tokens"
-				value="{promptTokens} tokens"
+				value="{promptTokens?.toLocaleString()} tokens"
 			/>
 
 			<ChatMessageStatisticsBadge
@@ -286,7 +288,7 @@
 				class="bg-transparent"
 				icon={Gauge}
 				tooltipLabel="Prompt processing speed"
-				value="{promptTokensPerSecond!.toFixed(2)} tokens/s"
+				value="{fixedFormatter.format(promptTokensPerSecond!)} tokens/s"
 			/>
 		{/if}
 	</div>

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageStatistics/ChatMessageStatistics.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageStatistics/ChatMessageStatistics.svelte
@@ -125,7 +125,7 @@
 
 	let formattedAgenticTotalTime = $derived(formatPerformanceTime(agenticTotalTimeMs));
 
-	const fixedFormatter = new Intl.NumberFormat(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2})
+	const fixedFormatter = new Intl.NumberFormat(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
 </script>
 
 {#snippet viewButton(opts: {


### PR DESCRIPTION
## Overview

This PR updates `tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageStatistics/ChatMessageStatistics.svelte` to use consistent `toLocaleString()` formatting across the following stats:

- tokensPerSecond
- agenticTimings!.toolCallsCount
- agenticToolsPerSecond
- agenticTimings!.turns
- promptTokens
- promptTokensPerSecond

It also adds a new `fixedFormatter` to the top of the file that is used to format stats with fraction digits.

Closes #27989 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- [X] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [X] AI usage disclosure: I used AI to help navigate the codebase to find the `.svelte` file where chat message statistics are located.