### PR TITLE
perplexity: respect --chunks when computing KL divergence

### DIFF
--- a/tools/perplexity/perplexity.cpp
+++ b/tools/perplexity/perplexity.cpp
@@ -1722,18 +1722,34 @@ static void kl_divergence(llama_context * ctx, const common_params & params) {
     }
 
     int n_vocab;
-    int n_chunk;
+    int n_chunk_file;
     in.read((char *)&n_vocab, sizeof(n_vocab));
-    in.read((char *)&n_chunk, sizeof(n_chunk));
+    in.read((char *)&n_chunk_file, sizeof(n_chunk_file));
     if (in.fail()) {
         LOG_ERR("%s: failed reading n_vocab, n_chunk from %s\n", __func__, params.logits_file.c_str());
         return;
     }
+
     if (n_vocab != llama_vocab_n_tokens(vocab)) {
         LOG_ERR("%s: inconsistent vocabulary (%d vs %d)\n", __func__, n_vocab, llama_vocab_n_tokens(vocab));
     }
 
-    std::vector<llama_token> tokens(size_t(n_ctx) * n_chunk);
+    if (params.n_chunks > n_chunk_file) {
+        LOG_ERR(
+            "%s: requested %d chunks with --chunks, but %s contains only %d chunks\n",
+            __func__,
+            params.n_chunks,
+            params.logits_file.c_str(),
+            n_chunk_file);
+        return;
+    }
+
+
+    const int n_chunk =
+        params.n_chunks < 0 ? n_chunk_file : params.n_chunks;
+
+    // Read all tokens to advance the stream to the log-probability data.
+    std::vector<llama_token> tokens(size_t(n_ctx) * n_chunk_file);
     if (in.read((char *)tokens.data(), tokens.size()*sizeof(tokens[0])).fail()) {
         LOG_ERR("%s: failed reading evaluation tokens from %s\n", __func__, params.logits_file.c_str());
         return;


### PR DESCRIPTION
## Overview

Use the given --chunks value to limit the number of chunks processed during KL divergence calculation, as documented by the option "--chunks N: max number of chunks to process (default: -1, -1 = all)". This was previously ignored, and all chunks from the base file were used.

This change now allows a single KL divergence base file to be reused for test runs with different chunk counts without requiring base files with different numbers of chunks.

The KL divergence calculation now returns an error when more chunks are requested than available in KL divergence base file.

## Additional information

Manual regression testing done to confirm previous and new intended behaviour: without --chunks, --chunks < base file chunks,  --chunks = base file chunks, and --chunks > base file chunks on a baseline file with 5 chunks. 

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, for discussing and verifying code changes and spell checking/translation.