### PR TITLE
Fix off-by-one validation for full-device tensor splits

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2859,7 +2859,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             const std::regex regex{ R"([,/]+)" };
             std::sregex_token_iterator it{ arg_next.begin(), arg_next.end(), regex, -1 };
             std::vector<std::string> split_arg{ it, {} };
-            if (split_arg.size() >= llama_max_devices()) {
+            if (split_arg.size() > llama_max_devices()) {
                 throw std::invalid_argument(
                     string_format("got %zu input configs, but system only has %zu devices", split_arg.size(), llama_max_devices())
                 );
@@ -2925,7 +2925,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
             const std::regex regex{ R"([,/]+)" };
             std::sregex_token_iterator it{ arg_next.begin(), arg_next.end(), regex, -1 };
             std::vector<std::string> split_arg{ it, {} };
-            if (split_arg.size() >= llama_max_devices()) {
+            if (split_arg.size() > llama_max_devices()) {
                 throw std::invalid_argument(
                     string_format("got %zu input configs, but system only has %zu devices", split_arg.size(), llama_max_devices())
                 );

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -229,6 +229,22 @@ static void test(void) {
     argv = {"binary_name", "-lm", "hello"};
     assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
 
+    {
+        std::string ts_values;
+        for (size_t i = 0; i <= llama_max_devices(); i++) {
+            ts_values += std::to_string(i + 1);
+            if (i < llama_max_devices()) {
+                ts_values += ",";
+            }
+        }
+        common_params ts_params;
+        argv = {"binary_name", "-m", "model.gguf", "-ts", ts_values};
+        assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), ts_params, LLAMA_EXAMPLE_COMMON));
+
+        argv = {"binary_name", "-m", "model.gguf", "--fit-target", ts_values};
+        assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), ts_params, LLAMA_EXAMPLE_COMMON));
+    }
+
     printf("test-arg-parser: test valid usage\n\n");
 
     argv = {"binary_name", "-m", "model_file.gguf"};
@@ -293,6 +309,29 @@ static void test(void) {
     argv = {"binary_name", "-lm", "dio"};
     assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
     assert(params.load_mode == LLAMA_LOAD_MODE_DIRECT_IO);
+
+    {
+        std::string ts_values;
+        for (size_t i = 0; i < llama_max_devices(); i++) {
+            ts_values += std::to_string(i + 1);
+            if (i + 1 < llama_max_devices()) {
+                ts_values += ",";
+            }
+        }
+        common_params ts_params;
+        argv = {"binary_name", "-m", "model.gguf", "-ts", ts_values};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), ts_params, LLAMA_EXAMPLE_COMMON));
+        for (size_t i = 0; i < llama_max_devices(); i++) {
+            assert(ts_params.tensor_split[i] == float(i + 1));
+        }
+
+        common_params fit_params;
+        argv = {"binary_name", "-m", "model.gguf", "--fit-target", ts_values};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), fit_params, LLAMA_EXAMPLE_COMMON));
+        for (size_t i = 0; i < llama_max_devices(); i++) {
+            assert(fit_params.fit_params_target[i] == size_t(i + 1) * 1024 * 1024);
+        }
+    }
 
     // multi-value args (CSV)
     argv = {"binary_name", "--lora", "file1.gguf,\"file2,2.gguf\",\"file3\"\"3\"\".gguf\",file4\".gguf"};


### PR DESCRIPTION
## Overview

Allow tensor-split and fit-target lists with exactly one value per supported device. The previous validation rejected valid full-device lists; this adds coverage for valid N-value input, invalid N+1 input, and fit-target conversion.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: NO