### PR TITLE
llama : synchronize before mutating graph state in process_ubatch

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1344,15 +1344,17 @@ llm_graph_result * llama_context::process_ubatch(const llama_ubatch & ubatch, ll
     // in order to correctly reuse a graph, it's full topology has to be uniquely determined by these parameters
     const auto gparams = graph_params(res, ubatch, mctx, gtype);
 
+    // the previous graph_compute_async may still be running on the GPU. synchronize before
+    // mutating any graph state: set_inputs overwrites input tensors (k_idxs/v_idxs/kq_mask/...)
+    // that the in-flight compute may still be reading, and sched_reset/alloc_graph remap the
+    // compute buffers under it. this is not limited to pipeline parallelism: on integrated
+    // GPUs the device reads graph inputs zero-copy from pinned host memory, so an
+    // unsynchronized overwrite scatters in-flight K/V writes to wrong cells and leaves stale
+    // K/V visible under the new mask (observed cross-request KV-cache contamination).
+    ggml_backend_sched_synchronize(sched.get());
+
     if (!graph_reuse_disable && res->can_reuse(gparams)) {
         //LLAMA_LOG_DEBUG("%s: reusing previous graph\n", __func__);
-
-        // with pipeline parallelism, the previous graph_compute_async may still be running
-        // on the GPU. we must synchronize before set_inputs to avoid overwriting input tensors
-        // that the previous compute is still reading.
-        if (cparams.pipeline_parallel) {
-            ggml_backend_sched_synchronize(sched.get());
-        }
 
         n_reused++;
     } else {

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -202,6 +202,12 @@ bool llama_memory_recurrent::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos
                 }
                 return false;
             }
+            // a mid-range partial erase cannot be represented in a recurrent state - reject it,
+            // otherwise callers (e.g. --cache-reuse KV surgery) would assume the erase succeeded
+            // while the state still contains the removed tokens, leaking state across requests
+            if (0 < p1 && p1 <= cell.pos) {
+                return false;
+            }
             // invalidate tails which will be cleared
             if (p0 <= cell.pos && cell.pos < p1) {
                 tail_id = -1;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3199,8 +3199,13 @@ private:
 
                                 const auto n_cache_reuse = slot.task->params.n_cache_reuse;
 
+                                // the cache-reuse surgery below needs mid-range seq_rm in addition to seq_add:
+                                // recurrent/hybrid memories (types NO/FULL/RS) cannot represent a partial erase,
+                                // so the seq_rm would be a no-op and stale recurrent state would leak into the
+                                // new prompt positions - only pure attention contexts (type PART) qualify
                                 const bool can_cache_reuse =
                                     llama_memory_can_shift(llama_get_memory(ctx_tgt)) &&
+                                    ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_PART &&
                                     !slot.prompt.tokens.has_mtmd;
 
                                 if (!can_cache_reuse && n_cache_reuse > 0) {


### PR DESCRIPTION
Fixes #28056 (cross-request KV-cache contamination on integrated GPUs — full root-cause analysis and probe evidence there).

## What

Two commits:

1. **`llama : synchronize before mutating graph state in process_ubatch`** — the core fix. The sync before `set_inputs` was gated on `cparams.pipeline_parallel` (always false on a single GPU), and the graph-rebuild path (`sched_reset` + `alloc_graph`) had no sync at all. Since `graph_compute` is fire-and-forget (`ggml_backend_sched_graph_compute_async`) and prefill ubatches produce no outputs, `llama_decode` returns with compute still in flight and the next ubatch's `set_inputs` overwrites input tensors (`k_idxs`/`v_idxs`/`kq_mask`/…) the device is still reading. On integrated GPUs those inputs are read zero-copy from pinned host memory (no protective split-input copy like on dGPUs), so the race scatters in-flight K/V writes to wrong cells and leaves stale K/V from a previous request visible under the new request's mask. The fix makes the synchronize unconditional and hoists it above the `can_reuse` branch so it also covers the rebuild path.

2. **`server : do not cache-reuse on memories that cannot erase a mid-range`** — related hardening found while investigating. A recurrent state cannot represent a partial erase, but `llama_memory_recurrent::seq_rm` returned `true` for one while leaving the removed tokens in the state, so the `--cache-reuse` KV surgery appeared to succeed and stale recurrent state leaked into the new prompt positions on hybrid/recurrent models. This rejects the unrepresentable erase and gates `can_cache_reuse` on the context being pure attention (seq_rm type `PART`). Happy to split this into a separate PR if preferred.

## Verification

Reproducer (AMD gfx1151 APU / Strix Halo, HIP, Qwen3.6-35B-A3B hybrid, `llama-server -b 2048 -ub 2048 -fa on -np 1`, deterministic sampling): chat about a distinctive topic → send an unrelated ~21k-token document + questions. Before: 4/4 responses quote the chat verbatim, and per-cell K-cache hash probes show chat-era data scattered into the document's cell range while document chunks fail to land. After: 0/12 contaminated across 3 runs, and the probed cell shows the healthy trajectory (boot value through the chat era, document data lands at its chunk and stays put).

## Performance

Zero measured cost on the affected hardware — the async pipeline only queued deeper, the GPU was already saturated:

| metric | before | after |
|---|---|---|
| 21k-token prefill | 1230.8 t/s | 1231.8 t/s |
| 2k-token prefill | 957–970 t/s | 957–966 t/s |
| decode | 48.5 t/s | 48.4 t/s |

A conservative alternative would gate the sync on the integrated/zero-copy condition; unconditional measured free here and also covers any other configuration where graph inputs are device-visible without a copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
