### PR TITLE
server : enable gzip compression (zlib)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ option(LLAMA_TESTS_INSTALL "llama: install tests" ON)
 
 # 3rd party libs
 option(LLAMA_OPENSSL    "llama: use openssl to support HTTPS" ON)
+option(LLAMA_ZLIB       "llama: use zlib to support HTTP gzip compression" ON)
 option(LLAMA_SUBPROCESS "llama-common: use subprocess, required by server tools and server router mode" ${LLAMA_SUBPROCESS_DEFAULT})
 option(LLAMA_LLGUIDANCE "llama-common: include LLGuidance library for structured output in common utils" OFF)
 

--- a/tools/server/server-http.cpp
+++ b/tools/server/server-http.cpp
@@ -143,6 +143,11 @@ bool server_http_context::init(const common_params & params) {
     });
 
     srv->set_error_handler([](const httplib::Request &, httplib::Response & res) {
+        // a provider-backed response (e.g. proxied from a child server) already
+        // carries its error body; set_content() on top would conflict with it
+        if (res.content_provider_) {
+            return;
+        }
         if (res.status == 404) {
             res.set_content(
                 safe_json_to_str(json {

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -2483,6 +2483,17 @@ server_http_proxy::server_http_proxy(
                 msg.content_type = value;
                 continue;
             }
+            if (lowered == "content-encoding") {
+                // strip codings the httplib client already decoded; unknown
+                // codings pass through undecoded and keep the header
+                bool decoded = false;
+#ifdef CPPHTTPLIB_ZLIB_SUPPORT
+                decoded |= to_lower_copy(string_strip(value)) == "gzip";
+#endif
+                if (decoded) {
+                    continue;
+                }
+            }
             msg.headers[key] = value;
         }
         return msg;
@@ -2525,11 +2536,24 @@ server_http_proxy::server_http_proxy(
     {
         req.method = method;
         req.path = path;
+        // explicit identity: with the header absent, the httplib client injects
+        // its own default and transparently decompresses the response
+        req.set_header("Accept-Encoding", "identity");
         for (const auto & [key, value] : headers) {
             const auto lowered = to_lower_copy(key);
             if (lowered == "accept-encoding") {
-                // disable Accept-Encoding to avoid compressed responses
                 continue;
+            }
+            if (lowered == "content-encoding") {
+                // the httplib server already decoded the incoming body; forwarding
+                // the header with the plain body would make the child decode it again
+                bool decoded = false;
+#ifdef CPPHTTPLIB_ZLIB_SUPPORT
+                decoded |= to_lower_copy(string_strip(value)) == "gzip";
+#endif
+                if (decoded) {
+                    continue;
+                }
             }
             if (lowered == "transfer-encoding") {
                 // the body is already decoded

--- a/vendor/cpp-httplib/CMakeLists.txt
+++ b/vendor/cpp-httplib/CMakeLists.txt
@@ -37,6 +37,18 @@ target_compile_definitions(${TARGET} PRIVATE
     CPPHTTPLIB_TCP_NODELAY=1
 )
 
+if (LLAMA_ZLIB)
+    find_package(ZLIB)
+    if (ZLIB_FOUND)
+        message(STATUS "ZLIB found: ${ZLIB_VERSION_STRING}")
+        # PUBLIC: the define changes httplib.h declarations, so all consumers must agree
+        target_compile_definitions(${TARGET} PUBLIC CPPHTTPLIB_ZLIB_SUPPORT)
+        target_link_libraries(${TARGET} PUBLIC ZLIB::ZLIB)
+    else()
+        message(WARNING "ZLIB not found, HTTP gzip compression disabled")
+    endif()
+endif()
+
 set(OPENSSL_NO_ASM ON CACHE BOOL "Disable OpenSSL ASM code when building BoringSSL or LibreSSL")
 
 if (LLAMA_BUILD_BORINGSSL)


### PR DESCRIPTION
## Overview

Ref #27357 (gzip only, no brotli).

This adds a `LLAMA_ZLIB` CMake option (default ON, gracefully disabled when zlib is not found) that builds the vendored cpp-httplib with `CPPHTTPLIB_ZLIB_SUPPORT`. cpp-httplib already implements both directions:

- Requests with `Content-Encoding: gzip` are decompressed automatically (decompressed size capped by `CPPHTTPLIB_PAYLOAD_MAX_LENGTH`, 100MB).
  This helps us save a lot of traffic in long, multi-turn conversations or even multimodal message conversations on compression API requests.
- JSON responses are compressed per `Accept-Encoding` negotiation. SSE streaming is unaffected (`text/event-stream` is excluded by httplib).
- SSE streaming is unaffected (`text/event-stream` is excluded by httplib)

### The fix in cpp-httplib

Enabling zlib exposed a double-encoding bug in cpp-httplib: the web UI serves build-time-gzipped assets with `Content-Encoding: gzip` set by the handler, and httplib compresses them a second time (Safari renders raw gzip bytes). The patch skips compression when the handler already set `Content-Encoding`, deciding the coding once so headers and body agree.

I'm submitted this patch upstream (PR: https://github.com/yhirose/cpp-httplib/pull/2575, merged) and will keep this PR as a draft until ~~the upstream author agrees with the approach~~ the cpp-httplib released new version.

## Additional information

Validation:
- gzip request body on `/v1/chat/completions` (text + image): same 200 and identical `prompt_tokens` as the uncompressed request; the gzip request even hits the prompt cache populated by the plain one, confirming the decompressed bytes are byte-identical.
- Web UI loads correctly on Safari and Chrome (single `Content-Encoding` header, single gzip layer); `Accept-Encoding: gzip` on `/props` returns a compressed response; SSE streaming unaffected.

Possible follow-ups: compressing request bodies from the web UI, brotli.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, helped by Claude Code.