### PR TITLE
common : draft KV cache no longer inherits --no-kv-offload

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2520,6 +2520,8 @@ common_params common_base_params_to_speculative(const common_params & params) {
 
     result.cache_type_k  = params_spec.cache_type_k;
     result.cache_type_v  = params_spec.cache_type_v;
+    // do not inherit --no-kv-offload: re-uploading the draft cache on every draft step is slow
+    result.no_kv_offload = false;
     result.n_outputs_max = params.n_parallel;
     result.n_outputs_max_per_seq = 1;
 

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -303,6 +303,14 @@ static void test(void) {
     assert(params.lora_adapters[2].path == "file3\"3\".gguf");
     assert(params.lora_adapters[3].path == "file4\".gguf");
 
+    printf("test-arg-parser: test draft context does not inherit --no-kv-offload\n\n");
+
+    params = common_params();
+    argv = {"binary_name", "-nkvo"};
+    assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SERVER));
+    assert(params.no_kv_offload == true);
+    assert(common_base_params_to_speculative(params).no_kv_offload == false);
+
 // skip this part on windows, because setenv is not supported
 #ifdef _WIN32
     printf("test-arg-parser: skip on windows build\n");


### PR DESCRIPTION
## Overview

Draft KV cache no longer inherits --no-kv-offload so it no longer copies over on every draft token

Fixes #28115 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Issue discovered , worked through and benched with Fable 5 (Claude Code).