### PR TITLE
dflash: pass missing NVFP4 scales to attention operations

### DIFF
--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -615,8 +615,8 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
         for (int il = 0; il < n_layer; ++il) {
             const auto & layer = model.layers[il];
 
-            ggml_tensor * Kcur = build_lora_mm(layer.wk, inp_g);
-            ggml_tensor * Vcur = build_lora_mm(layer.wv, inp_g);
+            ggml_tensor * Kcur = build_lora_mm(layer.wk, inp_g, layer.wk_s);
+            ggml_tensor * Vcur = build_lora_mm(layer.wv, inp_g, layer.wv_s);
 
             Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
             Vcur = ggml_reshape_3d(ctx0, Vcur, n_embd_head, n_head_kv, n_tokens);
@@ -698,9 +698,9 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
             cb(noise_norm, "attn_conv_in", il);
         }
 
-        ggml_tensor * Qcur = build_lora_mm(layer.wq, noise_norm);
-        ggml_tensor * Kcur = build_lora_mm(layer.wk, noise_norm);
-        ggml_tensor * Vcur = build_lora_mm(layer.wv, noise_norm);
+        ggml_tensor * Qcur = build_lora_mm(layer.wq, noise_norm, layer.wq_s);
+        ggml_tensor * Kcur = build_lora_mm(layer.wk, noise_norm, layer.wk_s);
+        ggml_tensor * Vcur = build_lora_mm(layer.wv, noise_norm, layer.wv_s);
 
         Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head,    n_tokens);
         Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
@@ -717,8 +717,8 @@ llama_model_dflash::graph<false>::graph(const llama_model & model, const llm_gra
 
         // cache-aware, non-causal attention
         ggml_tensor * cur = use_iswa
-            ? build_attn(inp_attn_iswa, layer.wo, NULL, NULL, Qcur, Kcur, Vcur, nullptr, layer.attn_sinks, nullptr, kq_scale, il)
-            : build_attn(inp_attn,      layer.wo, NULL, NULL, Qcur, Kcur, Vcur, nullptr, layer.attn_sinks, nullptr, kq_scale, il);
+            ? build_attn(inp_attn_iswa, layer.wo, NULL, layer.wo_s, Qcur, Kcur, Vcur, nullptr, layer.attn_sinks, nullptr, kq_scale, il)
+            : build_attn(inp_attn,      layer.wo, NULL, layer.wo_s, Qcur, Kcur, Vcur, nullptr, layer.attn_sinks, nullptr, kq_scale, il);
 
         if (attn_dynamic) {
             cur = build_dflash2_conv(*this, cur, attn_dynamic, layer.dflash_attn_conv_base, 1);


### PR DESCRIPTION
I tested the DFlash2 draft model provided by the https://huggingface.co/maurienne-ai/Qwen3.8-27B-DFlash2-NVFP4-RTNcal project. I found that the DFlash2 BF16 and Q8 versions performed normally, but the DFlash2 NVFP4 draft models produced almost no accepted speculative tokens because the Q, K, V, and output projection scales were not passed to the corresponding graph operations. I eventually traced the issue to a missing scale parameter pass in `dflash.cpp`; adding the missing code allowed it to compile and run correctly.

## Overview

Pass the missing NVFP4 weight scales to the DFlash graph operations:

- K and V projections in KV injection
- Q, K, and V projections in decoder attention
- Output projections in both attention paths

Without these scales, the NVFP4 draft model generated incorrect draft tokens, resulting in a near-zero acceptance rate and slower speculative decoding.

## Additional information

Benchmark configuration:

- GPU: NVIDIA GeForce RTX 5090
- Target model: Qwen3.8-27B-Q5_K_M
- Draft model: Qwen3.8-27b-DFlash2-NVFP4
- Full GPU offload and flash attention
- Greedy sampling with a fixed seed
- Maximum draft length: 7 tokens
- Single run with a fixed prompt

| Generated tokens | Master PR | Before acceptance | After Patch | After acceptance | DFlash improvement |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 128 | 34.4 t/s | 0.12% | 93.1 t/s | 36.33% | 2.71x |
| 512 | 35.7 t/s | 0.17% | 97.6 t/s | 25.59% | 2.73x |
| 1024 | 38.4 t/s | 0.39% | 119.0 t/s | 33.10% | 3.10x |

Compared with ordinary decoding from the patched build, DFlash achieved speedups of 1.65x, 1.62x, and 1.93x for 128, 512, and 1024 generated tokens, respectively.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Codex + Local Agent Tool

## Logs
Master PR(10689)
[master pr.txt](https://github.com/user-attachments/files/31608537/master.pr.txt)

Patched PR
[after_patch.txt](https://github.com/user-attachments/files/31608543/after_patch.txt)
