### PR TITLE
CUDA/HIP: Flash Attention tuning (gfx1201)

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -972,39 +972,6 @@ static __global__ void flash_attn_combine_results(
     dst[tid] = VKQ_numerator / VKQ_denominator;
 }
 
-struct fattn_stream_k_thresholds {
-    bool whole_tiles_allowed;
-    int  min_tile_waves;
-    int  min_tile_efficiency;
-};
-
-static fattn_stream_k_thresholds ggml_cuda_fattn_get_stream_k_thresholds(const int cc) {
-    //      whole_tiles_allowed, min_tile_waves, min_tile_efficiency
-    if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc < GGML_CUDA_CC_ADA_LOVELACE) {
-        return {true,  0, 75};
-    }
-    // On AMD WMMA stream-k collapses to a single low-occupancy wave, whole tiles are faster once the GPU is filled twice.
-    if (amd_wmma_available(cc)) {
-        return {true,  2, 75};
-    }
-    // NVIDIA Ada Lovelace and newer, AMD MFMA, MooreThreads: always stream-k.
-    return {false, 0,  0};
-}
-
-static bool ggml_cuda_fattn_use_stream_k(const int cc, const int ntiles_dst, const int max_blocks) {
-    const fattn_stream_k_thresholds thresholds = ggml_cuda_fattn_get_stream_k_thresholds(cc);
-    if (!thresholds.whole_tiles_allowed) {
-        return true;
-    }
-
-    const int tiles_nwaves             = (ntiles_dst + max_blocks - 1) / max_blocks;
-    const int tiles_efficiency_percent = 100 * ntiles_dst / (max_blocks*tiles_nwaves);
-
-    const bool whole_tiles = ntiles_dst >= thresholds.min_tile_waves*max_blocks
-        && tiles_efficiency_percent >= thresholds.min_tile_efficiency;
-    return !whole_tiles;
-}
-
 template <int DV, int ncols1, int ncols2>
 void launch_fattn(
     ggml_backend_cuda_context & ctx, ggml_tensor * dst, fattn_kernel_t fattn_kernel, const int nwarps, const size_t nbytes_shared,
@@ -1166,8 +1133,21 @@ void launch_fattn(
 
     dim3 blocks_num;
     if (stream_k) {
+        auto should_use_stream_k = [](const int cc, const int ntiles_dst, const int max_blocks, const int DKQ) {
+            const int tiles_nwaves             = (ntiles_dst + max_blocks - 1) / max_blocks;
+            const int tiles_efficiency_percent = 100 * ntiles_dst / (max_blocks*tiles_nwaves);
+
+            if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc >= GGML_CUDA_CC_ADA_LOVELACE) {
+                return true;
+            }
+            if (amd_wmma_available(cc) && DKQ == 64) {
+                return true; // TODO better configuration
+            }
+            return tiles_efficiency_percent < 75;
+        };
+
         const int  max_blocks   = max_blocks_per_sm*nsm;
-        const bool use_stream_k = ggml_cuda_fattn_use_stream_k(cc, ntiles_dst, max_blocks);
+        const bool use_stream_k = should_use_stream_k(cc, ntiles_dst, max_blocks, Q->ne[0]);
 
         blocks_num.x = ntiles_dst;
         blocks_num.y = 1;

--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -972,6 +972,39 @@ static __global__ void flash_attn_combine_results(
     dst[tid] = VKQ_numerator / VKQ_denominator;
 }
 
+struct fattn_stream_k_thresholds {
+    bool whole_tiles_allowed;
+    int  min_tile_waves;
+    int  min_tile_efficiency;
+};
+
+static fattn_stream_k_thresholds ggml_cuda_fattn_get_stream_k_thresholds(const int cc) {
+    //      whole_tiles_allowed, min_tile_waves, min_tile_efficiency
+    if (GGML_CUDA_CC_IS_NVIDIA(cc) && cc < GGML_CUDA_CC_ADA_LOVELACE) {
+        return {true,  0, 75};
+    }
+    // On AMD WMMA stream-k collapses to a single low-occupancy wave, whole tiles are faster once the GPU is filled twice.
+    if (amd_wmma_available(cc)) {
+        return {true,  2, 75};
+    }
+    // NVIDIA Ada Lovelace and newer, AMD MFMA, MooreThreads: always stream-k.
+    return {false, 0,  0};
+}
+
+static bool ggml_cuda_fattn_use_stream_k(const int cc, const int ntiles_dst, const int max_blocks) {
+    const fattn_stream_k_thresholds thresholds = ggml_cuda_fattn_get_stream_k_thresholds(cc);
+    if (!thresholds.whole_tiles_allowed) {
+        return true;
+    }
+
+    const int tiles_nwaves             = (ntiles_dst + max_blocks - 1) / max_blocks;
+    const int tiles_efficiency_percent = 100 * ntiles_dst / (max_blocks*tiles_nwaves);
+
+    const bool whole_tiles = ntiles_dst >= thresholds.min_tile_waves*max_blocks
+        && tiles_efficiency_percent >= thresholds.min_tile_efficiency;
+    return !whole_tiles;
+}
+
 template <int DV, int ncols1, int ncols2>
 void launch_fattn(
     ggml_backend_cuda_context & ctx, ggml_tensor * dst, fattn_kernel_t fattn_kernel, const int nwarps, const size_t nbytes_shared,
@@ -1133,12 +1166,8 @@ void launch_fattn(
 
     dim3 blocks_num;
     if (stream_k) {
-        // For short contexts it can be faster to have the SMs work on whole tiles because this lets us skip the fixup.
-        const int max_blocks = max_blocks_per_sm*nsm;
-        const int tiles_nwaves = (ntiles_dst + max_blocks - 1) / max_blocks;
-        const int tiles_efficiency_percent = 100 * ntiles_dst / (max_blocks*tiles_nwaves);
-
-        const bool use_stream_k = cc >= GGML_CUDA_CC_ADA_LOVELACE || amd_wmma_available(cc) || tiles_efficiency_percent < 75;
+        const int  max_blocks   = max_blocks_per_sm*nsm;
+        const bool use_stream_k = ggml_cuda_fattn_use_stream_k(cc, ntiles_dst, max_blocks);
 
         blocks_num.x = ntiles_dst;
         blocks_num.y = 1;

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -158,8 +158,8 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
 
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256,  8,  64, 2,  32, 128, 128, 128, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 16,  64, 2,  32, 128, 128, 128, 1, true);
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 32, 128, 2,  64, 128, 128,  64, 1, true);
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 128, 2,  64, 128, 128,  64, 1, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 32, 256, 2,  64, 128, 128,  64, 1, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE(256, 256, 64, 256, 2,  64, 128, 128,  64, 1, true);
 
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(320, 256, 32, 128, 2,  32, 160, 128, 128, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE(320, 256, 64, 128, 2,  32, 160, 128, 128, 1, true);
@@ -1826,7 +1826,7 @@ static __global__ void flash_attn_ext_f16(
 #endif // __CUDA_ARCH__ == GGML_CUDA_CC_TURING
 
 #if defined(AMD_WMMA_AVAILABLE)
-    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 128) {
+    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 256) {
         NO_DEVICE_CODE;
         return;
     }

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -221,7 +221,8 @@ static void ggml_cuda_flash_attn_ext_mma_f16_switch_ncols2(ggml_backend_cuda_con
         }
     }
 
-    if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+    // On RDNA it is preferable to minimize wasted compute vs. duplicate I/O for the mask.
+    if (amd_wmma_available(cc)) {
         if (use_gqa_opt && gqa_ratio % 8 == 0) {
             ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 8>(ctx, dst);
             return;
@@ -663,8 +664,9 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
         }
     }
 
-    // AMD WMMA is always faster than the tile kernel if the full tile width of 16 can be utilized.
-    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 256) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
+    // AMD WMMA is faster than the tile kernel if the wide tiles with high arithmetic intensity can be utilized.
+    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 256) && Q->ne[0] != 40 && Q->ne[0] != 72 &&
+            Q->ne[1] * gqa_ratio_eff > (Q->ne[0] <= 128 ? 8 : 16)) {
         return BEST_FATTN_KERNEL_MMA_F16;
     }
 

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -221,6 +221,23 @@ static void ggml_cuda_flash_attn_ext_mma_f16_switch_ncols2(ggml_backend_cuda_con
         }
     }
 
