### PR TITLE
vulkan: support TOP_K when k exceeds the workgroup limit

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -626,6 +626,8 @@ enum shader_reduction_mode {
 static constexpr uint32_t num_argsort_pipelines = 11;
 static constexpr uint32_t num_topk_moe_pipelines = 10;
 static constexpr uint32_t num_topk_pipelines = 11;
+// Row bound for the sort-the-whole-row TOP_K path; see ggml_backend_vk_device_supports_op.
+static constexpr int64_t  TOPK_LARGE_K_MAX_ROWS = 32;
 
 static constexpr std::initializer_list<ggml_op> topk_moe_early_softmax_norm{ GGML_OP_SOFT_MAX, GGML_OP_RESHAPE,  GGML_OP_ARGSORT,
                                                                              GGML_OP_VIEW,     GGML_OP_GET_ROWS, GGML_OP_RESHAPE,
@@ -13849,6 +13851,72 @@ static void ggml_vk_rope(ggml_backend_vk_context * ctx, vk_context& subctx, cons
         ggml_vk_make_rope_constants(cgraph->nodes[node_idx], src0, src2 != nullptr, backprop, set_rows_stride));
 }
 
+// Writes the full index permutation of each row of `src0_buf` into `out_buf`. `scratch` is
+// only read when the sort needs more than one workgroup, and must then hold 2*ncolsp2*nrows
+// ints. Split out of ggml_vk_argsort so ggml_vk_topk can reach it for k values that no
+// single workgroup can hold.
+static void ggml_vk_argsort_rows(ggml_backend_vk_context * ctx, vk_context& subctx,
+                                 vk_subbuffer src0_buf, vk_subbuffer out_buf, vk_subbuffer scratch,
+                                 uint32_t ncols, uint32_t nrows, uint32_t order) {
+    uint32_t ncols_pad_log2 = (uint32_t)ceilf(log2f(float(ncols)));
+    uint32_t ncolsp2 = 1 << ncols_pad_log2;
+
+    vk_op_argsort_push_constants pc { ncols, ncolsp2, ncols_pad_log2, nrows, order, 0, 0, 0, 0, };
+
+    uint32_t pipeline_idx = std::min(ncols_pad_log2, num_argsort_pipelines - 1);
+
+    bool use_small = ncols_pad_log2 <= ctx->device->max_workgroup_size_log2 &&
+                     ctx->device->pipeline_argsort_f32[pipeline_idx] != nullptr;
+
+    vk_pipeline pipeline = use_small ? ctx->device->pipeline_argsort_f32[pipeline_idx]
+                                     : ctx->device->pipeline_argsort_large_f32[pipeline_idx];
+
+    vk_subbuffer subbuf1 = use_small ? out_buf : scratch;
+
+    std::array<uint32_t, 3> elements;
+    elements[0] = ncolsp2;
+    elements[1] = std::min(nrows, ctx->device->properties.limits.maxComputeWorkGroupCount[1]);
+    elements[2] = 1;
+
+    // First dispatch initializes tmp_idx and does the first N passes where there is only
+    // communication between threads in the same workgroup.
+    {
+        vk_op_argsort_push_constants pc2 = pc;
+        pc2.outer_start = 0;
+        pc2.outer_end = std::min(ncols_pad_log2, ctx->device->max_workgroup_size_log2);
+        pc2.inner_start = 0;
+        pc2.inner_end = 100;
+        ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+        ggml_vk_dispatch_pipeline(ctx, subctx, pipeline, { src0_buf, subbuf1, out_buf }, pc2, elements);
+    }
+    if (!use_small) {
+        ggml_vk_sync_buffers(ctx, subctx);
+        // Loop over outer/inner passes, synchronizing between each pass.
+        for (uint32_t outer = ctx->device->max_workgroup_size_log2; outer < ncols_pad_log2; ++outer) {
+            for (uint32_t inner = 0; inner < outer + 1; ++inner) {
+                vk_op_argsort_push_constants pc2 = pc;
+                pc2.outer_start = outer;
+                pc2.outer_end = outer + 1;
+                pc2.inner_start = inner;
+                pc2.inner_end = inner + 1;
+                // When the inner idx is large enough, there's only communication within a
+                // workgroup, so the remaining inner iterations run in the same dispatch.
+                if (outer - inner < pipeline_idx) {
+                    pc2.inner_end = 100;
+                    inner = outer;
+                    pipeline = ctx->device->pipeline_argsort_large_f32[pipeline_idx];
+                } else {
+                    // Smaller workgroup empirically seems to perform better
+                    pipeline = ctx->device->pipeline_argsort_large_f32[pipeline_idx - 2];
+                }
+                ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
+                ggml_vk_dispatch_pipeline(ctx, subctx, pipeline, { src0_buf, subbuf1, out_buf }, pc2, elements);
+                ggml_vk_sync_buffers(ctx, subctx);
+            }
+        }
+    }
+}
+
 static void ggml_vk_argsort(ggml_backend_vk_context * ctx, vk_context& subctx, const ggml_tensor * src0, ggml_tensor * dst) {
     const uint32_t * op_params = (const uint32_t *)dst->op_params;
 
@@ -13858,21 +13926,12 @@ static void ggml_vk_argsort(ggml_backend_vk_context * ctx, vk_context& subctx, c
     uint32_t ncols_pad_log2 = (uint32_t)ceilf(log2f(float(ncols)));
     uint32_t ncolsp2 = 1 << ncols_pad_log2;
 
-    vk_op_argsort_push_constants pc { ncols, ncolsp2, ncols_pad_log2, nrows, op_params[0], 0, 0, 0, 0, };
-
-    // Pick the largest workgroup size <= ncolsp2
-    uint32_t pipeline_idx = std::min(ncols_pad_log2, num_argsort_pipelines - 1);
-
-    // Use the "small" argsort shader if the whole sort can be done by a single workgroup.
     bool use_small = ncols_pad_log2 <= ctx->device->max_workgroup_size_log2 &&
-                     ctx->device->pipeline_argsort_f32[pipeline_idx] != nullptr;
-
-    vk_pipeline pipeline = use_small ? ctx->device->pipeline_argsort_f32[pipeline_idx]
-                                     : ctx->device->pipeline_argsort_large_f32[pipeline_idx];
+                     ctx->device->pipeline_argsort_f32[std::min(ncols_pad_log2, num_argsort_pipelines - 1)] != nullptr;
 
     vk_subbuffer src0_buf = ggml_vk_tensor_subbuffer(ctx, src0);
-    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst);
-    vk_subbuffer subbuf1 = dst_buf;
+    vk_subbuffer dst_buf  = ggml_vk_tensor_subbuffer(ctx, dst);
+    vk_subbuffer scratch  = dst_buf;
 
     // Reserve space for ivec2 per element, with rows padded to a power of two
     if (!use_small) {
@@ -13885,60 +13944,70 @@ static void ggml_vk_argsort(ggml_backend_vk_context * ctx, vk_context& subctx, c
         if (ctx->prealloc_x_need_sync) {
             ggml_vk_sync_buffers(ctx, subctx);
         }
-        subbuf1 = { ctx->prealloc_x, 0, ctx->prealloc_x->size };
+        scratch = { ctx->prealloc_x, 0, ctx->prealloc_x->size };
     }
 
-    std::array<uint32_t, 3> elements;
+    ggml_vk_argsort_rows(ctx, subctx, src0_buf, dst_buf, scratch, ncols, nrows, op_params[0]);
 
-    elements[0] = ncolsp2;
-    elements[1] = std::min((uint32_t)ggml_nrows(src0), ctx->device->properties.limits.maxComputeWorkGroupCount[1]);
-    elements[2] = 1;
-
-    // First dispatch initializes tmp_idx and does the first N passes where
-    // there is only communication between threads in the same workgroup.
-    {
-        vk_op_argsort_push_constants pc2 = pc;
-        pc2.outer_start = 0;
-        pc2.outer_end = std::min(ncols_pad_log2, ctx->device->max_workgroup_size_log2);
-        pc2.inner_start = 0;
-        pc2.inner_end = 100;
-        ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
-        ggml_vk_dispatch_pipeline(ctx, subctx, pipeline, { src0_buf, subbuf1, dst_buf }, pc2, elements);
-    }
     if (!use_small) {
-        ggml_vk_sync_buffers(ctx, subctx);
-        // Loop over outer/inner passes, synchronizing between each pass.
-        for (uint32_t outer = ctx->device->max_workgroup_size_log2; outer < ncols_pad_log2; ++outer) {
-            for (uint32_t inner = 0; inner < outer + 1; ++inner) {
-                vk_op_argsort_push_constants pc2 = pc;
-                pc2.outer_start = outer;
-                pc2.outer_end = outer + 1;
-                pc2.inner_start = inner;
-                pc2.inner_end = inner + 1;
-                // When the inner idx is large enough, there's only communication
-                // within a workgroup. So the remaining inner iterations can all
-                // run in the same dispatch.
-                if (outer - inner < pipeline_idx) {
-                    pc2.inner_end = 100;
-                    inner = outer;
-                    pipeline = ctx->device->pipeline_argsort_large_f32[pipeline_idx];
-                } else {
-                    // Smaller workgroup empirically seems to perform better
-                    pipeline = ctx->device->pipeline_argsort_large_f32[pipeline_idx - 2];
-                }
-                ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
-                ggml_vk_dispatch_pipeline(ctx, subctx, pipeline, { src0_buf, subbuf1, dst_buf }, pc2, elements);
-                ggml_vk_sync_buffers(ctx, subctx);
-            }
-        }
         ctx->prealloc_x_need_sync = true;
     }
+}
+
+// The reduction shader needs one workgroup to hold every candidate on its last pass, so k
+// above that limit cannot go through it. Sort the whole row instead and keep the leading k:
+// ggml_top_k does not order its output (the CPU reference swaps the first two entries to say
+// so), so the leading k of a descending sort is a valid answer.
+static void ggml_vk_topk_large_k(ggml_backend_vk_context * ctx, vk_context& subctx, const ggml_tensor * src0, ggml_tensor * dst) {
+    const uint32_t ncols = src0->ne[0];
+    const uint32_t nrows = ggml_nrows(src0);
+    const uint32_t k     = dst->ne[0];
+
+    const uint32_t ncolsp2 = 1u << (uint32_t)ceilf(log2f(float(ncols)));
+
+    // prealloc_x carries the sort scratch followed by the permutation this pass produces.
+    const size_t align      = ctx->device->properties.limits.minStorageBufferOffsetAlignment;
+    const size_t scratch_sz = ROUNDUP_POW2(size_t{ncolsp2} * nrows * 2 * sizeof(int), align);
+    const size_t perm_sz    = ROUNDUP_POW2(size_t{ncols}   * nrows *     sizeof(int), align);
+
+    if (ctx->prealloc_size_x < scratch_sz + perm_sz) {
+        ctx->prealloc_size_x = scratch_sz + perm_sz;
+        ggml_vk_preallocate_buffers(ctx, subctx);
+    }
+    if (ctx->prealloc_x_need_sync) {
+        ggml_vk_sync_buffers(ctx, subctx);
+    }
+
+    vk_subbuffer scratch = { ctx->prealloc_x, 0,          scratch_sz };
+    vk_subbuffer perm    = { ctx->prealloc_x, scratch_sz, perm_sz    };
+
+    ggml_vk_argsort_rows(ctx, subctx, ggml_vk_tensor_subbuffer(ctx, src0), perm, scratch,
+                         ncols, nrows, GGML_SORT_ORDER_DESC);
+    ggml_vk_sync_buffers(ctx, subctx);
+
+    // Gather the leading k of every sorted row into the k-wide destination.
+    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst);
+    std::vector<vk::BufferCopy> slices;
+    slices.reserve(nrows);
+    for (uint32_t row = 0; row < nrows; ++row) {
+        slices.push_back({ perm.offset    + size_t{row} * ncols * sizeof(int),
+                           dst_buf.offset + size_t{row} * k     * sizeof(int),
+                           size_t{k} * sizeof(int) });
+    }
+    subctx->s->buffer->buf.copyBuffer(perm.buffer->buffer, dst_buf.buffer->buffer, slices);
+
+    ctx->prealloc_x_need_sync = true;
 }
 
 static void ggml_vk_topk(ggml_backend_vk_context * ctx, vk_context& subctx, const ggml_tensor * src0, ggml_tensor * dst) {
     uint32_t ncols = src0->ne[0];
     uint32_t nrows = ggml_nrows(src0);
     uint32_t k = dst->ne[0];
+
+    if (k > (1u << ctx->device->max_workgroup_size_log2)) {
+        ggml_vk_topk_large_k(ctx, subctx, src0, dst);
+        return;
+    }
 
     vk_op_topk_push_constants pc { ncols, ncols, ncols, k, nrows, 0, 0 };
 
@@ -18723,12 +18792,18 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                 if (!ggml_is_contiguous(op) || !ggml_is_contiguous(op->src[0])) {
                     return false;
                 }
-                // We could potentially support larger, using argsort to sort the
-                // whole thing. Not clear if this is needed.
+                // Past the workgroup limit, ggml_vk_topk_large_k sorts the whole row
+                // instead, which needs the same memory model as argsort_large. A full sort
+                // costs more than the selection it replaces, so it only pays for itself
+                // while the row count is low enough that the CPU round trip dominates:
+                // measured on gfx1151 with ncols 54822 / k 2051, 3 rows is 11% faster on
+                // the GPU and 1024 rows is 10% slower.
                 uint32_t min_pipeline = (uint32_t)log2f(float(op->ne[0])) + 1;
                 if (min_pipeline >= num_topk_pipelines ||
                     !device->pipeline_topk_f32[min_pipeline]) {
-                    return false;
+                    return device->vulkan_memory_model &&
+                           (uint32_t)op->ne[0] > (1u << device->max_workgroup_size_log2) &&
+                           ggml_nrows(op->src[0]) <= TOPK_LARGE_K_MAX_ROWS;
                 }
             }
             return true;

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9790,6 +9790,14 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             }
         }
     }
