### PR TITLE
server: trust a disk-restored slot on hybrid-recurrent (DSV4) models

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2651,6 +2651,23 @@ private:
                     slot->prompt.clear();
                     slot->prompt.tokens.insert(tokens);
 
+                    // DSV4/hybrid-recurrent models cannot roll back their recurrent state by
+                    // truncation, so the slot operator will only reuse the restored cache if a
+                    // context checkpoint covering it exists. Register one over the restored
+                    // sequence (pos_min == 0 always matches the search predicate).
+                    if (token_count > 0) {
+                        common_prompt_checkpoint ckpt;
+                        ckpt.update_pos(token_count, 0, (llama_pos) (token_count - 1));
+                        ckpt.update_tgt(ctx_tgt, slot->id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                        ckpt.update_dft(ctx_dft, slot->id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+                        common_speculative_get_state(spec.get(), slot->id, ckpt.data_spec);
+
+                        slot->prompt.checkpoints.push_back(std::move(ckpt));
+
+                        SLT_INF(*slot, "registered checkpoint over restored state (%" PRId64 " tokens, pos [0, %d])\n",
+                                ckpt.n_tokens, (int) token_count - 1);
+                    }
+
                     const int64_t t_end = ggml_time_us();
                     const double t_restore_ms = (t_end - t_start) / 1000.0;
 


### PR DESCRIPTION
## Overview

Fix `POST /slots/:id?action=restore` (`--slot-save-path`) being useless on hybrid-recurrent (DSV4) models, like qwen 3

`llama_kv_cache_dsv4::seq_pos_min()` intentionally returns `seq_pos_max` because DeltaNet recurrent state cannot be rewound, so `server-context.cpp` always requires a context checkpoint to reuse cached state. `SLOT_RESTORE` restored KV+recurrent via `llama_state_seq_load_file` but never populated `slot.prompt.checkpoints`, so the next request always logged `forcing full prompt re-processing due to lack of cache data` and re-prefilled from zero. Full-attention models unaffected.

Fix (17 lines, `tools/server/server-context.cpp:SLOT_RESTORE`): after successful load, register a `PARTIAL_ONLY` checkpoint covering `[0, token_count-1]` via `update_tgt`/`update_dft`/`common_speculative_get_state`. Next request finds it, restores recurrent state, and evaluates only the tail.

## Additional information


- Why not `cache-ram` alone: `--cache-reuse` is disabled for DSV4 (`get_can_shift()==false`) and `cache-ram` does not survive restart/idle unload; disk save/restore is the only mechanism that does.
- Verified on Qwen3.8-27B-AD (DSV4): before = 561ms/317t full re-prefill; after = `registered checkpoint over restored state (430 tokens, pos [0,429])` + `cached n_tokens=430`, 188ms/28t tail only, total 1103ms. 7112t/10-checkpoint context restores at `cached n_tokens=7112`. 
- Manual repro steps in description below. No small hybrid model available for automated `test_slot_save.py` coverage, so verification is via manual A/B logs and isolated build from `9de0fcf2b`.

Reproduction:

1. Build from this branch (`cmake -B build-pr -S . && cmake --build build-pr --target llama-server`)
2. `llama-server --slot-save-path /tmp/slots -np 1 -lv 4 -m <Qwen3.8-AD-Q5.gguf> --port 18082 --ctx-checkpoints 32`
3. Build conversation (~400t), `POST /slots/0?action=save {"filename":"a.bin"}`, overwrite slot with different prompt, `POST /slots/0?action=restore {"filename":"a.bin"}`, continue with original history+tail and check logs.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - used AI for the code writing. PR description double-cheked by me.

