### PR TITLE
kv-cache : index (seq,pos) cells to make ngram prev-token lookups O(log n) for qwen4exp decode speedup

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -8,7 +8,9 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <chrono>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <map>
@@ -1826,6 +1828,88 @@ bool llama_kv_cache::has_cell_ext() const {
     return hparams.n_pos_per_embd() > 1 || hparams.ple_n_heads > 0;
 }
 
+//
+// (seq, pos) -> token index for the n-gram predecessor lookups in get_prev_tokens()
+//
+// the llama_kv_cells::seq_pos index stores the rows of the cells per (seq, pos), which allows resolving the
+// predecessor tokens in O(needs * log n) instead of scanning all used cells once per ubatch. controlled by the
+// LLAMA_KV_PREV_TOKENS environment variable:
+//
+//   fast (default):   use the index for eligible ubatches, fall back to the general scan when not applicable
+//   verify:           run the general scan (source of truth) and the index for every call, compare them and log
+//                     mismatches (with a heartbeat of the scan / index cost). intended for testing and debugging
+//   off:              general scan only (the index is still maintained, but never queried)
+//
+
+enum class llama_prev_tokens_idx_mode {
+    VERIFY,
+    FAST,
+    OFF,
+};
+
+static llama_prev_tokens_idx_mode llama_prev_tokens_idx_mode_get() {
+    static const llama_prev_tokens_idx_mode mode = []() {
+        const char * env = getenv("LLAMA_KV_PREV_TOKENS");
+
+        if (env && strcmp(env, "verify") == 0) { return llama_prev_tokens_idx_mode::VERIFY; }
+        if (env && strcmp(env, "off")    == 0) { return llama_prev_tokens_idx_mode::OFF;    }
+
+        return llama_prev_tokens_idx_mode::FAST;
+    }();
+
+    return mode;
+}
+
+// diagnostic counters - decode is serialized per context, benign otherwise (reporting only):
+static struct {
+    uint64_t n_calls        = 0;
+    uint64_t n_needs        = 0;
+    uint64_t n_mismatch     = 0;
+    uint64_t n_not_applic   = 0; // ubatches the index cannot serve (multimodal)
+    uint64_t n_fast_hits    = 0;
+    double   t_scan_us      = 0.0;
+    double   t_index_us     = 0.0;
+} g_prev_tokens_diag;
+
+bool llama_kv_cache::get_prev_tokens_indexed(const llama_ubatch & ubatch, uint32_t n, std::vector<llama_token> & res) const {
+    // an embd (multimodal) ubatch can repeat one position for a whole image, so positions do not encode the
+    // token order - the general scan resolves those predecessors by ubatch order instead
+    if (!ubatch.token) {
+        return false;
+    }
+
+    res.clear();
+    res.resize(ubatch.n_tokens*n, LLAMA_TOKEN_NULL);
+
+    for (uint32_t i = 0; i < ubatch.n_tokens; ++i) {
+        // same choice as the general scan's consumer (the n-gram architectures reject shared tokens)
+        const llama_seq_id seq_id = ubatch.seq_id[i][0];
+
+        for (uint32_t j = 0; j < n; ++j) {
+            const llama_pos p = ubatch.pos[i] - (llama_pos) (n - j);
+
+            if (p < 0) {
+                continue;
+            }
+
+            llama_token tok = LLAMA_TOKEN_NULL;
+
+            for (uint32_t s = 0; s < n_stream; ++s) {
+                llama_token t = LLAMA_TOKEN_NULL;
+
+                // later stream wins, matching the general scan which merges all streams into one hist
+                if (v_cells[s].seq_pos_token_le(seq_id, p, &t)) {
+                    tok = t;
+                }
+            }
+
+            res[i*n + j] = tok;
+        }
+    }
+
+    return true;
+}
+
 void llama_kv_cache::get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, std::vector<llama_token> & res) const {
     const uint32_t n_tokens = ubatch.n_tokens;
 
@@ -1834,6 +1918,45 @@ void llama_kv_cache::get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, st
 
     if (n == 0) {
         return;
+    }
+
+    const llama_prev_tokens_idx_mode idx_mode = llama_prev_tokens_idx_mode_get();
+    const auto t_start = std::chrono::steady_clock::now();
+
+    if (idx_mode == llama_prev_tokens_idx_mode::FAST) {
+        const auto t_i0 = std::chrono::steady_clock::now();
+
+        if (get_prev_tokens_indexed(ubatch, n, res)) {
+            const auto t_i1 = std::chrono::steady_clock::now();
+
+            g_prev_tokens_diag.n_calls++;
+            g_prev_tokens_diag.n_needs += (uint64_t) n_tokens*n;
+            g_prev_tokens_diag.n_fast_hits++;
+            g_prev_tokens_diag.t_index_us += std::chrono::duration<double, std::micro>(t_i1 - t_i0).count();
+
+            if (g_prev_tokens_diag.n_calls % 2000 == 0) {
+                LLAMA_LOG_WARN("%s: PLE-IDX mode=fast calls=%llu needs=%llu hits=%llu not_applicable=%llu mismatches=%llu idx_avg=%.3f us used=%u\n",
+                        __func__,
+                        (unsigned long long) g_prev_tokens_diag.n_calls,
+                        (unsigned long long) g_prev_tokens_diag.n_needs,
+                        (unsigned long long) g_prev_tokens_diag.n_fast_hits,
+                        (unsigned long long) g_prev_tokens_diag.n_not_applic,
+                        (unsigned long long) g_prev_tokens_diag.n_mismatch,
+                        g_prev_tokens_diag.t_index_us / g_prev_tokens_diag.n_calls,
+                        v_cells[0].get_used());
+            }
+
+            return;
+        }
+
+        // the index is not applicable to this ubatch - run the general scan below
+        g_prev_tokens_diag.n_not_applic++;
+
+        res.clear();
+        res.resize(n_tokens*n, LLAMA_TOKEN_NULL);
+
+        LLAMA_LOG_WARN("%s: PLE-IDX mode=fast fell back to general scan (n_tokens=%u multimodal=%d)\n",
+                __func__, n_tokens, !ubatch.token);
     }
 
     // note: apply_ubatch() has already stored the current ubatch
@@ -1926,6 +2049,64 @@ void llama_kv_cache::get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, st
             }
 
             res[i*n + j] = lookup(seq_id, p);
