### PR TITLE
MTMD: Fix Qwen3-tts-0.6b

### DIFF
--- a/conversion/qwen3tts.py
+++ b/conversion/qwen3tts.py
@@ -276,6 +276,10 @@ class Qwen3TTSSpeakerEncoderModel(MmprojModel):
         # ConvTranspose1d kernels: only F16/F32 are implemented, no BF16
         if new_name.endswith(".conv.weight") and (".up.blk." in new_name or ".dac.blk." in new_name):
             return gguf.GGMLQuantizationType.F32
+        # the code predictor FFN intermediate peaks around 1.5e5, above the F16 range, and mul_mat
+        # casts its input to the weight type
+        if new_name.startswith("a.gen.code.blk.") and new_name.endswith(".ffn_down.weight"):
+            return gguf.GGMLQuantizationType.F32
         return super().tensor_force_quant(name, new_name, bid, n_dims)
 
     @classmethod

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -2988,9 +2988,9 @@ struct clip_model_loader {
                 } break;
             case PROJECTOR_TYPE_QWEN3TTS_GEN:
                 {
-                    // code_predictor
-                    model.gen_code_proj_in_w = get_tensor(string_format(TN_A_GEN_CODE_PROJ_IN, "weight"));
-                    model.gen_code_proj_in_b = get_tensor(string_format(TN_A_GEN_CODE_PROJ_IN, "bias"));
+                    // code_predictor, proj_in is absent when the talker and the predictor share the hidden size
+                    model.gen_code_proj_in_w = get_tensor(string_format(TN_A_GEN_CODE_PROJ_IN, "weight"), false);
+                    model.gen_code_proj_in_b = get_tensor(string_format(TN_A_GEN_CODE_PROJ_IN, "bias"),   false);
                     model.gen_code_embd_w     = get_tensor(string_format(TN_A_GEN_CODE_EMBD,     "weight"));
                     model.gen_code_head_w     = get_tensor(string_format(TN_A_GEN_CODE_HEAD,     "weight"));
                     model.gen_code_out_embd_w = get_tensor(string_format(TN_A_GEN_CODE_OUT_EMBD, "weight"));


### PR DESCRIPTION
## Overview

Fixes Qwen3-TTS-12Hz-0.6B: the loader no longer requires the code predictor input projection, which that checkpoint does not have, and the predictor ffn_down stays in F32 since its FFN intermediate peaks above the F16 range.

The fix spans both sides, C++ and conversion script. The C++ half only needs a rebuild, but the F32 rule lives in the conversion script, so please regenerate the mmproj GGUF files.

## Additional information

Qwen3-TTS-12Hz-0.6B failed in two different ways and this fixes both. The mmproj refused to load because the loader required the code predictor input projection, which the reference only builds when the talker and the predictor differ in hidden size, so the 0.6B checkpoint simply has no such tensor. With that out of the way the model then died on the first frame: its code predictor carries a massive activation, a spike about twice what F16 can represent, and since mul_mat casts its input to the weight type an F16 ffn_down turned that spike into infinity, then NaN, then an out of bounds gather. Keeping those five weights in F32 costs roughly 31 MB and makes the model run on CPU and CUDA again. The 1.7B is unaffected either way, it has more than six times the headroom under the F16 ceiling.

Existing mmproj GGUF files need to be regenerated: the fix lives in the conversion script, so a GGUF converted before this change still carries the F16 ffn_down and will still break on the 0.6B. The rule applies to every checkpoint in the family, so regenerate the 1.7B GGUF files as well and keep the published set on one consistent format.

Voice cloning stays speaker-embedding only for now: the helper exposes no reference transcript and builds only the speaker-slot prompt, and more fundamentally the conversion script packs just the decoder half of the speech tokenizer, so there is no codec encoder to turn a reference clip into the codes the in-context cloning mode feeds on.

Follow-up #26254

### Testing

Short sample: "the quick brown fox jumped over the lazy dog".

[qwen3tts-0.6B-clone-short.wav](https://github.com/user-attachments/files/31727007/qwen3tts-0.6B-clone-short.wav)
[qwen3tts-0.6B-tts-short.wav](https://github.com/user-attachments/files/31727009/qwen3tts-0.6B-tts-short.wav)
[qwen3tts-1.7B-clone-short.wav](https://github.com/user-attachments/files/31727011/qwen3tts-1.7B-clone-short.wav)
[qwen3tts-1.7B-tts-short.wav](https://github.com/user-attachments/files/31727014/qwen3tts-1.7B-tts-short.wav)

Long sample: "Here is what went wrong with the small model. Its code predictor carries one enormous activation, a single spike about twice the largest value a half precision float can hold. When the weights are stored in that format, the multiplication turns the spike into infinity, the next normalization turns infinity into a not a number, and the whole thing collapses into an out of bounds memory read. The fix keeps five small weight tensors in full precision. It costs about thirty megabytes, and it lets the model run everywhere again."

[qwen3tts-0.6B-clone-long.wav](https://github.com/user-attachments/files/31727005/qwen3tts-0.6B-clone-long.wav)
[qwen3tts-0.6B-tts-long.wav](https://github.com/user-attachments/files/31727008/qwen3tts-0.6B-tts-long.wav)
[qwen3tts-1.7B-clone-long.wav](https://github.com/user-attachments/files/31727010/qwen3tts-1.7B-clone-long.wav)
[qwen3tts-1.7B-tts-long.wav](https://github.com/user-attachments/files/31727012/qwen3tts-1.7B-tts-long.wav)

The plain TTS clips use the model's own default voice, the cloned ones are conditioned on a 17 s reference recording of a real speaker.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
