### PR TITLE
llama : keep explicit host buffer overrides when using mmap

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -259,6 +259,11 @@ static void parse_tensor_buffer_overrides(const std::string & value, std::vector
         if (buft) {
             buft_list[ggml_backend_buft_name(buft)] = buft;
         }
+        // host buffer types (e.g. CUDA_Host) so CPU-resident tensors can use pinned memory
+        auto * host_buft = ggml_backend_dev_host_buffer_type(dev);
+        if (host_buft) {
+            buft_list[ggml_backend_buft_name(host_buft)] = host_buft;
+        }
     }
 
     for (const auto & override : string_split<std::string>(value, ',')) {

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1644,6 +1644,15 @@ bool llama_model_loader::load_all_data(
                 auto & mmap_used = mmaps_used[weight->idx];
                 mmap_used.first  = std::min(mmap_used.first,  weight->offs);
                 mmap_used.second = std::max(mmap_used.second, weight->offs + n_size);
+            } else if (ggml_backend_buffer_is_host(cur->buffer)) {
+                // The destination is host memory (e.g. a pinned CUDA_Host buffer selected by -ot), so it can be
+                // filled directly from the file. Copying from the mapping instead would fault in every page one
+                // by one at queue depth 1 - and with --numa distribute the whole mapping carries POSIX_MADV_RANDOM,
+                // which disables readahead entirely. A plain read gets full readahead and is an order of magnitude
+                // faster. Non-host destinations keep the memcpy from the mapping below.
+                const auto & file = files.at(weight->idx);
+                file->seek(weight->offs, SEEK_SET);
+                file->read_raw(cur->data, n_size);
             } else {
                 ggml_backend_tensor_set(cur, data, 0, n_size);
             }

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -1223,6 +1223,7 @@ struct ggml_tensor * llama_model_loader::create_tensor(
         }
 
         ggml_backend_buffer_type_t buft = nullptr;
+        bool buft_overridden = false;
 
         // check overrides
         if (tensor_buft_overrides) {
@@ -1241,6 +1242,7 @@ struct ggml_tensor * llama_model_loader::create_tensor(
                         }
                     } else {
                         buft = overrides->buft;
+                        buft_overridden = true;
                     }
 
                     LLAMA_LOG_DEBUG("tensor %s (%zu MiB %s) buffer type overridden to %s\n",
@@ -1259,9 +1261,9 @@ struct ggml_tensor * llama_model_loader::create_tensor(
             }
         }
 
-        // avoid using a host buffer when using mmap
+        // avoid using a host buffer when using mmap, unless an override asks for it: the tensor is then copied into pinned memory
         auto * buft_dev = ggml_backend_buft_get_device(buft);
-        if (use_mmap && buft_dev && buft == ggml_backend_dev_host_buffer_type(buft_dev)) {
+        if (use_mmap && !buft_overridden && buft_dev && buft == ggml_backend_dev_host_buffer_type(buft_dev)) {
             auto * cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
             if (!cpu_dev) {
                 throw std::runtime_error("no CPU backend found");


### PR DESCRIPTION
## Overview

Testing revealed two things here that stop -ot "...=CUDA_Host" from working with a model that's mmapped. First thing is that on master, the argument parser does not offer host buffer types as -ot targets at all, so the flag is rejected at startup ("Available buffer types: CPU, CUDA0") and second, even when a host buffer type reaches the loader, it is replaced with a normal CPU buffer type under mmap (the loader's safety rule that avoids a second copy of bytes that are already in the mapping). The patch registers the device's host buffer types as -ot targets and also makes it so that when the buffer type comes from an explicit -ot rule, it skips the safety check it does and keeps the type you asked for which enables CPU resident experts to live in the pinned memory for op offload while the rest of the model stays memory mapped. Prefill of a 26k prompt went from 166 t/s to 330 t/s with a cold page cache, and to 379 t/s once the per-layer embedding rows were cached (warm), on 2x RTX 3090 with 40 expert layers on the host.

Now as for why the safety check exists and behaves the way it does. Under mmap, the bytes are already stored in the memory through the mapping, so putting a tensor in a host buffer makes a second copy. For the automatic choice that is waste, so the loader downgrades it, and that behaviour is unchanged. The change this PR brings only applies when the user names a host buffer type in an -ot rule. Default loading, --cpu-moe, --n-cpu-moe are not affected so that means the extra copy is the cost the user willingly chooses to pay. If the pinned allocation fails, the buffer falls back to pageable memory. A visible warning can be added if needed.

To test it out, you need to use the -ot rule with the target as a CUDA_Host, for example `-ot "ffn_(gate|up|down)_exps\.weight=CUDA_Host"`, and on a Dual CPU machine (Like Dual Xeons), you run under numactl --interleave=all.

The change lives in the check in create_tensor() in src/llama-model-loader.cpp, which now skips the host buffer downgrade when the new buft_overridden flag is set, and in parse_tensor_buffer_overrides() in common/arg.cpp, which now accepts the device's host buffer types (e.g. CUDA_Host) as targets.

The second commit (c59754b) fixes the load time of that pinned buffer. Under --numa distribute the mapping is MADV_RANDOM, so copying the expert tensors from it into the pinned buffer went through page faults one 4 KiB page at a time (236 MB/s, 450 s of a 512 s load). Host destination tensors are now read from the file with read_raw instead. Load to ready went from 512 s to 168 s on the same box, prefill and greedy output unchanged, the buffer still remains pinned, and the plain mmap path (no host override) is untouched. Details and the full table are in my comment below.

## Additional information

Setup: Qwen3.8-Flash-Next UD-Q6_K_XL (177B MoE, 512 experts, 10 active), 2x RTX 3090 24 GB (PCIe 3.0 x16),
2x Xeon E5-2696 v4, 188 GiB DDR4-2133, Ubuntu 24.04, CUDA 12.0. Context 261,888, `-ub 2048 -b 4096`, f16 KV,
4 expert layers per GPU, the other 40 layers (85 GiB) in CPU RAM. Server timings from `/completion`, temperature 0.7,
page cache dropped before each load, `--cache-ram 0`.

| Experts in | Prefill 26k, PLE cold | Prefill 26k, PLE warm | Prefill 131k | Decode short | Decode @131k | Load | RAM |
|---|---|---|---|---|---|---|---|
| `CPU` (mmap, pageable) | 166 t/s | (not measured, see note) | 193 t/s | ~16.3 t/s (a) | 9.1 t/s | 96 s | page cache |
| `CUDA_Host` (this PR) | 330 t/s | **379 t/s** | 300 t/s | 15.9 t/s | 11.3 t/s | 488 s (5cfa6a8) / 168 s (c59754b) | 89.6 GB pinned |

"PLE cold/warm": The model reads the per layer embedding table lazily. The first prompt reads the rows from disk, a second prompt with the same text reads the rows in the page cache. The warm-cache pass for the mmap row was not measured because my box lost power during that run.

Now as the table shows, loading time is longer because mmap defers reading until pages are touched, while a host buffer is allocated and filled at load time, so all 85 GiB are read from disk and page-locked before the server is ready. With the first commit alone that was 96 s to 488 s, most of it the page fault copy described above; with the second commit it is 96 s to 168 s. It is paid only by users who opt in, in exchange for 2x to 2.3x prefill on a server that runs for days.

(a) The run was cut off at 446 of 512 tokens by a reboot. mmap decode depends on NUMA page placement.

Also worth stating: ik_llama.cpp (fused MoE + pinned) does 353 t/s prefill on the same box, but 10 t/s decode.

Here are some related PR's/Issues I found: #26659, #26110, #25859, #26448, #28136.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. The code in both commits was written by an AI coding agent (Fable) working under my direction on my machine, the benchmarks were run and iterated by the agent on my hardware and I understand the fix proposed.