### PR TITLE
HIP: use a copy kernel instead of cudaMemcpyAsync for small D2D copies

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cu
+++ b/ggml/src/ggml-cuda/cpy.cu
@@ -202,6 +202,62 @@ cudaStream_t stream) {
     ggml_cuda_kernel_launch(cpy_scalar_contiguous<src_t, dst_t>, launch_params, cx, cdst, ne);
 }
 
+#if defined(GGML_USE_HIP)
+// Type-agnostic contiguous byte copy, used on HIP instead of a device-to-device
+// cudaMemcpyAsync. See ggml_cuda_cpy() for why. Being type-agnostic matters:
+// the same-type contiguous case also covers quantized types, which have no
+// per-type kernel below and would otherwise hit the GGML_ABORT.
+template<typename T>
+static __global__ void cpy_bytes_contiguous(const char * cx, char * cdst, const int64_t n) {
+    const int64_t i = (int64_t)blockDim.x*blockIdx.x + threadIdx.x;
+
+    if (i >= n) {
+        return;
+    }
+
+    ggml_cuda_pdl_sync();
+    ((T *) cdst)[i] = ((const T *) cx)[i];
+}
+
+static void ggml_cpy_bytes_contiguous_cuda(
+    const char * cx, char * cdst, const int64_t nbytes, cudaStream_t stream) {
+
+    // Use 16-byte accesses when both pointers and the length allow it; ggml's
+    // device allocations are at least 256-byte aligned, so this is the norm.
+    const bool aligned16 = (nbytes % 16 == 0) &&
+                           ((uintptr_t) cx   % 16 == 0) &&
+                           ((uintptr_t) cdst % 16 == 0);
+
+    const int64_t n = aligned16 ? nbytes/16 : nbytes;
+    const int64_t num_blocks = (n + CUDA_CPY_BLOCK_SIZE - 1) / CUDA_CPY_BLOCK_SIZE;
+    GGML_ASSERT(num_blocks <= INT_MAX);
+
+    const ggml_cuda_kernel_launch_params launch_params =
+        ggml_cuda_kernel_launch_params((dim3)num_blocks, CUDA_CPY_BLOCK_SIZE, 0, stream);
+
+    if (aligned16) {
+        ggml_cuda_kernel_launch(cpy_bytes_contiguous<uint4>, launch_params, cx, cdst, n);
+    } else {
+        ggml_cuda_kernel_launch(cpy_bytes_contiguous<char>, launch_params, cx, cdst, n);
+    }
+}
+
+// Copies at or below this size are done with a kernel on the compute queue
+// rather than by SDMA. Override with GGML_CUDA_CPY_D2D_KERNEL_MAX (bytes);
+// 0 restores the previous behaviour of always using cudaMemcpyAsync.
+//
+// SDMA remains the better engine for bulk transfers, hence the threshold.
+static size_t ggml_cuda_cpy_d2d_kernel_max() {
+    static const size_t max_bytes = []() -> size_t {
+        const char * env = getenv("GGML_CUDA_CPY_D2D_KERNEL_MAX");
+        // Treat an empty value as unset, so that clearing the variable to ""
+        // does not silently parse as 0 and disable this path.
+        return (env && *env) ? (size_t) strtoull(env, nullptr, 10) : (size_t) 16*1024*1024;
+    }();
+    return max_bytes;
+}
+#endif // GGML_USE_HIP
+
 template<typename src_t, typename dst_t, bool transposed = false>
 static void ggml_cpy_scalar_cuda(
     const char * cx, char * cdst, const int64_t ne,
@@ -470,6 +526,23 @@ void ggml_cuda_cpy(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, gg
             CUDA_CHECK(mudnnMemcpyAsync(ctx, src1, src0));
         } else
 #endif // GGML_USE_MUSA && GGML_MUSA_MUDNN_COPY
+#if defined(GGML_USE_HIP)
+        // On ROCm a device-to-device cudaMemcpyAsync is dispatched to the SDMA
+        // engine, which lives on a separate queue that does not overlap compute.
+        // Every such copy therefore costs a queue handoff plus a driver barrier
+        // that flushes and invalidates L2, which is far more expensive than an
+        // ordinary in-queue barrier.
+        //
+        // Recurrent models (Mamba/Mamba2/RWKV and hybrids) copy their state once
+        // per layer per token, so this dominates their decode. Dense models
+        // barely take this path and are unaffected.
+        //
+        // SDMA is still the right engine for bulk transfers, so only small copies
+        // are redirected.
+        if ((size_t) ggml_nbytes(src0) <= ggml_cuda_cpy_d2d_kernel_max()) {
+            ggml_cpy_bytes_contiguous_cuda(src0_ddc, src1_ddc, ggml_nbytes(src0), main_stream);
+        } else
+#endif // GGML_USE_HIP
         {
             CUDA_CHECK(cudaMemcpyAsync(src1_ddc, src0_ddc, ggml_nbytes(src0), cudaMemcpyDeviceToDevice, main_stream));
         }


### PR DESCRIPTION
## Overview

On ROCm, the device-to-device `cudaMemcpyAsync` fast path in `ggml_cuda_cpy()` is dispatched to the **SDMA engine**, which runs on a separate hardware queue that does not overlap compute. Every such copy costs a queue handoff plus a driver barrier that flushes and invalidates L2.

Recurrent models (Mamba, Mamba2, RWKV and hybrids) copy their state once per layer per token, so this dominates their token generation. Routing small copies to a copy kernel keeps them on the compute queue.

Measured on a Radeon 780M (gfx1103): **+29% to +195%** token generation on recurrent models, neutral on dense models.

### Root cause

`ggml_cuda_cpy()` short-circuits same-type contiguous copies to a D2D memcpy, which is the right call on CUDA. On ROCm, [`rocclr/device/pal/palresource.cpp`](https://github.com/ROCm/clr) routes buffer copies by size:

```cpp
bool cp_dma = dev().settings().disableSdma_ ||
              (... && (size[0] < dev().settings().cpDmaCopySizeMax_));
if (cp_dma) {
    gpu.addBarrier(RgpSqqtBarrierReason::MemDependency, BarrierType::KernelToCopy);
} else {
    gpu.releaseGpuMemoryFence();   // L2 flush
    gpu.engineID_ = SdmaEngine;    // separate queue
}
```

`cpDmaCopySizeMax_` defaults to **1 KiB**, so essentially every recurrent-state copy goes to SDMA.

This is worse on **integrated GPUs**. `KernelBlitManager::copyBuffer` prefers a compute-kernel copy, but only when neither buffer is host-accessible — which on a UMA APU is never true — and `DmaBlitManager` then explicitly excludes APUs from its CPU path (`!dev().settings().apuSystem_`). So on an APU the runtime's own kernel-copy path is unreachable.

Captured with Radeon GPU Profiler on a Mamba2 decode: the copy queue had **exactly 0.000 ms overlap** with compute, and each transfer was bracketed by a driver barrier flushing + invalidating L2 with a **~5.3 µs** drain, against ~0.15 µs for an ordinary barrier. GPU occupancy was **74.7%**, versus ~96% for the Vulkan backend on the same model and machine.

### Change

Under `#if defined(GGML_USE_HIP)`, copies at or below a threshold use a new type-agnostic contiguous byte-copy kernel. SDMA is retained for bulk transfers.

- **Type-agnostic on purpose** — the same-type contiguous case also covers quantized types, which have no per-type kernel further down and would hit `GGML_ABORT` if the memcpy branch were simply removed. The kernel copies raw bytes, using `uint4` when pointers and length allow and `char` otherwise.
- **Threshold, not a blanket change** — SDMA is the better engine for large transfers; the problem is many small ones.
- **Escape hatch** — `GGML_CUDA_CPY_D2D_KERNEL_MAX` (bytes); `0` restores the previous behaviour exactly.

Scoped to `ggml_cuda_cpy`, so unlike the ROCm environment variables that can work around this, it does not change copy routing process-wide. CUDA is unaffected.

### Benchmarks

AMD Ryzen 7 PRO 8840HS / Radeon 780M (gfx1103), ROCm 7.x, Windows.
`llama-bench -p 256 -n 64 -r 3`, 4 rotated rounds, **same binary** in both arms toggled via the env var, AC power, medians.

| model | architecture | tg before | tg after | gain |
|-------|--------------|----------:|---------:|-----:|
| rwkv7-1.5B-world | RWKV-7 (non-SSM recurrence) | 11.95 | 35.28 | **+195%** |
| Falcon-H1-1.5B | Mamba2 hybrid, d_state=256 | 19.00 | 34.44 | **+81%** |
| Jamba-Reasoning-3B | Mamba2 + attention + MoE | 19.79 | 26.46 | **+34%** |
| falcon-mamba-7B | pure Mamba | 8.89 | 11.50 | **+29%** |
| Nemotron3-Nano-4B | Mamba2 hybrid, d_state=128 | 18.64 | 21.18 | **+14%** |
| Qwen2.5-3B | dense | 26.56 | 26.18 | −1.4% |
| gemma-4-12B | dense | 7.58 | 7.64 | +0.9% |

Every recurrent architecture gains; both dense controls are within noise, as expected since they barely use this path. Prompt processing was neutral in longer runs (`-p 512`, 4–5 rounds).

RWKV-7 is worth calling out: it has no SSM and no selective scan, so the benefit is not Mamba-specific — it is about the copy path itself.

Structurally, on the Mamba2 model the copy queue drops from **36 submissions to 3** per capture window, and GPU occupancy rises from **74.7% to 95.3%**.

A standalone HIP reproducer (no ggml involved) shows the same effect: a copy kernel beats `hipMemcpyAsync` D2D by **2.8–4.5×** at 32 KB–512 KB on this APU.

### Correctness

`test-backend-ops -b ROCm0` on this branch:

| op | result |
|----|--------|
| `CPY` | 246/246 |
| `DUP` | 6/6 |
| `CONT` | 78/78 |
| `SET_ROWS` | 159/159 |
| `GET_ROWS` | 111/111 |
| `SSM_SCAN` | 13/13 |
| `SSM_CONV` | 45/45 |
| `MUL_MAT` | 1201/1201 |

## Additional information

- **Tested on one machine**, a gfx1103 APU.
- **Expected to be APU/iGPU-specific.** On discrete AMD GPUs device memory is not host-accessible, so ROCclr already takes its compute-kernel path and this cliff should not exist there. I do not have a discrete RDNA3 card, so I cannot confirm neutrality — **testing on a dGPU would be very welcome.** If maintainers prefer, the behaviour could be gated on `prop.integrated`, which would make it provably no-op on discrete hardware.
- The threshold default is not tuned; no copy observed in a decode graph came close to it (largest was 3.75 MiB).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: I used AI to help me in the testing and in describing the findings I hope this is not a problem