### PR TITLE
hexagon: fix CPY fence bug

### DIFF
--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -330,7 +330,7 @@ int op_cpy(struct htp_ops_context * octx) {
     }
 
     const struct htp_tensor *sync = octx->src[1];
-    if (sync) {
+    if (sync && (sync->flags & HTP_TENSOR_FENCE)) {
         if (!use_dma) {
             // htp_tensor_flush_all(octx->ctx, octx->dsts, 1);
             qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);


### PR DESCRIPTION
## Overview

On Hexagon backend, for normal CPY, `op_cpy()` treats any non-null `src[1]` as a synchronization fence and stores the fence sequence into the first four bytes of `src[1]`. This corrupts the ordinary CPY destination.

This PR adds a condition to limit the atomic fence store to only the explicit fence tensor with `HTP_TENSOR_FENCE` flag.

## Additional information

Test on Hexagon v81 with `test-backend-ops` shows that the normal CPY case is fixed. The test command is:

`test-backend-ops test -b HTP0 -o CPY`

|  | Passed | Failed |
| --- | --- | --- |
| Before | 0 | 134 |
| After | 134 | 0 |

<details>
<summary>Failed Test Case Example</summary>

`test-backend-ops test -b HTP0 -o 'CPY(type_src=f32,type_dst=f32,ne_src=[256,4,3,1],permute_src=[0,0,0,0],permute_dst=[0,0,0,0],_src_transpose=1)' -j 1`

```
ggml_opencl: selected platform: 'QUALCOMM Snapdragon(TM)'

ggml_opencl: device: 'QUALCOMM Adreno(TM) 840 (OpenCL 3.0 Adreno(TM) 840)'
ggml_opencl: default device: 'QUALCOMM Adreno(TM) 840 (OpenCL 3.0 Adreno(TM) 840)'
ggml-hex: Loading driver libcdsprpc.so
ggml-hex: FASTRPC_GET_DOMAINS[0]: type 1 id 1000 name 'nsp1000' status 1 instance-id 0
ggml-hex: using CDSP domain: instance-id 0 id 1000 name 'nsp1000'
ggml-hex: Hexagon backend (experimental) : allocating new registry : ndev 1
ggml-hex: Hexagon Arch version v81
ggml-hex: HTP0 allocating new session
ggml-hex: HTP0 hwinfo: threads 8, hvx 8, hmx 1, vtcm 8 MB
ggml-hex: HTP0 new session : session-id 0 domain-id 100000 uri file:///libggml-htp-v81.so?htp_iface_skel_handle_invoke&_modver=1.0&_dom=nsp1000&_session=0 handle 0xb4000070205c1a40
ggml-hex: HTP0 op batching: n-bufs 16 n-tensors 8192 n-ops 1024 vmem 3355443200
Testing 3 devices

Backend 1/3: GPUOpenCL
  Skipping
Backend 2/3: HTP0
  Device description: Hexagon
  Device memory: 0 MB (0 MB free)

[CPY] ERR = 0.000563718 > 0.000000000   CPY(type_src=f32,type_dst=f32,ne_src=[256,4,3,1],permute_src=[0,0,0,0],permute_dst=[0,0,0,0],_src_transpose=1): FAIL
  0/1 tests passed

Failing tests:
  CPY(type_src=f32,type_dst=f32,ne_src=[256,4,3,1],permute_src=[0,0,0,0],permute_dst=[0,0,0,0],_src_transpose=1)
  Backend HTP0: FAIL
Backend 3/3: CPU
  Skipping
2/3 backends passed
FAIL
```

</details>


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, this bug was found and analyzed by AI. I have run the tests, and I am responsible for all submitted changes.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
