### PR TITLE
llama : enable recurrent-state rollback for qwen3next / qwen4exp

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1098,6 +1098,8 @@ bool llm_arch_is_diffusion(const llm_arch & arch) {
 
 bool llm_arch_supports_rs_rollback(const llm_arch & arch) {
     switch (arch) {
+        case LLM_ARCH_QWEN3NEXT:
+        case LLM_ARCH_QWEN4EXP:
         case LLM_ARCH_QWEN35:
         case LLM_ARCH_QWEN35MOE:
         case LLM_ARCH_DEEPSEEK4:


### PR DESCRIPTION
qwen3next and qwen4exp use the same GDN recurrent state as qwen35 / qwen35moe,
which are already in `llm_arch_supports_rs_rollback`. They were just missing from
that list, so speculative decoding fell back to `SEQ_RM_TYPE_FULL` and
checkpointed the whole recurrent state to host on every round.

Adding the two arches lets the recurrent memory roll back natively (via
`n_rs_seq`), so no checkpointing is needed.

Numbers on a Strix Halo (gfx1151, Vulkan/RADV), Qwen3.8-Flash-Next Q4_K_M,
temp 0, `-np 1`, MTP draft head:

| | decode |
|---|---|
| no draft | 32 t/s |
| MTP, full checkpoint (before) | 6 t/s |
| MTP, this change (rollback) | 44 t/s |

Greedy output matches the no-draft run. This came out of the discussion in
#28118, where @ggerganov pointed out that rollback is the right fix instead of
speeding up the checkpoint.

I only tested `-np 1` with short/medium generations, so an extra look at the
qwen4exp graph for deep rejections, long context and multiple slots would be
good.