### PR TITLE
gguf-py: bound array element count by remaining file size

### DIFF
--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -256,8 +256,29 @@ class GGUFReader:
             if int(alen[0]) > GGUF_MAX_ARRAY_ELEMENTS:
                 raise ValueError(f'Array length {int(alen[0])} exceeds maximum {GGUF_MAX_ARRAY_ELEMENTS}')
             offs += int(alen.nbytes)
-            if int(alen[0]) > self.data.nbytes - offs:
-                raise ValueError(f'Array length {int(alen[0])} exceeds remaining file size {self.data.nbytes - offs}')
+            if int(alen[0]) > 0:
+                # Bound the declared element count by the smallest number of bytes
+                # those elements could occupy, mirroring the gguf_reader::read
+                # check in ggml/src/gguf.cpp. STRING elements carry a uint64 length
+                # prefix, and nested ARRAY elements a uint32 type plus a uint64
+                # count, so both have a fixed minimum even though their total size
+                # is not known here.
+                itype = GGUFValueType(int(raw_itype[0]))
+                nptype = self.gguf_scalar_to_np.get(itype)
+                if nptype is not None:
+                    min_elem_size = int(np.dtype(nptype).itemsize)
+                elif itype == GGUFValueType.STRING:
+                    min_elem_size = 8
+                elif itype == GGUFValueType.ARRAY:
+                    min_elem_size = 12
+                else:
+                    min_elem_size = 1
+                required = int(alen[0]) * min_elem_size
+                if required > max(self.data.nbytes - offs, 0):
+                    raise ValueError(
+                        f'Array of {int(alen[0])} {itype.name} elements requires at least '
+                        f'{required} bytes but only {self.data.nbytes - offs} remain'
+                    )
             aparts: list[npt.NDArray[Any]] = [raw_itype, alen]
             data_idxs: list[int] = []
             # FIXME: Handle multi-dimensional arrays properly instead of flattening

--- a/gguf-py/gguf/gguf_reader.py
+++ b/gguf-py/gguf/gguf_reader.py
@@ -256,6 +256,8 @@ class GGUFReader:
             if int(alen[0]) > GGUF_MAX_ARRAY_ELEMENTS:
                 raise ValueError(f'Array length {int(alen[0])} exceeds maximum {GGUF_MAX_ARRAY_ELEMENTS}')
             offs += int(alen.nbytes)
+            if int(alen[0]) > self.data.nbytes - offs:
+                raise ValueError(f'Array length {int(alen[0])} exceeds remaining file size {self.data.nbytes - offs}')
             aparts: list[npt.NDArray[Any]] = [raw_itype, alen]
             data_idxs: list[int] = []
             # FIXME: Handle multi-dimensional arrays properly instead of flattening

--- a/gguf-py/tests/test_gguf_reader_validation.py
+++ b/gguf-py/tests/test_gguf_reader_validation.py
@@ -35,3 +35,38 @@ def test_dims_product_no_uint64_wraparound(tmp_path):
     _write_gguf(p, len(dims), dims)
     with pytest.raises(ValueError):
         GGUFReader(p)
