### PR TITLE
CUDA: batch-invariant flash-attn for narrow widths on SM120

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -5,6 +5,21 @@
 #include "vecdotq.cuh"
 
 #include <cstdint>
+#include <cstdlib>
+
+// On SM120 the flash-attention dispatch selects the narrowest template instance that fits
+// Q->ne[1]. Speculative verification varies ne[1] from step to step, so one logical computation
+// is served by two instances that differ in tile geometry, and therefore in KV loop and combine
+// order, and so cannot agree bitwise. Widths 3 and 4 are routed to the 4 wide vector tile, which
+// widths 1 and 2 already reduce to, leaving a single instance across the whole 1..4 range.
+// Set LLAMA_SM120_FA_INVARIANT=0 to restore the stock dispatch.
+inline bool ggml_cuda_fa_sm120_invariant() {
+    static const bool enabled = []() {
+        const char * env = getenv("LLAMA_SM120_FA_INVARIANT");
+        return env == nullptr || atoi(env) != 0;
+    }();
+    return enabled;
+}
 
 #define FATTN_KQ_STRIDE       256
 #define HALF_MAX_HALF         __float2half(65504.0f/2) // Use neg. of this instead of -INFINITY to initialize KQ max vals to avoid NaN upon subtraction.

--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -545,6 +545,7 @@ void ggml_cuda_flash_attn_ext_vec_case_impl(ggml_backend_cuda_context & ctx, ggm
 
 template <int D, ggml_type type_K, ggml_type type_V>
 void ggml_cuda_flash_attn_ext_vec_case(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
+    const int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
     const ggml_tensor * KQV = dst;
     const ggml_tensor * Q   = dst->src[0];
 
@@ -553,6 +554,22 @@ void ggml_cuda_flash_attn_ext_vec_case(ggml_backend_cuda_context & ctx, ggml_ten
 
     if (Q->ne[1] == 1) {
         constexpr int cols_per_block = 1;
+        if (logit_softcap == 0.0f) {
+            constexpr bool use_logit_softcap = false;
+            ggml_cuda_flash_attn_ext_vec_case_impl<D, cols_per_block, type_K, type_V, use_logit_softcap>(ctx, dst);
+        } else {
+            constexpr bool use_logit_softcap = true;
+            ggml_cuda_flash_attn_ext_vec_case_impl<D, cols_per_block, type_K, type_V, use_logit_softcap>(ctx, dst);
+        }
+        return;
+    }
+
+    // ne[1] == 2 is served by the 2 wide tile below, which does half the work of
+    // the 4 wide one. ntiles_x stays 1 for widths 1 to 4, so the launch geometry
+    // and thus the result is the same for both tiles.
+    if (cc >= GGML_CUDA_CC_BLACKWELL && Q->ne[1] >= 3 && Q->ne[1] <= 4 && Q->ne[3] == 1 &&
+            ggml_cuda_fa_sm120_invariant()) {
+        constexpr int cols_per_block = 4;
         if (logit_softcap == 0.0f) {
             constexpr bool use_logit_softcap = false;
             ggml_cuda_flash_attn_ext_vec_case_impl<D, cols_per_block, type_K, type_V, use_logit_softcap>(ctx, dst);

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -457,6 +457,16 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     // 192 satisfies % 64 == 0 but has no vec instance (DKQ != DV); force it onto the MMA path.
     const bool can_use_vector_kernel = Q->ne[0] <= 256 && Q->ne[0] % 64 == 0 && Q->ne[0] != 192 && K->ne[1] % FATTN_KQ_STRIDE == 0;
 
+    // On Blackwell, small speculative-verification batches must follow the
+    // same arithmetic as ordinary one-token decoding.  The vector launcher
+    // uses a batch-invariant vector tile with independent query accumulators;
+    // unlike the MMA kernel selected for three or more queries, it remains
+    // bitwise invariant while sharing K/V loads in one CUDA graph node.
+    if (cc >= GGML_CUDA_CC_BLACKWELL && can_use_vector_kernel && Q->ne[1] <= 4 && Q->ne[3] == 1 &&
+            ggml_cuda_fa_sm120_invariant()) {
+        return BEST_FATTN_KERNEL_VEC;
+    }
+
     // If Turing tensor cores are available, use them:
     if (turing_mma_available(cc) && Q->ne[0] != 40 && Q->ne[0] != 72) {
         if (can_use_vector_kernel) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -4660,6 +4660,7 @@ struct test_mul_mat : public test_case {
     }
 };
 
+// GGML_OP_MUL_MAT: require batched MMVQ columns to match independent columns bit-for-bit.
 // GGML_HINT_SRC0_IS_HADAMARD
 struct test_mul_mat_hadamard : public test_mul_mat {
     test_mul_mat_hadamard(ggml_type type_a = GGML_TYPE_F32, ggml_type type_b = GGML_TYPE_F32,
@@ -7337,6 +7338,92 @@ struct test_flash_attn_ext : public test_case {
     bool grad_precise() override {
         return true;
     }
+};
+
+// Qwen3.8 full-attention shape: require a small Q8 KV verification batch to
+// produce the same F32 results as independent one-query flash-attention ops.
+struct test_flash_attn_ext_batch_invariance : public test_case {
+    const int64_t n_tokens;
+    const int64_t n_kv;
+
+    test_flash_attn_ext_batch_invariance(int64_t n_tokens, int64_t n_kv)
+        : n_tokens(n_tokens), n_kv(n_kv) {}
+
+    std::string vars() override {
+        return VARS_TO_STR2(n_tokens, n_kv);
+    }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        constexpr int64_t head_size = 256;
+        constexpr int64_t n_head_q  = 24;
+        constexpr int64_t n_head_kv = 4;
+
+        ggml_tensor * q = ggml_new_tensor_4d(ctx, GGML_TYPE_F32,
+                head_size, n_tokens, n_head_q, 1);
+        ggml_tensor * k_store = ggml_new_tensor_4d(ctx, GGML_TYPE_Q8_0,
+                head_size, 2*n_kv, n_head_kv, 1);
+        ggml_tensor * v_store = ggml_new_tensor_4d(ctx, GGML_TYPE_Q8_0,
+                head_size, 2*n_kv, n_head_kv, 1);
+        ggml_tensor * k = ggml_view_4d(ctx, k_store, head_size, n_kv, n_head_kv, 1,
+                k_store->nb[1], k_store->nb[2], k_store->nb[3], 0);
+        ggml_tensor * v = ggml_view_4d(ctx, v_store, head_size, n_kv, n_head_kv, 1,
+                v_store->nb[1], v_store->nb[2], v_store->nb[3], 0);
+        ggml_tensor * mask = ggml_new_tensor_4d(ctx, GGML_TYPE_F16, n_kv, n_tokens, 1, 1);
+        ggml_set_name(q, "q");
+        ggml_set_name(k_store, "k_store");
+        ggml_set_name(v_store, "v_store");
+        ggml_set_name(k, "k");
+        ggml_set_name(v, "v");
+        ggml_set_name(mask, "mask");
+
+        auto flash = [&](ggml_tensor * q_i, ggml_tensor * mask_i) {
+            ggml_tensor * result = ggml_flash_attn_ext(ctx, q_i, k, v, mask_i,
+                    1.0f/sqrtf((float) head_size), 0.0f, 0.0f);
+            ggml_flash_attn_ext_set_prec(result, GGML_PREC_F32);
+            return result;
+        };
+
+        ggml_tensor * batched = flash(q, mask);
+        ggml_set_name(batched, "batched");
+
+        ggml_tensor * serial = nullptr;
+        for (int64_t i = 0; i < n_tokens; ++i) {
+            ggml_tensor * q_i = ggml_view_4d(ctx, q, head_size, 1, n_head_q, 1,
+                    q->nb[1], q->nb[2], q->nb[3], i*q->nb[1]);
+            ggml_tensor * mask_i = ggml_view_4d(ctx, mask, n_kv, 1, 1, 1,
+                    mask->nb[1], mask->nb[2], mask->nb[3], i*mask->nb[1]);
+            ggml_tensor * out_i = flash(q_i, mask_i);
+            serial = serial == nullptr ? out_i : ggml_concat(ctx, serial, out_i, 2);
+        }
+        ggml_set_name(serial, "serial");
+
+        ggml_tensor * out = ggml_concat(ctx, batched, serial, 2);
+        ggml_set_name(out, "out");
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            if (ggml_is_view_op(t->op)) {
+                continue;
+            }
+            if (strcmp(t->name, "mask") == 0) {
+                init_tensor_kq_mask(t);
+            } else {
+                init_tensor_uniform(t);
+            }
+        }
+    }
+
+    double err(const float * backend, const float * /*cpu*/, size_t count) override {
+        GGML_ASSERT(count % 2 == 0);
+        return memcmp(backend, backend + count/2, count/2 * sizeof(float)) == 0 ? 0.0 : 1.0;
+    }
+
+    double max_err() override { return 0.0; }
+    double max_err(ggml_backend_t /*backend*/) override { return 0.0; }
+    bool run_whole_graph() override { return true; }
+    std::string op_desc(ggml_tensor * /*t*/) override { return "FLASH_ATTN_EXT_BATCH_INVARIANCE"; }
 };
 
 // GGML_OP_CROSS_ENTROPY_LOSS
@@ -10155,6 +10242,13 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_flash_attn_ext(192, 128, 4, {8, 1},  512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16, {0, 1, 2, 3}, true, true));
     test_cases.emplace_back(new test_flash_attn_ext(128, 128, 8, {4, 1},  512, 8, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16, GGML_TYPE_F16, {0, 1, 2, 3}, true, true));
     test_cases.emplace_back(new test_flash_attn_ext(64,  64,  4, {1, 1},  512, 1, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_Q8_0, GGML_TYPE_Q8_0, {0, 1, 2, 3}, true, true));
+    // KV length changes the number of parallel blocks the launcher picks, so a tile
+    // width that is invariant at one KV length is not automatically invariant at another.
+    for (int64_t n_kv : {2048, 7168, 16384}) {
+        for (int64_t n_tokens : {1, 2, 3, 4}) {
+            test_cases.emplace_back(new test_flash_attn_ext_batch_invariance(n_tokens, n_kv));
+        }
+    }
 
     // large-KV F16 cases (Qwen3.6-27B geometry and a llama-class control): the upstream matrix
     // stops at kv=1024, blind to long-context FA bugs (e.g. the oneDNN SDPA ordering race on BMG).


### PR DESCRIPTION
### Problem

The flash-attention dispatch picks the narrowest template instance that fits `Q->ne[1]`. Speculative decoding varies `ne[1]` from step to step — 1 for the reference decode, 3–4 for the verification pass at the default `--spec-draft-n-max 3` — so one logical computation is served by two instances that differ in tile geometry, and therefore in KV loop and combine order. They cannot agree bitwise.

Speculative decoding is lossless under greedy sampling by construction, since the target model ratifies every drafted token. On SM120 today it is not: enabling it changes the generated text.

### Reproduction

`test_flash_attn_ext_batch_invariance` (added here) compares one batched pass against per-token serial passes with `memcmp` and `max_err() = 0`, over `n_kv {2048, 7168, 16384}` × `n_tokens {1, 2, 3, 4}`.

On an RTX 5080 Laptop, current master:

```
FLASH_ATTN_EXT_BATCH_INVARIANCE(n_tokens=3,n_kv=2048)    FAIL
FLASH_ATTN_EXT_BATCH_INVARIANCE(n_tokens=4,n_kv=2048)    FAIL
FLASH_ATTN_EXT_BATCH_INVARIANCE(n_tokens=3,n_kv=7168)    FAIL
FLASH_ATTN_EXT_BATCH_INVARIANCE(n_tokens=4,n_kv=7168)    FAIL
FLASH_ATTN_EXT_BATCH_INVARIANCE(n_tokens=3,n_kv=16384)   FAIL
FLASH_ATTN_EXT_BATCH_INVARIANCE(n_tokens=4,n_kv=16384)   FAIL
6/12 tests passed
```

`n_tokens` 1 and 2 pass; the failures are exactly the widths a 3-token draft produces.

End to end, Qwen3.8-27B-UD-Q3_K_XL, `--temp 0 --seed 1 -fa on`, 640 tokens, same prompt:

| run | vs. non-speculative reference |
|---|---|
| `--spec-type ngram-mod`, master | **diverges** — different text from the first paragraph on |
| `--spec-type ngram-mod`, this PR | **byte identical** |

A low-entropy prompt (verbatim code edit) produced identical output either way, so whether it is user-visible depends on how close the top-2 logits are. The determinism property is broken regardless.

### Fix

On Blackwell, route widths 3 and 4 to the 4-wide vector tile, which widths 1 and 2 already reduce to. That leaves a single instance across the whole 1..4 range. Columns past `ne[1]` are masked and `ntiles_x` stays 1 over that range, so launch geometry is unchanged. `LLAMA_SM120_FA_INVARIANT=0` restores the stock dispatch.

With the change: `12/12 tests passed`.

### Cost

`test-backend-ops perf`, same card, hs 256 / 24 q-heads / 4 kv-heads / kv 7168 / q8_0 KV. Medians of interleaved runs, first round discarded. Widths 1, 2, 5 and 8 are controls — the change must not touch them:

| nb | master | this PR | delta |
|---|---|---|---|
| 1 | 87.44 µs | 87.32 | −0.1% |
| 2 | 132.52 | 132.62 | +0.1% |
| **3** | 159.56 | 185.81 | **+16.5%** |
| **4** | 162.04 | 187.15 | **+15.5%** |
| 5 | 184.16 | 182.83 | −0.7% |
| 8 | 186.38 | 186.16 | −0.1% |

The cost is confined to the affected widths, and it is not anomalous: it brings nb=3/4 to ~186 µs, which is what nb=5 and nb=8 already cost. The 4-wide tile does 4-wide-tile work.

An alternative that pins one MMA instance across widths 1..4 instead was measured and rejected — it is free at widths 3–4 (+0.4%) but costs **+84.5% at nb=1** and +21.2% at nb=2, i.e. it taxes ordinary single-token decode.

### Testing

- `test-backend-ops test -b CUDA0`: **14607/14607 passed, 2/2 backends**, no failures.
- Compiles clean for `CMAKE_CUDA_ARCHITECTURES=75;86;120`, and runtime behaviour is identical to a 120-only build.
- Hardware: RTX 5080 Laptop (SM120) only. The change is gated to Blackwell and leaves every other architecture on the existing dispatch — I cannot test whether other architectures have the same property.
