### PR TITLE
ui : fix MCP image attachments not displayed in tool block (#25789)

### DIFF
--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
@@ -194,7 +194,7 @@
 		/>
 	{:else if section.type === AgenticSectionType.TOOL_CALL || section.type === AgenticSectionType.TOOL_CALL_PENDING || section.type === AgenticSectionType.TOOL_CALL_STREAMING}
 		<ChatMessageToolCallBlock
-			attachments={message?.extra}
+			attachments={section.toolResultExtras ?? message?.extra}
 			isExecuting={section.toolCallId !== undefined &&
 				section.toolCallId === currentlyExecutingToolCallId}
 			{isStreaming}

--- a/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
+++ b/tools/ui/src/lib/components/app/chat/ChatMessages/ChatMessageAgenticContent.svelte
@@ -194,7 +194,7 @@
 		/>
 	{:else if section.type === AgenticSectionType.TOOL_CALL || section.type === AgenticSectionType.TOOL_CALL_PENDING || section.type === AgenticSectionType.TOOL_CALL_STREAMING}
 		<ChatMessageToolCallBlock
-			attachments={section.toolResultExtras ?? message?.extra}
+			attachments={section.toolResultExtras}
 			isExecuting={section.toolCallId !== undefined &&
 				section.toolCallId === currentlyExecutingToolCallId}
 			{isStreaming}

--- a/tools/ui/src/lib/constants/agentic.constants.ts
+++ b/tools/ui/src/lib/constants/agentic.constants.ts
@@ -2,8 +2,11 @@ import type { AgenticConfig } from '$lib/types/agentic';
 
 export const ATTACHMENT_SAVED_REGEX = /\[Attachment saved: ([^\]]+)\]/;
 
