### PR TITLE
server : add --cache-disk for a persistent prompt cache

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1718,6 +1718,23 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_CACHE_RAM").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
+        {"--cache-disk"}, "PATH",
+        "persist prompt cache state under this directory and restore it after server restart",
+        [](common_params & params, const std::string & value) {
+            params.cache_disk_path = value;
+        }
+    ).set_env("LLAMA_ARG_CACHE_DISK").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--cache-disk-max"}, "N",
+        string_format("set the maximum disk cache size in MiB (default: %d, -1 - no limit, 0 - disable)", params.cache_disk_max_mib),
+        [](common_params & params, int value) {
+            if (value < -1) {
+                throw std::invalid_argument("cache-disk-max must be -1 or non-negative");
+            }
+            params.cache_disk_max_mib = value;
+        }
+    ).set_env("LLAMA_ARG_CACHE_DISK_MAX").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-kvu", "--kv-unified"},
         {"-no-kvu", "--no-kv-unified"},
         "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",
@@ -1728,7 +1745,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     add_opt(common_arg(
         {"--cache-idle-slots"},
         {"--no-cache-idle-slots"},
-        "save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires cache-ram)",
+        "save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires a prompt cache)",
         [](common_params & params, bool value) {
             params.cache_idle_slots = value;
         }

--- a/common/common.h
+++ b/common/common.h
@@ -630,6 +630,9 @@ struct common_params {
     int32_t kv_unified_per_slot = 0;     // max context per parallel slot; 0 = unset
     int32_t checkpoint_min_step = 8192;  // minimum spacing between context checkpoints
     int32_t cache_ram_mib       = 8192;  // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
+    int32_t cache_disk_max_mib  = -1;    // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
+
+    std::string cache_disk_path;
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -167,8 +167,10 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-ctxcp, --ctx-checkpoints, --swa-checkpoints N` | max number of context checkpoints to create per slot (default: 32)[(more info)](https://github.com/ggml-org/llama.cpp/pull/15293)<br/>(env: LLAMA_ARG_CTX_CHECKPOINTS) |
 | `-cms, --checkpoint-min-step N` | minimum spacing between context checkpoints in tokens (default: 8192, 0 = no minimum)<br/>(env: LLAMA_ARG_CHECKPOINT_MIN_SPACING_NT) |
 | `-cram, --cache-ram N` | set the maximum cache size in MiB (default: 8192, -1 - no limit, 0 - disable)[(more info)](https://github.com/ggml-org/llama.cpp/pull/16391)<br/>(env: LLAMA_ARG_CACHE_RAM) |
+| `--cache-disk PATH` | persist prompt cache state under this directory and restore it after server restart<br/>(env: LLAMA_ARG_CACHE_DISK) |
+| `--cache-disk-max N` | set the maximum disk cache size in MiB (default: -1, -1 - no limit, 0 - disable)<br/>(env: LLAMA_ARG_CACHE_DISK_MAX) |
 | `-kvu, --kv-unified, -no-kvu, --no-kv-unified` | use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)<br/>(env: LLAMA_ARG_KV_UNIFIED) |
-| `--cache-idle-slots, --no-cache-idle-slots` | save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires cache-ram)<br/>(env: LLAMA_ARG_CACHE_IDLE_SLOTS) |
+| `--cache-idle-slots, --no-cache-idle-slots` | save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires a prompt cache)<br/>(env: LLAMA_ARG_CACHE_IDLE_SLOTS) |
 | `--context-shift, --no-context-shift` | whether to use context shift on infinite text generation (default: disabled)<br/>(env: LLAMA_ARG_CONTEXT_SHIFT) |
 | `-r, --reverse-prompt PROMPT` | halt generation at PROMPT, return control in interactive mode |
 | `-sp, --special` | special tokens output enabled (default: false) |

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -21,9 +21,12 @@
 #include <cstddef>
 #include <cinttypes>
 #include <exception>
+#include <iomanip>
+#include <limits>
 #include <memory>
 #include <filesystem>
 #include <random>
+#include <sstream>
 #include <utility>
 #include <fstream>
 
@@ -37,6 +40,79 @@
 #endif
 
 constexpr int HTTP_POLLING_SECONDS = 1;
+
+static void server_prompt_cache_key_add_file(
+        std::ostringstream & key,
+        const char * label,
+        const std::string & path) {
+    key << label << '=' << path.size() << ':' << path;
+    if (path.empty()) {
+        key << "\n";
+        return;
+    }
+
+    std::error_code ec;
+    const auto absolute_path = std::filesystem::absolute(path, ec);
+    if (!ec) {
+        const std::string normalized = absolute_path.lexically_normal().string();
+        key << '|' << normalized.size() << ':' << normalized;
+    }
+
+    ec.clear();
+    const auto size = std::filesystem::file_size(path, ec);
+    key << "|size=" << (ec ? 0 : size);
+
+    ec.clear();
+    const auto modified = std::filesystem::last_write_time(path, ec);
+    key << "|mtime=" << static_cast<long long>(ec ? 0 : modified.time_since_epoch().count()) << "\n";
+}
+
+static std::string server_prompt_cache_key(
+        const common_params & params,
+        const llama_context * ctx_tgt,
+        const llama_context * ctx_dft) {
+    std::ostringstream key;
+    key << "format=1\n";
+    key << "commit=" << llama_commit() << "\n";
+    server_prompt_cache_key_add_file(key, "model", params.model.path);
+    server_prompt_cache_key_add_file(key, "draft", params.speculative.draft.mparams.path);
+    server_prompt_cache_key_add_file(key, "mmproj", params.mmproj.path);
+
+    key << "n_ctx_tgt=" << llama_n_ctx(ctx_tgt) << "\n";
+    key << "n_batch_tgt=" << llama_n_batch(ctx_tgt) << "\n";
+    key << "n_ubatch_tgt=" << llama_n_ubatch(ctx_tgt) << "\n";
+    key << "n_ctx_dft=" << (ctx_dft ? llama_n_ctx(ctx_dft) : 0) << "\n";
+    key << "n_batch_dft=" << (ctx_dft ? llama_n_batch(ctx_dft) : 0) << "\n";
+    key << "n_ubatch_dft=" << (ctx_dft ? llama_n_ubatch(ctx_dft) : 0) << "\n";
+    key << "n_parallel=" << params.n_parallel << "\n";
+    key << "cache_type_k=" << (int) params.cache_type_k << "\n";
+    key << "cache_type_v=" << (int) params.cache_type_v << "\n";
+    key << "draft_cache_type_k=" << (int) params.speculative.draft.cache_type_k << "\n";
+    key << "draft_cache_type_v=" << (int) params.speculative.draft.cache_type_v << "\n";
+    key << "swa_full=" << params.swa_full << "\n";
+    key << "kv_unified=" << params.kv_unified << "\n";
+    key << "flash_attn=" << (int) params.flash_attn_type << "\n";
+    key << "no_kv_offload=" << params.no_kv_offload << "\n";
+
+    key << std::hexfloat;
+    key << "rope_freq_base=" << params.rope_freq_base << "\n";
+    key << "rope_freq_scale=" << params.rope_freq_scale << "\n";
+    key << "yarn_ext_factor=" << params.yarn_ext_factor << "\n";
+    key << "yarn_attn_factor=" << params.yarn_attn_factor << "\n";
+    key << "yarn_beta_fast=" << params.yarn_beta_fast << "\n";
+    key << "yarn_beta_slow=" << params.yarn_beta_slow << "\n";
+    key << "yarn_orig_ctx=" << params.yarn_orig_ctx << "\n";
+    for (const auto & lora : params.lora_adapters) {
+        server_prompt_cache_key_add_file(key, "lora", lora.path);
+        key << "lora_scale=" << lora.scale << "\n";
+    }
+    for (const auto & control_vector : params.control_vectors) {
+        server_prompt_cache_key_add_file(key, "control_vector", control_vector.fname);
+        key << "control_vector_strength=" << control_vector.strength << "\n";
+    }
+
+    return key.str();
+}
 
 static common_speculative_output_limits server_output_limits(const common_params & params) {
     if (params.embedding ||
@@ -314,16 +390,46 @@ struct server_slot {
             return false;
         }
 
-        llama_state_seq_get_data_ext(ctx_tgt, cur->data.main.data(), cur_size_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
-        if (ctx_dft) {
-            llama_state_seq_get_data_ext(ctx_dft, cur->data.drft.data(), cur_size_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+        if (cur->data.is_disk()) {
+            GGML_ASSERT(cur->data.mapping != nullptr);
+
+            const size_t n_tgt = llama_state_seq_get_data_ext(
+                ctx_tgt, cur->data.mapping, cur_size_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+            if (n_tgt != cur_size_tgt) {
+                SLT_WRN(*this, "failed to save target prompt state: expected %zu bytes, wrote %zu\n", cur_size_tgt, n_tgt);
+                prompt_cache.discard(cur);
+                return false;
+            }
+            if (ctx_dft) {
+                const size_t n_dft = llama_state_seq_get_data_ext(
+                    ctx_dft, cur->data.mapping + cur_size_tgt, cur_size_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+                if (n_dft != cur_size_dft) {
+                    SLT_WRN(*this, "failed to save draft prompt state: expected %zu bytes, wrote %zu\n", cur_size_dft, n_dft);
+                    prompt_cache.discard(cur);
+                    return false;
+                }
+            }
+
+            return prompt_cache.commit(cur);
+        } else {
+            llama_state_seq_get_data_ext(ctx_tgt, cur->data.main.data(), cur_size_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+            if (ctx_dft) {
+                llama_state_seq_get_data_ext(ctx_dft, cur->data.drft.data(), cur_size_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE);
+            }
         }
 
         return true;
     }
 
-    bool prompt_load(server_prompt_cache & prompt_cache, const server_tokens & tokens) {
-        bool res = prompt_cache.load(prompt, tokens, ctx_tgt, ctx_dft, id);
+    bool prompt_load(
+            server_prompt_cache & prompt_cache,
+            const server_tokens & tokens,
+            bool cache_prompt,
+            bool needs_checkpoint,
+            int32_t n_swa,
+            float slot_prompt_similarity) {
+        bool res = prompt_cache.load(
+            prompt, tokens, ctx_tgt, ctx_dft, id, cache_prompt, needs_checkpoint, n_swa, slot_prompt_similarity);
         if (!res) {
             SLT_WRN(*this, "%s", "failed to load prompt from cache\n");
         }
@@ -1348,17 +1454,41 @@ private:
             batch.init(std::max(n_batch, params_base.n_parallel), n_embd);
         }
 
-        if (params_base.cache_ram_mib != 0) {
-            if (params_base.cache_ram_mib < 0) {
-                SRV_TRC("prompt cache is enabled, size limit: %s\n", "no limit");
-            } else {
-                SRV_TRC("prompt cache is enabled, size limit: %d MiB\n", params_base.cache_ram_mib);
-            }
-            SRV_TRC("%s", "use `--cache-ram 0` to disable the prompt cache\n");
+        const bool cache_disk_enabled = !params_base.cache_disk_path.empty() && params_base.cache_disk_max_mib != 0;
+        const bool prompt_cache_enabled = cache_disk_enabled || params_base.cache_ram_mib != 0;
 
-            prompt_cache = std::make_unique<server_prompt_cache>(params_base.cache_ram_mib, n_ctx);
+        if (prompt_cache_enabled) {
+            const int32_t cache_limit_mib = cache_disk_enabled ? params_base.cache_disk_max_mib : params_base.cache_ram_mib;
+            const size_t cache_limit_tokens = cache_disk_enabled ? 0 : n_ctx;
+
+            if (cache_disk_enabled) {
+                std::error_code ec;
+                std::filesystem::create_directories(params_base.cache_disk_path, ec);
+                const bool cache_dir_valid = !ec && std::filesystem::is_directory(params_base.cache_disk_path, ec);
+                if (ec || !cache_dir_valid) {
+                    SRV_ERR("failed to create prompt cache directory %s: %s\n",
+                            params_base.cache_disk_path.c_str(), ec ? ec.message().c_str() : "path is not a directory");
+                    return false;
+                }
+                SRV_TRC("prompt cache is enabled on disk: %s\n", params_base.cache_disk_path.c_str());
+            } else {
+                SRV_TRC("%s", "prompt cache is enabled in RAM\n");
+            }
+
+            if (cache_limit_mib < 0) {
+                SRV_TRC("prompt cache size limit: %s\n", "no limit");
+            } else {
+                SRV_TRC("prompt cache size limit: %d MiB\n", cache_limit_mib);
+            }
+
+            prompt_cache = std::make_unique<server_prompt_cache>(
+                cache_limit_mib,
+                cache_limit_tokens,
+                cache_disk_enabled ? params_base.cache_disk_path : "",
+                cache_disk_enabled ? server_prompt_cache_key(params_base, ctx_tgt, ctx_dft) : "",
+                mctx != nullptr);
         } else {
-            SRV_TRC("%s", "prompt cache is disabled - use `--cache-ram N` to enable it\n");
+            SRV_TRC("%s", "prompt cache is disabled - use `--cache-ram N` or `--cache-disk PATH` to enable it\n");
         }
         SRV_TRC("%s", "for more info see https://github.com/ggml-org/llama.cpp/pull/16391\n");
 
@@ -1418,8 +1548,8 @@ private:
         metrics.init();
 
         if (params_base.cache_idle_slots) {
-            if (params_base.cache_ram_mib == 0) {
-                SRV_WRN("%s", "--cache-idle-slots requires --cache-ram, disabling\n");
+            if (!prompt_cache) {
+                SRV_WRN("%s", "--cache-idle-slots requires a prompt cache, disabling\n");
                 params_base.cache_idle_slots = false;
             } else {
                 if (params_base.kv_unified) {
@@ -1635,7 +1765,17 @@ private:
 
                 ret->prompt_save(*prompt_cache);
 
-                if (!ret->prompt_load(*prompt_cache, task.tokens)) {
+                const bool needs_checkpoint =
+                    ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL ||
+                    ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_RS   ||
+                    n_swa > 0;
+                if (!ret->prompt_load(
+                        *prompt_cache,
+                        task.tokens,
+                        task.params.cache_prompt,
+                        needs_checkpoint,
+                        n_swa,
+                        slot_prompt_similarity)) {
                     ret->prompt_clear();
                 }
 
@@ -3267,7 +3407,7 @@ private:
                             const bool has_new_tokens = (n_past < slot.task->n_tokens());
 
                             // the largest pos_min required for a checkpoint to be useful
-                            const auto pos_min_thold = std::max(0, pos_next - n_swa - (has_new_tokens ? 0 : 1));
+                            const auto pos_min_thold = server_prompt_pos_min_thold(pos_next, n_swa, has_new_tokens);
 
                             if (n_past > 0 && n_past <= slot.prompt.n_tokens()) {
                                 const auto pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id);
@@ -3321,17 +3461,21 @@ private:
 
                                 if (pos_min >= pos_min_thold) {
                                     // search for a context checkpoint
+                                    int checkpoint_reuse = -1;
                                     const auto it = std::find_if(
                                         slot.prompt.checkpoints.rbegin(),
                                         slot.prompt.checkpoints.rend(),
                                         [&](const auto & cur) {
                                             // guarantee that a checkpoint will result in at least one token being processed [TAG_PROMPT_LOGITS]
                                             SLT_TRC(slot, "checking checkpoint with [%d, %d] against %d...\n", cur.pos_min, cur.pos_max, pos_min_thold);
-                                            // workaround for [TAG_CHECKPOINTS_FIX_POS_MIN]
-                                            if (cur.pos_max > pos_next) {
-                                                return false;
-                                            }
-                                            return cur.pos_min < pos_min_thold || cur.pos_min == 0;
+                                            checkpoint_reuse = server_prompt_checkpoint_reuse(
+                                                slot.prompt.tokens,
+                                                cur.n_tokens,
+                                                cur.pos_min,
+                                                cur.pos_max,
+                                                pos_next,
+                                                pos_min_thold);
+                                            return checkpoint_reuse >= 0;
                                         }
                                     );
 
@@ -3345,7 +3489,7 @@ private:
                                         common_speculative_set_state(spec.get(), slot.id, it->data_spec);
 
                                         pos_next = std::min(pos_next, std::max(it->pos_min + 1, it->pos_max));
-                                        n_past   = std::min(slot.prompt.tokens.size_up_to_pos(pos_next), (size_t) it->n_tokens);
+                                        n_past   = checkpoint_reuse;
                                         SLT_TRC(slot, "restored context checkpoint (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", n_past = %d, size = %.3f MiB)\n", it->pos_min, it->pos_max, it->n_tokens, n_past, (float) it->size() / 1024 / 1024);
                                     }
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -10,7 +10,29 @@
 #include "speculative.h"
 #include "server-common.h"
 
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <limits>
 #include <sstream>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 //
 // task_params
@@ -1688,6 +1710,723 @@ json server_task_result_apply_lora::to_json() {
 //
 // server_prompt_cache
 //
+server_prompt_data::~server_prompt_data() {
+    clear();
+}
+
+server_prompt_data::server_prompt_data(server_prompt_data && other) noexcept {
+    *this = std::move(other);
+}
+
+server_prompt_data & server_prompt_data::operator=(server_prompt_data && other) noexcept {
+    if (this == &other) {
+        return *this;
+    }
+
+    clear();
+
+    main         = std::move(other.main);
+    drft         = std::move(other.drft);
+    cache_file   = std::move(other.cache_file);
+    mapping      = other.mapping;
+    mapping_size = other.mapping_size;
+    main_size    = other.main_size;
+    drft_size    = other.drft_size;
+    remove_file_on_destroy = other.remove_file_on_destroy;
+
+#ifdef _WIN32
+    file_handle    = other.file_handle;
+    mapping_handle = other.mapping_handle;
+    other.file_handle    = nullptr;
+    other.mapping_handle = nullptr;
+#endif
+
+    other.mapping      = nullptr;
+    other.mapping_size = 0;
+    other.main_size    = 0;
+    other.drft_size    = 0;
+    other.remove_file_on_destroy = true;
+    other.cache_file.clear();
+
+    return *this;
+}
+
+void server_prompt_data::clear() {
+    if (mapping != nullptr) {
+#ifdef _WIN32
+        UnmapViewOfFile(mapping);
+#else
+        munmap(mapping, mapping_size);
+#endif
+        mapping = nullptr;
+    }
+
+#ifdef _WIN32
+    if (mapping_handle != nullptr) {
+        CloseHandle((HANDLE) mapping_handle);
+        mapping_handle = nullptr;
+    }
+    if (file_handle != nullptr) {
+        CloseHandle((HANDLE) file_handle);
+        file_handle = nullptr;
+    }
+#endif
+
+    if (!cache_file.empty()) {
+        if (remove_file_on_destroy) {
+            std::error_code ec;
+            std::filesystem::remove(cache_file, ec);
+            if (ec) {
+                SRV_WRN("failed to remove disk cache file %s: %s\n", cache_file.c_str(), ec.message().c_str());
+            }
+
+            ec.clear();
+            const std::string metadata_file = cache_file + ".meta";
+            std::filesystem::remove(metadata_file, ec);
+            if (ec) {
+                SRV_WRN("failed to remove disk cache metadata %s: %s\n", metadata_file.c_str(), ec.message().c_str());
+            }
+        }
+        cache_file.clear();
+    }
+
+    mapping_size = 0;
+    main_size = 0;
+    drft_size = 0;
+    remove_file_on_destroy = true;
+    main.clear();
+    drft.clear();
+}
+
+void server_prompt_data::discard() {
+    remove_file_on_destroy = true;
+    clear();
+}
+
+static bool server_prompt_cache_alloc_disk(
+        server_prompt_data & data,
+        const std::string & cache_dir,
+        uint64_t & next_file_id,
+        size_t size) {
+    if (size == 0) {
+        SRV_ERR("%s", "cannot allocate an empty disk cache state\n");
+        return false;
+    }
+
+    if (next_file_id == 0) {
+        next_file_id = (uint64_t) ggml_time_us();
+    }
+
+    for (;;) {
+        const std::filesystem::path path = std::filesystem::path(cache_dir) /
+            ("llama-prompt-cache-" + std::to_string(next_file_id++) + ".bin");
+        const std::string path_str = path.string();
+
+#ifdef _WIN32
+        HANDLE file = CreateFileA(
+            path_str.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+            CREATE_NEW, FILE_ATTRIBUTE_TEMPORARY, nullptr);
+        if (file == INVALID_HANDLE_VALUE) {
+            if (GetLastError() == ERROR_FILE_EXISTS) {
+                continue;
+            }
+            SRV_ERR("failed to create disk cache file %s (error %lu)\n", path_str.c_str(), GetLastError());
+            return false;
+        }
+
+        LARGE_INTEGER file_size;
+        file_size.QuadPart = size;
+        if (!SetFilePointerEx(file, file_size, nullptr, FILE_BEGIN) || !SetEndOfFile(file)) {
+            SRV_ERR("failed to resize disk cache file %s (error %lu)\n", path_str.c_str(), GetLastError());
+            CloseHandle(file);
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+            return false;
+        }
+
+        HANDLE mapping_handle = CreateFileMappingA(file, nullptr, PAGE_READWRITE, 0, 0, nullptr);
+        if (mapping_handle == nullptr) {
+            SRV_ERR("failed to map disk cache file %s (error %lu)\n", path_str.c_str(), GetLastError());
+            CloseHandle(file);
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+            return false;
+        }
+
+        void * mapping = MapViewOfFile(mapping_handle, FILE_MAP_ALL_ACCESS, 0, 0, size);
+        if (mapping == nullptr) {
+            SRV_ERR("failed to open disk cache mapping %s (error %lu)\n", path_str.c_str(), GetLastError());
+            CloseHandle(mapping_handle);
+            CloseHandle(file);
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+            return false;
+        }
+
+        data.cache_file    = path_str;
+        data.mapping       = (uint8_t *) mapping;
+        data.mapping_size  = size;
+        data.file_handle   = file;
+        data.mapping_handle = mapping_handle;
+#else
+        if (size > (size_t) std::numeric_limits<off_t>::max()) {
+            SRV_ERR("disk cache state is too large: %zu bytes\n", size);
+            return false;
+        }
+
+        const int fd = open(path_str.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+        if (fd < 0) {
+            if (errno == EEXIST) {
+                continue;
+            }
+            SRV_ERR("failed to create disk cache file %s: %s\n", path_str.c_str(), strerror(errno));
+            return false;
+        }
+
+        if (ftruncate(fd, (off_t) size) != 0) {
+            SRV_ERR("failed to resize disk cache file %s: %s\n", path_str.c_str(), strerror(errno));
+            close(fd);
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+            return false;
+        }
+
+        void * mapping = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        const int mmap_errno = errno;
+        close(fd);
+        if (mapping == MAP_FAILED) {
+            SRV_ERR("failed to map disk cache file %s: %s\n", path_str.c_str(), strerror(mmap_errno));
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+            return false;
+        }
+
+        data.cache_file   = path_str;
+        data.mapping      = (uint8_t *) mapping;
+        data.mapping_size = size;
+#endif
+
+        return true;
+    }
+}
+
+namespace {
+
+constexpr char SERVER_PROMPT_CACHE_META_MAGIC[8] = {'L', 'L', 'P', 'C', 'A', 'C', 'H', 'E'};
+constexpr uint32_t SERVER_PROMPT_CACHE_META_VERSION = 1;
+constexpr uint32_t SERVER_PROMPT_CACHE_META_FLAG_MTMD = 1u << 0;
+constexpr uint64_t SERVER_PROMPT_CACHE_META_HEADER_SIZE = 64;
+constexpr uint64_t SERVER_PROMPT_CACHE_META_CHECKPOINT_SIZE = 80;
+
+template <typename T>
+bool server_prompt_cache_meta_write(std::ostream & output, const T & value) {
+    static_assert(std::is_trivially_copyable<T>::value, "cache metadata values must be trivially copyable");
+    output.write(reinterpret_cast<const char *>(&value), sizeof(value));
+    return output.good();
+}
+
+template <typename T>
+bool server_prompt_cache_meta_read(std::istream & input, T & value) {
+    static_assert(std::is_trivially_copyable<T>::value, "cache metadata values must be trivially copyable");
+    input.read(reinterpret_cast<char *>(&value), sizeof(value));
+    return input.good();
+}
+
+bool server_prompt_cache_u64_add(uint64_t & value, uint64_t addend) {
+    if (addend > std::numeric_limits<uint64_t>::max() - value) {
+        return false;
+    }
+    value += addend;
+    return true;
+}
+
+bool server_prompt_cache_u64_mul(uint64_t lhs, uint64_t rhs, uint64_t & result) {
+    if (lhs != 0 && rhs > std::numeric_limits<uint64_t>::max() / lhs) {
+        return false;
+    }
+    result = lhs * rhs;
+    return true;
+}
+
+bool server_prompt_cache_range_valid(uint64_t offset, uint64_t size, uint64_t total) {
+    return offset <= total && size <= total - offset;
+}
+
+void server_prompt_cache_remove_files(const std::filesystem::path & data_path) {
+    std::error_code ec;
+    std::filesystem::remove(data_path, ec);
+    if (ec) {
+        SRV_WRN("failed to remove disk cache file %s: %s\n", data_path.string().c_str(), ec.message().c_str());
+    }
+
+    ec.clear();
+    const std::filesystem::path metadata_path = data_path.string() + ".meta";
+    std::filesystem::remove(metadata_path, ec);
+    if (ec) {
+        SRV_WRN("failed to remove disk cache metadata %s: %s\n", metadata_path.string().c_str(), ec.message().c_str());
+    }
+
+    ec.clear();
+    const std::filesystem::path temporary_path = metadata_path.string() + ".tmp";
+    std::filesystem::remove(temporary_path, ec);
+    if (ec) {
+        SRV_WRN("failed to remove temporary disk cache metadata %s: %s\n", temporary_path.string().c_str(), ec.message().c_str());
+    }
+}
+
+bool server_prompt_cache_flush_disk(server_prompt_data & data) {
+#ifdef _WIN32
+    if (!FlushViewOfFile(data.mapping, data.mapping_size)) {
+        SRV_ERR("failed to flush disk cache mapping %s (error %lu)\n", data.cache_file.c_str(), GetLastError());
+        return false;
+    }
+    if (!FlushFileBuffers((HANDLE) data.file_handle)) {
+        SRV_ERR("failed to flush disk cache file %s (error %lu)\n", data.cache_file.c_str(), GetLastError());
+        return false;
+    }
+#else
+    if (msync(data.mapping, data.mapping_size, MS_SYNC) != 0) {
+        SRV_ERR("failed to flush disk cache file %s: %s\n", data.cache_file.c_str(), strerror(errno));
+        return false;
+    }
+#endif
+    return true;
+}
+
+bool server_prompt_cache_open_disk(
+        server_prompt_data & data,
+        const std::filesystem::path & path,
+        size_t size) {
+    const std::string path_str = path.string();
+
+#ifdef _WIN32
+    HANDLE file = CreateFileA(
+        path_str.c_str(), GENERIC_READ | GENERIC_WRITE, 0, nullptr,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        SRV_WRN("failed to open disk cache file %s (error %lu)\n", path_str.c_str(), GetLastError());
+        return false;
+    }
+
+    LARGE_INTEGER file_size;
+    if (!GetFileSizeEx(file, &file_size) || file_size.QuadPart < 0 || (uint64_t) file_size.QuadPart != size) {
+        SRV_WRN("disk cache file has an unexpected size: %s\n", path_str.c_str());
+        CloseHandle(file);
+        return false;
+    }
+
+    HANDLE mapping_handle = CreateFileMappingA(file, nullptr, PAGE_READWRITE, 0, 0, nullptr);
+    if (mapping_handle == nullptr) {
+        SRV_WRN("failed to map disk cache file %s (error %lu)\n", path_str.c_str(), GetLastError());
+        CloseHandle(file);
+        return false;
+    }
+
+    void * mapping = MapViewOfFile(mapping_handle, FILE_MAP_ALL_ACCESS, 0, 0, size);
+    if (mapping == nullptr) {
+        SRV_WRN("failed to open disk cache mapping %s (error %lu)\n", path_str.c_str(), GetLastError());
+        CloseHandle(mapping_handle);
+        CloseHandle(file);
+        return false;
+    }
+
+    data.file_handle    = file;
+    data.mapping_handle = mapping_handle;
+#else
+    const int fd = open(path_str.c_str(), O_RDWR);
+    if (fd < 0) {
+        SRV_WRN("failed to open disk cache file %s: %s\n", path_str.c_str(), strerror(errno));
+        return false;
+    }
+
+    struct stat st;
+    if (fstat(fd, &st) != 0 || st.st_size < 0 || (uint64_t) st.st_size != size) {
+        SRV_WRN("disk cache file has an unexpected size: %s\n", path_str.c_str());
+        close(fd);
+        return false;
+    }
+
+    void * mapping = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    const int mmap_errno = errno;
+    close(fd);
+    if (mapping == MAP_FAILED) {
+        SRV_WRN("failed to map disk cache file %s: %s\n", path_str.c_str(), strerror(mmap_errno));
+        return false;
+    }
+#endif
+
+    data.cache_file = path_str;
+    data.mapping = (uint8_t *) mapping;
+    data.mapping_size = size;
+    data.remove_file_on_destroy = false;
+
+    return true;
+}
+
+bool server_prompt_cache_write_metadata(
+        const server_prompt_cache_state & state,
+        const std::string & cache_key) {
+    const std::vector<char> serialized_tokens = state.prompt.tokens.serialize();
+
+    const std::filesystem::path metadata_path = state.data.cache_file + ".meta";
+    const std::filesystem::path temporary_path = metadata_path.string() + ".tmp";
+
+    std::ofstream output(temporary_path, std::ios::binary | std::ios::trunc);
+    if (!output) {
+        SRV_ERR("failed to create disk cache metadata %s\n", temporary_path.string().c_str());
+        return false;
+    }
+
+    const uint32_t version = SERVER_PROMPT_CACHE_META_VERSION;
+    const uint32_t flags = state.prompt.tokens.has_mtmd ? SERVER_PROMPT_CACHE_META_FLAG_MTMD : 0;
+    const uint64_t key_size = cache_key.size();
+    const uint64_t tokens_size = serialized_tokens.size();
+    const uint64_t payload_size = state.data.mapping_size;
+    const uint64_t main_size = state.data.main_size;
+    const uint64_t drft_size = state.data.drft_size;
+    const uint64_t checkpoint_count = state.checkpoints_disk.size();
+
+    output.write(SERVER_PROMPT_CACHE_META_MAGIC, sizeof(SERVER_PROMPT_CACHE_META_MAGIC));
+    bool ok = output.good() &&
+        server_prompt_cache_meta_write(output, version) &&
+        server_prompt_cache_meta_write(output, flags) &&
+        server_prompt_cache_meta_write(output, key_size) &&
+        server_prompt_cache_meta_write(output, tokens_size) &&
+        server_prompt_cache_meta_write(output, payload_size) &&
+        server_prompt_cache_meta_write(output, main_size) &&
+        server_prompt_cache_meta_write(output, drft_size) &&
+        server_prompt_cache_meta_write(output, checkpoint_count);
+
+    if (ok && key_size > 0) {
+        output.write(cache_key.data(), key_size);
+        ok = output.good();
+    }
+    if (ok && tokens_size > 0) {
+        output.write(serialized_tokens.data(), tokens_size);
+        ok = output.good();
+    }
+
+    for (const auto & checkpoint : state.checkpoints_disk) {
+        const int64_t n_tokens = checkpoint.n_tokens;
+        const int32_t id_task = checkpoint.id_task;
+        const uint32_t reserved = 0;
+        const int64_t pos_min = checkpoint.pos_min;
+        const int64_t pos_max = checkpoint.pos_max;
+        const uint64_t offset_tgt = checkpoint.offset_tgt;
+        const uint64_t size_tgt = checkpoint.size_tgt;
+        const uint64_t offset_dft = checkpoint.offset_dft;
+        const uint64_t size_dft = checkpoint.size_dft;
+        const uint64_t offset_spec = checkpoint.offset_spec;
+        const uint64_t size_spec = checkpoint.size_spec;
+
+        ok = ok &&
+            server_prompt_cache_meta_write(output, n_tokens) &&
+            server_prompt_cache_meta_write(output, id_task) &&
+            server_prompt_cache_meta_write(output, reserved) &&
+            server_prompt_cache_meta_write(output, pos_min) &&
+            server_prompt_cache_meta_write(output, pos_max) &&
+            server_prompt_cache_meta_write(output, offset_tgt) &&
+            server_prompt_cache_meta_write(output, size_tgt) &&
+            server_prompt_cache_meta_write(output, offset_dft) &&
+            server_prompt_cache_meta_write(output, size_dft) &&
+            server_prompt_cache_meta_write(output, offset_spec) &&
+            server_prompt_cache_meta_write(output, size_spec);
+    }
+
+    output.close();
+    ok = ok && !output.fail();
+
+    if (!ok) {
+        SRV_ERR("failed to write disk cache metadata %s\n", temporary_path.string().c_str());
+        std::error_code ec;
+        std::filesystem::remove(temporary_path, ec);
+        return false;
+    }
+
+    std::error_code ec;
+    std::filesystem::rename(temporary_path, metadata_path, ec);
+    if (ec) {
+        SRV_ERR("failed to commit disk cache metadata %s: %s\n", metadata_path.string().c_str(), ec.message().c_str());
+        ec.clear();
+        std::filesystem::remove(temporary_path, ec);
+        return false;
+    }
+
+    return true;
+}
+
+bool server_prompt_cache_read_metadata(
+        const std::filesystem::path & metadata_path,
+        const std::string & expected_cache_key,
+        bool expected_has_mtmd,
+        server_prompt_cache_state & state) {
+    std::error_code ec;
+    const uintmax_t metadata_file_size = std::filesystem::file_size(metadata_path, ec);
+    if (ec || metadata_file_size < SERVER_PROMPT_CACHE_META_HEADER_SIZE) {
+        return false;
+    }
+
+    std::ifstream input(metadata_path, std::ios::binary);
+    if (!input) {
+        return false;
+    }
+
+    char magic[sizeof(SERVER_PROMPT_CACHE_META_MAGIC)];
+    input.read(magic, sizeof(magic));
+
+    uint32_t version = 0;
+    uint32_t flags = 0;
+    uint64_t key_size = 0;
+    uint64_t tokens_size = 0;
+    uint64_t payload_size = 0;
+    uint64_t main_size = 0;
+    uint64_t drft_size = 0;
+    uint64_t checkpoint_count = 0;
+
+    bool ok = input.good() &&
+        server_prompt_cache_meta_read(input, version) &&
+        server_prompt_cache_meta_read(input, flags) &&
+        server_prompt_cache_meta_read(input, key_size) &&
+        server_prompt_cache_meta_read(input, tokens_size) &&
+        server_prompt_cache_meta_read(input, payload_size) &&
+        server_prompt_cache_meta_read(input, main_size) &&
+        server_prompt_cache_meta_read(input, drft_size) &&
+        server_prompt_cache_meta_read(input, checkpoint_count);
+
+    uint64_t checkpoint_bytes = 0;
+    uint64_t expected_metadata_size = SERVER_PROMPT_CACHE_META_HEADER_SIZE;
+    ok = ok && memcmp(magic, SERVER_PROMPT_CACHE_META_MAGIC, sizeof(magic)) == 0 &&
+        version == SERVER_PROMPT_CACHE_META_VERSION &&
+        (flags & ~SERVER_PROMPT_CACHE_META_FLAG_MTMD) == 0 &&
+        ((flags & SERVER_PROMPT_CACHE_META_FLAG_MTMD) != 0) == expected_has_mtmd &&
+        key_size <= 64 * 1024 &&
+        tokens_size > 0 &&
+        tokens_size <= 1024ull * 1024ull * 1024ull &&
+        tokens_size <= std::numeric_limits<size_t>::max() &&
+        tokens_size % sizeof(llama_token) == 0 &&
+        payload_size > 0 &&
+        payload_size <= std::numeric_limits<size_t>::max() &&
+        main_size <= std::numeric_limits<size_t>::max() &&
+        drft_size <= std::numeric_limits<size_t>::max() &&
+        checkpoint_count <= 1024 * 1024 &&
+        checkpoint_count <= std::numeric_limits<size_t>::max() &&
+        server_prompt_cache_u64_mul(checkpoint_count, SERVER_PROMPT_CACHE_META_CHECKPOINT_SIZE, checkpoint_bytes) &&
+        server_prompt_cache_u64_add(expected_metadata_size, key_size) &&
+        server_prompt_cache_u64_add(expected_metadata_size, tokens_size) &&
+        server_prompt_cache_u64_add(expected_metadata_size, checkpoint_bytes) &&
+        expected_metadata_size == metadata_file_size &&
+        main_size <= payload_size &&
+        drft_size <= payload_size - main_size;
+    if (!ok) {
+        return false;
+    }
+
+    std::string cache_key(key_size, '\0');
+    if (key_size > 0) {
+        input.read(cache_key.data(), key_size);
+    }
+    if (!input.good() || cache_key != expected_cache_key) {
+        return false;
+    }
+
+    std::vector<char> serialized_tokens(tokens_size);
+    input.read(serialized_tokens.data(), tokens_size);
+    if (!input.good()) {
+        return false;
+    }
+
+    llama_tokens packed_tokens(tokens_size / sizeof(llama_token));
+    memcpy(packed_tokens.data(), serialized_tokens.data(), tokens_size);
+    try {
+        state.prompt.tokens = server_tokens::deserialize(packed_tokens, expected_has_mtmd);
+    } catch (const std::exception & e) {
+        SRV_WRN("failed to deserialize tokens from disk cache metadata %s: %s\n", metadata_path.string().c_str(), e.what());
+        return false;
+    }
+    if (state.prompt.tokens.empty()) {
+        return false;
+    }
+
+    state.data.main_size = main_size;
+    state.data.drft_size = drft_size;
+    state.checkpoints_disk.reserve(checkpoint_count);
+
+    uint64_t next_offset = main_size + drft_size;
+    for (uint64_t i = 0; i < checkpoint_count; ++i) {
+        int64_t n_tokens = 0;
+        int32_t id_task = -1;
+        uint32_t reserved = 0;
+        int64_t pos_min = 0;
+        int64_t pos_max = 0;
+        uint64_t offset_tgt = 0;
+        uint64_t size_tgt = 0;
+        uint64_t offset_dft = 0;
+        uint64_t size_dft = 0;
+        uint64_t offset_spec = 0;
+        uint64_t size_spec = 0;
+
+        ok =
+            server_prompt_cache_meta_read(input, n_tokens) &&
+            server_prompt_cache_meta_read(input, id_task) &&
+            server_prompt_cache_meta_read(input, reserved) &&
+            server_prompt_cache_meta_read(input, pos_min) &&
+            server_prompt_cache_meta_read(input, pos_max) &&
+            server_prompt_cache_meta_read(input, offset_tgt) &&
+            server_prompt_cache_meta_read(input, size_tgt) &&
+            server_prompt_cache_meta_read(input, offset_dft) &&
+            server_prompt_cache_meta_read(input, size_dft) &&
+            server_prompt_cache_meta_read(input, offset_spec) &&
+            server_prompt_cache_meta_read(input, size_spec);
+
+        ok = ok && reserved == 0 &&
+            n_tokens >= 0 && (uint64_t) n_tokens <= state.prompt.tokens.size() &&
+            pos_min >= std::numeric_limits<llama_pos>::min() && pos_min <= std::numeric_limits<llama_pos>::max() &&
+            pos_max >= std::numeric_limits<llama_pos>::min() && pos_max <= std::numeric_limits<llama_pos>::max() &&
+            offset_tgt == next_offset && server_prompt_cache_range_valid(offset_tgt, size_tgt, payload_size);
+        if (!ok || !server_prompt_cache_u64_add(next_offset, size_tgt)) {
+            return false;
+        }
+        ok = offset_dft == next_offset && server_prompt_cache_range_valid(offset_dft, size_dft, payload_size);
+        if (!ok || !server_prompt_cache_u64_add(next_offset, size_dft)) {
+            return false;
+        }
+        ok = offset_spec == next_offset && server_prompt_cache_range_valid(offset_spec, size_spec, payload_size);
+        if (!ok || !server_prompt_cache_u64_add(next_offset, size_spec)) {
+            return false;
+        }
+
+        state.checkpoints_disk.push_back({
+            n_tokens,
+            id_task,
+            (llama_pos) pos_min,
+            (llama_pos) pos_max,
+            (size_t) offset_tgt,
+            (size_t) size_tgt,
+            (size_t) offset_dft,
+            (size_t) size_dft,
+            (size_t) offset_spec,
+            (size_t) size_spec,
+        });
+    }
+
+    if (!input.good() || next_offset != payload_size) {
+        return false;
+    }
+
+    std::filesystem::path data_path = metadata_path;
+    data_path.replace_extension();
+    if (!server_prompt_cache_open_disk(state.data, data_path, payload_size)) {
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace
+
+server_prompt_cache::server_prompt_cache(
+    int32_t limit_size_mib,
+    size_t limit_tokens,
+    const std::string & cache_dir,
+    const std::string & cache_key,
+    bool has_mtmd) :
+    limit_size(1024ull*1024ull*(limit_size_mib < 0 ? 0 : limit_size_mib)),
+    limit_tokens(limit_tokens),
+    cache_dir(cache_dir),
+    cache_key(cache_key),
+    has_mtmd(has_mtmd) {
+    if (cache_dir.empty()) {
+        return;
+    }
+
+    std::vector<std::filesystem::path> metadata_paths;
+    std::error_code ec;
+    for (const auto & entry : std::filesystem::directory_iterator(cache_dir, ec)) {
+        if (ec) {
+            break;
+        }
+        if (!entry.is_regular_file(ec) || ec) {
+            ec.clear();
+            continue;
+        }
+
+        const std::string filename = entry.path().filename().string();
+        const bool is_cache_file = filename.rfind("llama-prompt-cache-", 0) == 0;
+        if (!is_cache_file) {
+            continue;
+        }
+
+        if (string_ends_with(filename, ".bin.meta")) {
+            metadata_paths.push_back(entry.path());
+        } else if (string_ends_with(filename, ".bin.meta.tmp")) {
+            std::filesystem::remove(entry.path(), ec);
+            ec.clear();
+        }
+    }
+    if (ec) {
+        SRV_WRN("failed to scan prompt cache directory %s: %s\n", cache_dir.c_str(), ec.message().c_str());
+        return;
+    }
+
+    std::sort(metadata_paths.begin(), metadata_paths.end(), [](const auto & lhs, const auto & rhs) {
+        std::error_code lhs_ec;
+        std::error_code rhs_ec;
+        const auto lhs_time = std::filesystem::last_write_time(lhs, lhs_ec);
+        const auto rhs_time = std::filesystem::last_write_time(rhs, rhs_ec);
+        if (lhs_ec || rhs_ec) {
+            return lhs.string() < rhs.string();
+        }
+        return lhs_time < rhs_time;
+    });
+
+    for (const auto & metadata_path : metadata_paths) {
+        server_prompt_cache_state state;
+        bool loaded = false;
+        try {
+            loaded = server_prompt_cache_read_metadata(metadata_path, cache_key, has_mtmd, state);
+        } catch (const std::exception & e) {
+            SRV_WRN("failed to read disk prompt cache metadata %s: %s\n", metadata_path.string().c_str(), e.what());
+        }
+        if (!loaded) {
+            std::filesystem::path data_path = metadata_path;
+            data_path.replace_extension();
+            SRV_WRN("removing incompatible or invalid disk prompt cache entry %s\n", data_path.string().c_str());
+            server_prompt_cache_remove_files(data_path);
+            continue;
+        }
+        states.push_back(std::move(state));
+    }
+
+    // Raw files without a committed metadata sidecar are interrupted writes.
+    for (const auto & entry : std::filesystem::directory_iterator(cache_dir, ec)) {
+        if (ec) {
+            break;
+        }
+        if (!entry.is_regular_file(ec) || ec) {
+            ec.clear();
+            continue;
+        }
+        const std::string filename = entry.path().filename().string();
+        if (filename.rfind("llama-prompt-cache-", 0) != 0 || !string_ends_with(filename, ".bin")) {
+            continue;
+        }
+        const std::filesystem::path metadata_path = entry.path().string() + ".meta";
+        if (!std::filesystem::exists(metadata_path, ec) || ec) {
+            ec.clear();
+            SRV_WRN("removing incomplete disk prompt cache entry %s\n", entry.path().string().c_str());
+            server_prompt_cache_remove_files(entry.path());
+        }
+    }
+
+    const size_t restored = states.size();
+    update();
+    SRV_INF("restored %zu persistent prompt cache entries (%.3f MiB) from %s\n",
+            states.size(), size() / (1024.0 * 1024.0), cache_dir.c_str());
+    if (states.size() < restored) {
+        SRV_INF("evicted %zu restored prompt cache entries to satisfy configured limits\n", restored - states.size());
+    }
+}
+
 size_t server_prompt_cache::size() const {
     size_t res = 0;
 
@@ -1741,6 +2480,7 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
         if (len == (int) it->prompt.tokens.size()) {
             SRV_TRC(" - removing obsolete cached prompt with length %d\n", len);
 
+            it->data.discard();
             it = states.erase(it);
         } else {
             ++it;
@@ -1753,52 +2493,205 @@ server_prompt_cache_state * server_prompt_cache::alloc(const server_prompt & pro
             SRV_WRN(" - making room for prompt cache entry, removing oldest entry (size = %.3f MiB)\n",
                     states.front().size() / (1024.0 * 1024.0));
 
+            states.front().data.discard();
             states.pop_front();
         }
     }
 
-    std::vector<uint8_t> state_data_tgt;
-    std::vector<uint8_t> state_data_dft;
+    server_prompt_cache_state state;
+    state.prompt.tokens = prompt.tokens.clone();
 
-    // check if we can allocate enough memory for the new state
-    try {
-        state_data_tgt.resize(state_size_tgt);
-        state_data_dft.resize(state_size_dft);
-    } catch (const std::bad_alloc & e) {
-        SRV_ERR("failed to allocate memory for prompt cache state: %s\n", e.what());
+    if (!cache_dir.empty()) {
+        if (!server_prompt_cache_alloc_disk(state.data, cache_dir, next_file_id, state_size_new)) {
+            return nullptr;
+        }
 
-        limit_size = std::max<size_t>(1, 0.4*size());
+        state.data.main_size = state_size_tgt;
+        state.data.drft_size = state_size_dft;
 
-        SRV_WRN(" - cache size limit reduced to %.3f MiB\n", limit_size / (1024.0 * 1024.0));
+        size_t offset = state_size_tgt + state_size_dft;
+        state.checkpoints_disk.reserve(prompt.checkpoints.size());
+        for (const auto & checkpoint : prompt.checkpoints) {
+            server_prompt_cache_checkpoint checkpoint_disk;
+            checkpoint_disk.n_tokens = checkpoint.n_tokens;
+            checkpoint_disk.id_task  = checkpoint.id_task;
+            checkpoint_disk.pos_min  = checkpoint.pos_min;
+            checkpoint_disk.pos_max  = checkpoint.pos_max;
 
-        update();
+            checkpoint_disk.offset_tgt = offset;
+            checkpoint_disk.size_tgt   = checkpoint.data_tgt.size();
+            if (checkpoint_disk.size_tgt > 0) {
+                memcpy(state.data.mapping + offset, checkpoint.data_tgt.data(), checkpoint_disk.size_tgt);
+                offset += checkpoint_disk.size_tgt;
+            }
 
-        return nullptr;
+            checkpoint_disk.offset_dft = offset;
+            checkpoint_disk.size_dft   = checkpoint.data_dft.size();
+            if (checkpoint_disk.size_dft > 0) {
+                memcpy(state.data.mapping + offset, checkpoint.data_dft.data(), checkpoint_disk.size_dft);
+                offset += checkpoint_disk.size_dft;
+            }
+
+            checkpoint_disk.offset_spec = offset;
+            checkpoint_disk.size_spec   = checkpoint.data_spec.size();
+            if (checkpoint_disk.size_spec > 0) {
+                memcpy(state.data.mapping + offset, checkpoint.data_spec.data(), checkpoint_disk.size_spec);
+                offset += checkpoint_disk.size_spec;
+            }
+
+            state.checkpoints_disk.push_back(checkpoint_disk);
+        }
+        GGML_ASSERT(offset == state_size_new);
+    } else {
+        state.prompt.checkpoints = prompt.checkpoints;
+
+        try {
+            state.data.main.resize(state_size_tgt);
+            state.data.drft.resize(state_size_dft);
+        } catch (const std::bad_alloc & e) {
+            SRV_ERR("failed to allocate memory for prompt cache state: %s\n", e.what());
+
+            limit_size = std::max<size_t>(1, 0.4*size());
+
+            SRV_WRN(" - cache size limit reduced to %.3f MiB\n", limit_size / (1024.0 * 1024.0));
+
+            update();
+
+            return nullptr;
+        }
     }
 
-    states.push_back({
-        /*.prompt =*/ {
-            /*.tokens      =*/ prompt.tokens.clone(),
-            /*.checkpoints =*/ prompt.checkpoints,
-        },
-        /*.data   =*/ {
-            /*.main =*/ std::move(state_data_tgt),
-            /*.drft =*/ std::move(state_data_dft),
-        },
-    });
+    states.push_back(std::move(state));
 
     return &states.back();
 }
 
-bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_tgt, llama_context * ctx_dft, int32_t id_slot) {
+bool server_prompt_cache::commit(server_prompt_cache_state * state) {
+    if (state == nullptr || !state->data.is_disk()) {
+        return state != nullptr;
+    }
+
+    auto it = std::find_if(states.begin(), states.end(), [state](const auto & candidate) {
+        return &candidate == state;
+    });
+    if (it == states.end()) {
+        return false;
+    }
+
+    bool ok = server_prompt_cache_flush_disk(it->data);
+    try {
+        ok = ok && server_prompt_cache_write_metadata(*it, cache_key);
+    } catch (const std::exception & e) {
+        SRV_ERR("failed to serialize disk prompt cache metadata: %s\n", e.what());
+        ok = false;
+    }
+
+    if (!ok) {
+        it->data.discard();
+        states.erase(it);
+        return false;
+    }
+
+    it->data.remove_file_on_destroy = false;
+    return true;
+}
+
+void server_prompt_cache::discard(server_prompt_cache_state * state) {
+    if (state == nullptr) {
+        return;
+    }
+
+    auto it = std::find_if(states.begin(), states.end(), [state](const auto & candidate) {
+        return &candidate == state;
+    });
+    if (it == states.end()) {
+        return;
+    }
+
+    it->data.discard();
+    states.erase(it);
+}
+
+llama_pos server_prompt_pos_min_thold(llama_pos pos_next, int32_t n_swa, bool has_new_tokens) {
+    return std::max(0, pos_next - n_swa - (has_new_tokens ? 0 : 1));
+}
+
+int server_prompt_checkpoint_reuse(
+        const server_tokens & tokens,
+        int64_t               n_tokens,
+        llama_pos             checkpoint_pos_min,
+        llama_pos             checkpoint_pos_max,
+        llama_pos             pos_next,
+        llama_pos             pos_min_thold) {
+    if (checkpoint_pos_max > pos_next) {
+        return -1;
+    }
+
+    if (checkpoint_pos_min >= pos_min_thold && checkpoint_pos_min != 0) {
+        return -1;
+    }
+
+    const llama_pos checkpoint_pos_next = std::min(
+        pos_next, std::max(checkpoint_pos_min + 1, checkpoint_pos_max));
+    return (int) std::min(tokens.size_up_to_pos(checkpoint_pos_next), (size_t) n_tokens);
+}
+
+bool server_prompt_cache::load(
+        server_prompt & prompt,
+        const server_tokens & tokens_new,
+        llama_context * ctx_tgt,
+        llama_context * ctx_dft,
+        int32_t id_slot,
+        bool cache_prompt,
+        bool needs_checkpoint,
+        int32_t n_swa,
+        float slot_prompt_similarity) {
+    if (tokens_new.empty()) {
+        return true;
+    }
+
     const int lcp_best = prompt.tokens.get_common_prefix(tokens_new);
 
     float f_keep_best = prompt.tokens.size() > 0 ? float(lcp_best) / prompt.tokens.size() : -1.0f; // empty slot: any cache entry wins
     float f_sim_best  = float(lcp_best) / tokens_new.size();
 
-    SRV_TRC(" - looking for better prompt, base f_keep = %.3f, f_sim = %.3f\n", f_keep_best, f_sim_best);
+    const bool has_disk_cache = !cache_dir.empty();
+    int effective_prefix_reuse_base = 0;
+    if (has_disk_cache && !prompt.tokens.empty() && lcp_best > 0) {
+        effective_prefix_reuse_base = lcp_best;
+
+        const llama_pos pos_next = prompt.tokens.pos_next(lcp_best);
+        const bool has_new_tokens = lcp_best < (int) tokens_new.size();
+        const llama_pos pos_min_thold = server_prompt_pos_min_thold(pos_next, n_swa, has_new_tokens);
+        const llama_pos pos_min = llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), id_slot);
+
+        if (pos_min >= pos_min_thold) {
+            effective_prefix_reuse_base = 0;
+            for (auto it = prompt.checkpoints.rbegin(); it != prompt.checkpoints.rend(); ++it) {
+                const int reuse = server_prompt_checkpoint_reuse(
+                    prompt.tokens, it->n_tokens, it->pos_min, it->pos_max, pos_next, pos_min_thold);
+                if (reuse >= 0) {
+                    effective_prefix_reuse_base = reuse;
+                    break;
+                }
+            }
+        }
+
+        if (effective_prefix_reuse_base == (int) tokens_new.size()) {
+            effective_prefix_reuse_base--;
+        }
+    }
+
+    if (has_disk_cache) {
+        SRV_TRC(" - looking for better prompt, base f_keep = %.3f, f_sim = %.3f, effective_prefix_reuse = %d\n",
+                f_keep_best, f_sim_best, effective_prefix_reuse_base);
+    } else {
+        SRV_TRC(" - looking for better prompt, base f_keep = %.3f, f_sim = %.3f\n", f_keep_best, f_sim_best);
+    }
 
     auto it_best = states.end();
+    int effective_prefix_reuse_best = -1;
+    size_t mapping_size_best = 0;
 
     // find the most similar cached prompt, that would also preserve the most context
     for (auto it = states.begin(); it != states.end(); ++it) {
@@ -1807,7 +2700,60 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
         const float f_keep_cur = float(lcp_cur) / it->prompt.tokens.size();
         const float f_sim_cur  = float(lcp_cur) / tokens_new.size();
 
-        SRV_TRC("   - prompt with length %7zu, lcp = %7d, f_keep = %.3f, f_sim = %.3f\n", it->prompt.tokens.size(), lcp_cur, f_keep_cur, f_sim_cur);
+        if (it->data.is_disk()) {
+            if (!cache_prompt) {
+                continue;
+            }
+
+            int effective_prefix_reuse = lcp_cur;
+            if (needs_checkpoint) {
+                effective_prefix_reuse = 0;
+
+                const llama_pos pos_next = it->prompt.tokens.pos_next(lcp_cur);
+                const bool has_new_tokens = lcp_cur < (int) tokens_new.size();
+                const llama_pos pos_min_thold = server_prompt_pos_min_thold(pos_next, n_swa, has_new_tokens);
+                for (auto checkpoint = it->checkpoints_disk.rbegin(); checkpoint != it->checkpoints_disk.rend(); ++checkpoint) {
+                    const int reuse = server_prompt_checkpoint_reuse(
+                        it->prompt.tokens,
+                        checkpoint->n_tokens,
+                        checkpoint->pos_min,
+                        checkpoint->pos_max,
+                        pos_next,
+                        pos_min_thold);
+                    if (reuse >= 0) {
+                        effective_prefix_reuse = reuse;
+                        break;
+                    }
+                }
+            }
+
+            if (effective_prefix_reuse == (int) tokens_new.size()) {
+                effective_prefix_reuse--;
+            }
+
+            SRV_TRC("   - prompt with length %7zu, lcp = %7d, f_keep = %.3f, f_sim = %.3f, effective_prefix_reuse = %d\n",
+                    it->prompt.tokens.size(), lcp_cur, f_keep_cur, f_sim_cur, effective_prefix_reuse);
+
+            const float effective_similarity = float(effective_prefix_reuse) / tokens_new.size();
+            const bool is_admissible =
+                effective_prefix_reuse > effective_prefix_reuse_base &&
+                effective_similarity > slot_prompt_similarity;
+            const bool is_better = is_admissible &&
+                (it_best == states.end() ||
+                 effective_prefix_reuse > effective_prefix_reuse_best ||
+                 (effective_prefix_reuse == effective_prefix_reuse_best && it->data.mapping_size <= mapping_size_best));
+            if (is_better) {
+                effective_prefix_reuse_best = effective_prefix_reuse;
+                mapping_size_best = it->data.mapping_size;
+                f_keep_best = f_keep_cur;
+                f_sim_best  = f_sim_cur;
+                it_best = it;
+            }
+            continue;
+        }
+
+        SRV_TRC("   - prompt with length %7zu, lcp = %7d, f_keep = %.3f, f_sim = %.3f\n",
+                it->prompt.tokens.size(), lcp_cur, f_keep_cur, f_sim_cur);
 
         // don't trash large prompts
         if (f_keep_cur < 0.25f) {
@@ -1823,39 +2769,114 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
     }
 
     if (it_best != states.end()) {
-        SRV_TRC(" - found better prompt with f_keep = %.3f, f_sim = %.3f\n", f_keep_best, f_sim_best);
+        if (it_best->data.is_disk()) {
+            SRV_TRC(" - found better prompt with f_keep = %.3f, f_sim = %.3f, effective_prefix_reuse = %d\n",
+                    f_keep_best, f_sim_best, effective_prefix_reuse_best);
+        } else {
+            SRV_TRC(" - found better prompt with f_keep = %.3f, f_sim = %.3f\n", f_keep_best, f_sim_best);
+        }
 
-        {
-            auto & data = it_best->data.main;
+        if (it_best->data.is_disk()) {
+            auto & data = it_best->data;
 
-            const size_t size = data.size();
-            const size_t n = llama_state_seq_set_data_ext(ctx_tgt, data.data(), size, id_slot, 0);
-            if (n != size) {
-                SRV_ERR("failed to restore state with size %zu\n", size);
-
+            const size_t n_tgt = llama_state_seq_set_data_ext(ctx_tgt, data.mapping, data.main_size, id_slot, 0);
+            if (n_tgt != data.main_size) {
+                SRV_ERR("failed to restore state with size %zu\n", data.main_size);
+                data.discard();
+                states.erase(it_best);
                 return false;
             }
 
-            data.clear();
-            data.shrink_to_fit();
-        }
+            if (data.drft_size > 0) {
+                if (ctx_dft == nullptr) {
+                    SRV_ERR("%s", "cannot restore draft state without a draft context\n");
+                    data.discard();
+                    states.erase(it_best);
+                    return false;
+                }
 
-        {
-            auto & data = it_best->data.drft;
+                const size_t n_dft = llama_state_seq_set_data_ext(ctx_dft, data.mapping + data.main_size, data.drft_size, id_slot, 0);
+                if (n_dft != data.drft_size) {
+                    SRV_WRN("failed to restore state with size %zu\n", data.drft_size);
+                    data.discard();
+                    states.erase(it_best);
+                    return false;
+                }
+            }
 
-            if (!data.empty()) {
-                GGML_ASSERT(ctx_dft);
+            server_prompt restored;
+            restored.tokens = it_best->prompt.tokens.clone();
+            try {
+                for (const auto & checkpoint_disk : it_best->checkpoints_disk) {
+                    common_prompt_checkpoint checkpoint;
+                    checkpoint.n_tokens = checkpoint_disk.n_tokens;
+                    checkpoint.id_task  = checkpoint_disk.id_task;
+                    checkpoint.pos_min  = checkpoint_disk.pos_min;
+                    checkpoint.pos_max  = checkpoint_disk.pos_max;
+
+                    checkpoint.data_tgt.assign(
+                        data.mapping + checkpoint_disk.offset_tgt,
+                        data.mapping + checkpoint_disk.offset_tgt + checkpoint_disk.size_tgt);
+                    checkpoint.data_dft.assign(
+                        data.mapping + checkpoint_disk.offset_dft,
+                        data.mapping + checkpoint_disk.offset_dft + checkpoint_disk.size_dft);
+                    checkpoint.data_spec.assign(
+                        data.mapping + checkpoint_disk.offset_spec,
+                        data.mapping + checkpoint_disk.offset_spec + checkpoint_disk.size_spec);
+
+                    restored.checkpoints.push_back(std::move(checkpoint));
+                }
+            } catch (const std::bad_alloc & e) {
+                SRV_ERR("failed to allocate memory for restored prompt checkpoints: %s\n", e.what());
+                return false;
+            }
+
+            prompt = std::move(restored);
+
+            std::error_code ec;
+            std::filesystem::last_write_time(
+                data.cache_file + ".meta", std::filesystem::file_time_type::clock::now(), ec);
+            if (ec) {
+                SRV_WRN("failed to update disk cache access time %s: %s\n", data.cache_file.c_str(), ec.message().c_str());
+            }
+
+            // Disk entries are reusable and persistent. Move the hit to the
+            // back so size-based eviction remains least-recently-used.
+            states.splice(states.end(), states, it_best);
+            return true;
+        } else {
+            {
+                auto & data = it_best->data.main;
 
                 const size_t size = data.size();
-                const size_t n = llama_state_seq_set_data_ext(ctx_dft, data.data(), size, id_slot, 0);
+                const size_t n = llama_state_seq_set_data_ext(ctx_tgt, data.data(), size, id_slot, 0);
                 if (n != size) {
-                    SRV_WRN("failed to restore state with size %zu\n", size);
+                    SRV_ERR("failed to restore state with size %zu\n", size);
 
                     return false;
                 }
 
                 data.clear();
                 data.shrink_to_fit();
+            }
+
+            {
+                auto & data = it_best->data.drft;
+
+                if (!data.empty()) {
+                    GGML_ASSERT(ctx_dft);
+
+                    const size_t size = data.size();
+                    const size_t n = llama_state_seq_set_data_ext(ctx_dft, data.data(), size, id_slot, 0);
+                    if (n != size) {
+                        SRV_WRN("failed to restore state with size %zu\n", size);
+
+                        return false;
+                    }
+
+                    data.clear();
+                    data.shrink_to_fit();
+                }
             }
         }
 
@@ -1872,6 +2893,7 @@ void server_prompt_cache::update() {
         while (!states.empty() && size() > limit_size) {
             SRV_WRN(" - cache size limit reached, removing oldest entry (size = %.3f MiB)\n", states.front().size() / (1024.0 * 1024.0));
 
+            states.front().data.discard();
             states.pop_front();
         }
     }
@@ -1887,6 +2909,7 @@ void server_prompt_cache::update() {
             SRV_WRN(" - cache token limit (%zu, est: %zu) reached, removing oldest entry (size = %.3f MiB)\n",
                     limit_tokens, limit_tokens_cur, states.front().size() / (1024.0 * 1024.0));
 
+            states.front().data.discard();
             states.pop_front();
         }
     }
@@ -1896,6 +2919,8 @@ void server_prompt_cache::update() {
 
     for (const auto & state : states) {
         SRV_TRC("   - prompt %p: %7d tokens, checkpoints: %2zu, %9.3f MiB\n",
-                (const void *)&state, state.prompt.n_tokens(), state.prompt.checkpoints.size(), state.size() / (1024.0 * 1024.0));
+                (const void *)&state, state.prompt.n_tokens(),
+                state.data.is_disk() ? state.checkpoints_disk.size() : state.prompt.checkpoints.size(),
+                state.size() / (1024.0 * 1024.0));
     }
 }

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -585,18 +585,83 @@ struct server_prompt {
     }
 };
 
+llama_pos server_prompt_pos_min_thold(
+        llama_pos pos_next,
+        int32_t   n_swa,
+        bool      has_new_tokens);
+
+// Returns -1 when the checkpoint cannot be used, otherwise the resulting n_past.
+int server_prompt_checkpoint_reuse(
+        const server_tokens & tokens,
+        int64_t               n_tokens,
+        llama_pos             checkpoint_pos_min,
+        llama_pos             checkpoint_pos_max,
+        llama_pos             pos_next,
+        llama_pos             pos_min_thold);
+
 struct server_prompt_data {
     std::vector<uint8_t> main;
     std::vector<uint8_t> drft;
 
+    std::string cache_file;
+    uint8_t * mapping = nullptr;
+    size_t mapping_size = 0;
+    size_t main_size = 0;
+    size_t drft_size = 0;
+
+    // Newly-created files are removed if saving is interrupted. Once the
+    // metadata sidecar is committed, they survive object destruction and are
+    // removed only by explicit cache eviction.
+    bool remove_file_on_destroy = true;
+
+#ifdef _WIN32
+    void * file_handle = nullptr;
+    void * mapping_handle = nullptr;
+#endif
+
+    server_prompt_data() = default;
+    ~server_prompt_data();
+
+    server_prompt_data(const server_prompt_data &) = delete;
+    server_prompt_data & operator=(const server_prompt_data &) = delete;
+
+    server_prompt_data(server_prompt_data && other) noexcept;
+    server_prompt_data & operator=(server_prompt_data && other) noexcept;
+
+    bool is_disk() const {
+        return !cache_file.empty();
+    }
+
+    void clear();
+    void discard();
+
     size_t size() const {
+        if (is_disk()) {
+            return mapping_size;
+        }
         return main.size() + drft.size();
     }
+};
+
+struct server_prompt_cache_checkpoint {
+    int64_t n_tokens = 0;
+    int id_task = -1;
+
+    llama_pos pos_min = 0;
+    llama_pos pos_max = 0;
+
+    size_t offset_tgt = 0;
+    size_t size_tgt = 0;
+    size_t offset_dft = 0;
+    size_t size_dft = 0;
+    size_t offset_spec = 0;
+    size_t size_spec = 0;
 };
 
 struct server_prompt_cache_state {
     server_prompt prompt;
     server_prompt_data data;
+    std::vector<server_prompt_cache_checkpoint> checkpoints_disk;
 
     size_t size() const {
         size_t res = data.size();
@@ -610,10 +675,12 @@ struct server_prompt_cache_state {
 };
 
 struct server_prompt_cache {
-    server_prompt_cache(int32_t limit_size_mib, size_t limit_tokens) {
-        this->limit_size   = 1024ull*1024ull*(limit_size_mib < 0 ? 0 : limit_size_mib);
-        this->limit_tokens = limit_tokens;
-    }
+    server_prompt_cache(
+        int32_t limit_size_mib,
+        size_t limit_tokens,
+        const std::string & cache_dir = "",
+        const std::string & cache_key = "",
+        bool has_mtmd = false);
 
     std::list<server_prompt_cache_state> states;
 
@@ -623,13 +690,32 @@ struct server_prompt_cache {
     // in tokens, 0 = no limit
     size_t limit_tokens = 0;
 
+    std::string cache_dir;
+    std::string cache_key;
+
+    bool has_mtmd = false;
+
+    uint64_t next_file_id = 0;
+
     size_t size() const;
 
     size_t n_tokens() const;
 
     server_prompt_cache_state * alloc(const server_prompt & prompt, size_t state_size_main, size_t state_size_drft);
 
-    bool load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_tgt, llama_context * ctx_dft, int32_t id_slot);
+    bool commit(server_prompt_cache_state * state);
+    void discard(server_prompt_cache_state * state);
+
+    bool load(
+            server_prompt & prompt,
+            const server_tokens & tokens_new,
+            llama_context * ctx_tgt,
+            llama_context * ctx_dft,
+            int32_t id_slot,
+            bool cache_prompt,
+            bool needs_checkpoint,
+            int32_t n_swa,
+            float slot_prompt_similarity);
 
     void update();
 };

--- a/tools/server/tests/unit/test_prompt_cache_disk.py
+++ b/tools/server/tests/unit/test_prompt_cache_disk.py
@@ -1,0 +1,352 @@
+import math
+import os
+import re
+import struct
+import time
+
+from utils import *
+
+
+MIB = 1024 * 1024
+
+LONG_PROMPT = (
+    "Once upon a time in a land far away, there lived a brave knight "
+    "who traveled across mountains and rivers to find the legendary "
+    "golden sword hidden deep within the enchanted forest of whispers. "
+    "He met many creatures along the way including dragons and fairies "
+    "and wizards who helped him on his noble quest to save the kingdom. "
+) * 4
+
+
+def make_server() -> ServerProcess:
+    server = ServerPreset.tinygemma3()
+    server.no_mmproj = True
+    server.n_predict = 4
+    server.temperature = 0.0
+    server.server_slots = True
+    server.kv_unified = True
+    return server
+
+
+def make_pure_attention_server() -> ServerProcess:
+    server = ServerPreset.tinyllama2()
+    server.n_predict = 1
+    server.server_slots = True
+    server.kv_unified = True
+    return server
+
+
+def completion(
+        server: ServerProcess,
+        prompt: str | list[int],
+        id_slot: int | None = None,
+        cache_prompt: bool = True) -> dict:
+    data = {
+        "prompt": prompt,
+        "cache_prompt": cache_prompt,
+    }
+    if id_slot is not None:
+        data["id_slot"] = id_slot
+    res = server.make_request("POST", "/completion", data=data)
+    assert res.status_code == 200
+    return res.body["timings"]
+
+
+def cache_files(cache_dir):
+    return [path for path in cache_dir.iterdir() if path.is_file()]
+
+
+def cache_data_files(cache_dir):
+    return [path for path in cache_files(cache_dir) if path.name.endswith(".bin")]
+
+
+def cache_meta_files(cache_dir):
+    return {path for path in cache_files(cache_dir) if path.name.endswith(".bin.meta")}
+
+
+def tokenize(server: ServerProcess, prompt: str, add_special: bool = True) -> list[int]:
+    res = server.make_request("POST", "/tokenize", data={
+        "content": prompt,
+        "add_special": add_special,
+    })
+    assert res.status_code == 200
+    return res.body["tokens"]
+
+
+def common_prefix_length(lhs: list[int], rhs: list[int]) -> int:
+    return next(
+        (i for i, pair in enumerate(zip(lhs, rhs)) if pair[0] != pair[1]),
+        min(len(lhs), len(rhs)))
+
+
+def meta_checkpoint_count(path) -> int:
+    # magic[8], version, flags, key_size, tokens_size, payload_size, main_size, drft_size
+    header = path.read_bytes()[:64]
+    assert header[:8] == b"LLPCACHE"
+    return struct.unpack_from("<Q", header, 56)[0]
+
+
+def test_disk_cache_restores_across_server_restart(tmp_path):
+    server = make_server()
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = 256
+    server.start()
+
+    timings_full = completion(server, LONG_PROMPT, 0)
+    completion(server, "This prompt moves the first prompt into the disk cache.", 1)
+
+    cached_files = {path.name for path in cache_files(tmp_path)}
+    assert any(name.endswith(".bin") for name in cached_files)
+    assert any(name.endswith(".bin.meta") for name in cached_files)
+
+    # the test model uses SWA, so the cached state must carry context checkpoints
+    metas = [path for path in cache_files(tmp_path) if path.name.endswith(".bin.meta")]
+    assert all(meta_checkpoint_count(path) > 0 for path in metas)
+
+    server.stop()
+    assert cached_files.issubset({path.name for path in cache_files(tmp_path)})
+
+    server.start()
+    timings_restored = completion(server, LONG_PROMPT)
+    assert timings_restored["cache_n"] + timings_restored["prompt_n"] == timings_full["prompt_n"]
+    assert timings_restored["cache_n"] > timings_full["prompt_n"] * 0.8
+    assert timings_restored["prompt_n"] < timings_full["prompt_n"] * 0.2
+    assert cached_files.issubset({path.name for path in cache_files(tmp_path)})
+
+
+def test_disk_cache_removes_incomplete_and_invalid_entries(tmp_path):
+    incomplete = tmp_path / "llama-prompt-cache-incomplete.bin"
+    invalid = tmp_path / "llama-prompt-cache-invalid.bin"
+    invalid_metadata = tmp_path / "llama-prompt-cache-invalid.bin.meta"
+    incomplete.write_bytes(b"incomplete")
+    invalid.write_bytes(b"invalid")
+    invalid_metadata.write_bytes(b"invalid metadata")
+
+    server = make_server()
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = 256
+    server.start()
+
+    assert not incomplete.exists()
+    assert not invalid.exists()
+    assert not invalid_metadata.exists()
+    completion(server, "The server remains usable after cache cleanup.", 0)
+
+
+def test_disk_cache_size_limit_keeps_recent_entries(tmp_path):
+    server = make_server()
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = -1
+    server.start()
+
+    completion(server, LONG_PROMPT, 0)
+    completion(server, "Measure the disk state size.", 1)
+    data_files = cache_data_files(tmp_path)
+    assert len(data_files) == 1
+    entry_size = data_files[0].stat().st_size
+
+    server.stop()
+    for path in cache_files(tmp_path):
+        path.unlink()
+
+    server.cache_disk_max = max(1, math.ceil(2.25 * entry_size / MIB))
+    server.start()
+
+    prompts = [f"Cache entry {index}. {LONG_PROMPT}" for index in range(4)]
+    for index, prompt in enumerate(prompts):
+        completion(server, prompt, index % 2)
+    completion(server, "Move the last prompt into the disk cache.", 0)
+
+    cache_limit = server.cache_disk_max * MIB
+    assert sum(path.stat().st_size for path in cache_files(tmp_path)) <= cache_limit
+    assert len(cache_data_files(tmp_path)) <= 2
+
+    timings = completion(server, prompts[-1])
+    assert timings["cache_n"] > 0
+    assert timings["prompt_n"] < timings["cache_n"]
+
+
+def test_disk_cache_strict_extension_matches_predicted_reuse(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLAMA_ARG_LOG_VERBOSITY", "4")
+
+    server = make_server()
+    server.n_predict = 1
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = 256
+    server.log_path = str(tmp_path / "server.log")
+    server.start()
+
+    cached_tokens = tokenize(server, LONG_PROMPT)
+    suffix_tokens = tokenize(server, "The cached story continues with a new chapter.", add_special=False)
+    extended_tokens = cached_tokens + suffix_tokens
+    assert common_prefix_length(cached_tokens, extended_tokens) == len(cached_tokens)
+    assert len(cached_tokens) < len(extended_tokens)
+
+    completion(server, cached_tokens, 0)
+    completion(server, "Move the strict-extension prompt into the disk cache.", 1)
+    [metadata] = cache_meta_files(tmp_path)
+    assert meta_checkpoint_count(metadata) > 0
+
+    server.stop()
+    server.start()
+    timings = completion(server, extended_tokens)
+    server.stop()
+
+    log = (tmp_path / "server.log").read_text()
+    predicted = re.findall(r"found better prompt .*effective_prefix_reuse = (\d+)", log)
+    assert predicted
+    assert timings["cache_n"] == int(predicted[-1])
+    assert timings["cache_n"] > timings["prompt_n"]
+
+
+def test_disk_cache_no_usable_checkpoint_skips_candidate(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLAMA_ARG_CTX_CHECKPOINTS", "0")
+
+    server = make_server()
+    server.n_predict = 1
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = 256
+    server.start()
+
+    cached_prompt = LONG_PROMPT + " This cached branch ends at the red gate."
+    divergent_prompt = LONG_PROMPT + " This requested branch ends at the blue harbor."
+    cached_tokens = tokenize(server, cached_prompt)
+    divergent_tokens = tokenize(server, divergent_prompt)
+    raw_lcp = common_prefix_length(cached_tokens, divergent_tokens)
+    assert raw_lcp < len(cached_tokens)
+    assert raw_lcp / len(cached_tokens) > 0.25
+
+    completion(server, cached_prompt, 0)
+    completion(server, "Move the no-checkpoint prompt into the disk cache.", 1)
+    [metadata] = cache_meta_files(tmp_path)
+    assert meta_checkpoint_count(metadata) == 0
+    server.stop()
+
+    old_time = time.time() - 3600
+    os.utime(metadata, (old_time, old_time))
+    mtime_before = metadata.stat().st_mtime_ns
+
+    server.start()
+    timings = completion(server, divergent_prompt)
+    assert timings["cache_n"] == 0
+    assert metadata.stat().st_mtime_ns == mtime_before
+
+
+def test_disk_cache_selector_prefers_smaller_equal_prefix(tmp_path):
+    server = make_pure_attention_server()
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = 256
+    server.start()
+
+    shared = LONG_PROMPT[:len(LONG_PROMPT) // 4]
+    long_prompt = shared + (" The old branch follows the mountain road." * 12)
+    short_prompt = shared + " The newer branch stops beside the river."
+    request_prompt = shared + " The requested branch sails across the ocean."
+
+    long_tokens = tokenize(server, long_prompt)
+    short_tokens = tokenize(server, short_prompt)
+    request_tokens = tokenize(server, request_prompt)
+    raw_lcp = common_prefix_length(short_tokens, request_tokens)
+    assert common_prefix_length(long_tokens, request_tokens) == raw_lcp
+    assert raw_lcp < len(request_tokens)
+    assert raw_lcp / len(long_tokens) > 0.25
+
+    completion(server, long_prompt, 0)
+    before = cache_meta_files(tmp_path)
+    completion(server, "Move the older long prompt into the disk cache.", 1)
+    [long_metadata] = cache_meta_files(tmp_path) - before
+
+    completion(server, short_prompt, 0)
+    before = cache_meta_files(tmp_path)
+    completion(server, "Move the newer short prompt into the disk cache.", 1)
+    [short_metadata] = cache_meta_files(tmp_path) - before
+    server.stop()
+
+    assert long_metadata.with_suffix("").stat().st_size > short_metadata.with_suffix("").stat().st_size
+
+    old_time = time.time() - 3600
+    os.utime(long_metadata, (old_time, old_time))
+    os.utime(short_metadata, (old_time + 1, old_time + 1))
+    long_mtime = long_metadata.stat().st_mtime_ns
+    short_mtime = short_metadata.stat().st_mtime_ns
+
+    server.start()
+    timings = completion(server, request_prompt)
+    assert timings["cache_n"] == raw_lcp
+    assert long_metadata.stat().st_mtime_ns == long_mtime
+    assert short_metadata.stat().st_mtime_ns > short_mtime
+
+
+def test_disk_cache_reuses_long_entry_below_keep_threshold(tmp_path):
+    server = make_pure_attention_server()
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = 256
+    server.start()
+
+    shared = LONG_PROMPT[:len(LONG_PROMPT) // 8]
+    shared_tokens = tokenize(server, shared)
+    long_tail = tokenize(server, "Cached sessions keep going down the mountain road.", add_special=False)
+    request_tail = tokenize(server, "Different requests ask something else entirely.", add_special=False)
+    tail_lcp = common_prefix_length(long_tail, request_tail)
+    long_tail = long_tail[tail_lcp:]
+    request_tail = request_tail[tail_lcp:]
+    assert long_tail and request_tail
+    assert long_tail[0] != request_tail[0]
+    target_tail_length = 3 * len(shared_tokens) + 1
+    long_tail = (long_tail * math.ceil(target_tail_length / len(long_tail)))[:target_tail_length]
+    long_tokens = shared_tokens + long_tail
+    request_tokens = shared_tokens + request_tail
+    raw_lcp = common_prefix_length(long_tokens, request_tokens)
+
+    assert raw_lcp == len(shared_tokens)
+    assert raw_lcp < len(request_tokens)
+    assert raw_lcp / len(long_tokens) < 0.25
+    assert raw_lcp / len(request_tokens) > 0.1
+    assert server.n_ctx is not None and len(long_tokens) < server.n_ctx
+
+    completion(server, long_tokens, 0)
+    before = cache_meta_files(tmp_path)
+    completion(server, "Move the long session into the disk cache.", 1)
+    [long_metadata] = cache_meta_files(tmp_path) - before
+    server.stop()
+
+    old_time = time.time() - 3600
+    os.utime(long_metadata, (old_time, old_time))
+    long_mtime = long_metadata.stat().st_mtime_ns
+
+    server.start()
+    timings = completion(server, request_tokens)
+    server.stop()
+
+    assert timings["cache_n"] == raw_lcp
+    assert long_metadata.stat().st_mtime_ns > long_mtime
+
+
+def test_disk_cache_does_not_load_when_prompt_cache_disabled(tmp_path):
+    server = make_server()
+    server.n_predict = 1
+    server.cache_ram = 0
+    server.cache_disk = str(tmp_path)
+    server.cache_disk_max = 256
+    server.start()
+
+    completion(server, LONG_PROMPT, 0)
+    completion(server, "Move the disabled-cache prompt into the disk cache.", 1)
+    [metadata] = cache_meta_files(tmp_path)
+    server.stop()
+
+    old_time = time.time() - 3600
+    os.utime(metadata, (old_time, old_time))
+    mtime_before = metadata.stat().st_mtime_ns
+
+    server.start()
+    timings = completion(server, LONG_PROMPT, cache_prompt=False)
+    assert timings["cache_n"] == 0
+    assert metadata.stat().st_mtime_ns == mtime_before

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -113,6 +113,8 @@ class ServerProcess:
     media_path: str | None = None
     sleep_idle_seconds: int | None = None
     cache_ram: int | None = None
+    cache_disk: str | None = None
+    cache_disk_max: int | None = None
     no_cache_idle_slots: bool = False
     log_path: str | None = None
     ui_mcp_proxy: bool = False
@@ -278,6 +280,10 @@ class ServerProcess:
             server_args.extend(["--sleep-idle-seconds", self.sleep_idle_seconds])
         if self.cache_ram is not None:
             server_args.extend(["--cache-ram", self.cache_ram])
+        if self.cache_disk is not None:
+            server_args.extend(["--cache-disk", self.cache_disk])
+        if self.cache_disk_max is not None:
+            server_args.extend(["--cache-disk-max", self.cache_disk_max])
         if self.no_cache_idle_slots:
             server_args.append("--no-cache-idle-slots")
         if self.ui_mcp_proxy:


### PR DESCRIPTION
## Overview

Implements a persistent prompt cache that supports hybrid/SWA context
checkpoints, restores automatically across process restarts, and provides
corrupt-entry cleanup and LRU eviction bounded by disk size.

Closes #20697

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the implementation was written by Codex and the tests were written by Claude. I defined the requirements and verified the results.
