### PR TITLE
ci : add check for unzip

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -732,6 +732,11 @@ function gg_check_build_requirements {
         gg_printf 'ctest not found, please install\n'
         exit 1
     fi
+
+    if ! command -v unzip &> /dev/null; then
+        gg_printf 'unzip not found, please install\n'
+        exit 1
+    fi
 }
 
 function gg_run_test_backend_ops_cpu {


### PR DESCRIPTION
## Overview

`ci/run.sh` fails if `unzip` is not installed.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Tidak
- Language disclosure: Ma'anyan