### PR TITLE
server : fall back to full prompt re-processing when memory rollback fails

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3414,7 +3414,19 @@ private:
 
                     SLT_TRC(slot, "cached n_tokens = %d, memory_seq_rm [%d, end)\n", slot.prompt.n_tokens(), p0);
 
-                    slot.mem.seq_rm(slot.id, p0, -1);
+                    // note: recurrent memories (e.g. hybrid models) can refuse to remove tokens
+                    // if the rollback exceeds the recurrent snapshot ring
+                    const bool rm_tgt = llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, p0, -1);
+                    const bool rm_dft = !ctx_dft || llama_memory_seq_rm(llama_get_memory(ctx_dft), slot.id, p0, -1);
+                    if (!rm_tgt || !rm_dft) {
+                        // the cached prefix can no longer be used - clear the sequence and re-process the full prompt
+                        SLT_WRN(slot, "memory could not roll back to pos %d - clearing the sequence and re-processing the full prompt\n", p0);
+                        llama_memory_seq_rm(llama_get_memory(ctx_tgt), slot.id, -1, -1);
+                        if (ctx_dft) {
+                            llama_memory_seq_rm(llama_get_memory(ctx_dft), slot.id, -1, -1);
+                        }
+                        slot.prompt.tokens.keep_first(0);
+                    }
 
                     // If using an alora, there may be uncached tokens that come
                     // before the invocation sequence. When this happens, the


### PR DESCRIPTION
Recurrent memories (e.g. hybrid models) can refuse to remove tokens when the rollback exceeds the recurrent snapshot ring. The result of the removal was ignored, which either aborted the process via `common_context_seq_rm`, or left the slot with a stale recurrent state and a truncated token list.

Check the `seq_rm` result and, on failure, clear the sequence and re-process the full prompt.

Fixes #27931

## Overview

On hybrid models with recurrent state (e.g. qwen3_5_moe: Gated DeltaNet layers + attention), `llama_memory_recurrent::seq_rm` refuses a partial rollback when the rollback distance exceeds the recurrent snapshot ring (`n_rs_seq`, 0 by default). At the server prompt-processing site the boolean result of `slot.mem.seq_rm(slot.id, p0, -1)` was discarded:

- `common_memory::seq_rm` routes through `common_context_seq_rm`, which calls `GGML_ABORT` on the refusal, so the server process dies (fail-fast, 0xc0000409 on Windows).
- When the refusal is not surfaced, the KV cache and the recurrent memory disagree with the truncated token list: the slot continues on a stale recurrent state (silent quality degradation, the `find_slot: non-consecutive token position` warning storm) and with some batch geometries the process eventually crashes.

Note that `llama_memory_hybrid::seq_rm` short-circuits: when the recurrent part refuses, the KV part is not truncated either, so after a refusal the whole cached prefix is unusable. A full re-process is the only sound fallback.

This PR checks the `seq_rm` result at the prompt truncation site and, on failure, clears the sequence (`seq_rm(seq_id, -1, -1)`, which recurrent memories always support) and resets the cached token list, so the slot re-processes the full prompt. This mirrors the existing "forcing full prompt re-processing" policy the server already applies for SWA/hybrid memories. The draft context is covered as well when speculative decoding is enabled.

## Additional information

- Testing: existing server suites pass (built on current master, CUDA): test_basic (7), test_completion (38), test_chat_completion + test_ctx_shift (57), test_slot_save + test_speculative (17), test_stream + test_kv_keep_only_active + test_ignore_eos + test_tokenize + test_infill (17). Total 136 passed, 0 failed.
- Manual validation with a 35B qwen3_5_moe hybrid + mmproj model on 2 GPUs (`--split-mode tensor`), which is the configuration that reproduces the abort/stale state: multi-turn chat with alternating text/image turns, prompt-prefix divergence (edited history), identical-prompt retries and slot save/restore all complete without crashes and without `non-consecutive token position` warnings. Before the change the same workload deterministically aborted the server.
- A minimal CI repro is not practical: it requires a hybrid recurrent model with an mmproj projector (multi-GB), so no new test was added; happy to add one if maintainers can point at a suitable tiny model.
- Reproduction details and analysis: #27931.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used an AI coding agent (opencode with GLM) to analyze the crash and prepare the fix; the change was reviewed and submitted by me (see `Assisted-by:` in the commit)