### PR TITLE
opencl: fix missing element squaring in RMSNorm

### DIFF
--- a/ggml/src/ggml-opencl/kernels/rms_norm.cl
+++ b/ggml/src/ggml-opencl/kernels/rms_norm.cl
@@ -73,7 +73,7 @@ kernel void kernel_rms_norm(
     }
     if (get_local_id(0) == 0) {
         for (int i = 4 * (ne00 / 4); i < ne00; i++) {
-            sum[0] += x_scalar[i];
+            sum[0] += x_scalar[i] * x_scalar[i];
         }
         sum[0] /= ne00;
     }


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Fix a scalar remainder bug in OpenCL `rms_norm.cl`.
When `ne00 % 4 != 0`, the kernel falls back to a scalar loop for the remaining elements (`ne00 % 4`). While the main vectorized loop correctly accumulates squared values (`x * x`) for the mean square computation, the scalar fallback loop was missing the square operation and accumulated `x_scalar[i]` directly.

This PR updates the scalar path to accumulate `x_scalar[i] * x_scalar[i]`, ensuring consistent mean square computation across all elements.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
- Affected file: `ggml/src/ggml-opencl/kernels/rms_norm.cl`
- When `ne00` is not a multiple of 4, leftover elements must be squared before summation to compute the correct mean square.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES<!-- mention: YES / NO - if yes, describe how AI was used -->
    - Draft Translation (GPT-5.6 Sol)

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
