### PR TITLE
vulkan : fix GGML_PREC_F32 being silently ignored for flash attention on fp16-capable GPUs

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
     add_subdirectory(debug)
     add_subdirectory(embedding)
     add_subdirectory(eval-callback)
+    add_subdirectory(mla-repro)
 
     add_subdirectory(gguf-hash)
     add_subdirectory(gguf)

--- a/examples/mla-repro/CMakeLists.txt
+++ b/examples/mla-repro/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TARGET llama-mla-repro)
+add_executable(${TARGET} mla-repro.cpp)
+install(TARGETS ${TARGET} RUNTIME)
+target_link_libraries(${TARGET} PRIVATE common llama ${CMAKE_THREAD_LIBS_INIT})
+target_compile_features(${TARGET} PRIVATE cxx_std_17)

--- a/examples/mla-repro/mla-repro.cpp
+++ b/examples/mla-repro/mla-repro.cpp
@@ -1,0 +1,117 @@
+// Standalone repro for the qwen35-mla / MLA long-context Vulkan flash-attention
+// corruption: unlike test-backend-ops' single-op FLASH_ATTN_EXT test (which only
+// shows a small ~0.1% numerical discrepancy at large kv), the real corruption only
+// appears when the *same compiled graph* gets reused across *many separate
+// llama_decode() submissions* as the KV cache grows incrementally -- exactly how
+// llama-perplexity actually drives the model. This reproduces that exact pattern
+// in a minimal driver, with a per-tensor eval callback (host-side, reads back from
+// GPU via ggml_backend_tensor_get -- no GPU-side debugPrintfEXT needed, so no
+// buffer-flush issues) watching a specific MLA attention tensor's running sum
+// across every decode step.
+#include "arg.h"
+#include "common.h"
+#include "debug.h"
+#include "log.h"
+#include "llama.h"
+#include "llama-cpp.h"
+
+#include <clocale>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static bool run(llama_context * ctx, const common_params & params) {
+    const llama_model * model = llama_get_model(ctx);
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+
+    const bool add_bos = llama_vocab_get_add_bos(vocab);
+
+    std::vector<llama_token> tokens = common_tokenize(ctx, params.prompt, add_bos, true);
+
+    if (tokens.empty()) {
+        LOG_ERR("%s : there are not input tokens to process - (try to provide a prompt with '-p' or '-f')\n", __func__);
+        return false;
+    }
+
+    const int n_batch = params.n_batch;
+    LOG_INF("total tokens = %zu, n_batch = %d, decoding in %zu chunks\n",
+            tokens.size(), n_batch, (tokens.size() + n_batch - 1) / n_batch);
+
+    size_t n_done = 0;
+    int chunk = 0;
+    while (n_done < tokens.size()) {
+        const size_t n_this = std::min((size_t) n_batch, tokens.size() - n_done);
+        LOG_INF("=== chunk %d: tokens [%zu, %zu) ===\n", chunk, n_done, n_done + n_this);
+
+        llama_batch batch = llama_batch_get_one(tokens.data() + n_done, n_this);
+        if (llama_decode(ctx, batch)) {
+            LOG_ERR("%s : failed to eval chunk %d\n", __func__, chunk);
+            return false;
+        }
+
+        n_done += n_this;
+        ++chunk;
+    }
+
+    return true;
+}
+
+int main(int argc, char ** argv) {
+    std::setlocale(LC_NUMERIC, "C");
+
+    common_params params;
+
+    common_init();
+
+    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_COMMON)) {
+        return 1;
+    }
+
+    llama_backend_init();
+    llama_numa_init(params.numa);
+
+    // pass the callback to the backend scheduler; it fires for each node
+    // during graph computation, for every llama_decode() call -- i.e. once
+    // per chunk, not just once overall. Filter to the MLA attention output
+    // tensor (named via cb(cur, "attn_pregate", il) in qwen35-mla.cpp) so the
+    // dump stays readable across many chunks; override via MLA_REPRO_FILTER.
+    // Constructed in place (not default-constructed then reassigned): the
+    // constructor stashes `this` into params.cb_eval_user_data, so building a
+    // temporary and move-assigning it into a longer-lived variable leaves
+    // that pointer dangling the moment the temporary is destroyed -- crashes
+    // on the very next callback invocation. Bit me once already.
+    const char * filter_env = getenv("MLA_REPRO_FILTER");
+    std::vector<std::string> filters = { filter_env ? filter_env : "attn_pregate" };
+    base_callback_data cb_data(params, filters);
+    params.warmup = false;
+
+    // init
+    auto llama_init = common_init_from_params(params);
+
+    auto * model = llama_init->model();
+    auto * ctx   = llama_init->context();
+
+    if (model == nullptr || ctx == nullptr) {
+        LOG_ERR("%s : failed to init\n", __func__);
+        return 1;
+    }
+
+    // print system information
+    {
+        LOG_INF("\n");
+        LOG_INF("%s\n", common_params_get_system_info(params).c_str());
+        LOG_INF("\n");
+    }
+
+    bool OK = run(ctx, params);
+    if (!OK) {
+        return 1;
+    }
+
+    LOG("\n");
+    llama_perf_context_print(ctx);
+
+    llama_backend_free();
+
+    return 0;
+}

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3442,15 +3442,55 @@ static void ggml_vk_load_shaders(vk_device& device) {
             } \
         }
 