+        }
+    }
+
+    if (idx_mode == llama_prev_tokens_idx_mode::OFF) {
+        return;
+    }
+
+    // verify the index against the general scan, which remains the source of truth (no speedup intended here):
+    // any MISMATCH line means the index and the scan disagree and must not be trusted yet
+    {
+        const auto t_g1 = std::chrono::steady_clock::now();
+
+        std::vector<llama_token> res_idx;
+
+        const auto t_i0 = std::chrono::steady_clock::now();
+        const bool applicable = get_prev_tokens_indexed(ubatch, n, res_idx);
+        const auto t_i1 = std::chrono::steady_clock::now();
+
+        g_prev_tokens_diag.n_calls++;
+        g_prev_tokens_diag.t_scan_us  += std::chrono::duration<double, std::micro>(t_g1 - t_start).count();
+        g_prev_tokens_diag.t_index_us += std::chrono::duration<double, std::micro>(t_i1 - t_i0).count();
+
+        if (!applicable) {
+            g_prev_tokens_diag.n_not_applic++;
+        } else {
+            for (uint32_t i = 0; i < n_tokens; ++i) {
+                for (uint32_t j = 0; j < n; ++j) {
+                    const llama_token a = res[i*n + j];
+                    const llama_token b = res_idx[i*n + j];
+
+                    if (a == b) {
+                        continue;
+                    }
+
+                    if (g_prev_tokens_diag.n_mismatch < 32) {
+                        LLAMA_LOG_ERROR("%s: PLE-IDX MISMATCH calls=%llu i=%u j=%u seq=%d pos[i]=%d scan=%d index=%d\n",
+                                __func__,
+                                (unsigned long long) g_prev_tokens_diag.n_calls,
+                                i, j, ubatch.seq_id[i][0], ubatch.pos[i], a, b);
+                    }
+
+                    g_prev_tokens_diag.n_mismatch++;
+                }
+            }
+
+            g_prev_tokens_diag.n_needs += (uint64_t) n_tokens*n;
+        }
+
+        if (g_prev_tokens_diag.n_calls % 2000 == 0) {
+            LLAMA_LOG_WARN("%s: PLE-IDX mode=verify calls=%llu needs=%llu mismatches=%llu not_applicable=%llu scan_avg=%.1f us index_avg=%.3f us used=%u\n",
+                    __func__,
+                    (unsigned long long) g_prev_tokens_diag.n_calls,
+                    (unsigned long long) g_prev_tokens_diag.n_needs,
+                    (unsigned long long) g_prev_tokens_diag.n_mismatch,
+                    (unsigned long long) g_prev_tokens_diag.n_not_applic,
+                    g_prev_tokens_diag.t_scan_us  / g_prev_tokens_diag.n_calls,
+                    g_prev_tokens_diag.t_index_us / g_prev_tokens_diag.n_calls,
+                    v_cells[0].get_used());
         }
     }
 }

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -243,6 +243,11 @@ public:
     // note: used by n-gram input embeddings
     void get_prev_tokens(const llama_ubatch & ubatch, uint32_t n, std::vector<llama_token> & res) const;
 
