### PR TITLE
server: preserve prompt cache across sleep

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3825,6 +3825,13 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples({LLAMA_EXAMPLE_SERVER}));
     add_opt(common_arg(
+        {"--sleep-preserve-cache"},
+        string_format("save idle slot states to the prompt cache before sleeping, and restore them after waking up (default: %s)", params.sleep_preserve_cache ? "enabled" : "disabled"),
+        [](common_params & params) {
+            params.sleep_preserve_cache = true;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"--simple-io"},
         "use basic IO for better compatibility in subprocesses and limited consoles",
         [](common_params & params) {

--- a/common/common.h
+++ b/common/common.h
@@ -650,6 +650,7 @@ struct common_params {
     int enable_reasoning = -1; // -1 = auto, 0 = disable, 1 = enable
     bool prefill_assistant = true; // if true, any trailing assistant message will be prefilled into the response
     int sleep_idle_seconds = -1;   // if >0, server will sleep after this many seconds of idle time
+    bool sleep_preserve_cache = false; // save slot states to the prompt cache before sleeping, and restore them on wake
 
     std::vector<std::string> api_keys;
 

--- a/src/llama-kv-cache-iswa.cpp
+++ b/src/llama-kv-cache-iswa.cpp
@@ -102,7 +102,7 @@ llama_kv_cache_iswa::llama_kv_cache_iswa(
     kv_swa = std::make_unique<llama_kv_cache>(
             model, hparams, type_k, type_v,
             v_trans, offload, unified, size_swa, n_seq_max, n_pad,
-            hparams.n_swa, hparams.swa_type, mem_other_swa, filter_swa, reuse, share);
+            hparams.n_swa, hparams.swa_type, mem_other_swa, filter_swa, reuse, share, swa_full);
 }
 
 void llama_kv_cache_iswa::clear(bool data) {

--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -80,9 +80,10 @@ llama_kv_cache::llama_kv_cache(
     const layer_filter_cb & filter,
     const  layer_reuse_cb & reuse,
     const  layer_share_cb & share,
+             bool   swa_full,
              const char *   name_tag) :
     model(model), hparams(hparams), v_trans(v_trans),
-    n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa), swa_type(swa_type),
+    n_seq_max(n_seq_max), n_stream(unified ? 1 : n_seq_max), n_pad(n_pad), n_swa(n_swa), swa_type(swa_type), swa_full(swa_full),
     other(static_cast<llama_kv_cache *>(mem_other)),
     v_cells_impl(other ? other->v_cells_impl : std::make_shared<llama_kv_cells_vec>()),
     v_cells(*v_cells_impl) {
@@ -2119,7 +2120,8 @@ void llama_kv_cache::state_write(llama_io_write_i & io, llama_seq_id seq_id, lla
             add_cell = add_cell && (seq_id == -1 || cells.seq_has(i, seq_id));
 
             // check the cell is not SWA-masked
-            if (add_cell && seq_id != -1) {
+            // note: with a full-size SWA cache the masked cells are retained, so save them too
+            if (add_cell && seq_id != -1 && !swa_full) {
                 const bool is_masked = llama_hparams::is_masked_swa(n_swa, swa_type, cells.pos_get(i), cells.seq_pos_max(seq_id));
 
                 add_cell = !is_masked;

--- a/src/llama-kv-cache.h
+++ b/src/llama-kv-cache.h
@@ -113,6 +113,8 @@ public:
         const layer_filter_cb & filter,
         const  layer_reuse_cb & reuse,
         const  layer_share_cb & share,
+        // full-size SWA cache: masked cells are retained, so they can be saved in the seq state
+                     bool   swa_full = false,
         // a model can hold more than one cache, so the tensor names have to stay unique
                  const char *   name_tag = "");
 
@@ -269,6 +271,9 @@ private:
 
     // SWA
     const uint32_t n_swa = 0;
+
+    // full-size SWA cache: never evicts SWA-masked cells (see llama_kv_cache_iswa)
+    const bool swa_full = false;
 
     // env: LLAMA_ATTN_ROT_DISABLE
     bool attn_rot_k = false;

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -2074,6 +2074,8 @@ The server supports an automatic sleep mode that activates after a specified per
 
 When the server enters sleep mode, the model and its associated memory (including the KV cache) are unloaded from RAM to conserve resources. Any new incoming task will automatically trigger the model to reload.
 
+Starting with `--sleep-preserve-cache`, idle slots are saved to the prompt cache before sleeping (requires `--cache-ram`, which is enabled by default), so cached prompts are reused after waking up instead of being reprocessed. The flag is disabled by default.
+
 The sleeping status can be retrieved from the `GET /props` endpoint (or `/props?model=(model_name)` in router mode).
 
 Note that the following endpoints are exempt from being considered as incoming tasks. They do not trigger model reloading and do not reset the idle timer:

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -306,6 +306,10 @@ struct server_slot {
 
         const size_t cur_size = cur_size_tgt + cur_size_dft;
 
+        if (cur_size == 0) {
+            return false;
+        }
+
         SRV_TRC(" - saving prompt with length %d, total state size = %.3f MiB (draft: %.3f MiB)\n",
                 (int) prompt.tokens.size(), cur_size / (1024.0 * 1024.0), cur_size_dft / (1024.0 * 1024.0));
 
@@ -314,9 +318,13 @@ struct server_slot {
             return false;
         }
 
-        llama_state_seq_get_data_ext(ctx_tgt, cur->data.main.data(), cur_size_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
-        if (ctx_dft) {
-            llama_state_seq_get_data_ext(ctx_dft, cur->data.drft.data(), cur_size_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+        if (cur_size_tgt > 0 && llama_state_seq_get_data_ext(ctx_tgt, cur->data.main.data(), cur_size_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE) != cur_size_tgt) {
+            prompt_cache.states.erase(std::prev(prompt_cache.states.end()));
+            return false;
+        }
+        if (ctx_dft && cur_size_dft > 0 && llama_state_seq_get_data_ext(ctx_dft, cur->data.drft.data(), cur_size_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE) != cur_size_dft) {
+            prompt_cache.states.erase(std::prev(prompt_cache.states.end()));
+            return false;
         }
 
         return true;
@@ -959,6 +967,17 @@ private:
                 // note: for sleeping == false, event is emitted by load_model()
             }
             SRV_INF("%s", "server is entering sleeping state\n");
+
+            // save idle slot states to the prompt cache, so they survive the reload after sleeping
+            if (prompt_cache && params_base.sleep_preserve_cache && params_base.cache_idle_slots) {
+                for (auto & slot : slots) {
+                    if (!slot.is_processing()) {
+                        slot.prompt_save(*prompt_cache);
+                    }
+                }
+                prompt_cache->update();
+            }
+
             destroy();
         } else {
             SRV_INF("%s", "server is exiting sleeping state\n");
@@ -1356,7 +1375,10 @@ private:
             }
             SRV_TRC("%s", "use `--cache-ram 0` to disable the prompt cache\n");
 
-            prompt_cache = std::make_unique<server_prompt_cache>(params_base.cache_ram_mib, n_ctx);
+            // keep existing states when resuming from sleeping with cache preservation enabled
+            if (!prompt_cache || !params_base.sleep_preserve_cache) {
+                prompt_cache = std::make_unique<server_prompt_cache>(params_base.cache_ram_mib, n_ctx);
+            }
         } else {
             SRV_TRC("%s", "prompt cache is disabled - use `--cache-ram N` to enable it\n");
         }


### PR DESCRIPTION
## Overview
Two commits:
1. Adds an option "--sleep-preserve-cache" to preserve prompt cache across model sleep after idle. Off by default
2. Fix save/restore of SWA model prompt cache, validated with gemma 4 models. 

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes, I agree
- AI usage disclosure: YES, used for diagnosing the issue and suggesting a fix. Code was reviewed manually