### PR TITLE
llama-model: guard NaN device splits and clamp layer->device index (fixes draft-model load crash on Windows)

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1462,8 +1462,17 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         split_sum += splits[i];
         splits[i] = split_sum;
     }
-    for (size_t i = 0; i < n_devices(); ++i) {
-        splits[i] /= split_sum;
+    if (split_sum > 0.0f) {
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] /= split_sum;
+        }
+    } else {
+        // all devices reported zero free memory (a draft model loads after the
+        // target has filled VRAM; WDDM reports 0 free) - dividing would poison
+        // splits with NaN and send upper_bound() past the last device
+        for (size_t i = 0; i < n_devices(); ++i) {
+            splits[i] = float(i + 1) / float(n_devices());
+        }
     }
 
     const int i_gpu_start = std::max(n_layer_all + 1 - n_gpu_layers, 0);
@@ -1474,7 +1483,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s, is_swa = %d\n", il, ggml_backend_dev_name(cpu_dev), is_swa);
             return {cpu_dev, &pimpl->cpu_buft_list};
         }
-        const int layer_gpu = std::upper_bound(splits.begin(), splits.begin() + n_devices(), float(il - i_gpu_start)/act_gpu_layers) - splits.begin();
+        const int layer_gpu = std::min<size_t>(std::upper_bound(splits.begin(), splits.begin() + n_devices(), float(il - i_gpu_start)/act_gpu_layers) - splits.begin(), n_devices() - 1);
         auto * dev = devices.at(layer_gpu).dev;
         LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s, is_swa = %d\n", il, ggml_backend_dev_name(dev), is_swa);
         return {dev, &pimpl->gpu_buft_list.at(dev)};


### PR DESCRIPTION
## Overview

Fixes the draft-model load crash on Windows tracked in #27454 (throws `std::out_of_range`, reported by MSVC as "invalid vector subscript").

What happens: the target model fills VRAM, then the draft model loads and the CUDA device reports free == 0 with total != 0 on WDDM. The host-memory fallback in `src/llama-model.cpp` only covers `free == 0 && total == 0`, so it does not trigger. `splits[i] /= split_sum` then divides 0 by 0 and gives NaN, `std::upper_bound` walks past the end of the splits, and `devices.at()` throws.

The fix, two lines in `src/llama-model.cpp`:

- if `split_sum == 0`, use evenly spaced split points instead of dividing by zero
- clamp the layer-to-device index to `n_devices() - 1` before `devices.at()`

This overlaps with #27657 (NaN guard) and #27887 (index clamp), each of which covers one half. I put both in one PR so the crash is fully closed by a single merge. If maintainers prefer one of the existing PRs, I will close this one.

## Additional information

Reproduced 100% on Windows 11 26200, RTX 5060 Ti 16 GB (sm_120), official release binaries b10734, with Qwen3.8-27B-DFlash2 GGUF drafts (official Q4_K_M from incoai, and a self-converted copy with identical metadata). Both crash on unpatched binaries.

After applying this patch and rebuilding at d5d993a09 (MSVC 19.44, CUDA 13.2), the same draft loads and runs, with normal draft acceptance. MTP speculative decoding is not affected by this bug (it does not load a second model), before or after the patch.

While testing this I ran into a separate problem: speculative decoding runs at ~2 tok/s on MSVC builds or with an explicit `-ts`, while official Clang binaries run the same flags at 38 tok/s. Filed as #28218 since it looks unrelated to this patch.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- [x] AI usage disclosure: YES — the code patch was written with AI assistance, and this description was drafted with AI help from my own test results. All testing was done by me on my own machine and I have reviewed everything. I understand I am responsible for all submitted changes.
