### PR TITLE
CUDA/ROCm: Fix pathological graph capture in test-backend-ops

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2557,6 +2557,11 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
     for (int i = 0; i < cgraph->n_nodes; i++) {
         ggml_tensor * node = cgraph->nodes[i];
 
+        // Reject pathological capture - duplicated nodes in test-backend-ops create huge fake graphs
+        if (i > 0 && node == cgraph->nodes[i - 1]) {
+            use_cuda_graph = false;
+        }
+
         if (ggml_cuda_is_view_or_noop(node)) {
             continue;
         }

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1567,13 +1567,6 @@ struct test_case {
         ggml_cgraph * gf = ggml_new_graph_custom(ctx.get(), graph_nodes, false);
         ggml_build_forward_expand(gf, out);
 
-        // warmup run
-        ggml_status status = ggml_backend_graph_compute(backend, gf);
-        if (status != GGML_STATUS_SUCCESS) {
-            fprintf(stderr, "%s: ggml_backend_graph_compute failed. status=%s \n", __func__, ggml_status_to_string(status));
-            return false;
-        }
-
         // determine number of runs
         int n_runs;
         bool is_cpu = ggml_backend_dev_type(ggml_backend_get_device(backend)) == GGML_BACKEND_DEVICE_TYPE_CPU;
@@ -1596,6 +1589,13 @@ struct test_case {
         // duplicate the op
         for (int i = 1; i < n_runs; i++) {
             ggml_graph_add_node(gf, out);
+        }
+
+        // warmup run
+        ggml_status status = ggml_backend_graph_compute(backend, gf);
+        if (status != GGML_STATUS_SUCCESS) {
+            fprintf(stderr, "%s: ggml_backend_graph_compute failed. status=%s \n", __func__, ggml_status_to_string(status));
+            return false;
         }
 
         // calculate memory


### PR DESCRIPTION
## Overview

`test-backend-ops` was misbehaving with the graph capture behavior of the testing graphs - it duplicated the operation and then captured a graph with the repeated operation as one single big graph.

## Additional information

Put warmup on the final graph instead of the initial one and restricted graph capture in cases of pathological duplication (same node one after another).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes
