### PR TITLE
spec : handle missing block_count key in speculative type detection

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2299,7 +2299,11 @@ std::vector<common_speculative_type> common_speculative_types_from_gguf(const st
 
     const std::string arch = gguf_get_val_str(gguf_ctx.get(), arch_id);
     if (arch != "dflash") {
-        const uint32_t block_count = gguf_get_val_u32(gguf_ctx.get(), gguf_find_key(gguf_ctx.get(), (arch + ".block_count").c_str()));
+        const int64_t block_count_id = gguf_find_key(gguf_ctx.get(), (arch + ".block_count").c_str());
+        if (block_count_id < 0) {
+            return {};
+        }
+        const uint32_t block_count = gguf_get_val_u32(gguf_ctx.get(), block_count_id);
 
         if (gguf_find_tensor(gguf_ctx.get(), ("blk." + std::to_string(block_count - 1) + ".nextn.eh_proj.weight").c_str()) >= 0) {
             return { COMMON_SPECULATIVE_TYPE_DRAFT_MTP };


### PR DESCRIPTION
## Overview

In common_speculative_types_from_gguf(), we look up the <arch>.block_count key in the draft model's GGUF. gguf_find_key() returns -1 when that key isn't found. Previously the -1 was sent directly into gguf_get_val_u32(), whose internal GGML_ASSERT(key_id >= 0 ...) then aborted the process. The fix checks the result of gguf_find_key() for < 0 and returns gracefully when the key is missing . the same thing is already been used for arch_id a few lines above.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: yes , used deepseekV4 flash validated the change

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