+    // qwen4exp QSA indexer: k is indexer_top_k + compress_ratio - 1 over the whole KV
+    // window, so it runs past any one workgroup while nrows tracks the ubatch. 33 rows
+    // is over the bound the large-k path carries, so it covers the fallback too.
+    for (int nrows : {1, 3, 32, 33}) {
+        test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {54822, nrows, 1, 1}, 2051));
+        test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {54822, nrows, 1, 1}, 2051, true));
+    }
+
     for (int k : {4, 8, 16, 32}) {
         for (int nrows : {1, 8, 16}) {
             test_cases.emplace_back(new test_top_k(GGML_TYPE_F32, {202048, nrows, 1, 1}, k));


### PR DESCRIPTION
## Problem

On Vulkan, `TOP_K` falls back to the CPU once k goes past 1024. Qwen3.8-Flash-Next
(qwen4exp) hits that on 12 attention layers for every token it decodes, so past about 1K of
context the model is doing 12 round trips per token. It is a real problem for me — this is
my daily driver and every session runs past that point.

The limit is in `supports_op`:

```c
uint32_t min_pipeline = (uint32_t)log2f(float(op->ne[0])) + 1;
if (min_pipeline >= num_topk_pipelines || !device->pipeline_topk_f32[min_pipeline]) {
    return false;
}
```

`op` is the destination, so `op->ne[0]` is k. `ggml_vk_topk` reduces a row one workgroup at
a time and the last pass has to hold all k candidates in a single workgroup, which caps at
1024 invocations. qwen4exp's QSA indexer asks for
`min(n_kv, indexer_top_k + compress_ratio - 1)` = `min(n_kv, 2051)`, so below ~1K of context
k is the window and fits, and above it k pins at 2051 and the scheduler moves all twelve
nodes to the CPU.

It shows up as unsupported rather than slow:

```
$ test-backend-ops test -o TOP_K
TOP_K(type=f32,ne=[54822,33,1,1],k=2051,ties=0): not supported [Vulkan0]
```

## Change

The comment already in `supports_op` suggested the way out:

```c
// We could potentially support larger, using argsort to sort the
// whole thing. Not clear if this is needed.
```

So: when k is larger than one workgroup can hold, sort the whole row with the existing
`argsort_large` pipelines and keep the leading k. That is a valid answer because
`ggml_top_k` does not order its output — the CPU reference swaps the first two entries to
make the point:

```c
std::partial_sort(tmp, tmp + top_k, tmp + ne00, cmp_top_k{src_data});
std::copy(tmp, tmp + top_k, dst_data);
// emphasize that the order is not important
if (top_k > 1) { std::swap(dst_data[0], dst_data[1]); }
```

The argsort dispatch was only reachable through `ggml_vk_argsort`, which took its buffers
from the tensors, so it is split into `ggml_vk_argsort_rows` taking explicit subbuffers.
`ggml_vk_argsort` becomes a wrapper and is otherwise unchanged. `prealloc_x` holds the sort
scratch followed by the permutation, and one `copyBuffer` with a region per row gathers the
leading k into the destination.

### Why it is gated on row count

A full sort is more work than the selection it replaces, so it only pays for itself while
the row count is low enough that the round trip dominates. Measured here with
`ncols 54822, k 2051`:

| rows | what submits it | GPU vs CPU fallback |
| ---: | --- | --- |
| 3 | an MTP decode step | 11% faster |
| 1024 | a prefill ubatch | 10% slower |

The bound is 32 — above any decode batch, well below any prefill ubatch. My first version
had no bound and traded a 10% prefill regression for the decode win; it was only visible
because prefill was measured too. `llama-bench -p 0 -n 128` measures generation alone and
hides it.

## Numbers

gfx1151 (Radeon 8060S, RADV, Mesa 26.1.7), Qwen3.8-Flash-Next UD-Q4_K_XL,
`llama-bench -fa 1 -n 128 -d ...`. Same build both columns; "before" only has the
`supports_op` relaxation reverted.

| depth | before | after |        |
| ----: | -----: | ----: | ------ |
| 0     |  25.72 | 25.78 |        |
| 1024  |  23.63 | 25.21 | +6.7%  |
| 4096  |  21.70 | 24.31 | +12.0% |
| 16384 |  18.72 | 21.61 | +15.4% |
| 32768 |  16.53 | 19.04 | +15.2% |
| 65536 |  12.58 | 14.01 | +11.4% |

The gain starts where k crosses the limit and not before: at depth 0 the window is still
narrower than k, so the node never takes the new path.

On the server, with the MTP draft head and a 52K prompt, five runs each: decode
`21.46 -> 23.39` (+9.0%), prefill `192.0 -> 190.0` (unchanged).

Note this is a slope here, not the cliff #27856 reports on HIP. This is an APU, so the
fallback pays for a synchronisation rather than a transfer. #27466 fixes the CUDA/HIP side
of the same limit; I did not find anything covering Vulkan.

## Tests

`test-backend-ops -o TOP_K` passes, 523/523. The `k = 9999` cases already in the suite now
run on Vulkan instead of being skipped as unsupported.

Added cases in the shape qwen4exp produces — `k = 2051` over 54822 columns, with and
without ties, at 1, 3, 32 and 33 rows. 33 is over the bound, so the fallback side is covered
too.

## AI disclosure

The code was written with AI assistance. I reviewed it, I understand it, and I will maintain
it.