-// JSON detection: trimmed content opens with an object or array literal.
-export const TOOL_RESULT_JSON_OPEN_REGEX = /^[[{]/;
+// JSON detection: an attachment placeholder also starts with `[`, but is
+// plain text (`[Attachment saved: ...]`), not an array literal. Require the
+// first array value (or the closing bracket for an empty array) to look like
+// a valid JSON token before attempting JSON.parse.
+export const TOOL_RESULT_JSON_OPEN_REGEX = /^(?:\{|\[\s*(?:[\]"{\-0-9]|true|false|null))/;
 
 // Search-summary wire format used by file-glob and grep tools:
 //   <matches>

--- a/tools/ui/src/lib/constants/agentic.constants.ts
+++ b/tools/ui/src/lib/constants/agentic.constants.ts
@@ -6,7 +6,7 @@ export const ATTACHMENT_SAVED_REGEX = /\[Attachment saved: ([^\]]+)\]/;
 // plain text (`[Attachment saved: ...]`), not an array literal. Require the
 // first array value (or the closing bracket for an empty array) to look like
 // a valid JSON token before attempting JSON.parse.
-export const TOOL_RESULT_JSON_OPEN_REGEX = /^(?:\{|\[\s*(?:[\]"{\-0-9]|true|false|null))/;
+export const TOOL_RESULT_JSON_OPEN_REGEX = /^(?:\{|\[\s*(?:[\[\]"{\-0-9]|true|false|null))/;
 
 // Search-summary wire format used by file-glob and grep tools:
 //   <matches>

--- a/tools/ui/src/lib/constants/agentic.constants.ts
+++ b/tools/ui/src/lib/constants/agentic.constants.ts
@@ -6,7 +6,7 @@ export const ATTACHMENT_SAVED_REGEX = /\[Attachment saved: ([^\]]+)\]/;
 // plain text (`[Attachment saved: ...]`), not an array literal. Require the
 // first array value (or the closing bracket for an empty array) to look like
 // a valid JSON token before attempting JSON.parse.
-export const TOOL_RESULT_JSON_OPEN_REGEX = /^(?:\{|\[\s*(?:[\[\]"{\-0-9]|true|false|null))/;
+export const TOOL_RESULT_JSON_OPEN_REGEX = /^(?:\{|\[\s*(?:[[\]"{\-0-9]|true|false|null))/;
 
 // Search-summary wire format used by file-glob and grep tools:
 //   <matches>

--- a/tools/ui/tests/unit/classify-tool-result.test.ts
+++ b/tools/ui/tests/unit/classify-tool-result.test.ts
@@ -37,6 +37,10 @@ describe('classifyToolResult', () => {
 			expect(classifyToolResult('["a", "b", "c"]')).toBe('json');
 		});
 
+		it('classifies a nested JSON array', () => {
+			expect(classifyToolResult('[[1, 2], [3, 4]]')).toBe('json');
+		});
+
 		it('classifies a pretty-printed JSON object', () => {
 			expect(classifyToolResult('{\n  "key": "value"\n}')).toBe('json');
 		});


### PR DESCRIPTION
Fixes regression from #25450 where ChatMessageAgenticContent passed message.extra instead of section.toolResultExtras to tool blocks, leaving tool images invisible. Also fixes TOOL_RESULT_JSON_OPEN_REGEX which misclassified "[Attachment saved: ...]" as JSON.

Fixes #25789

Assisted-by: Muse Spark

## Overview

Fixes a regression where MCP image attachments were not displayed in tool-call blocks.

Tool blocks now receive the attachments stored in the corresponding agentic section, with a fallback to the message-level extras for compatibility. The tool-result JSON detection regex was also tightened so `[Attachment saved: ...]` placeholders are treated as plain text rather than JSON arrays.

Also, regex in `TOOL_RESULT_JSON_OPEN_REGEX` constant in agentic.constants.ts has been updated:

The old regex was: `/^[[{]/`
The new regex is: ` /^(?:\{|\[\s*(?:[\]"{\-0-9]|true|false|null))/`

It can be read as follows:

- `^`: starts at the beginning of the text.
- `(?:\{|...)`: directly accepts `{`, indicating a possible JSON object.
- `\[\s*`: or accepts `[`, followed by optional whitespace.
- After `[`, it requires something that could begin a JSON value:
  - `]` for an empty array: `[]`
  - `"` for a string: `["image.png"]`
  - `{` for an object: `[{"name":"x"}]`
  - `-` or a digit for a number: `[-1]`, `[42]`
  - `true`, `false`, or `null`

Therefore, these cases look like JSON:

-   `{}`
-   `[]`
-   `["file.png"]`
-   `[{"id": 1}]`
-   `[true, null]`

However, this placeholder no longer matches the detection:

- `[Attachment saved: image.png]`

The regex does not fully validate JSON; it only determines whether attempting to parse the content is worthwhile. The real validation is still performed by JSON.parse(). This avoids obvious false positives without turning the regular expression into a complete JSON parser.

Fixes #25789 .

## Screenshots

|Device|Before|After|
|-------|-------|-------|
|PC|<img width="775" height="919" alt="imagen" src="https://github.com/user-attachments/assets/8af2ef61-9efa-44b1-b1a7-f344fee71400" />|<img width="775" height="919" alt="Captura desde 2026-09-04 19-20-58" src="https://github.com/user-attachments/assets/6e512487-e646-460f-b0b2-5785d2cd5ef5" />|
|Mobile|<img width="1200" height="2608" alt="Screenshot_2026-09-04-19-48-51-123_org mozilla firefox" src="https://github.com/user-attachments/assets/1e502503-f5bd-4d03-b769-65bcfaab8c8e" />|<img width="1200" height="2608" alt="Screenshot_2026-09-04-19-40-59-934_org mozilla firefox" src="https://github.com/user-attachments/assets/576383f7-2d85-446a-8e9c-9f854fd3b8f4" />|

## Additional information

This regression was introduced by #25450 (specific line [here](https://github.com/ggml-org/llama.cpp/pull/25450/changes#diff-5dc76f4d24818c1afc5f07fd143738f7f7a6ef7c37fbbfc7fa4bc2a7c82808dbR212)), where `ChatMessageAgenticContent` passed `message.extra` instead of `section.toolResultExtras` to tool blocks.

The change was assisted by Muse Spark.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Muse Spark assisted with this change.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->