+// Like CREATE_FA but restricted to FA_SCALAR: when f32acc is requested (prec ==
+// GGML_PREC_F32), bind the true FLOAT_TYPE=float shader body (the "_fp32"
+// suffixed variant) instead of the FLOAT_TYPE=float16_t one -- see the comment
+// at its call site for why this matters.
+#define CREATE_FA_SCALAR_F32ACC_FIX(TYPE, NAMELC) \
+        for (auto &fa : device->pipeline_flash_attn_f32_f16[TYPE]) { \
+            FaCodePath path = fa.first.path; \
+            uint32_t Br = fa.first.Br; \
+            uint32_t Bc = fa.first.Bc; \
+            bool aligned = fa.first.aligned; \
+            bool f32acc = fa.first.f32acc; \
+            uint32_t fa_sgs = fa.first.subgroup_size; \
+            bool fa_ds = fa.first.subgroup_size == 0; \
+            if (path == FA_SCALAR) { \
+                if (aligned) { \
+                    if (f32acc) { \
+                        ggml_vk_create_pipeline(device, fa.second, "flash_attn_f32_f16_aligned_f32acc" #NAMELC, flash_attn_f32_f16_ ## NAMELC ## _fp32_len,  flash_attn_f32_f16_ ## NAMELC ## _fp32_data,  "main", 7, sizeof(vk_flash_attn_push_constants), {Br, 1, 1}, get_fa_spec_constants(fa.first), Bc, true, !fa_ds, (!fa_ds ? fa_sgs : 0));     \
+                    } else { \
+                        ggml_vk_create_pipeline(device, fa.second, "flash_attn_f32_f16_aligned_f16acc" #NAMELC, flash_attn_f32_f16_ ## NAMELC ## _f16acc_len,  flash_attn_f32_f16_ ## NAMELC ## _f16acc_data,  "main", 7, sizeof(vk_flash_attn_push_constants), {Br, 1, 1}, get_fa_spec_constants(fa.first), Bc, true, !fa_ds, (!fa_ds ? fa_sgs : 0));     \
+                    } \
+                } else { \
+                    if (f32acc) { \
+                        ggml_vk_create_pipeline(device, fa.second, "flash_attn_f32_f16_f32acc"         #NAMELC, flash_attn_f32_f16_ ## NAMELC ## _fp32_len,  flash_attn_f32_f16_ ## NAMELC ## _fp32_data,  "main", 7, sizeof(vk_flash_attn_push_constants), {Br, 1, 1}, get_fa_spec_constants(fa.first), 1,  true, !fa_ds, (!fa_ds ? fa_sgs : 0));     \
+                    } else { \
+                        ggml_vk_create_pipeline(device, fa.second, "flash_attn_f32_f16_f16acc"         #NAMELC, flash_attn_f32_f16_ ## NAMELC ## _f16acc_len,  flash_attn_f32_f16_ ## NAMELC ## _f16acc_data,  "main", 7, sizeof(vk_flash_attn_push_constants), {Br, 1, 1}, get_fa_spec_constants(fa.first), 1,  true, !fa_ds, (!fa_ds ? fa_sgs : 0));     \
+                    } \
+                } \
+            } \
+        }
+
     if (device->fp16) {
-        CREATE_FA(GGML_TYPE_F32, f32, FA_SCALAR, )
-        CREATE_FA(GGML_TYPE_F16, f16, FA_SCALAR, )
-        CREATE_FA(GGML_TYPE_Q4_0, q4_0, FA_SCALAR, )
-        CREATE_FA(GGML_TYPE_Q8_0, q8_0, FA_SCALAR, )
-        CREATE_FA(GGML_TYPE_Q4_1, q4_1, FA_SCALAR, )
-        CREATE_FA(GGML_TYPE_Q5_0, q5_0, FA_SCALAR, )
-        CREATE_FA(GGML_TYPE_Q5_1, q5_1, FA_SCALAR, )
-        CREATE_FA(GGML_TYPE_IQ4_NL, iq4_nl, FA_SCALAR, )
+        // f32acc (prec==GGML_PREC_F32) only ever selected the FLOAT_TYPE=float16_t
+        // shader body compiled with an fp32 ACC_TYPE (the raw QK^T score
+        // accumulator) -- the online-softmax running accumulators Of/Lf/Mf stayed
+        // float16_t regardless, silently truncating on every KV block. That's a
+        // correctness gap versus what GGML_PREC_F32 means everywhere else in ggml
+        // (full fp32), and it compounds catastrophically for architectures like
+        // MLA with very information-dense per-token values at long context. Route
+        // f32acc==true to the true FLOAT_TYPE=float shader body (already compiled
+        // as the "_fp32" suffixed variant, previously only reachable on devices
+        // lacking fp16 hardware support at all) instead of the fp16-body one.
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_F32, f32)
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_F16, f16)
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_Q4_0, q4_0)
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_Q8_0, q8_0)
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_Q4_1, q4_1)
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_Q5_0, q5_0)
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_Q5_1, q5_1)
+        CREATE_FA_SCALAR_F32ACC_FIX(GGML_TYPE_IQ4_NL, iq4_nl)
     } else {
         CREATE_FA(GGML_TYPE_F32, f32, FA_SCALAR, _fp32)
         CREATE_FA(GGML_TYPE_F16, f16, FA_SCALAR, _fp32)

--- a/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/flash_attn.comp
@@ -90,19 +90,33 @@ void main() {
     barrier();
 
     FLOAT_TYPEV4 Of[rows_per_thread][HSV_per_thread / 4];
+    // Kahan (compensated) summation running error term for Of, so the running
+    // sum over up to KV/Bc blocks doesn't accumulate O(KV) rounding error. This
+    // is a secondary refinement on top of the ggml_vk_load_shaders fix (see
+    // ggml-vulkan.cpp, CREATE_FA_SCALAR_F32ACC_FIX) that makes prec=GGML_PREC_F32
+    // actually reach this FLOAT_TYPE=float shader body -- with that fix alone,
+    // FLASH_ATTN_EXT's NMSE against the CPU reference still grows mildly with KV
+    // (ordinary float32 non-associativity vs. the CPU reference's summation
+    // order); Kahan summation here trims that residual further. Composes with
+    // the eM rescaling below by rescaling the compensation term the same way
+    // the sum itself is rescaled.
+    FLOAT_TYPEV4 Oc[rows_per_thread][HSV_per_thread / 4];
     [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
         [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
             Of[r][d] = FLOAT_TYPEV4(0.0);
+            Oc[r][d] = FLOAT_TYPEV4(0.0);
         }
     }
 
     float Lf[rows_per_thread], Mf[rows_per_thread];
+    float Lc[rows_per_thread]; // Kahan compensation term for Lf, see Oc above
 
     // Use -FLT_MAX/2 rather than -inf to reduce the possibility of NaNs, e.g. when computing Mold-M.
     const float NEG_FLT_MAX_OVER_2 = uintBitsToFloat(0xFEFFFFFF);
 
     [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
         Lf[r] = 0;
+        Lc[r] = 0;
         Mf[r] = NEG_FLT_MAX_OVER_2;
     }
 
@@ -320,11 +334,13 @@ void main() {
             Mf[r] = max(rowmaxf, Moldf);
             eMf[r] = exp(Moldf - Mf[r]);
             Lf[r] = eMf[r]*Lf[r];
+            Lc[r] = eMf[r]*Lc[r]; // keep the Kahan compensation term in the same scale as Lf
         }
 
         [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 Of[r][d] = FLOAT_TYPE(eMf[r]) * Of[r][d];
+                Oc[r][d] = FLOAT_TYPE(eMf[r]) * Oc[r][d]; // ditto for Of's compensation term
             }
         }
 
@@ -360,7 +376,14 @@ void main() {
             FLOAT_TYPE Pf[rows_per_thread];
             [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
                 Pf[r] = FLOAT_TYPE(exp(float(Sf[r][c]) - Mf[r]));
-                Lf[r] += Pf[r];
+                // Kahan summation: Lf[r] += Pf[r], but tracking (and correcting
+                // for) the rounding error lost on each addition -- see Oc's
+                // comment above for why this is a secondary refinement, not
+                // the main fix.
+                float Ly = float(Pf[r]) - Lc[r];
+                float Lt = Lf[r] + Ly;
+                Lc[r] = (Lt - Lf[r]) - Ly;
+                Lf[r] = Lt;
             }
 
             [[unroll]] for (uint32_t d = 0; d < HSV_per_thread / 4; ++d) {
@@ -378,7 +401,11 @@ void main() {
 #endif
                 }
                 [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-                    Of[r][d] += FLOAT_TYPEV4(Pf[r] * Vf);
+                    // Kahan summation, same reasoning as Lf above.
+                    FLOAT_TYPEV4 Oy = FLOAT_TYPEV4(Pf[r] * Vf) - Oc[r][d];
+                    FLOAT_TYPEV4 Ot = Of[r][d] + Oy;
+                    Oc[r][d] = (Ot - Of[r][d]) - Oy;
+                    Of[r][d] = Ot;
                 }
             }
         }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1415,11 +1415,37 @@ struct test_case {
             double err = ud->tc->err(f1.data(), f2.data(), f1.size());
             if (err > ud->tc->max_err(ud->backend1)) {
                 printf("[%s] ERR = %.9f > %.9f ", ggml_op_desc(t1), err, ud->tc->max_err(ud->backend1));
-                //for (int i = 0; i < (int) f1.size(); i++) {
-                //    printf("%5d %9.6f %9.6f, diff = %9.6f\n", i, f1[i], f2[i], f1[i] - f2[i]);
-                //}
-                //printf("\n");
-                //exit(1);
+                if (getenv("MLA_DIFF_DUMP")) {
+                    // out tensor layout here is {hsv_padded, nh*nr23[0], nb, nr23[1]} --
+                    // decode flat index into (d, head, token) so we can see *where*
+                    // (which head, which token position) the divergence actually is.
+                    int64_t ne0 = t1->ne[0], ne1 = t1->ne[1], ne2 = t1->ne[2];
+                    int n_printed = 0;
+                    double max_diff = 0;
+                    int64_t max_diff_idx = -1;
+                    for (int64_t i = 0; i < (int64_t) f1.size(); i++) {
+                        double diff = std::fabs((double) f1[i] - (double) f2[i]);
+                        if (diff > max_diff) { max_diff = diff; max_diff_idx = i; }
+                        if (diff > 1.0 && n_printed < 200) {
+                            int64_t d = i % ne0;
+                            int64_t head = (i / ne0) % ne1;
+                            int64_t tok = (i / (ne0 * ne1)) % ne2;
+                            printf("\n  [diff>1] flat=%lld (d=%lld,head=%lld,tok=%lld) ref=%9.6f got=%9.6f diff=%9.6f",
+                                   (long long) i, (long long) d, (long long) head, (long long) tok, f1[i], f2[i], (float) diff);
+                            n_printed++;
+                        }
+                    }
+                    if (max_diff_idx >= 0) {
+                        int64_t d = max_diff_idx % ne0;
+                        int64_t head = (max_diff_idx / ne0) % ne1;
+                        int64_t tok = (max_diff_idx / (ne0 * ne1)) % ne2;
+                        printf("\n  [MAX DIFF] flat=%lld (d=%lld,head=%lld,tok=%lld) ref=%9.6f got=%9.6f diff=%9.6f (ne0=%lld ne1=%lld ne2=%lld)",
+                               (long long) max_diff_idx, (long long) d, (long long) head, (long long) tok,
+                               f1[max_diff_idx], f2[max_diff_idx], (float) max_diff,
+                               (long long) ne0, (long long) ne1, (long long) ne2);
+                    }
+                    printf("\n");
+                }
                 ud->ok = false;
             }
             return true;
@@ -8602,6 +8628,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
         }
     }
 
