### PR TITLE
ggml-cpu: do not tile Q0 MMA at n=4 on ppc64le

### DIFF
--- a/ggml/src/ggml-cpu/llamafile/sgemm.cpp
+++ b/ggml/src/ggml-cpu/llamafile/sgemm.cpp
@@ -2440,9 +2440,10 @@ class tinyBLAS_Q0_PPC {
         int64_t n_aligned = 0;
         if (n % n_chunk == 0) {
             n_aligned = n;
-        } else if (n == 4) {
-            n_aligned = 4;
         } else if (n < n_chunk) {
+            // n==4 used to force tiled with nc=4, but KERNEL_Q0 is 8-wide in N
+            // (save_acc jj+4, B pack stride 32*kc). That OOB-stores C and
+            // segfaults on the k-tail add_save_acc. mnpack KERNEL_8x4 handles n=4.
             n_aligned = (n / 8) * 8;
         } else {
             n_aligned = (n / n_chunk) * n_chunk;


### PR DESCRIPTION
Fixes #28180

`tinyBLAS_Q0_PPC::KERNEL_Q0` is 8-wide in N (`save_acc(jj+4)`, B pack stride `32*kc`). The tiled path was forced at `n==4` with `nc=4`, which writes past `C`. A second K-tile then `add_save_acc`s the OOB location and segfaults.

Reproduced on POWER11 ppc64le, gcc 14.2.1, `-mcpu=power11`, `GGML_LLAMAFILE=ON`:

- Q8_0/Q4_0 × F32, `m % 64 == 0`, `n == 4`, `k = 96` → SIGSEGV
- same shape with `-mno-mma` or `-DGGML_LLAMAFILE=OFF` → OK
- after this change, C matches `-mno-mma` at max_abs ~1e-6

n=4 now uses the existing `mnpack` / `KERNEL_8x4` path.

Tested: IBM Power11 S1122, CentOS Stream 9.

* I have read and agree with the contributing guidelines
* AI usage disclosure: used an AI coding assistant to help isolate the OOB store (dump/diff of ggml MUL_MAT vs `-mno-mma`) and to draft this PR. The diagnosis, repro, and patch were verified on the hardware above.

Signed-off-by: John DeMaris <jdemaris@gmail.com>