+    if (GGML_CUDA_CC_IS_RDNA4(cc)) {
+        if (use_gqa_opt && gqa_ratio % 8 == 0) {
+            ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 8>(ctx, dst);
+            return;
+        }
+
+        if (use_gqa_opt && gqa_ratio % 4 == 0) {
+            ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 4>(ctx, dst);
+            return;
+        }
+
+        if (use_gqa_opt && gqa_ratio % 2 == 0) {
+            ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 2>(ctx, dst);
+            return;
+        }
+    }
+
     if (use_gqa_opt && gqa_ratio > 4) {
         ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1<DKQ, DV, 8>(ctx, dst);
         return;
@@ -647,7 +664,7 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     }
 
     // AMD WMMA is always faster than the tile kernel if the full tile width of 16 can be utilized.
-    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 128) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
+    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 256) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
         return BEST_FATTN_KERNEL_MMA_F16;
     }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10658,6 +10658,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
                                                         GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     }
 
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1},   512, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1},  4096,  64, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1},  4096,  16, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {2, 1},  4096, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {4, 1},  4096, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {12, 1}, 4096, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+
     // dense-allocated (non-view) quant K/V at batch >= 64, in cache and native layouts
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {1, 1}, 512, 75, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, {0, 2, 1, 3}, false));
     test_cases.emplace_back(new test_flash_attn_ext(64, 64, 4, {4, 1}, 512, 75, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, {0, 2, 1, 3}, false));