+    // qwen35-mla / TransMLA-style MQA-absorbed shape (hsk=kv_lora_rank+qk_mqa_dim=320,
+    // hsv=kv_lora_rank=256 -- the "Mistral4 MLA" shape above, but at gqa_ratio=16,
+    // which the sweep above never tests (it only covers nr2 in {1,4,12,20,32}).
+    // Reproduces a long-context LongPPL blowup seen on Vulkan at non-power-of-2 kv,
+    // absent on CPU and with -fa off. Testing both small (matching the sweep's own
+    // granularity) and large (our real workload's) kv, power-of-2 and not.
+    for (int kv : { 113, 512, 1024, 1536, 2048, 4096, 8192, 16384, 24576, 32768, 40960, 49152, 65536 }) {
+        test_cases.emplace_back(new test_flash_attn_ext(320, 256, 1, {16, 1}, kv, 512, true, false, 0, 0, GGML_PREC_F32, GGML_TYPE_F16));
+    }
+
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {   10, 5, 4, 3}));
     test_cases.emplace_back(new test_cross_entropy_loss     (GGML_TYPE_F32, {30000, 1, 1, 1}));
     test_cases.emplace_back(new test_cross_entropy_loss_back(GGML_TYPE_F32, {   10, 5, 4, 3}));
