### PR TITLE
Add sm70 FlashAttention config case for DKQ=256, DV=256, ncols=64

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -120,6 +120,8 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(576, 512, 32, 128, 2,  32, 160, 128,  64, 1, false);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(576, 512, 64, 256, 1,  32, 160, 128,  64, 1, false);
 
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 128, 2, 32, 128, 64, 128, 2, false);
+
     // TODO tune specifically for Volta
     return ggml_cuda_fattn_mma_get_config_ampere(DKQ, DV, ncols);
 }


### PR DESCRIPTION
## Overview
Added SM70 FlashAttention config improving performance around 20% based on the model. Previously the config for 256x256 head fell back onto the Ampere config which was suboptimal for SM70. 
```
Upstream fallback:
255 registers/thread
552 B stack

Edited FA config:
255 registers/thread
56 B stack
```
My goal was to optimize the Qwen 3.8 27B performance in agentic workflows and it uses the DKQ=256, DV=256, ncols=64 which configuration was suboptimal.  

To simulate agentic turn I used 100k cached KV tokens + 1024 PP and 512 TG. 

### Simulated Agentic Turn

repeats: 4

```bash
-d 100000 -pg 1024,512 
```
| Model | PP upstream | PP edited | PP Δ | TG upstream | TG edited | TG Δ |
|---|---:|---:|---:|---:|---:|---:|
| Qwen3.8 27B | 276.1 | 352.9 | **+27.84%** | 16.27 | 16.37 | +0.60% |
| Ornith 1.5 35B | 485.5 | 580.4 | **+19.54%** | 59.26 | 59.39 | +0.21% |
| Gemma 4 12B | 483.4 | 486.7 | **+0.67%** | 39.45 | 39.46 | +0.03% |

### Prompt Processing Scaling

repeats: 10
repeats for 100k PP: 5
| Model | KV depth | Upstream | Edited | Δ |
|---|---:|---:|---:|---:|
| Qwen3.8 | 100k | 275.18 | 349.18 | **+26.89%** |
| Qwen3.8 | 65k | 356.23 | 434.18 | **+21.88%** |
| Ornith + MMQ | 65k | 760.65 | 895.97 | **+17.79%** |
| Qwen3.8 | 16k | 609.02 | 657.61 | **+7.98%** |
| Ornith + MMQ | 16k | 1171.40 | 1238.42 | **+5.72%** |
| Qwen3.8 | 4k | 736.72 | 754.63 | **+2.43%** |

MMQ flag means adding `GGML_CUDA_FORCE_MMQ=ON` during compilation

| Model | pp512 | pp2048 | pp4096 |
|---|---:|---:|---:|
| Ornith 1.5 | 865 → 891 (**+2.94%**) | 840 → 872 (**+3.77%**) | 821 → 837 (**+2.00%**) |
| Gemma 4 | 1896 → 1918 (**+1.15%**) | 1831 → 1872 (**+2.22%**) | 1767 → 1810 (**+2.43%**) |
| Qwen3.8 | 897 → 899 (**+0.26%**) | 880 → 884 (**+0.46%**) | 856 → 867 (**+1.29%**) |

## Additional information
It would be good to test it on other SM70 gpus then just purely v100 tested here. 

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes, GPT-5.6 Sol. I was trying to optimize performance on Qwen 3.8 27B.  GPT 5.6 Sol was used during the performance exploration. 