### PR TITLE
sched: fix backend assignment for ops with view-backed outputs

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1263,6 +1263,7 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
     }
 
     // pass 4: assign backends to remaining src from dst and view_src
+    //         and ensure ops that write into a view run on a backend that can access the view_src buffer
     for (int i = 0; i < graph->n_nodes; i++) {
         struct ggml_tensor * node = graph->nodes[i];
         int * cur_backend_id = &tensor_backend_id(node);

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1266,9 +1266,26 @@ void ggml_backend_sched_split_graph(ggml_backend_sched_t sched, struct ggml_cgra
     for (int i = 0; i < graph->n_nodes; i++) {
         struct ggml_tensor * node = graph->nodes[i];
         int * cur_backend_id = &tensor_backend_id(node);
-        if (node->view_src != NULL && *cur_backend_id == -1) {
-            *cur_backend_id = tensor_backend_id(node->view_src);
-            SET_CAUSE(node, "4.vsrc");
+        if (node->view_src != NULL) {
+            const int vsrc_backend_id = tensor_backend_id(node->view_src);
+            if (*cur_backend_id == -1) {
+                *cur_backend_id = vsrc_backend_id;
+                GGML_ASSERT(vsrc_backend_id == -1 || ggml_backend_supports_op(sched->backends[*cur_backend_id], node));
+                SET_CAUSE(node, "4.vsrc");
+            } else if (!ggml_is_view_op(node->op) && !ggml_backend_sched_buffer_supported(sched, node->view_src, *cur_backend_id) && vsrc_backend_id != -1) {
+                bool found = false;
+                for (int b = 0;b < sched->n_backends;b++) {
+                    if (ggml_backend_sched_buffer_supported(sched, node->view_src, b) && ggml_backend_supports_op(sched->backends[b], node)) {
+                        found = true;
+                        *cur_backend_id = b;
+                        break;
+                    }
+                }
+                if (!found) {
+                    GGML_ABORT("op (%s) writes into a view of (%s) but no backend can access the buffer and run the op", ggml_op_name(node->op), node->view_src->name);
+                }
+                SET_CAUSE(node, "4.vsrc");
+            }
         }
         for (int j = 0; j < GGML_MAX_SRC; j++) {
             struct ggml_tensor * src = node->src[j];

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -517,12 +517,6 @@ static bool arch_supported(const llm_arch arch) {
     if (arch == LLM_ARCH_DEEPSEEK2OCR) {
         return false;
     }
-    // FIXME: these hit scheduler/view-backed-output issues with WebGPU on CI.
-#ifdef GGML_USE_WEBGPU
-    if (arch == LLM_ARCH_DEEPSEEK32 || arch == LLM_ARCH_GLM_DSA || arch == LLM_ARCH_DOTS3NOTE || arch == LLM_ARCH_QWEN4EXP) {
-        return false;
-    }
-#endif // GGML_USE_WEBGPU
 
     // FIXME: jamba produces incorrect output (~0.55 NMSE vs CPU) on the HIP
     // backend on RDNA3.5 (gfx1151); the SSM kernels need investigation.


### PR DESCRIPTION
## Overview

This PR fixes a scheduler bug and enables the WebGPU backend to pass all the
currently skipped models in test-llama-archs (deepseek32, glm-dsa, dots3note,
qwen4exp).

When a node writes into a view of another tensor, it must be assigned to a
backend that can access the `view_src` buffer, since the scheduler copies inputs
across backends but not outputs.

For the skipped models on the WebGPU backend, the following code in the DSA
variant of build_attn causes the error:

```cpp
ggml_tensor * kq_mask_all = ggml_fill(ctx0, kq_mask, -INFINITY);
…
ggml_tensor * kq_mask_top_k = ggml_set_rows(ctx0, kq_mask_all, …);
```

The WebGPU FILL op does not support the F16 `kq_mask`, so the FILL is assigned to the CPU but the SET_ROWS is assigned to WebGPU. The SET_ROWS output is a view of the FILL result, which causes the error.

So this PR adds logic to reassign the writer node to a backend that can access
the view_src buffer.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes — used for root cause analysis and for discussing/reviewing the changes.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