+    // (seq, pos) -> token index variant of get_prev_tokens - O(needs * log n) instead of scanning all cells
+    // returns false if the ubatch is not eligible (multimodal predecessors are resolved by ubatch order)
+    // see llama_kv_cells::seq_pos_token_le() and the LLAMA_KV_PREV_TOKENS modes in llama-kv-cache.cpp
+    bool get_prev_tokens_indexed(const llama_ubatch & ubatch, uint32_t n, std::vector<llama_token> & res) const;
+
 private:
     const llama_model & model;
     const llama_hparams & hparams;

--- a/src/llama-kv-cells.h
+++ b/src/llama-kv-cells.h
@@ -246,7 +246,7 @@ public:
         assert(seq_id >= 0);
 
         seq[i].reset(seq_id);
-        seq_pos_dec(seq_id, pos[i]);
+        seq_pos_dec(seq_id, pos[i], i);
 
         if (seq[i].none()) {
             pos[i] = -1;
@@ -270,7 +270,7 @@ public:
             seq[i].reset();
 
             seq[i].set(seq_id);
-            seq_pos_inc(seq_id, pos[i]);
+            seq_pos_inc(seq_id, pos[i], i);
 
             return false;
         }
@@ -340,7 +340,7 @@ public:
         assert(!seq[i].test(seq_id));
 
         seq[i].set(seq_id);
-        seq_pos_inc(seq_id, pos[i]);
+        seq_pos_inc(seq_id, pos[i], i);
     }
 
     // return the sequence id of this cell
@@ -367,7 +367,7 @@ public:
             return -1;
         }
 
-        assert(seq_pos[seq_id].begin()->second > 0);
+        assert(!seq_pos[seq_id].begin()->second.empty());
 
         return seq_pos[seq_id].begin()->first;
     }
@@ -382,9 +382,34 @@ public:
             return -1;
         }
 
-        assert(seq_pos[seq_id].rbegin()->second > 0);
+        assert(!seq_pos[seq_id].rbegin()->second.empty());
 
         return seq_pos[seq_id].rbegin()->first;
+    }
+
+    // the token of the newest cell (largest row) at the largest position <= p for the given sequence
+    // this reproduces the result of an ascending scan over all cells building a (seq, pos) -> token map, where
+    // the last cell written for a (seq, pos) pair wins - see llama_kv_cache::get_prev_tokens()
+    // return values:
+    //  +1: found, *tok is set
+    //   0: the sequence has no cell at or before p
+    int seq_pos_token_le(llama_seq_id seq_id, llama_pos p, llama_token * tok) const {
+        assert(seq_id >= 0);
+        assert(seq_id < LLAMA_MAX_SEQ);
+
+        const auto & m = seq_pos[seq_id];
+
+        auto it = m.upper_bound(p);
+        if (it == m.begin()) {
+            return 0;
+        }
+
+        --it;
+        assert(!it->second.empty());
+
+        *tok = ext[*it->second.rbegin()].tok;
+
+        return 1;
     }
 
     // note: call only if the cell is not empty
@@ -516,7 +541,7 @@ private:
     // the bitset seq[i] tells us which sequences are currently occupying the i-th cell
     std::vector<seq_set_t> seq;
 
-    // the set seq_pos[s][p] tells us how many times the position p is currently present for sequence s
+    // the set seq_pos[s][p] contains the rows (cell indices) of all cells currently occupying position p for sequence s
     // if the position p is not present, seq_pos[s][p] is not set
     // this way seq_pos[s].begin() and seq_pos[s].rbegin() give us the min/max positions currently in the cache
     //
@@ -524,28 +549,34 @@ private:
     //  - during performing a cache reuse via (rm + add)
     //  - some vision models have input embeddings with repeating positions
     //
