### PR TITLE
cuda : fail gracefully when CUDA pool allocation fails during graph compute

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -5,6 +5,7 @@
 #include "ggml-cuda.h"
 
 #include <cstdint>
+#include <exception>
 #include <cstdlib>
 #include <memory>
 #include <mutex>
@@ -1164,6 +1165,12 @@ const ggml_cuda_device_info & ggml_cuda_info();
 void ggml_cuda_set_device(int device);
 int ggml_cuda_get_device();
 
+struct ggml_cuda_pool_alloc_failure : std::exception {
+    const char * what() const noexcept override {
+        return "ggml-cuda pool allocation failed: out of VRAM";
+    }
+};
+
 struct ggml_cuda_pool {
     virtual ~ggml_cuda_pool() = default;
 
@@ -1197,6 +1204,9 @@ struct ggml_cuda_pool_alloc {
         GGML_ASSERT(pool != nullptr);
         GGML_ASSERT(ptr == nullptr);
         ptr = (T *) pool->alloc(size * sizeof(T), &this->actual_size);
+        if (ptr == nullptr) {
+            throw ggml_cuda_pool_alloc_failure();
+        }
         return ptr;
     }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -506,7 +506,11 @@ struct ggml_cuda_pool_leg : public ggml_cuda_pool {
                 GGML_LOG_DEBUG(GGML_CUDA_NAME " pool[%d]: retry succeeded\n", device);
             }
         }
-        CUDA_CHECK(err);
+        if (err != cudaSuccess) {
+            // out of VRAM: fail gracefully (return nullptr) instead of aborting the
+            // process, so the caller can propagate GGML_STATUS_ALLOC_FAILED
+            return nullptr;
+        }
         *actual_size = look_ahead_size;
         pool_size += look_ahead_size;
 #ifdef DEBUG_CUDA_MALLOC
@@ -587,7 +591,11 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
             prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
             prop.location.id = physical_device;
             CUmemGenericAllocationHandle handle;
-            CU_CHECK(cuMemCreate(&handle, reserve_size, &prop, 0));
+            if (cuMemCreate(&handle, reserve_size, &prop, 0) != CUDA_SUCCESS) {
+                // out of VRAM: fail gracefully (return nullptr) instead of aborting the
+                // process, so the caller can propagate GGML_STATUS_ALLOC_FAILED
+                return nullptr;
+            }
 
             // reserve virtual address space (if not already reserved)
             if (pool_addr == 0) {
@@ -4308,7 +4316,24 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
         CUDA_CHECK(cudaStreamBeginCapture(cuda_ctx->stream(), cudaStreamCaptureModeRelaxed));
     }
 
-    ggml_cuda_graph_evaluate_and_capture(cuda_ctx, cgraph, use_cuda_graph, cuda_graph_update_required, graph_key);
+    try {
+        ggml_cuda_graph_evaluate_and_capture(cuda_ctx, cgraph, use_cuda_graph, cuda_graph_update_required, graph_key);
+    } catch (const ggml_cuda_pool_alloc_failure &) {
+        // the pool ran out of VRAM: unwind any in-flight capture and report the failure
+        // instead of aborting the whole process
+        cudaStream_t stream = cuda_ctx->stream();
+        cudaStreamCaptureStatus capture_status = cudaStreamCaptureStatusNone;
+        cudaStreamIsCapturing(stream, &capture_status);
+        if (capture_status != cudaStreamCaptureStatusNone) {
+            cudaGraph_t captured_graph = nullptr;
+            cudaError_t err = cudaStreamEndCapture(stream, &captured_graph);
+            if (err == cudaSuccess && captured_graph != nullptr) {
+                cudaGraphDestroy(captured_graph);
+            }
+        }
+        GGML_LOG_ERROR("%s: CUDA pool allocation failed (out of VRAM), failing graph compute\n", __func__);
+        return GGML_STATUS_ALLOC_FAILED;
+    }
 
     return GGML_STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Overview

CUDA pool allocation can fail at runtime even when the model loads fine
(e.g. the QSA top-k CUB argsort workspace at high context). Before this PR,
that failure aborted the whole server process.

This PR changes that into a per-request error: pool allocation failures now
return an error, graph compute returns GGML_STATUS_ALLOC_FAILED, and
llama-server answers the request with HTTP 500 while the server keeps running.

Repro on 3x RTX 3090 (72GB), Qwen3.8-Flash-Next-UD-Q3_K_XL, ctx 192K:
- before: model loads, a 16-token request works, a 20K-token fill kills the
  server in ~5s (cuMemCreate OOM)
- after: same request returns HTTP 500, server stays up

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes
- I have tested the changes on CUDA (3x RTX 3090, sm_86, CUDA 12.0)

## Additional information

Files: ggml/src/ggml-cuda/ggml-cuda.cu, ggml/src/ggml-cuda/common.cuh.
Related: #27871, #24718.