+
+
+def _write_gguf_array(path, elem_type, count, payload=b'', pad=0):
+    key = b'arr'
+    buf = b'GGUF' + struct.pack('<IQQ', 3, 0, 1)  # version 3, 0 tensors, 1 kv
+    buf += struct.pack('<Q', len(key)) + key
+    buf += struct.pack('<I', 9)  # GGUFValueType.ARRAY
+    buf += struct.pack('<I', elem_type)
+    buf += struct.pack('<Q', count)
+    buf += payload + b'\x00' * pad
+    path.write_bytes(buf)
+
+
+def test_array_length_bounded_by_element_size(tmp_path):
+    # A file that declares 5_000_000 FLOAT64 elements but is only ~5 MB. The
+    # element count alone is smaller than the bytes remaining, so a bound that
+    # compares the count against remaining bytes lets this through and the
+    # per-element loop runs 5_000_000 times. Those elements need 40 MB, so the
+    # declared array cannot fit and must be rejected up front.
+    p = tmp_path / 'evil_array.gguf'
+    _write_gguf_array(p, 12, 5_000_000, pad=5_200_008)  # 12 = FLOAT64
+    with pytest.raises(ValueError, match='requires at least'):
+        GGUFReader(p)
+
+
+def test_array_of_minimum_size_elements_still_parses(tmp_path):
+    # Guard against over-rejecting: a UINT8 array whose elements really are one
+    # byte each fits exactly, and an empty array of any element type is legal.
+    p = tmp_path / 'ok_uint8.gguf'
+    _write_gguf_array(p, 0, 64, payload=b'\x01' * 64)  # 0 = UINT8
+    assert GGUFReader(p).fields['arr'].contents() == [1] * 64
+
+    p = tmp_path / 'ok_empty.gguf'
+    _write_gguf_array(p, 12, 0)  # 12 = FLOAT64, no elements
+    assert GGUFReader(p).fields['arr'].contents() == []


### PR DESCRIPTION
## Overview

The array branch of `_get_field_parts` validates a declared element count against `GGUF_MAX_ARRAY_ELEMENTS`, but never against the space actually left in the file. A count below that ceiling still drives a full per-element loop, so a file can declare an array far larger than it could possibly contain and the parse cost scales with the declared count rather than with the file.

An earlier revision of this PR bounded the declared count against the number of bytes remaining. As @CISC pointed out, that check is incorrect: it compares a count of elements against a count of bytes, which only holds if every element occupies at least one byte, and that is not a property of the format. It lets through any array whose declared count is smaller than the remaining bytes but whose elements cannot fit. A file declaring 5,000,000 `FLOAT64` elements with 5,200,008 bytes remaining passes it, though those elements require 40,000,000 bytes; the parse takes about 17 seconds with or without that check.

This revision bounds the count by the minimum on-disk size of the declared element type, which is what `gguf_reader::read` in `ggml/src/gguf.cpp` already does on the C++ side. Scalar widths come from `gguf_scalar_to_np`. `STRING` elements carry a `uint64` length prefix, and nested `ARRAY` elements a `uint32` type plus a `uint64` count, so both have a fixed minimum even though their full size is not known at this point. The check is skipped when the declared count is zero, so the set of accepted files does not change.

## Additional information

The 5.2 MB file described above is rejected in under a millisecond instead of parsing for ~17 seconds.

Two tests are added to `gguf-py/tests/test_gguf_reader_validation.py`:

- `test_array_length_bounded_by_element_size` builds that file and asserts it raises. Against the previous check this test fails with `DID NOT RAISE` after 16.9s, so it does test the fix rather than passing either way.
- `test_array_of_minimum_size_elements_still_parses` covers the other direction: a `UINT8` array whose elements genuinely are one byte each fits exactly and must still parse, as must an empty array.

`gguf-py` test suite: 9 passed. Separately, 60 hand-built valid files (every scalar element type at several lengths, empty arrays, arrays at exact EOF, string arrays including an empty string, nested arrays, nested arrays with empty inner arrays, arrays followed by further KV fields, and a 5,000-element `FLOAT32` array alongside a real tensor) parse identically before and after.

One limitation worth stating plainly: this restores parse cost proportional to file size, but does not remove the per-element Python loop. A genuine 2 MB file consisting of 2,000,000 single-byte elements still takes roughly 8 seconds, unchanged by this patch. That looks like a separate problem.

The original issue was found by fuzzing `gguf-py` with Atheris.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. The bug was found by my own fuzzing campaign against gguf-py. I used AI assistance to investigate the maintainer's review comment, construct the reproduction, write the fix and tests, and draft this description. I reviewed and tested the change before submitting and I am responsible for it.
