### PR TITLE
cuda : dispatch batched top-k to the argsort path instead of per-row DeviceTopK

### DIFF
--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -36,7 +36,9 @@ static void top_k_cub(ggml_cuda_pool & pool,
                          ncols, k, env));
 }
 
-#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+#endif  // CUB_TOP_K_AVAILABLE
+
+#ifdef GGML_CUDA_USE_CUB
 
 static int next_power_of_2(int x) {
     int n = 1;
@@ -46,7 +48,7 @@ static int next_power_of_2(int x) {
     return n;
 }
 
-#endif                            // CUB_TOP_K_AVAILABLE
+#endif  // GGML_CUDA_USE_CUB
 
 #if !defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP)
 
@@ -225,15 +227,23 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const int64_t    nrows = ggml_nrows(src0);
     const int64_t    k     = dst->ne[0];
     ggml_cuda_pool & pool  = ctx.pool();
+#ifdef GGML_CUDA_USE_CUB
 #ifdef CUB_TOP_K_AVAILABLE
+    // DeviceTopK processes a single row per call, so a batched op means a serial
+    // per-row loop of 3-4 kernel launches each; prompt processing can hand this op
+    // hundreds of rows at once. Keep DeviceTopK for decode-shaped calls and dispatch
+    // larger batches to the row-parallel argsort path below.
     // TODO: Switch to `DeviceSegmentedTopK` for multi-row TopK once implemented
     // https://github.com/NVIDIA/cccl/issues/6391
     // TODO: investigate if there exists a point where parallelized argsort is faster than sequential top-k
-    for (int i = 0; i < nrows; i++) {
-        top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+    if (nrows <= 4) {
+        for (int i = 0; i < nrows; i++) {
+            top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+        }
+        return;
     }
-#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
-    // Fall back to argsort + copy
+#endif  // CUB_TOP_K_AVAILABLE
+    // argsort + copy
     const int    ncols_pad      = next_power_of_2(ncols);
     const size_t shared_mem     = ncols_pad * sizeof(int);
     const size_t max_shared_mem = ggml_cuda_info().devices[ggml_cuda_get_device()].smpb;
@@ -257,7 +267,7 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         src0_d += ncols * iter_nrows;
         dst_d  += k     * iter_nrows;
     }
-#else                             // GGML_CUDA_USE_CUB
+#else   // GGML_CUDA_USE_CUB
 #if defined(GGML_USE_HIP)
     if (ncols > 1024) {
         top_k_radix_cuda(pool, src0_d, dst_d, ncols, nrows, k, stream);


### PR DESCRIPTION
### Problem

With CCCL >= 3.2 (`GGML_CUDA_CUB_3DOT2=ON`), `ggml_cuda_op_top_k` runs `cub::DeviceTopK::MaxPairs` in a serial per-row loop. Decode-shaped calls (`nrows == 1`) are fine, but prompt processing hands this op hundreds of rows at once: profiling one 141K-token prefill of a qwen4exp model (512-row ubatches x 12 QSA layers) showed **903,702 DeviceTopK invocations**, each launching 3-4 kernels. DeepSeek V3.2 / V4 indexer top-k hits the same path.

### Change

Keep `DeviceTopK` for `nrows <= 4` and dispatch larger batches to the existing row-parallel argsort+copy path, until `DeviceSegmentedTopK` exists (NVIDIA/cccl#6391 — the existing TODO in this file). The argsort fallback previously only compiled when CCCL < 3.2; it is now reachable in both configurations, so `next_power_of_2` moves out of the `#elif`.

### Results

End-to-end prompt processing, Qwen3.8-Flash-Next UD-IQ4_XS on 2x RTX A6000 (sm_86), CUDA 12.1 + CCCL 3.2, master `e4b9af00` vs master + this change (cold full prefills; multiple reps; contention-free samples only, foreign GPU activity sampled at 1 Hz):

| prompt tokens | per-row DeviceTopK | batched dispatch |
|---------------|--------------------|------------------|
| 129,584 | 563-580 tok/s | 712-713 tok/s (+25%) |
| 61,767  | 675-698 tok/s | 872-874 tok/s (+27%) |
| 30,802  | 758-781 tok/s | 921-923 tok/s (+20%) |

At the shapes covered by `test-backend-ops perf` (nrows <= 16) the two paths are within noise of each other (e.g. `ne=[32768,16],k=16`: 257.8 vs 259.9 us/run), so the dispatch changes nothing measurable for small batches; the win comes from prompt-processing-scale row counts (hundreds of rows per op), where the serial launch overhead dominates.

`test-backend-ops -o TOP_K` passes (the suite covers nrows 1-16, which exercises both dispatch branches). Also verified the CCCL < 3.2 configuration still compiles (stock CUDA 12.1).