@@ -8858,6 +8894,7 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
             }
         }
     }
+
 
     for (int col : {8192, 16384, 32768, 65536, 131072, 262144, 524288}) {
         for (int rows : {1, 4, 16}){


### PR DESCRIPTION
Fixes #28124

## Overview

Discovered that on the Vulkan back-end when a caller asks for full fp32 precision in flash attention (GGML_PREC_F32) that request gets dropped on any GPU with fp16 hardware support. The pipeline-selection code always binds the fp16 precision shader variant regardless of what is actually requested.

This is invisible for most models at normal context lengths as the drift is tiny, but for architectures with compressed information dense value representations (in this case MLA style attention), at long context the per layer drift compounds across many layers into severe output corruption. That's how this was discovered, a model producing garbage past 50k tokens but only on the Vulkan backend and only with Flash Attention turned on.

The fix is to make the pipeline honor the precision request and to route to the true fp32 shader variant when full precision was asked for independent of whether the GPU also supports fp16. The default path is untouched.

## Additional information

- Isolated test-backend-ops FLASH_ATTN_EXT test at the specific shape (GQA ratio 16, not previously covered by the existing MLA sweep which only tests 1,4,12,20,32)
- Full FLASH_ATTN_EXT suite ran before and after with the same pass count (3289/3293) so nothing regressed
- Built a small standalone repro tool in examples/mla-repro/ that replicates the incremental multi-decode pattern because single isolated op test's only show ~0.1 - 0.2% drift and the real corruption only shows up once that compounds across many forward passes and layers.
- Additional changes to flash_attn.comp for Kahan summation, a small secondary refinement in addition to the real fix. Was initially attempted as the fix thinking the issue was plain uncompensated float32 summation error building up in the softmax loop. However upon testing it did nothing. That pointed towards the real bug as the shader body containing the Kahan code wasn't the one being bound to the GPU pipeline. However after fixing the pipeline the still present Kahan summation showed a real 20-25% additional reduction in the isolated tests residual error.
- PPL measurement on llama-perplexity at a depth of 49152 with -fa on vs -fa off was 12.6148 vs 12.5748 after the fix, functionally identical. Conversely pre-fix -fa on was 2110.6593.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Substantial, debugging partner throughout the process. Helped form and test hypotheses and wrote the actual fix code and the mla-repro tool and ran the verification suite. I  directed the strategy, refused to just drop flash attention as a workaround, and conducted additional testing and verification of results before publishing.




