### PR TITLE
ggml : check for allocation failures to prevent crashes

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1641,7 +1641,10 @@ static bool ggml_backend_sched_alloc_splits(ggml_backend_sched_t sched) {
             ggml_backend_synchronize(sched->backends[i]);
         }
 
-        ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids);
+        if (!ggml_gallocr_reserve_n(sched->galloc, &sched->graph, sched->node_backend_ids, sched->leaf_backend_ids)) {
+            GGML_LOG_ERROR("%s: failed to reserve graph\n", __func__);
+            return false;
+        }
         if (!ggml_gallocr_alloc_graph(sched->galloc, &sched->graph)) {
             GGML_LOG_ERROR("%s: failed to allocate graph\n", __func__);
             return false;

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -4390,7 +4390,7 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
     ggml_backend_sched_reset(ctx->sched.get());
     ggml_cgraph * gf = clip_get_graph_builder(ctx, imgs, params)->build();
     if (!ggml_backend_sched_alloc_graph(ctx->sched.get(), gf)) {
-        LOG_ERR("%s: failed to allocate compute buffers\n", __func__);
+        LOG_ERR("%s: failed to allocate compute graph\n", __func__);
         return false;
     }
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -4389,7 +4389,10 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
     // build the inference graph
     ggml_backend_sched_reset(ctx->sched.get());
     ggml_cgraph * gf = clip_get_graph_builder(ctx, imgs, params)->build();
-    ggml_backend_sched_alloc_graph(ctx->sched.get(), gf);
+    if (!ggml_backend_sched_alloc_graph(ctx->sched.get(), gf)) {
+        LOG_ERR("%s: failed to allocate compute buffers\n", __func__);
+        return false;
+    }
 
     // set inputs
     const auto & model   = ctx->model;


### PR DESCRIPTION
## Overview

- The result of `ggml_gallocr_reserve_n` wasn't considered so `ggml_gallocr_alloc_graph` crashed on buffers that weren't allocated
- The return value from `ggml_backend_sched_reserve`  wasn't considered either, caused `SIGABRT`

Related to #27817

## Additional information

```
build/bin/llama-mtmd-cli -m qwen3.8-27b-q4_0.gguf --mmproj Qwen3.8-mmproj-BF16.gguf \
  --image apple.jpg --image tmp/big.jpg -p describe \
  --image-min-tokens 1024 -dev CUDA0 -mmdev Vulkan1 -fitt 1200
```
Here `-fitt 1200` leaves us with 1200 MiB free for 888 MiB mmproj plus 123 MiB for the first image but not 480 MiB second image. 

A command to create the second image:
```
magick -size 3000x3000 plasma:fractal -quality 90 tmp/big.jpg
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I used AI to debug and find the place for the fix.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
