### PR TITLE
llama-tts: default context size to 4096

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1402,6 +1402,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         params.parse_special = true; // parse special tokens by default, like the old tokenize tool
     } else if (ex == LLAMA_EXAMPLE_TTS) {
         params.out_file = "output.wav";
+        params.n_ctx = 4096;
         params.sampling.penalty_repeat = 1.05f;
         params.sampling.penalty_last_n = -1;
     }

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -172,6 +172,39 @@ static void test(void) {
 
     std::vector<std::string> argv;
 
+    {
+        common_params tts_params;
+
+        argv = {
+            "binary_name",
+            "-m", "dummy-model.gguf",
+            "-mm", "dummy-mmproj.gguf",
+        };
+        assert(true == common_params_parse(
+                argv.size(),
+                list_str_to_char(argv).data(),
+                tts_params,
+                LLAMA_EXAMPLE_TTS));
+        assert(tts_params.n_ctx == 4096);
+    }
+
+    {
+        common_params tts_params;
+
+        argv = {
+            "binary_name",
+            "-m", "dummy-model.gguf",
+            "-mm", "dummy-mmproj.gguf",
+            "-c", "8192",
+        };
+        assert(true == common_params_parse(
+                argv.size(),
+                list_str_to_char(argv).data(),
+                tts_params,
+                LLAMA_EXAMPLE_TTS));
+        assert(tts_params.n_ctx == 8192);
+    }
+
     printf("test-arg-parser: test invalid usage\n\n");
 
     // missing value


### PR DESCRIPTION
## Overview

Sets the default context size for `llama-tts` to 4096 instead of inheriting the model's full context size.

With Qwen3-TTS, the current `n_ctx = 0` default can result in allocating the full 32768-cell KV cache. Setting the TTS-specific default to 4096 avoids this unnecessary allocation while still allowing users to override it with `-c` or request the model's full context with `-c 0`.

Adds parser tests verifying both the 4096 TTS default and an explicit `-c 8192` override.

Fixes #27937.

## Additional information

Verified locally:

- `test-arg-parser`: all tests OK
- `llama-tts --help` reports `--ctx-size` default as 4096

PocketTTS currently uses `max_position_embeddings = 4096`, so this default is also consistent with its existing context bound.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to assist with source-code investigation, implementation discussion, and test drafting. I reviewed and tested the submitted changes locally.