### PR TITLE
bench : fix verbosity filter to show GGML_LOG_ERROR (#28107)

### DIFF
--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2162,6 +2162,10 @@ static bool test_gen(llama_context * ctx, int n_gen, int n_threads) {
 }
 
 static void llama_null_log_callback(enum ggml_log_level level, const char * text, void * user_data) {
+    if (level == GGML_LOG_LEVEL_ERROR) {
+        fprintf(stderr, "%s", text);
+        return;
+    }
     (void) level;
     (void) text;
     (void) user_data;

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -2166,8 +2166,6 @@ static void llama_null_log_callback(enum ggml_log_level level, const char * text
         fprintf(stderr, "%s", text);
         return;
     }
-    (void) level;
-    (void) text;
     (void) user_data;
 }
 


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
`llama-bench` without `-v` installed `llama_null_log_callback` (tools/llama-bench/llama-bench.cpp:2164) which dropped all levels.
As issue #28107  says "Errors should bypass the verbosity filter" , i am only fixing in this scope allowing ERROR level logs to pass the filter. Built in WSL, and tested with/without -v . 

## Additional information
https://github.com/ggml-org/llama.cpp/issues/28107#issuecomment-5488972233

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