-    std::map<llama_pos, int> seq_pos[LLAMA_MAX_SEQ];
+    // keeping the rows (and not just a reference count) allows resolving the token of a (seq, pos) pair without
+    // scanning all cells. the rows are sorted, so *rbegin() reproduces the "last cell wins" result of an ascending
+    // scan over all cells - see llama_kv_cache::get_prev_tokens() and llama_kv_cells::seq_pos_token_le()
+    //
+    std::map<llama_pos, std::set<uint32_t>> seq_pos[LLAMA_MAX_SEQ];
 
     // helper functions for updating `seq_pos`, once cell at a time:
 
-    void seq_pos_dec(llama_seq_id s, llama_pos p) {
+    void seq_pos_dec(llama_seq_id s, llama_pos p, uint32_t row) {
         auto it = seq_pos[s].find(p);
         assert(it != seq_pos[s].end());
 
-        if (--it->second == 0) {
+        it->second.erase(row);
+
+        if (it->second.empty()) {
             seq_pos[s].erase(it);
         }
     }
 
-    void seq_pos_inc(llama_seq_id s, llama_pos p) {
-        seq_pos[s][p]++;
+    void seq_pos_inc(llama_seq_id s, llama_pos p, uint32_t row) {
+        seq_pos[s][p].insert(row);
     }
 
     // remove cell i
     void seq_pos_rm(uint32_t i) {
         for (int s = 0; s < LLAMA_MAX_SEQ; ++s) {
             if (seq[i].test(s)) {
-                seq_pos_dec(s, pos[i]);
+                seq_pos_dec(s, pos[i], i);
             }
         }
     }
@@ -554,7 +585,7 @@ private:
     void seq_pos_add(uint32_t i) {
         for (int s = 0; s < LLAMA_MAX_SEQ; ++s) {
             if (seq[i].test(s)) {
-                seq_pos_inc(s, pos[i]);
+                seq_pos_inc(s, pos[i], i);
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -289,6 +289,7 @@ llama_build_and_test(test-thread-safety.cpp ARGS -m "${MODEL_DEST}" -ngl 99 -p "
 set_tests_properties(test-thread-safety PROPERTIES FIXTURES_REQUIRED test-download-model)
 
 llama_build_and_test(test-arg-parser.cpp)
+llama_build_and_test(test-kv-prev-tokens.cpp)
 llama_build_and_test(test-model-resolution.cpp)
 # the test serves its repos from an httplib server, and the library links it privately
 target_link_libraries(test-model-resolution PRIVATE cpp-httplib)

--- a/tests/test-kv-prev-tokens.cpp
+++ b/tests/test-kv-prev-tokens.cpp
@@ -1,0 +1,210 @@
+// unit test: llama_kv_cells::seq_pos_token_le vs brute-force ascending scan
+//
+// the reference implements exactly what llama_kv_cache::get_prev_tokens() does:
+// scan all cells ascending (for_each_token_in visits `used` in ascending row order), build
+// hist[(seq, pos)] = token with last-write-wins (= largest row), then resolve each need by
+// walking q = p..0 and taking the first hit. compares against the O(log n) index lookup.
+//
+// (llama_kv_cells is header-inline; built as a standalone unit test via tests/CMakeLists.txt)
+
+#include "llama-kv-cells.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <map>
+#include <random>
+#include <set>
+#include <vector>
+
+static int n_fail = 0;
+static int n_checked = 0;
+
+using hist_t = std::map<std::pair<int, llama_pos>, llama_token>;
+
+static hist_t build_hist(const llama_kv_cells & cells, uint32_t p_max) {
+    hist_t hist;
+    std::bitset<LLAMA_MAX_SEQ> all;
+    all.set();
+
+    cells.for_each_token_in(all, 0, p_max + 1, [&](llama_seq_id s, llama_pos p, llama_token t) {
+        hist[{s, p}] = t; // ascending rows: last write (largest row) wins
+    });
+
+    return hist;
+}
+
+// reference answer for (seq, p): token at the largest position <= p, per the hist
+static llama_token ref_lookup(const hist_t & hist, llama_seq_id s, llama_pos p) {
+    for (llama_pos q = p; q >= 0; --q) {
+        auto it = hist.find({ s, q });
+        if (it != hist.end()) {
+            return it->second;
+        }
+    }
+    return LLAMA_TOKEN_NULL;
+}
+
+static void check(const llama_kv_cells & cells, uint32_t p_max, const char * stage) {
+    const hist_t hist = build_hist(cells, p_max);
+
+    for (llama_seq_id s = 0; s < 4; ++s) {
+        for (llama_pos p = -2; p <= (llama_pos) p_max + 2; ++p) {
+            if (p < 0) {
+                continue;
+            }
+
+            llama_token tok = LLAMA_TOKEN_NULL;
+            const int rc = cells.seq_pos_token_le(s, p, &tok);
+
+            const llama_token idx = rc > 0 ? tok : LLAMA_TOKEN_NULL;
+            const llama_token ref = ref_lookup(hist, s, p);
+
+            n_checked++;
+
+            if (idx != ref) {
+                printf("FAIL [%s] seq=%d p=%d: index=%d reference=%d\n", stage, s, p, idx, ref);
+                n_fail++;
+            }
+        }
+    }
+}
+
+static void add_cell(llama_kv_cells & cells, uint32_t row, llama_pos p, llama_seq_id s, llama_token t) {
+    cells.pos_set(row, p);
+    llama_kv_cell_ext e;
+    e.tok = t;
+    cells.ext_set(row, e);
+    cells.seq_add(row, s);
+}
+
+int main() {
+    // scenario 1: sequential append
+    {
+        llama_kv_cells cells;
+        cells.resize(64);
+        for (uint32_t i = 0; i < 20; ++i) {
+            add_cell(cells, i, (llama_pos) i, 0, (llama_token) (100 + i));
+        }
+        check(cells, 19, "sequential");
+    }
+
+    // scenario 2: holes (removed middle cells) -> nearest <= fallback
+    {
+        llama_kv_cells cells;
+        cells.resize(64);
+        for (uint32_t i = 0; i < 20; ++i) {
+            add_cell(cells, i, (llama_pos) i, 0, (llama_token) (100 + i));
+        }
+        // remove positions 7..12 via seq_rm + cleanup
+        for (uint32_t i = 7; i <= 12; ++i) {
+            if (cells.seq_rm(i, 0)) { /* becomes empty */ }
+        }
+        check(cells, 19, "holes");
+    }
+
+    // scenario 3: duplicate positions (checkpoint-style copies), incl. removal of copies
+    {
+        llama_kv_cells cells;
+        cells.resize(64);
+        for (uint32_t i = 0; i < 10; ++i) {
+            add_cell(cells, i, (llama_pos) i, 0, (llama_token) (100 + i));
+        }
+        // "checkpoint" copy of rows 0..9 into rows 32..41, same positions, same seq, different tokens
+        for (uint32_t i = 0; i < 10; ++i) {
+            add_cell(cells, 32 + i, (llama_pos) i, 0, (llama_token) (900 + i));
+        }
+        check(cells, 15, "dup-positions");
+
+        // erase the originals (rows 0..9) -> copies must still resolve
+        for (uint32_t i = 0; i < 10; ++i) {
+            cells.seq_rm(i, 0);
+        }
+        check(cells, 15, "dup-orig-removed");
+
+        // erase the copies too
+        for (uint32_t i = 32; i < 42; ++i) {
+            cells.seq_rm(i, 0);
+        }
+        check(cells, 15, "dup-copies-removed");
+    }
+
+    // scenario 4: restore via set() (prompt-cache load), rows out of position order
+    {
+        llama_kv_cells cells;
+        cells.resize(64);
+        add_cell(cells, 0, 0, 0, 100);
+        add_cell(cells, 1, 1, 0, 101);
+
+        // simulate memory_seq_cp: write a state block at a LOW row range with HIGH positions
+        llama_kv_cells src;
+        src.resize(8);
+        for (uint32_t j = 0; j < 8; ++j) {
+            add_cell(src, j, (llama_pos) (100 + j), 1, (llama_token) (500 + j));
+        }
+        cells.set(2, src); // rows 2..9 now hold positions 100..107 for seq 1
+
+        // decode continues at 108 on a high row
+        add_cell(cells, 10, 108, 1, 600);
+        check(cells, 110, "restore-low-rows");
+    }
+
+    // scenario 5: multi-seq shared cells
+    {
+        llama_kv_cells cells;
+        cells.resize(32);
+        for (uint32_t i = 0; i < 6; ++i) {
+            add_cell(cells, i, (llama_pos) i, 0, (llama_token) (100 + i));
+            cells.seq_add(i, 1);
+        }
+        for (uint32_t i = 6; i < 10; ++i) {
+            add_cell(cells, i, (llama_pos) i, 1, (llama_token) (200 + i));
+        }
+        check(cells, 12, "multi-seq");
+    }
+
+    // scenario 6: randomized fuzz - random adds/removes/multi-seq vs reference
+    // the mirror tracks (row -> seq set) so that seq_rm/seq_add are called only when valid
+    {
+        std::mt19937 rng(42);
+        llama_kv_cells cells;
+        cells.resize(256);
+
+        std::map<uint32_t, std::set<llama_seq_id>> mirror;
+
+        for (int step = 0; step < 3000; ++step) {
+            const uint32_t row = rng() % 256;
+
+            auto it = mirror.find(row);
+            if (it == mirror.end()) {
+                const llama_seq_id s = rng() % 3;
+                add_cell(cells, row, (llama_pos) (rng() % 60), s, (llama_token) (1000 + rng() % 1000));
+                mirror[row].insert(s);
+            } else if (it->second.size() < 2 && rng() % 5 == 0) {
+                const llama_seq_id s = rng() % 3;
+                if (!it->second.count(s)) {
+                    cells.seq_add(row, s);
+                    it->second.insert(s);
+                }
+            } else {
+                const llama_seq_id s = *it->second.begin();
+                const bool empty = cells.seq_rm(row, s);
+                it->second.erase(s);
+                if (empty != it->second.empty()) {
+                    printf("FAIL [fuzz-consistency] row=%u seq_rm returned %d, mirror left %zu\n", row, (int) empty, it->second.size());
+                    n_fail++;
+                }
+                if (it->second.empty()) {
+                    mirror.erase(it);
+                }
+            }
+
+            if (step % 97 == 0) {
+                check(cells, 64, "fuzz");
+            }
+        }
+        check(cells, 64, "fuzz-final");
+    }
+
+    printf("%s: %d lookups checked, %d failures\n", n_fail ? "FAILED" : "PASSED", n_checked, n_fail);
+    return n_fail ? 1 : 0;
+}


### PR DESCRIPTION
## Overview

While testing qwen4exp I noticed decode is cpu limited. Found get_prev_tokens() scans all used cells to resolve the n-gram predecessor tokens. This implements a TODO by @ngxson from llama_kv_cache::get_prev_tokens, mostly just to show the impact.

On my test HW with 2xL40s this PR achieves 2.7x speedup at 240k ctx.

## Additional information

llama_kv_cells now maintains a per-seq index of cell rows per position (seq_pos: pos -> set<rows>) instead of refcount. Updated by the existing seq_pos_inc/dec, so add/remove/defrag/copy (memory_seq_cp) paths update it. Multimodal falls back to original scan.

There is a bit of debug/verification plumbing, using LLAMA_KV_PREV_TOKENS env: fast (default) | verify | off.

- verify runs both paths for every call and logs mismatches + a cost heartbeat; used to validate the index
- off just maintains index, its not used

Verify plumbing would be removed if this is the way. Test suite passed.

*This adds a small memory/cpu cost for every other model, while only qwen4exp is using it.*

measured (qwen4exp, 2xL40S, unified KV, 256k ctx):
| ctx | verify (≈stock) | fast | gain |
|---|---|---|---|
| 0       | 61.13 ± 1.66 | 61.12 ± 1.35 | 1.00× |
| 4096    | 57.11 ± 1.47 | 61.20 ± 1.95 | 1.07× |
| 16384   | 43.86 ± 0.88 | 55.59 ± 1.37 | 1.27× |
| 65536   | 24.00 ± 0.25 | 44.14 ± 0.93 | 1.84× |
| 131072  | 14.93 ± 0.12 | 34.99 ± 0.54 | 2.34× |
| 240000  |  8.92 ± 0.10 | 24.25 ± 0.38 | **2.72×** |

numbers from: llama-bench -hf "unsloth/Qwen3.8-Flash-Next-GGUF:UD-Q4_K_XL" -ngl 999 -fa 1 -p 0 -n 32 -fitt 128 -d 0,4096,16384,65536,131072,240000

Possibly related upstream work: #27941 (qsa correctness; likely fixes the 65535 gridDim.y abort at n_kv 262144), #27977 (shrinks the general scan constants + qsa gather windows). complementary; can be combined.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, debugging, tracing, coding possible solutions, verification, explanations using Qwen38-Next-Flash itself