### PR TITLE
server : do not re-verify replayed draft tokens after a checkpoint restore

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -3884,12 +3884,25 @@ private:
                 common_sampler_ptr smpl_save(common_sampler_clone(slot.smpl.get()));
 
                 GGML_ASSERT(slot.spec_i_batch.size() == n_draft + 1);
-                const auto & synth_probs = common_speculative_get_synth_probs(spec.get());
-                auto accepted = synth_probs.empty()
-                    ? common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft)
-                    : server_sample_and_accept_synth(
-                            slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft,
-                            synth_probs, slot.spec_synth_rng, slot.spec_is_replay);
+                std::vector<llama_token> accepted;
+                if (slot.spec_is_replay) {
+                    // replayed tokens were accepted before the restore; re-verifying them can
+                    // disagree when logits depend on batch shape, and each disagreement restores
+                    // the same checkpoint again - the slot stops making progress
+                    accepted = slot.spec_draft;
+                    for (const llama_token id : accepted) {
+                        common_sampler_accept(slot.smpl.get(), id, true);
+                    }
+                    accepted.push_back(common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch.back()));
+                    common_sampler_accept(slot.smpl.get(), accepted.back(), true);
+                } else {
+                    const auto & synth_probs = common_speculative_get_synth_probs(spec.get());
+                    accepted = synth_probs.empty()
+                        ? common_sampler_sample_and_accept_n(slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft)
+                        : server_sample_and_accept_synth(
+                                slot.smpl.get(), slot.ctx_tgt, slot.spec_i_batch, slot.spec_draft,
+                                synth_probs, slot.spec_synth_rng, slot.spec_is_replay);
+                }
                 slot.spec_i_batch.clear();
 
                 GGML_ASSERT(accepted.size() >= 1);


### PR DESCRIPTION
Fixes #28060.

### What

With full-checkpoint rollback, a partial draft acceptance restores the pre-round state and re-decodes the accepted tokens to rebuild it. That replay currently runs through the same verification as a fresh draft. On backends where logits depend on batch shape or memory layout (Vulkan), the re-verification can reject a token the original verification accepted; the rejection restores the same checkpoint and replays again, and the slot loops on one position without emitting anything.

This accepts the replayed tokens without re-verifying, and samples only the continuation from the final position. The replayed prefix was already accepted by the verification that triggered the restore — the replay exists to rebuild state, not to re-decide.

### Credit

**The diagnosis and the patch are @Nathanw1014's**, from [`strix-halo-vulkan`](https://github.com/Nathanw1014/llama.cpp/commits/strix-halo-vulkan) commit [`9c5d899ff`](https://github.com/Nathanw1014/llama.cpp/commit/9c5d899ff), preserved here with authorship intact. I am submitting it because I hit the surrounding area while porting MTP onto current master and thought the fix should not stay on a fork. @Nathanw1014 — happy to close this if you would rather submit it yourself.

Symptom independently reported by @flobob45 in #27836.

### Conflict resolution

The commit does not apply to current master unchanged: master has since added the `synth_probs` sampling path, and the original also carried a `spec_dists` branch that master does not have (`spec_dists` has no references in `tools/server/`; `spec_is_replay` has 6). I kept master's `synth_probs` path, grafted on only the replay short-circuit, and dropped the `spec_dists` branch. That resolution is mine and is the part most worth reviewing.

### Testing

- Builds clean on `9723942` (Vulkan, `-DGGML_VULKAN=ON`).
- On an AMD Strix Halo (gfx1151) / RADV, running MTP speculative decoding on a tree carrying this fix: a 400-token generation at temp 1.0 / top-p 0.95 / top-k 20 completes in 26 s, with flat decode throughput across generation lengths of 50/100/200/400 tokens (18.32 / 15.01 / 15.92 / 15.61 tok/s) and 68-81% draft acceptance. No collapse.

**Not verified by me:** I have not reproduced the livelock on unmodified master — see the issue for why. The original author reports the change is bit-identical on CPU (800-token greedy pair, 118 restore rounds), which matches the expectation that only batch-shape-sensitive backends are affected. Reviewers with a CUDA or Metal setup that exercises checkpoint rollback may want to confirm no behaviour change there.
