### PR TITLE
server : propagate speculative params to default props response

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -4573,7 +4573,8 @@ static json get_res_props(const server_context_meta & meta, const common_params 
     // note: do NOT use ctx_server here, otherwise it's not possible to use this during sleep
 
     task_params tparams;
-    tparams.sampling = params.sampling;
+    tparams.sampling    = params.sampling;
+    tparams.speculative = params.speculative;
     json default_generation_settings_for_props = json {
         { "params", tparams.to_json(true) },
         { "n_ctx",  meta.slot_n_ctx },


### PR DESCRIPTION
## Overview

I'm using multiple computers with llama.cpp in a tiered setup . Tool calling (tools running in containers on tier 1 machine) did not work correctly when using `Qwen3-14B-Q5_K_M.gguf` with `-md Qwen3-14B-speculator.eagle3-Q8_0.gguf` on the second tier. \
Gemini Flash found a missing parameter in `server-context.cpp` in function `get_res_props()`. After `tparams.speculative = params.speculative` was added and llama.cpp rebuilt, the issue was gone. I waited a few weeks to find the fix in the main branch, but it seems this issue remains unnoticed.

## Additional information

I verified the fix by running llama-server with speculative parameters and checking the output of GET /props. The response now shows `"speculative.types": "none,draft-eagle3"`:
```
curl -s http://<IP>:<port>/props | jq '.default_generation_settings.params["speculative.types"]'
"none,draft-eagle3"
```
I've regularly built all my llama.cpp instances with this patch since and have not found any issues.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, Gemini Flash was used for the detection of the issue, locating the file and function and the patch. I reviewed the patch and tested it on three local llama.cpp instances.
