### PR TITLE
metal : add top-k radix implementation

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-device.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-device.cpp
@@ -1336,7 +1336,7 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_fwht(ggml_metal_
     return res;
 }
 
-// note: reuse the argsort kernel for top_k
+// note: reuse the argsort kernel for the bitonic top_k fallback
 ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k(ggml_metal_library_t lib, const ggml_tensor * op) {
     assert(op->op == GGML_OP_TOP_K);
 
@@ -1354,6 +1354,23 @@ ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k(ggml_metal
     };
 
     snprintf(base, 256, "kernel_argsort_%s_%s_%s", ggml_type_name(op->src[0]->type), ggml_type_name(op->type), order_str);
+    snprintf(name, 256, "%s", base);
+
+    ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);
+    if (!res.pipeline) {
+        res = ggml_metal_library_compile_pipeline(lib, base, name, nullptr);
+    }
+
+    return res;
+}
+
+ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k_radix(ggml_metal_library_t lib, const ggml_tensor * op) {
+    assert(op->op == GGML_OP_TOP_K);
+
+    char base[256];
+    char name[256];
+
+    snprintf(base, 256, "kernel_top_k_%s_%s", ggml_type_name(op->src[0]->type), ggml_type_name(op->type));
     snprintf(name, 256, "%s", base);
 
     ggml_metal_pipeline_with_params res = ggml_metal_library_get_pipeline(lib, name);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -145,6 +145,7 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort  
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_argsort_merge     (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_fwht              (ggml_metal_library_t lib, int n);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k             (ggml_metal_library_t lib, const struct ggml_tensor * op);
+struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k_radix       (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_top_k_merge       (ggml_metal_library_t lib, const struct ggml_tensor * op);
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin               (ggml_metal_library_t lib, const struct ggml_tensor * op, int32_t n_fuse );
 struct ggml_metal_pipeline_with_params ggml_metal_library_get_pipeline_bin_one           (ggml_metal_library_t lib, enum ggml_op op);

--- a/ggml/src/ggml-metal/ggml-metal-impl.h
+++ b/ggml/src/ggml-metal/ggml-metal-impl.h
@@ -1190,6 +1190,17 @@ typedef struct {
 } ggml_metal_kargs_argsort_merge;
 
 typedef struct {
+    int32_t  ne00;   // number of columns (elements per row)
+    int32_t  ne01;   // rows
+    int32_t  ne02;
+    int32_t  ne03;
+    uint64_t nb01;   // row stride in src0
+    uint64_t nb02;
+    uint64_t nb03;
+    int32_t  top_k;  // k
+} ggml_metal_kargs_top_k;
+
+typedef struct {
     int32_t nrows;
 } ggml_metal_kargs_fwht;
 

--- a/ggml/src/ggml-metal/ggml-metal-ops.cpp
+++ b/ggml/src/ggml-metal/ggml-metal-ops.cpp
@@ -5091,7 +5091,9 @@ int ggml_metal_op_argsort(ggml_metal_op_t ctx, int idx) {
     return 1;
 }
 
-int ggml_metal_op_top_k(ggml_metal_op_t ctx, int idx) {
+// bitonic-sort + merge fallback: efficient when k is small and there are few rows,
+// where the single-workgroup-per-row radix-select cannot reach enough parallelism
+static void ggml_metal_op_top_k_bitonic(ggml_metal_op_t ctx, int idx) {
     ggml_tensor * op = ctx->node(idx);
 
     ggml_metal_library_t lib = ctx->lib;
@@ -5198,6 +5200,74 @@ int ggml_metal_op_top_k(ggml_metal_op_t ctx, int idx) {
         std::swap(bid_dst, bid_tmp);
 
         len <<= 1;
+    }
+}
+
+// radix-select: one workgroup per row. Maps each float to an order-preserving unsigned
+// key, finds the k-th largest via 4 radix-8 histogram passes, then compacts the top-k
+// indices. Fast for large k and/or many rows.
+static void ggml_metal_op_top_k_radix(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    ggml_metal_library_t lib = ctx->lib;
+    ggml_metal_encoder_t enc = ctx->enc;
+
+    GGML_ASSERT(ggml_is_contiguous_rows(op->src[0]));
+
+    GGML_TENSOR_LOCALS( int32_t, ne0, op->src[0], ne);
+    GGML_TENSOR_LOCALS(uint64_t, nb0, op->src[0], nb);
+
+    auto pipeline = ggml_metal_library_get_pipeline_top_k_radix(lib, op);
+
+    // one workgroup per row; radix-select the k-th largest value
+    const int nth = std::min(1024, ggml_metal_pipeline_max_theads_per_threadgroup(pipeline));
+
+    ggml_metal_kargs_top_k args = {
+        /*.ne00  =*/ ne00,
+        /*.ne01  =*/ ne01,
+        /*.ne02  =*/ ne02,
+        /*.ne03  =*/ ne03,
+        /*.nb01  =*/ nb01,
+        /*.nb02  =*/ nb02,
+        /*.nb03  =*/ nb03,
+        /*.top_k =*/ (int32_t) op->ne[0],
+    };
+
+    // shared memory: 256-entry histogram + bucket/above scalars + output counter
+    const size_t smem_histo  = GGML_PAD(256*sizeof(uint32_t), 16);
+    const size_t smem_bucket = GGML_PAD(    sizeof(uint32_t), 16);
+    const size_t smem_above  = GGML_PAD(    sizeof(uint32_t), 16);
+    const size_t smem_out    = GGML_PAD(    sizeof(uint32_t), 16);
+
+    ggml_metal_encoder_set_pipeline(enc, pipeline);
+    ggml_metal_encoder_set_bytes   (enc, &args, sizeof(args), 0);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op->src[0]), 1);
+    ggml_metal_encoder_set_buffer  (enc, ggml_metal_get_buffer_id(op),         2);
+
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, smem_histo,  0);
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, smem_bucket, 1);
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, smem_above,  2);
+    ggml_metal_encoder_set_threadgroup_memory_size(enc, smem_out,    3);
+
+    ggml_metal_encoder_dispatch_threadgroups(enc, ne01, ne02, ne03, nth, 1, 1);
+}
+
+int ggml_metal_op_top_k(ggml_metal_op_t ctx, int idx) {
+    ggml_tensor * op = ctx->node(idx);
+
+    // radix-select has a fixed single-workgroup-per-row cost (~50-60us) that is only
+    // amortized for long rows, many rows, or a large k; otherwise the bitonic path wins
+    const int ncols = op->src[0]->ne[0];
+    const int k     = op->ne[0];
+    const int nrows = ggml_nrows(op->src[0]);
+
+    const bool use_radix =
+        ncols > 2048 && (k > 64 || (nrows > 4 && ncols >= 8192));
+
+    if (use_radix) {
+        ggml_metal_op_top_k_radix(ctx, idx);
+    } else {
+        ggml_metal_op_top_k_bitonic(ctx, idx);
     }
 
     return 1;

--- a/ggml/src/ggml-metal/kernels/argsort.metal
+++ b/ggml/src/ggml-metal/kernels/argsort.metal
@@ -230,3 +230,108 @@ kernel void kernel_argsort_merge_f32_i32(
 
 template [[host_name("kernel_argsort_merge_f32_i32_asc")]]  kernel argsort_merge_t kernel_argsort_merge_f32_i32<GGML_SORT_ORDER_ASC>;
 template [[host_name("kernel_argsort_merge_f32_i32_desc")]] kernel argsort_merge_t kernel_argsort_merge_f32_i32<GGML_SORT_ORDER_DESC>;
+
+static inline uint ggml_top_k_f2ui(float x) {
+    uint y = as_type<uint>(x);
+    if ((y & 0x80000000u) != 0u) {
+        y ^= 0xFFFFFFFFu; // negative floats: flip all bits
+    } else {
+        y |= 0x80000000u; // positive floats: set the sign bit
+    }
+    return y;
+}
+
+kernel void kernel_top_k_f32_i32(
+        constant   ggml_metal_kargs_top_k & args,
+        device   const char * src0,
+        device      int32_t * dst,
+        threadgroup atomic_uint * histo     [[threadgroup(0)]],
+        threadgroup        uint * sh_bucket [[threadgroup(1)]],
+        threadgroup        uint * sh_above  [[threadgroup(2)]],
+        threadgroup atomic_uint * out_count [[threadgroup(3)]],
+        uint3   tgpig[[threadgroup_position_in_grid]],
+        ushort3 tpitg[[thread_position_in_threadgroup]],
+        ushort3   ntg[[threads_per_threadgroup]]) {
+
+    const uint ncols = args.ne00;
+    const uint top_k = args.top_k;
+    const uint i01   = tgpig[0];
+    const uint i02   = tgpig[1];
+    const uint i03   = tgpig[2];
+
+    device const float * src0_row = (device const float *) (src0 + args.nb01*i01 + args.nb02*i02 + args.nb03*i03);
+
+    device int32_t * dst_row = dst + top_k*(i01 + args.ne01*i02 + args.ne01*args.ne02*i03);
+
+    const uint tid = tpitg.x;
+    const uint ntg_x = ntg.x;
+
+    uint prefix  = 0;     // fixed high bits of the threshold key
+    uint desired = top_k; // count still needed from the candidate range
+
+    for (int shift = 24; shift >= 0; shift -= 8) {
+        for (uint i = tid; i < 256; i += ntg_x) {
+            atomic_store_explicit(&histo[i], 0u, memory_order_relaxed);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        const uint hi_mask   = (shift + 8 >= 32) ? 0u : (0xFFFFFFFFu << uint(shift + 8));
+        const uint prefix_hi = prefix & hi_mask;
+
+        for (uint i = tid; i < ncols; i += ntg_x) {
+            const uint key = ggml_top_k_f2ui(src0_row[i]);
+            if ((key & hi_mask) == prefix_hi) {
+                atomic_fetch_add_explicit(&histo[(key >> uint(shift)) & 0xFFu], 1u, memory_order_relaxed);
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        // top-down scan for the bucket holding the k-th value
+        if (tid == 0) {
+            uint acc = 0;
+            uint b   = 0;
+            for (int bb = 255; bb >= 0; --bb) {
+                const uint c = atomic_load_explicit(&histo[bb], memory_order_relaxed);
+                if (acc + c >= desired) {
+                    b = uint(bb);
+                    break;
+                }
+                acc += c;
+            }
+            *sh_bucket = b;
+            *sh_above  = acc;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        prefix  |= *sh_bucket << uint(shift);
+        desired -= *sh_above;
+
+        // ensure every thread has consumed sh_bucket/sh_above before the next pass
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+        atomic_store_explicit(out_count, 0u, memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // emit everything above the threshold, then fill the rest from ties
+    const uint threshold = prefix;
+
+    for (uint i = tid; i < ncols; i += ntg_x) {
+        if (ggml_top_k_f2ui(src0_row[i]) > threshold) {
+            const uint pos = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+            dst_row[pos] = (int32_t) i;
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint i = tid; i < ncols; i += ntg_x) {
+        if (ggml_top_k_f2ui(src0_row[i]) == threshold) {
+            const uint pos = atomic_fetch_add_explicit(out_count, 1u, memory_order_relaxed);
+            if (pos < top_k) {
+                dst_row[pos] = (int32_t) i;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Modeled after https://github.com/ggml-org/llama.cpp/pull/28032

### Perf

<details>
<summary>M2 Ultra</summary>

| Backend   | GGML op   | Op parameters                            |   Bandwidth (GB/s) master |   Bandwidth (GB/s) gg/metal-top-k |   Speedup |
|:----------|:----------|:-----------------------------------------|--------------------------:|----------------------------------:|----------:|
| MTL0      | TOP_K     | type=f32,ne=[1,1,1,1],k=1,ties=0         |                      0.00 |                              0.00 |      0.94 |
| MTL0      | TOP_K     | type=f32,ne=[1,16,1,1],k=1,ties=0        |                      0.04 |                              0.04 |      1.04 |
| MTL0      | TOP_K     | type=f32,ne=[10,1,1,1],k=10,ties=0       |                      0.01 |                              0.01 |      0.96 |
| MTL0      | TOP_K     | type=f32,ne=[10,16,1,1],k=10,ties=0      |                      0.15 |                              0.16 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=1,ties=0      |                      0.12 |                              0.12 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=10,ties=0     |                      0.12 |                              0.12 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=16,ties=0     |                      0.12 |                              0.12 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=32,ties=0     |                      0.12 |                              0.12 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=4,ties=0      |                      0.12 |                              0.12 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=40,ties=0     |                      0.12 |                              0.12 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=400,ties=0    |                      0.17 |                              0.17 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=8,ties=0      |                      0.12 |                              0.12 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=1,ties=0     |                      1.91 |                              1.91 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=10,ties=0    |                      1.94 |                              1.92 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=16,ties=0    |                      1.95 |                              1.94 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=32,ties=0    |                      1.97 |                              1.97 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=4,ties=0     |                      1.92 |                              1.91 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=40,ties=0    |                      1.99 |                              1.99 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=400,ties=0   |                      2.68 |                              2.67 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=8,ties=0     |                      1.93 |                              1.92 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[12288,1,1,1],k=16,ties=0    |                      0.87 |                              0.85 |      0.98 |
| MTL0      | TOP_K     | type=f32,ne=[12288,16,1,1],k=16,ties=0   |                      9.00 |                             13.21 |      1.47 |
| MTL0      | TOP_K     | type=f32,ne=[131072,1,1,1],k=16,ties=0   |                      4.99 |                              4.98 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[131072,16,1,1],k=16,ties=0  |                     14.48 |                             32.57 |      2.25 |
| MTL0      | TOP_K     | type=f32,ne=[16,1,1,1],k=16,ties=0       |                      0.02 |                              0.02 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[16,16,1,1],k=16,ties=0      |                      0.25 |                              0.25 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[16384,1,1,1],k=16,ties=0    |                      1.13 |                              1.13 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[16384,16,1,1],k=16,ties=0   |                      9.32 |                             17.16 |      1.84 |
| MTL0      | TOP_K     | type=f32,ne=[2,1,1,1],k=1,ties=0         |                      0.00 |                              0.00 |      1.06 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=1,ties=0    |                      7.44 |                              7.34 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=10,ties=0   |                      6.21 |                              6.18 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=16,ties=0   |                      5.57 |                              5.55 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=32,ties=0   |                      4.63 |                              4.63 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=4,ties=0    |                      6.99 |                              6.98 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=40,ties=0   |                      4.31 |                              4.35 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=400,ties=0  |                      1.18 |                              2.73 |      2.31 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=8,ties=0    |                      6.28 |                              6.30 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=1,ties=0   |                     15.91 |                             26.08 |      1.64 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=10,ties=0  |                     15.22 |                             26.96 |      1.77 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=16,ties=0  |                     14.84 |                             26.42 |      1.78 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=32,ties=0  |                     13.89 |                             26.48 |      1.91 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=4,ties=0   |                     15.63 |                             26.04 |      1.67 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=40,ties=0  |                     13.52 |                             25.45 |      1.88 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=400,ties=0 |                      6.77 |                             26.64 |      3.93 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=8,ties=0   |                     15.32 |                             25.82 |      1.68 |
| MTL0      | TOP_K     | type=f32,ne=[24576,1,1,1],k=16,ties=0    |                      1.50 |                              1.46 |      0.97 |
| MTL0      | TOP_K     | type=f32,ne=[24576,16,1,1],k=16,ties=0   |                     10.37 |                             23.03 |      2.22 |
| MTL0      | TOP_K     | type=f32,ne=[32,1,1,1],k=32,ties=0       |                      0.02 |                              0.02 |      0.97 |
| MTL0      | TOP_K     | type=f32,ne=[32,16,1,1],k=32,ties=0      |                      0.37 |                              0.38 |      1.02 |
| MTL0      | TOP_K     | type=f32,ne=[32768,1,1,1],k=16,ties=0    |                      2.01 |                              1.97 |      0.98 |
| MTL0      | TOP_K     | type=f32,ne=[32768,16,1,1],k=16,ties=0   |                     11.16 |                             27.11 |      2.43 |
| MTL0      | TOP_K     | type=f32,ne=[4,1,1,1],k=4,ties=0         |                      0.01 |                              0.01 |      1.05 |
| MTL0      | TOP_K     | type=f32,ne=[4,16,1,1],k=4,ties=0        |                      0.10 |                              0.10 |      1.02 |
| MTL0      | TOP_K     | type=f32,ne=[40,1,1,1],k=40,ties=0       |                      0.02 |                              0.02 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[40,16,1,1],k=40,ties=0      |                      0.38 |                              0.39 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[400,1,1,1],k=400,ties=0     |                      0.13 |                              0.13 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[400,16,1,1],k=400,ties=0    |                      2.14 |                              2.14 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[4096,1,1,1],k=16,ties=0     |                      0.36 |                              0.36 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[4096,16,1,1],k=16,ties=0    |                      5.78 |                              5.79 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=1,ties=0     |                      4.05 |                              4.04 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=10,ties=0    |                      3.58 |                              3.53 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=16,ties=0    |                      3.42 |                              3.39 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=32,ties=0    |                      2.91 |                              2.91 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=4,ties=0     |                      3.75 |                              3.76 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=40,ties=0    |                      2.86 |                              2.82 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=400,ties=0   |                      1.02 |                              2.00 |      1.96 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=8,ties=0     |                      3.57 |                              3.60 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=1,ties=0    |                     13.87 |                             33.60 |      2.42 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=10,ties=0   |                     13.46 |                             33.50 |      2.49 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=16,ties=0   |                     13.25 |                             33.45 |      2.53 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=32,ties=0   |                     12.63 |                             33.07 |      2.62 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=4,ties=0    |                     13.70 |                             33.58 |      2.45 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=40,ties=0   |                     12.41 |                             33.03 |      2.66 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=400,ties=0  |                      7.05 |                             31.21 |      4.42 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=8,ties=0    |                     13.52 |                             33.41 |      2.47 |
| MTL0      | TOP_K     | type=f32,ne=[65536,1,1,1],k=16,ties=0    |                      3.40 |                              3.38 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[65536,16,1,1],k=16,ties=0   |                     13.50 |                             34.56 |      2.56 |
| MTL0      | TOP_K     | type=f32,ne=[8,1,1,1],k=8,ties=0         |                      0.01 |                              0.01 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[8,16,1,1],k=8,ties=0        |                      0.16 |                              0.16 |      1.03 |
| MTL0      | TOP_K     | type=f32,ne=[8192,1,1,1],k=16,ties=0     |                      0.64 |                              0.63 |      0.99 |
| MTL0      | TOP_K     | type=f32,ne=[8192,16,1,1],k=16,ties=0    |                      8.45 |                             11.14 |      1.32 |
</details>

<details>
<summary>M5 Max</summary>

| Backend   | GGML op   | Op parameters                            |   Bandwidth (GB/s) master |   Bandwidth (GB/s) gg/metal-top-k |   Speedup |
|:----------|:----------|:-----------------------------------------|--------------------------:|----------------------------------:|----------:|
| MTL0      | TOP_K     | type=f32,ne=[1,1,1,1],k=1,ties=0         |                      0.00 |                              0.00 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[1,16,1,1],k=1,ties=0        |                      0.05 |                              0.05 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[10,1,1,1],k=10,ties=0       |                      0.02 |                              0.02 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[10,16,1,1],k=10,ties=0      |                      0.31 |                              0.31 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=1,ties=0      |                      0.19 |                              0.19 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=10,ties=0     |                      0.19 |                              0.19 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=16,ties=0     |                      0.19 |                              0.19 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=32,ties=0     |                      0.20 |                              0.20 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=4,ties=0      |                      0.19 |                              0.19 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=40,ties=0     |                      0.20 |                              0.20 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=400,ties=0    |                      0.27 |                              0.27 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,1,1,1],k=8,ties=0      |                      0.19 |                              0.19 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=1,ties=0     |                      3.05 |                              3.06 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=10,ties=0    |                      3.08 |                              3.08 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=16,ties=0    |                      3.11 |                              3.11 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=32,ties=0    |                      3.16 |                              3.16 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=4,ties=0     |                      3.06 |                              3.06 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=40,ties=0    |                      3.15 |                              3.17 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=400,ties=0   |                      4.28 |                              4.26 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[1000,16,1,1],k=8,ties=0     |                      3.07 |                              3.08 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[12288,1,1,1],k=16,ties=0    |                      1.45 |                              1.46 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[12288,16,1,1],k=16,ties=0   |                      8.66 |                             21.97 |      2.54 |
| MTL0      | TOP_K     | type=f32,ne=[131072,1,1,1],k=16,ties=0   |                      5.89 |                              5.95 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[131072,16,1,1],k=16,ties=0  |                     10.26 |                             48.94 |      4.77 |
| MTL0      | TOP_K     | type=f32,ne=[16,1,1,1],k=16,ties=0       |                      0.03 |                              0.03 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[16,16,1,1],k=16,ties=0      |                      0.49 |                              0.50 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[16384,1,1,1],k=16,ties=0    |                      1.96 |                              1.93 |      0.98 |
| MTL0      | TOP_K     | type=f32,ne=[16384,16,1,1],k=16,ties=0   |                      8.79 |                             28.14 |      3.20 |
| MTL0      | TOP_K     | type=f32,ne=[2,1,1,1],k=1,ties=0         |                      0.00 |                              0.00 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=1,ties=0    |                      7.89 |                              7.91 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=10,ties=0   |                      7.50 |                              7.50 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=16,ties=0   |                      7.32 |                              7.32 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=32,ties=0   |                      6.89 |                              6.90 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=4,ties=0    |                      7.71 |                              7.72 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=40,ties=0   |                      6.66 |                              6.68 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=400,ties=0  |                      2.79 |                              3.60 |      1.29 |
| MTL0      | TOP_K     | type=f32,ne=[200000,1,1,1],k=8,ties=0    |                      7.56 |                              7.56 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=1,ties=0   |                     10.97 |                             41.79 |      3.81 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=10,ties=0  |                     10.56 |                             41.47 |      3.93 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=16,ties=0  |                     10.87 |                             40.80 |      3.75 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=32,ties=0  |                     10.71 |                             40.78 |      3.81 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=4,ties=0   |                     10.95 |                             40.85 |      3.73 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=40,ties=0  |                     10.45 |                             40.77 |      3.90 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=400,ties=0 |                      7.57 |                             41.55 |      5.49 |
| MTL0      | TOP_K     | type=f32,ne=[200000,16,1,1],k=8,ties=0   |                     10.93 |                             40.82 |      3.74 |
| MTL0      | TOP_K     | type=f32,ne=[24576,1,1,1],k=16,ties=0    |                      2.64 |                              2.63 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[24576,16,1,1],k=16,ties=0   |                      9.46 |                             36.44 |      3.85 |
| MTL0      | TOP_K     | type=f32,ne=[32,1,1,1],k=32,ties=0       |                      0.05 |                              0.05 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[32,16,1,1],k=32,ties=0      |                      0.83 |                              0.83 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[32768,1,1,1],k=16,ties=0    |                      3.51 |                              3.50 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[32768,16,1,1],k=16,ties=0   |                      9.82 |                             41.33 |      4.21 |
| MTL0      | TOP_K     | type=f32,ne=[4,1,1,1],k=4,ties=0         |                      0.01 |                              0.01 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[4,16,1,1],k=4,ties=0        |                      0.17 |                              0.17 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[40,1,1,1],k=40,ties=0       |                      0.05 |                              0.05 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[40,16,1,1],k=40,ties=0      |                      0.84 |                              0.84 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[400,1,1,1],k=400,ties=0     |                      0.31 |                              0.31 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[400,16,1,1],k=400,ties=0    |                      4.85 |                              4.86 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[4096,1,1,1],k=16,ties=0     |                      0.61 |                              0.61 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[4096,16,1,1],k=16,ties=0    |                      6.67 |                              6.65 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=1,ties=0     |                      5.11 |                              5.11 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=10,ties=0    |                      4.87 |                              4.88 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=16,ties=0    |                      4.82 |                              4.80 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=32,ties=0    |                      4.66 |                              4.66 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=4,ties=0     |                      4.95 |                              4.94 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=40,ties=0    |                      4.59 |                              4.58 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=400,ties=0   |                      3.00 |                              2.83 |      0.94 |
| MTL0      | TOP_K     | type=f32,ne=[65000,1,1,1],k=8,ties=0     |                      4.89 |                              4.87 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=1,ties=0    |                     10.48 |                             46.66 |      4.45 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=10,ties=0   |                     10.12 |                             46.48 |      4.59 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=16,ties=0   |                     10.38 |                             46.45 |      4.48 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=32,ties=0   |                     10.30 |                             46.07 |      4.47 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=4,ties=0    |                     10.43 |                             46.65 |      4.47 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=40,ties=0   |                     10.24 |                             45.90 |      4.48 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=400,ties=0  |                      8.78 |                             43.85 |      4.99 |
| MTL0      | TOP_K     | type=f32,ne=[65000,16,1,1],k=8,ties=0    |                     10.40 |                             46.52 |      4.47 |
| MTL0      | TOP_K     | type=f32,ne=[65536,1,1,1],k=16,ties=0    |                      4.85 |                              4.85 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[65536,16,1,1],k=16,ties=0   |                     10.08 |                             46.90 |      4.65 |
| MTL0      | TOP_K     | type=f32,ne=[8,1,1,1],k=8,ties=0         |                      0.02 |                              0.02 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[8,16,1,1],k=8,ties=0        |                      0.29 |                              0.29 |      1.01 |
| MTL0      | TOP_K     | type=f32,ne=[8192,1,1,1],k=16,ties=0     |                      1.10 |                              1.10 |      1.00 |
| MTL0      | TOP_K     | type=f32,ne=[8192,16,1,1],k=16,ties=0    |                      7.25 |                             18.54 |      2.56 |

</details>

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/DeepSeek-v4-Flash-0731

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