@@ -11123,6 +11130,15 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {16, 1}, 20000, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0));
     test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {16, 1}, 10000, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
     test_cases.emplace_back(new test_flash_attn_ext(256, 256, 2, {16, 1}, 20000, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 4096, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 4096, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 16384, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 16384, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 65536, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 65536, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 131072, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
+    test_cases.emplace_back(new test_flash_attn_ext(256, 256, 4, {6, 1}, 131072, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16));
 
     for (int kv : { 4096, 8192, 16384,32768, 65536, }) {
         for (int hs : { 64, 128, 256, 576, }) {


### PR DESCRIPTION
## Overview

So, got my new R9700 PRO. It's nice and shiny and has 32GB VRAM, so I decided to try out Qwen3.8 27B. That was a mistake. The prefill performance at longer contexts was abysmal, so I decided to do something about it. Also managed to fix a HS=256 bug in the general CUDA FA code which was preventing the selection of 256 kernels before.

## Additional information

Before:

| model                          |       size |     params | backend    | threads | dev          |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ------------ | --------------: | -------------------: |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |           pp512 |     1101.41 ± 221.33 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |           tg128 |         29.81 ± 0.19 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |  pp512 @ d40000 |       426.36 ± 37.60 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |  tg128 @ d40000 |         26.75 ± 0.46 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        | pp512 @ d150000 |        164.42 ± 5.79 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        | tg128 @ d150000 |         19.70 ± 0.20 |

After:

 model                          |       size |     params | backend    | threads | dev          |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | ------------ | --------------: | -------------------: |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |           pp512 |     1103.66 ± 254.83 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |           tg128 |         29.87 ± 0.46 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |  pp512 @ d40000 |      639.46 ± 185.36 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        |  tg128 @ d40000 |         26.94 ± 0.46 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        | pp512 @ d150000 |       399.01 ± 30.87 |
| qwen35 27B IQ4_XS - 4.25 bpw   |  13.26 GiB |    27.32 B | BLAS,CUDA,ROCm,Vulkan |       8 | ROCm0        | tg128 @ d150000 |         19.67 ± 0.39 |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes