### PR TITLE
convert_lora_to_gguf: support Qwen3.5/3.8 multimodal LoRA

### DIFF
--- a/convert_lora_to_gguf.py
+++ b/convert_lora_to_gguf.py
@@ -273,6 +273,12 @@ def get_base_tensor_name(lora_tensor_name: str) -> str:
     # models produced by mergekit-extract-lora have token embeddings in the adapter
     base_name = base_name.replace(".lora_embedding_A", ".weight")
     base_name = base_name.replace(".lora_embedding_B", ".weight")
+    # Multimodal conditional-generation bases (e.g. Qwen3_5ForConditionalGeneration)
+    # nest the language stack under `model.language_model.layers.N...`; the base
+    # converter strips `language_model.` (convert_hf_to_gguf.py). Without this
+    # strip the LoRA tensor names cannot be mapped and conversion fails with
+    # "Can not map tensor".
+    base_name = base_name.replace("model.language_model.", "model.")
     return base_name
 
 


### PR DESCRIPTION
## Overview

Fix `convert_lora_to_gguf.py` so a LoRA trained on a Qwen3.5/3.8 multimodal base (architecture `Qwen3_5ForConditionalGeneration`, e.g. `Qwen/Qwen3.8-27B`) converts to GGUF instead of failing.

The failure: `ValueError: Can not map tensor 'model.language_model.layers.11.self_attn.k_proj.weight'`

Root cause: multimodal conditional-generation bases nest the language stack under `model.language_model.layers.N...`. `get_base_tensor_name()` strips only `base_model.model.`, so the mapped name still has the `language_model.` segment, which the base tensor map does not recognize. The base converter (`convert_hf_to_gguf.py`) already strips `language_model.` when building the base GGUF; the LoRA converter never applies the same strip.

The change is one line in `get_base_tensor_name`:
```python
base_name = base_name.replace("model.language_model.", "model.")
```
It applies only to the exact prefix the base converter already strips. Dense (non-multimodal) models have no `language_model.` in their names, so they are unaffected.

## Additional information

Verified on `Qwen/Qwen3.8-27B`: a PEFT LoRA (r=16, attention projections only) with 128 tensors converts cleanly after the fix. Before the fix the same command fails with the error above. The adapter (F16 GGUF, 21MB, 128 tensors) loads and serves against the base.

Reproduction:
```
python convert_lora_to_gguf.py <adapter_dir> \
  --base /path/to/Qwen3.8-27B-HF --outfile out.gguf
```

## Requirements

- I have read and agree with the contributing guidelines.
- AI usage disclosure: YES. I diagnosed the root cause with assistance from an AI coding agent; the fix is a one-line tensor-name strip that I reviewed, tested, and own. Per AGENTS.md, I am responsible for this change and can discuss it independently.