### PR TITLE
memory : return an error instead of aborting on multi-range on-device state save

### DIFF
--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -822,7 +822,8 @@ void llama_memory_recurrent::state_write(llama_io_write_i & io, llama_seq_id seq
     }
 
     if ((flags & LLAMA_STATE_SEQ_FLAGS_ON_DEVICE) && cell_ranges.size() > 1) {
-        GGML_ABORT("cannot save/load multiple ranges of cells to/from device memory\n");
+        // throw instead of aborting: state_seq_get_size/get_data catch this and return 0
+        throw std::runtime_error("cannot save/load multiple ranges of cells to/from device memory");
     }
 
     // DEBUG CHECK: Sum of cell counts in ranges should equal the total cell count


### PR DESCRIPTION
state_write in llama-memory-recurrent.cpp calls GGML_ABORT when an on-device sequence state spans more than one cell range, which takes the whole process down. The single-range limit is real (#23520), but a fragmented state should be recoverable, not fatal.

This replaces the abort with a throw — state_seq_get_size / state_seq_get_data already catch it and return 0. Unchanged for the common single-range case. The abort only shows up with on-device state usage (e.g. #28118) at -np > 1.