### PR TITLE
metal : use implicit GEMM kernel for CONV_3D

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -2009,6 +2009,37 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d(ggml_met
     return res;
 }
 
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_mm(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_CONV_2D);
+
+    GGML_ASSERT(ggml_is_contiguous(op->src[0]));
+    GGML_ASSERT(op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->src[1]->type == GGML_TYPE_F32);
+    GGML_ASSERT(op->type         == GGML_TYPE_F32);
+
+    char base[256];
+    char name[256];
+
+    const int nr0 = op->src[0]->ne[3] <= 32 ? 32 : 64;
+    const int nr1 = 2048/nr0;
+
+    snprintf(base, 256, "kernel_conv_2d_mm_%s_%s_%dx%d", ggml_type_name(op->src[0]->type), ggml_type_name(op->src[1]->type), nr0, nr1);
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    res.nr0 = nr0;
+    res.nr1 = nr1;
+    res.nsg = 4;
+
+    res.smem = nr0*nr1*sizeof(float);
+
+    return res;
+}
+
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_dw(ggml_metal_library_t lib, const ggml_tensor * op, bool tiled) {
     assert(op->op == GGML_OP_CONV_2D_DW);
 

--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -2009,8 +2009,8 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d(ggml_met
     return res;
 }
 
-ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_mm(ggml_metal_library_t lib, const ggml_tensor * op) {
-    assert(op->op == GGML_OP_CONV_2D);
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_mm(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_CONV_2D || op->op == GGML_OP_CONV_3D);
 
     GGML_ASSERT(ggml_is_contiguous(op->src[0]));
     GGML_ASSERT(op->src[0]->type == GGML_TYPE_F16 || op->src[0]->type == GGML_TYPE_F32);
@@ -2020,10 +2020,12 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_mm(ggml_
     char base[256];
     char name[256];
 
-    const int nr0 = op->src[0]->ne[3] <= 32 ? 32 : 64;
+    const int OC = op->op == GGML_OP_CONV_2D ? op->src[0]->ne[3] : ((const int32_t *) op->op_params)[11];
+
+    const int nr0 = OC <= 32 ? 32 : 64;
     const int nr1 = 2048/nr0;
 
-    snprintf(base, 256, "kernel_conv_2d_mm_%s_%s_%dx%d", ggml_type_name(op->src[0]->type), ggml_type_name(op->src[1]->type), nr0, nr1);
+    snprintf(base, 256, "kernel_conv_%dd_mm_%s_%s_%dx%d", op->op == GGML_OP_CONV_2D ? 2 : 3, ggml_type_name(op->src[0]->type), ggml_type_name(op->src[1]->type), nr0, nr1);
     snprintf(name, 256, "%s", base);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -158,6 +158,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_tran
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_col2im_1d         (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_snake             (ggml_metal_library_t lib, enum ggml_type type);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d           (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_mm        (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_dw        (ggml_metal_library_t lib, const struct ggml_tensor * op, bool tiled);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_3d           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_upscale           (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -158,7 +158,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_tran
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_col2im_1d         (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_snake             (ggml_metal_library_t lib, enum ggml_type type);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d           (ggml_metal_library_t lib, const struct ggml_tensor * op);
-struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_mm        (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_mm           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_2d_dw        (ggml_metal_library_t lib, const struct ggml_tensor * op, bool tiled);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_conv_3d           (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_upscale           (ggml_metal_library_t lib, const struct ggml_tensor * op);

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -694,6 +694,41 @@ typedef struct {
 } ggml_metal_kargs_conv_2d;
 
 typedef struct {
+    uint64_t nbw;
+    uint64_t nb10;
+    uint64_t nb11;
+    uint64_t nb12;
+    uint64_t nb13;
+    uint64_t nb14;
+    uint64_t nb0;
+    uint64_t nb1;
+    uint64_t nb2;
+    uint64_t nb3;
+    uint64_t nb4;
+    int32_t  IW;
+    int32_t  IH;
+    int32_t  ID;
+    int32_t  KW;
+    int32_t  KH;
+    int32_t  KD;
+    int32_t  IC;
+    int32_t  OC;
+    int32_t  OW;
+    int32_t  OH;
+    int32_t  OD;
+    int32_t  N;
+    int32_t  s0;
+    int32_t  s1;
+    int32_t  s2;
+    int32_t  p0;
+    int32_t  p1;
+    int32_t  p2;
+    int32_t  d0;
+    int32_t  d1;
+    int32_t  d2;
+} ggml_metal_kargs_conv_mm;
+
+typedef struct {
     uint64_t nb00;  // kernel strides
     uint64_t nb01;
     uint64_t nb02;

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -4241,6 +4241,30 @@ int ggml_metal_op_im2col(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
+static void ggml_metal_op_conv_mm(ggml_metal_op_t ctx, const ggml_tensor * op, ggml_metal_kargs_conv_mm & args) {
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    auto pipeline = ggml_metal_library_get_pipeline_conv_mm(lib, op);
+
+    const int nr0 = pipeline.nr0;
+    const int nr1 = pipeline.nr1;
+    const int nsg = pipeline.nsg;
+
+    const int64_t NP = (int64_t) args.N*args.OD*args.OH*args.OW;
+    const int64_t OC = args.OC;
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
+
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, pipeline.smem, 0);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, (NP + nr1 - 1)/nr1, (OC + nr0 - 1)/nr0, 1, 32, nsg, 1);
+}
+
 int ggml_metal_op_conv_2d(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
@@ -4299,24 +4323,42 @@ int ggml_metal_op_conv_2d(ggml_metal_op_t ctx, int idx) {
     const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
 
     if (props_dev->has_simdgroup_mm) {
-        auto pipeline = ggml_metal_library_get_pipeline_conv_2d_mm(lib, op);
+        ggml_metal_kargs_conv_mm args_mm = {
+            /*.nbw  =*/ nb03,
+            /*.nb10 =*/ nb10,
+            /*.nb11 =*/ nb11,
+            /*.nb12 =*/ 0,
+            /*.nb13 =*/ nb12,
+            /*.nb14 =*/ nb13,
+            /*.nb0  =*/ nb0,
+            /*.nb1  =*/ nb1,
+            /*.nb2  =*/ 0,
+            /*.nb3  =*/ nb2,
+            /*.nb4  =*/ nb3,
+            /*.IW   =*/ ne10,
+            /*.IH   =*/ ne11,
+            /*.ID   =*/ 1,
+            /*.KW   =*/ ne00,
+            /*.KH   =*/ ne01,
+            /*.KD   =*/ 1,
+            /*.IC   =*/ ne02,
+            /*.OC   =*/ ne03,
+            /*.OW   =*/ ne0,
+            /*.OH   =*/ ne1,
+            /*.OD   =*/ 1,
+            /*.N    =*/ ne3,
+            /*.s0   =*/ s0,
+            /*.s1   =*/ s1,
+            /*.s2   =*/ 1,
+            /*.p0   =*/ p0,
+            /*.p1   =*/ p1,
+            /*.p2   =*/ 0,
+            /*.d0   =*/ d0,
+            /*.d1   =*/ d1,
+            /*.d2   =*/ 1,
+        };
 
-        const int nr0 = pipeline.nr0;
-        const int nr1 = pipeline.nr1;
-        const int nsg = pipeline.nsg;
-
-        const int64_t NP = ne3*ne1*ne0;
-        const int64_t OC = ne03;
-
-        ggml_metal_encoder_set_pipeline(enc, pipeline);
-        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
-        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
-        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
-        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
-
-        ggml_metal_encoder_set_threadgroup_memory_size(enc, pipeline.smem, 0);
-
-        ggml_metal_encoder_dispatch_threadgroups(enc, (NP + nr1 - 1)/nr1, (OC + nr0 - 1)/nr0, 1, 32, nsg, 1);
+        ggml_metal_op_conv_mm(ctx, op, args_mm);
 
         return 1;
     }
@@ -4468,6 +4510,49 @@ int ggml_metal_op_conv_3d(ggml_metal_op_t ctx, int idx) {
         nb10, nb11, nb12, nb13, // Input strides
         nb0,  nb1,  nb2,  nb3   // Output strides
     };
+
+    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
+
+    if (props_dev->has_simdgroup_mm) {
+        ggml_metal_kargs_conv_mm args_mm = {
+            /*.nbw  =*/ IC*nb03,
+            /*.nb10 =*/ nb10,
+            /*.nb11 =*/ nb11,
+            /*.nb12 =*/ nb12,
+            /*.nb13 =*/ nb13,
+            /*.nb14 =*/ IC*nb13,
+            /*.nb0  =*/ nb0,
+            /*.nb1  =*/ nb1,
+            /*.nb2  =*/ nb2,
+            /*.nb3  =*/ nb3,
+            /*.nb4  =*/ OC*nb3,
+            /*.IW   =*/ args.IW,
+            /*.IH   =*/ args.IH,
+            /*.ID   =*/ args.ID,
+            /*.KW   =*/ args.KW,
+            /*.KH   =*/ args.KH,
+            /*.KD   =*/ args.KD,
+            /*.IC   =*/ IC,
+            /*.OC   =*/ OC,
+            /*.OW   =*/ args.OW,
+            /*.OH   =*/ args.OH,
+            /*.OD   =*/ args.OD,
+            /*.N    =*/ N,
+            /*.s0   =*/ s0,
+            /*.s1   =*/ s1,
+            /*.s2   =*/ s2,
+            /*.p0   =*/ p0,
+            /*.p1   =*/ p1,
+            /*.p2   =*/ p2,
+            /*.d0   =*/ d0,
+            /*.d1   =*/ d1,
+            /*.d2   =*/ d2,
+        };
+
+        ggml_metal_op_conv_mm(ctx, op, args_mm);
+
+        return 1;
+    }
 
     // 4. Fetch the JIT pipeline
     auto pipeline = ggml_metal_library_get_pipeline_conv_3d(lib, op);

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -4296,6 +4296,31 @@ int ggml_metal_op_conv_2d(ggml_metal_op_t ctx, int idx) {
         /*.d1   =*/ d1,
     };
 
+    const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx->dev);
+
+    if (props_dev->has_simdgroup_mm) {
+        auto pipeline = ggml_metal_library_get_pipeline_conv_2d_mm(lib, op);
+
+        const int nr0 = pipeline.nr0;
+        const int nr1 = pipeline.nr1;
+        const int nsg = pipeline.nsg;
+
+        const int64_t NP = ne3*ne1*ne0;
+        const int64_t OC = ne03;
+
+        ggml_metal_encoder_set_pipeline(enc, pipeline);
+        ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[1]), 2);
+        ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         3);
+
+        ggml_metal_encoder_set_threadgroup_memory_size(enc, pipeline.smem, 0);
+
+        ggml_metal_encoder_dispatch_threadgroups(enc, (NP + nr1 - 1)/nr1, (OC + nr0 - 1)/nr0, 1, 32, nsg, 1);
+
+        return 1;
+    }
+
     auto pipeline = ggml_metal_library_get_pipeline_conv_2d(lib, op);
 
     int nth = ggml_metal_pipeline_max_theads_per_threadgroup(pipeline);

--- a/ggml/src/ggml-metal/kernels/conv.metal
+++ b/ggml/src/ggml-metal/kernels/conv.metal
@@ -274,6 +274,187 @@ kernel void kernel_conv_2d<half>(
         uint3   tpitg[[thread_position_in_threadgroup]],
         uint3     ntg[[threads_per_threadgroup]]);
 
+template <typename TK, short NR0, short NR1>
+kernel void kernel_conv_2d_mm(
+        constant ggml_metal_kargs_conv_2d & args,
+        device const char * weights,
+        device const char * src,
+        device       char * dst,
+        threadgroup  char * shmem [[threadgroup(0)]],
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort  tiitg[[thread_index_in_threadgroup]],
+        ushort  tiisg[[thread_index_in_simdgroup]],
+        ushort  sgitg[[simdgroup_index_in_threadgroup]]) {
+    constexpr short NSG = 4;
+    constexpr short NTH = 32*NSG;
+    constexpr short NK  = 32;
+    constexpr short NKB = NK/8;
+
+    constexpr short NB = 72;
+
+    constexpr short SGY = NR0/32;
+
+    threadgroup half * sa = (threadgroup half *) shmem;
+    threadgroup half * sb = (threadgroup half *) shmem + (NR0/8)*NKB*NB;
+
+    const int K  = args.IC*args.KH*args.KW;
+    const int NP = args.N*args.OH*args.OW;
+
+    const int r0 = tgpig.y*NR0;
+    const int r1 = tgpig.x*NR1;
+
+    constexpr short NPL = NR1/32;
+
+    const short lb_n = 8*sgitg + tiisg%8;
+    const short lb_k = 8*(tiisg/8);
+
+    int  ix0[NPL];
+    int  iy0[NPL];
+    bool ip_ok[NPL];
+
+    device const char * srcb[NPL];
+
+    FOR_UNROLL (short t = 0; t < NPL; t++) {
+        const int ip = r1 + 32*t + lb_n;
+
+        const int iow = ip % args.OW;
+        const int ioh = (ip / args.OW) % args.OH;
+        const int in  = ip / (args.OW*args.OH);
+
+        ix0[t] = iow*args.s0 - args.p0;
+        iy0[t] = ioh*args.s1 - args.p1;
+
+        ip_ok[t] = ip < NP;
+
+        srcb[t] = src + in*args.nb13;
+    }
+
+    simdgroup_half8x8  ma[4];
+    simdgroup_half8x8  mb[2];
+    simdgroup_float8x8 mc[8];
+
+    for (short i = 0; i < 8; i++) {
+        mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
+    }
+
+    for (int k0 = 0; k0 < K; k0 += NK) {
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        {
+            const short k  = tiisg;
+            const int   kk = k0 + k;
+
+            FOR_UNROLL (short j = 0; j < NR0/NSG; j++) {
+                const short row = (NR0/NSG)*sgitg + j;
+                const int   oc  = r0 + row;
+
+                half v = 0;
+                if (kk < K && oc < args.OC) {
+                    v = *((device const TK *)(weights + oc*args.nb03) + kk);
+                }
+
+                const short ib = NKB*(row/8) + k/8;
+
+                sa[NB*ib + 8*(row%8) + k%8] = v;
+            }
+        }
+
+        {
+            int kk = k0 + lb_k;
+
+            int kw = kk % args.KW;
+            int kh = (kk / args.KW) % args.KH;
+            int ic = kk / (args.KW*args.KH);
+
+            FOR_UNROLL (short i = 0; i < 8; i++) {
+                const short k = lb_k + i;
+
+                FOR_UNROLL (short t = 0; t < NPL; t++) {
+                    const short n = 32*t + lb_n;
+
+                    const int ix = ix0[t] + kw*args.d0;
+                    const int iy = iy0[t] + kh*args.d1;
+
+                    half v = 0;
+                    if (ip_ok[t] && kk < K && ix >= 0 && ix < args.IW && iy >= 0 && iy < args.IH) {
+                        v = *(device const float *)(srcb[t] + ic*args.nb12 + iy*args.nb11 + ix*args.nb10);
+                    }
+
+                    const short ib = NKB*(n/8) + k/8;
+
+                    sb[NB*ib + 8*(k%8) + n%8] = v;
+                }
+
+                kk++;
+                if (++kw == args.KW) {
+                    kw = 0;
+                    if (++kh == args.KH) {
+                        kh = 0;
+                        ic++;
+                    }
+                }
+            }
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const short nkb = min((K - k0 + 7)/8, (int) NKB);
+
+        for (short ik = 0; ik < nkb; ik++) {
+            FOR_UNROLL (short i = 0; i < 4; i++) {
+                simdgroup_load(ma[i], sa + NB*(NKB*(4*(sgitg%SGY) + i) + ik), 8, 0, false);
+            }
+
+            FOR_UNROLL (short j = 0; j < 2; j++) {
+                simdgroup_load(mb[j], sb + NB*(NKB*(2*(sgitg/SGY) + j) + ik), 8, 0, false);
+            }
+
+            FOR_UNROLL (short i = 0; i < 8; i++) {
+                simdgroup_multiply_accumulate(mc[i], ma[i%4], mb[i/4], mc[i]);
+            }
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    threadgroup float * sc = (threadgroup float *) shmem;
+
+    for (short i = 0; i < 8; i++) {
+        simdgroup_store(mc[i], sc + NR1*(32*(sgitg%SGY) + 8*(i%4)) + 16*(sgitg/SGY) + 8*(i/4), NR1, 0, false);
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const short cn = tiitg%NR1;
+    const int   p  = r1 + cn;
+
+    if (p >= NP) {
+        return;
+    }
+
+    const int ow = p % args.OW;
+    const int oh = (p / args.OW) % args.OH;
+    const int n  = p / (args.OW*args.OH);
+
+    device char * dstp = dst + n*args.nb3 + oh*args.nb1 + ow*args.nb0;
+
+    for (short j = 0; j < NR0*NR1/NTH; j++) {
+        const short row = tiitg/NR1 + (NTH/NR1)*j;
+        const int   oc  = r0 + row;
+
+        if (oc < args.OC) {
+            *(device float *)(dstp + oc*args.nb2) = sc[NR1*row + cn];
+        }
+    }
+}
+
+typedef decltype(kernel_conv_2d_mm<float, 64, 32>) kernel_conv_2d_mm_t;
+
+template [[host_name("kernel_conv_2d_mm_f32_f32_64x32")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<float, 64, 32>;
+template [[host_name("kernel_conv_2d_mm_f16_f32_64x32")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<half,  64, 32>;
+template [[host_name("kernel_conv_2d_mm_f32_f32_32x64")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<float, 32, 64>;
+template [[host_name("kernel_conv_2d_mm_f16_f32_32x64")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<half,  32, 64>;
+
 typedef void (conv_transpose_1d_t)(
         constant ggml_metal_kargs_conv_transpose_1d & args,
         device const float * src0,

--- a/ggml/src/ggml-metal/kernels/conv.metal
+++ b/ggml/src/ggml-metal/kernels/conv.metal
@@ -274,9 +274,9 @@ kernel void kernel_conv_2d<half>(
         uint3   tpitg[[thread_position_in_threadgroup]],
         uint3     ntg[[threads_per_threadgroup]]);
 
-template <typename TK, short NR0, short NR1>
-kernel void kernel_conv_2d_mm(
-        constant ggml_metal_kargs_conv_2d & args,
+template <typename TK, short NR0, short NR1, short DIMS>
+kernel void kernel_conv_mm(
+        constant ggml_metal_kargs_conv_mm & args,
         device const char * weights,
         device const char * src,
         device       char * dst,
@@ -297,8 +297,14 @@ kernel void kernel_conv_2d_mm(
     threadgroup half * sa = (threadgroup half *) shmem;
     threadgroup half * sb = (threadgroup half *) shmem + (NR0/8)*NKB*NB;
 
-    const int K  = args.IC*args.KH*args.KW;
-    const int NP = args.N*args.OH*args.OW;
+    const int KD = DIMS == 3 ? args.KD : 1;
+    const int OD = DIMS == 3 ? args.OD : 1;
+
+    const int KWH = args.KW*args.KH;
+    const int OWH = args.OW*args.OH;
+
+    const int K  = args.IC*KD*KWH;
+    const int NP = args.N*OD*OWH;
 
     const int r0 = tgpig.y*NR0;
     const int r1 = tgpig.x*NR1;
@@ -310,6 +316,7 @@ kernel void kernel_conv_2d_mm(
 
     int  ix0[NPL];
     int  iy0[NPL];
+    int  iz0[NPL];
     bool ip_ok[NPL];
 
     device const char * srcb[NPL];
@@ -319,14 +326,16 @@ kernel void kernel_conv_2d_mm(
 
         const int iow = ip % args.OW;
         const int ioh = (ip / args.OW) % args.OH;
-        const int in  = ip / (args.OW*args.OH);
+        const int iod = (ip / OWH) % OD;
+        const int in  = ip / (OWH*OD);
 
         ix0[t] = iow*args.s0 - args.p0;
         iy0[t] = ioh*args.s1 - args.p1;
+        iz0[t] = iod*args.s2 - args.p2;
 
         ip_ok[t] = ip < NP;
 
-        srcb[t] = src + in*args.nb13;
+        srcb[t] = src + in*args.nb14;
     }
 
     simdgroup_half8x8  ma[4];
@@ -350,7 +359,7 @@ kernel void kernel_conv_2d_mm(
 
                 half v = 0;
                 if (kk < K && oc < args.OC) {
-                    v = *((device const TK *)(weights + oc*args.nb03) + kk);
+                    v = *((device const TK *)(weights + oc*args.nbw) + kk);
                 }
 
                 const short ib = NKB*(row/8) + k/8;
@@ -364,7 +373,8 @@ kernel void kernel_conv_2d_mm(
 
             int kw = kk % args.KW;
             int kh = (kk / args.KW) % args.KH;
-            int ic = kk / (args.KW*args.KH);
+            int kd = (kk / KWH) % KD;
+            int ic = kk / (KWH*KD);
 
             FOR_UNROLL (short i = 0; i < 8; i++) {
                 const short k = lb_k + i;
@@ -375,9 +385,21 @@ kernel void kernel_conv_2d_mm(
                     const int ix = ix0[t] + kw*args.d0;
                     const int iy = iy0[t] + kh*args.d1;
 
+                    bool ok = ip_ok[t] && kk < K && ix >= 0 && ix < args.IW && iy >= 0 && iy < args.IH;
+
+                    uint64_t offs = ic*args.nb13 + iy*args.nb11 + ix*args.nb10;
+
+                    if (DIMS == 3) {
+                        const int iz = iz0[t] + kd*args.d2;
+
+                        ok = ok && iz >= 0 && iz < args.ID;
+
+                        offs += iz*args.nb12;
+                    }
+
                     half v = 0;
-                    if (ip_ok[t] && kk < K && ix >= 0 && ix < args.IW && iy >= 0 && iy < args.IH) {
-                        v = *(device const float *)(srcb[t] + ic*args.nb12 + iy*args.nb11 + ix*args.nb10);
+                    if (ok) {
+                        v = *(device const float *)(srcb[t] + offs);
                     }
 
                     const short ib = NKB*(n/8) + k/8;
@@ -390,7 +412,10 @@ kernel void kernel_conv_2d_mm(
                     kw = 0;
                     if (++kh == args.KH) {
                         kh = 0;
-                        ic++;
+                        if (++kd == KD) {
+                            kd = 0;
+                            ic++;
+                        }
                     }
                 }
             }
@@ -434,26 +459,31 @@ kernel void kernel_conv_2d_mm(
 
     const int ow = p % args.OW;
     const int oh = (p / args.OW) % args.OH;
-    const int n  = p / (args.OW*args.OH);
+    const int od = (p / OWH) % OD;
+    const int n  = p / (OWH*OD);
 
-    device char * dstp = dst + n*args.nb3 + oh*args.nb1 + ow*args.nb0;
+    device char * dstp = dst + n*args.nb4 + od*args.nb2 + oh*args.nb1 + ow*args.nb0;
 
     for (short j = 0; j < NR0*NR1/NTH; j++) {
         const short row = tiitg/NR1 + (NTH/NR1)*j;
         const int   oc  = r0 + row;
 
         if (oc < args.OC) {
-            *(device float *)(dstp + oc*args.nb2) = sc[NR1*row + cn];
+            *(device float *)(dstp + oc*args.nb3) = sc[NR1*row + cn];
         }
     }
 }
 
-typedef decltype(kernel_conv_2d_mm<float, 64, 32>) kernel_conv_2d_mm_t;
+typedef decltype(kernel_conv_mm<float, 64, 32, 2>) kernel_conv_mm_t;
 
-template [[host_name("kernel_conv_2d_mm_f32_f32_64x32")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<float, 64, 32>;
-template [[host_name("kernel_conv_2d_mm_f16_f32_64x32")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<half,  64, 32>;
-template [[host_name("kernel_conv_2d_mm_f32_f32_32x64")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<float, 32, 64>;
-template [[host_name("kernel_conv_2d_mm_f16_f32_32x64")]] kernel kernel_conv_2d_mm_t kernel_conv_2d_mm<half,  32, 64>;
+template [[host_name("kernel_conv_2d_mm_f32_f32_64x32")]] kernel kernel_conv_mm_t kernel_conv_mm<float, 64, 32, 2>;
+template [[host_name("kernel_conv_2d_mm_f16_f32_64x32")]] kernel kernel_conv_mm_t kernel_conv_mm<half,  64, 32, 2>;
+template [[host_name("kernel_conv_2d_mm_f32_f32_32x64")]] kernel kernel_conv_mm_t kernel_conv_mm<float, 32, 64, 2>;
+template [[host_name("kernel_conv_2d_mm_f16_f32_32x64")]] kernel kernel_conv_mm_t kernel_conv_mm<half,  32, 64, 2>;
+template [[host_name("kernel_conv_3d_mm_f32_f32_64x32")]] kernel kernel_conv_mm_t kernel_conv_mm<float, 64, 32, 3>;
+template [[host_name("kernel_conv_3d_mm_f16_f32_64x32")]] kernel kernel_conv_mm_t kernel_conv_mm<half,  64, 32, 3>;
+template [[host_name("kernel_conv_3d_mm_f32_f32_32x64")]] kernel kernel_conv_mm_t kernel_conv_mm<float, 32, 64, 3>;
+template [[host_name("kernel_conv_3d_mm_f16_f32_32x64")]] kernel kernel_conv_mm_t kernel_conv_mm<half,  32, 64, 3>;
 
 typedef void (conv_transpose_1d_t)(
         constant ggml_metal_kargs_conv_transpose_1d & args,


### PR DESCRIPTION
## Summary
- 
- 
- 

## Performance (Apple M5)
| N | IC | Input (ID,IH,IW) | OC | Kernel | Type | Master | PR | Speedup |
| --- | --- | --- | --- | --- | --- | ---: | ---: | ---: |
| 1 | 320 | 8x38x26 | 1280 | 3x3x3 | f32 | 2761.7 ms | 107.4 ms | 25.71x |
| 1 | 1280 | 8x38x26 | 1280 | 3x3x3 | f32 | 11071.3 ms | 459.5 ms | 24.09x |
| 1 | 320 | 8x76x52 | 1280 | 3x3x3 | f32 | 10993.9 ms | 433.9 ms | 25.34x |
| 1 | 1280 | 8x76x52 | 1280 | 3x3x3 | f32 | 49909.4 ms | 1923.6 ms | 25.95x |
| 1 | 320 | 8x152x104 | 1280 | 3x3x3 | f32 | 48128.8 ms | 1973.2 ms | 24.39x |
| 1 | 320 | 8x38x26 | 1280 | 3x3x3 | f16 | 3173.2 ms | 111.2 ms | 28.52x |
| 1 | 1280 | 8x38x26 | 1280 | 3x3x3 | f16 | 12249.2 ms | 461.6 ms | 26.54x |
| 1 | 320 | 8x76x52 | 1280 | 3x3x3 | f16 | 12131.3 ms | 448.4 ms | 27.06x |
| 1 | 1280 | 8x76x52 | 1280 | 3x3x3 | f16 | 47724.9 ms | 1831.4 ms | 26.06x |
| 1 | 320 | 8x152x104 | 1280 | 3x3x3 | f16 | 118263.9 ms | 1996.9 ms | 59.22x |


## Test plan
- [ ] `test-backend-ops test -o CONV_3D`
- [ ] `test-backend-ops perf -o CONV_3D`

## Additional information


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 
