### PR TITLE
Add per-entry prompt-cache context limit

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1718,6 +1718,16 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_CACHE_RAM").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
+        {"-kvcpc", "--kv-cache-prompt-context"}, "N",
+        "maximum context length of an individual prompt-cache entry (-1 = legacy aggregate limit, 0 = effective slot context, >0 = per-entry limit)",
+        [](common_params & params, int value) {
+            if (value < -1) {
+                throw std::invalid_argument("kv-cache-prompt-context must be -1 or non-negative");
+            }
+            params.prompt_cache_max_tokens = value;
+        }
+    ).set_env("LLAMA_ARG_KV_CACHE_PROMPT_CONTEXT").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-kvu", "--kv-unified"},
         {"-no-kvu", "--no-kv-unified"},
         "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",

--- a/common/common.h
+++ b/common/common.h
@@ -630,6 +630,7 @@ struct common_params {
     int32_t kv_unified_per_slot = 0;     // max context per parallel slot; 0 = unset
     int32_t checkpoint_min_step = 8192;  // minimum spacing between context checkpoints
     int32_t cache_ram_mib       = 8192;  // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
+    int32_t prompt_cache_max_tokens = -1; // -1 = legacy aggregate limit, 0 = effective slot context, >0 = per-entry limit
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -167,6 +167,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-ctxcp, --ctx-checkpoints, --swa-checkpoints N` | max number of context checkpoints to create per slot (default: 32)[(more info)](https://github.com/ggml-org/llama.cpp/pull/15293)<br/>(env: LLAMA_ARG_CTX_CHECKPOINTS) |
 | `-cms, --checkpoint-min-step N` | minimum spacing between context checkpoints in tokens (default: 8192, 0 = no minimum)<br/>(env: LLAMA_ARG_CHECKPOINT_MIN_SPACING_NT) |
 | `-cram, --cache-ram N` | set the maximum cache size in MiB (default: 8192, -1 - no limit, 0 - disable)[(more info)](https://github.com/ggml-org/llama.cpp/pull/16391)<br/>(env: LLAMA_ARG_CACHE_RAM) |
+| `-kvcpc, --kv-cache-prompt-context N` | maximum number of tokens in each prompt-cache entry; `-1` keeps the legacy aggregate token limit, `0` uses the effective context available to one server slot, and a positive value sets an explicit per-entry limit<br/>(env: LLAMA_ARG_KV_CACHE_PROMPT_CONTEXT) |
 | `-kvu, --kv-unified, -no-kvu, --no-kv-unified` | use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)<br/>(env: LLAMA_ARG_KV_UNIFIED) |
 | `--cache-idle-slots, --no-cache-idle-slots` | save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires cache-ram)<br/>(env: LLAMA_ARG_CACHE_IDLE_SLOTS) |
 | `--context-shift, --no-context-shift` | whether to use context shift on infinite text generation (default: disabled)<br/>(env: LLAMA_ARG_CONTEXT_SHIFT) |

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1356,7 +1356,14 @@ private:
             }
             SRV_TRC("%s", "use `--cache-ram 0` to disable the prompt cache\n");
 
-            prompt_cache = std::make_unique<server_prompt_cache>(params_base.cache_ram_mib, n_ctx);
+            const bool limit_tokens_per_entry = params_base.prompt_cache_max_tokens >= 0;
+            const size_t prompt_cache_max_tokens = params_base.prompt_cache_max_tokens == 0
+                ? static_cast<size_t>(n_ctx_slot())
+                : params_base.prompt_cache_max_tokens > 0
+                    ? static_cast<size_t>(params_base.prompt_cache_max_tokens)
+                    : static_cast<size_t>(n_ctx);
+            prompt_cache = std::make_unique<server_prompt_cache>(
+                params_base.cache_ram_mib, prompt_cache_max_tokens, limit_tokens_per_entry);
         } else {
             SRV_TRC("%s", "prompt cache is disabled - use `--cache-ram N` to enable it\n");
         }

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -1709,6 +1709,12 @@ size_t server_prompt_cache::n_tokens() const {
 }
 
 server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & prompt, size_t state_size_tgt, size_t state_size_dft) {
+    if (limit_tokens_per_entry && limit_tokens > 0 && prompt.tokens.size() > limit_tokens) {
+        SRV_WRN(" - prompt cache entry has %zu tokens, exceeding per-entry limit of %zu tokens, skipping\n",
+                prompt.tokens.size(), limit_tokens);
+        return nullptr;
+    }
+
     // first check if the current state is contained fully in the cache
     for (auto it = states.begin(); it != states.end(); ++it) {
         const int cur_lcp_len = it->prompt.tokens.get_common_prefix(prompt.tokens);
@@ -1882,7 +1888,7 @@ void server_prompt_cache::update() {
     // dynamically increase the token limit if it can fit in the memory limit
     const size_t limit_tokens_cur = limit_size > 0 ? std::max<size_t>(limit_tokens, limit_size/size_per_token) : limit_tokens;
 
-    if (limit_tokens > 0) {
+    if (!limit_tokens_per_entry && limit_tokens > 0) {
         while (!states.empty() && n_tokens() > limit_tokens_cur) {
             SRV_WRN(" - cache token limit (%zu, est: %zu) reached, removing oldest entry (size = %.3f MiB)\n",
                     limit_tokens, limit_tokens_cur, states.front().size() / (1024.0 * 1024.0));

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -610,9 +610,10 @@ struct server_prompt_cache_state {
 };
 
 struct server_prompt_cache {
-    server_prompt_cache(int32_t limit_size_mib, size_t limit_tokens) {
+    server_prompt_cache(int32_t limit_size_mib, size_t limit_tokens, bool limit_tokens_per_entry) {
         this->limit_size   = 1024ull*1024ull*(limit_size_mib < 0 ? 0 : limit_size_mib);
         this->limit_tokens = limit_tokens;
+        this->limit_tokens_per_entry = limit_tokens_per_entry;
     }
 
     std::list<server_prompt_cache_state> states;
@@ -622,6 +623,8 @@ struct server_prompt_cache {
 
     // in tokens, 0 = no limit
     size_t limit_tokens = 0;
+    // if true, limit_tokens applies independently to each cache entry
+    bool limit_tokens_per_entry = false;
 
     size_t size() const;
 

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -113,6 +113,7 @@ class ServerProcess:
     media_path: str | None = None
     sleep_idle_seconds: int | None = None
     cache_ram: int | None = None
+    kv_cache_prompt_context: int | None = None
     no_cache_idle_slots: bool = False
     log_path: str | None = None
     ui_mcp_proxy: bool = False
@@ -278,6 +279,8 @@ class ServerProcess:
             server_args.extend(["--sleep-idle-seconds", self.sleep_idle_seconds])
         if self.cache_ram is not None:
             server_args.extend(["--cache-ram", self.cache_ram])
+        if self.kv_cache_prompt_context is not None:
+            server_args.extend(["--kv-cache-prompt-context", self.kv_cache_prompt_context])
         if self.no_cache_idle_slots:
             server_args.append("--no-cache-idle-slots")
         if self.ui_mcp_proxy:


### PR DESCRIPTION
## Overview

Add `-kvcpc N, --kv-cache-prompt-context N` to control how the token limit is applied to the RAM-backed prompt cache.

The current cache has an aggregate token limit derived from the server context. This can prevent multiple independent conversations from being retained even when the configured `--cache-ram` budget has not been reached.

This change adds an optional per-entry policy while preserving the existing behavior by default.

## Additional information

### Semantics

- `-kvcpc -1`: legacy behavior; token limit remains aggregate across the prompt-cache pool.
- `-kvcpc 0`: per-entry mode; use the **effective context available to one server slot/sequence**.
- `-kvcpc N`: per-entry mode; use `N` as the maximum tokens for each cache entry.

Values below `-1` are rejected.

## Why `0` uses the effective slot context

The implementation should not calculate this as `--ctx-size / --parallel` itself.

`llama-server` already obtains the actual slot context from the initialized llama context:

```cpp
int n_ctx_slot = llama_n_ctx_seq(ctx_tgt);
```

and assigns that value to `server_slot::n_ctx`.

`-kvcpc 0` reuses this already-calculated value. This is important because unified and non-unified KV configurations can have different per-sequence capacities. It also avoids duplicating context-sizing logic in the prompt-cache subsystem.

The option therefore means:

> cache no more tokens for one prompt than that prompt can actually use in one active server slot under the current configuration.

This does not modify the active context, KV allocation, slot count, or scheduling.

## Motivation

A practical use case is an agent harness in which one llama-server instance is used as a driver and can spawn independent sub-agents.

For example, a driver may have one conversation while three worker agents are active. The driver and workers can each have useful, independently reusable context. Their combined cached token count can nevertheless exceed the server's aggregate context-derived cache token limit.

With the existing behavior, the driver plus three workers can exhaust that aggregate token budget before the host-memory cache reaches its configured RAM budget. The result is cache eviction/misses and repeated prompt processing; in a harness this can cascade into failures when components assume their model context can remain cached.

The desired policy is instead:

```text
driver    <= effective slot context
worker 1  <= effective slot context
worker 2  <= effective slot context
worker 3  <= effective slot context
...
```

while:

```text
all cache entries combined <= --cache-ram
```

For systems deliberately provisioned with large system-memory capacity, this makes it possible to use that RAM as a large pool of independent prompt-cache entries rather than treating the configured context size as an aggregate cache-token budget.

## Compatibility

The default remains `-1`, so existing users retain the current cache policy.

## Scope

This only changes the host-memory prompt-cache admission/eviction policy.

It does not change:

- `--ctx-size`
- effective active slot context
- `n_ctx_per_seq`
- KV allocation
- `--parallel`
- unified/non-unified KV behavior
- slot scheduling
- prompt matching
- context shifting

## Tests

The test plan should include:

- reject `-kvcpc -2`;
- accept `-kvcpc -1`, `0`, and positive values;
- preserve aggregate eviction in legacy mode;
- allow multiple entries whose combined token count exceeds the per-entry limit in per-entry mode;
- accept an entry exactly at the per-entry limit;
- reject an entry above the per-entry limit;
- continue enforcing `--cache-ram` in per-entry mode;
- verify `-kvcpc 0` follows the actual `llama_n_ctx_seq(ctx_tgt)` value for both unified and non-unified KV configurations;
- verify an entry larger than the available RAM-cache budget cannot bypass the RAM limit.

## Memory caveat

`--cache-ram` is an internally accounted prompt-cache storage limit, not a hard guarantee that process RSS can never exceed that value. Backend allocations, checkpoints, multimodal state, allocator behavior, and concurrent restore/save activity can involve additional memory.

This option intentionally makes it possible to keep many large cache entries, so users should size `--cache-ram` according to the host memory they are willing to dedicate to the workload.

## Example

```text
llama-server \
    --ctx-size 131072 \
    --parallel 4 \
    --kv-unified \
    --cache-ram 98304 \
    --kv-cache-prompt-context 0
```

Here `0` does not mean `131072` by definition. It means "use whatever context capacity the initialized server gives one sequence." The cache can then retain multiple independent prompts until the aggregate cache RAM budget is reached.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI (Google AI mode, ChatGPT, and a local Qwen3.8-27B) helped diagnose the root cause and draft the patch and PR text; I directed the fix, reviewed and corrected the AI output, and I fully understand and take responsibility for all submitted changes.