### PR TITLE
server : truncate speculative results at EOG before rollback

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -256,6 +256,7 @@ struct server_slot {
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
     bool spec_is_replay = false;
+    bool                     spec_skip_draft_once = false;
     std::mt19937 spec_synth_rng;
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
@@ -370,6 +371,7 @@ struct server_slot {
         SLT_DBG(*this, "%s", "\n");
 
         spec_is_replay = false;
+        spec_skip_draft_once = false;
 
         last_nl_pos    = 0;
         generated_text = "";
@@ -2974,6 +2976,11 @@ private:
                 const bool use_ckpt_tgt = ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
                 const bool use_ckpt_dft = ctx_dft_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
 
+                if (slot.spec_skip_draft_once) {
+                    slot.spec_skip_draft_once = false;
+                    return;
+                }
+
                 const int n_draft_max = slot.get_n_draft_max();
 
                 if (n_draft_max > 0) {
@@ -3894,6 +3901,17 @@ private:
 
                 GGML_ASSERT(accepted.size() >= 1);
 
+                bool accepted_eog = false;
+                if (!slot.spec_is_replay) {
+                    for (size_t i = 0; i + 1 < accepted.size(); ++i) {
+                        if (llama_vocab_is_eog(vocab, accepted[i])) {
+                            accepted.resize(i + 1);
+                            accepted_eog = true;
+                            break;
+                        }
+                    }
+                }
+
                 const uint32_t n_rollback = slot.spec_draft.size() + 1 - accepted.size();
 
                 const bool use_ckpt_tgt =
@@ -3908,7 +3926,18 @@ private:
                         }
 
                         // partial acceptance is not supported by the context -> truncate the draft and restore the state
-                        slot.spec_is_replay = true;
+                        slot.spec_is_replay = !accepted_eog;
+                        if (accepted_eog) {
+                            accepted.pop_back();
+                            slot.spec_skip_draft_once = accepted.empty();
+                            if (slot.spec_skip_draft_once) {
+                                common_speculative_accept(spec.get(), slot.id, 0);
+                                slot.stats.n_draft_verif_steps += 1;
+                                if (slot.n_accepted_per_pos.empty()) {
+                                    slot.n_accepted_per_pos.resize(common_speculative_n_max(spec.get()), 0);
+                                }
+                            }
+                        }
                         slot.spec_draft = std::move(accepted);
 
                         const auto & ckpt = slot.spec_ckpt;

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -152,6 +152,80 @@ def test_synth_ignores_target_tokens():
     assert res.body["stop_type"] == "limit"
 
 
+def test_ngram_eog_draft_tail_is_not_accepted():
+    global server
+    server = ServerPreset.tinyllama2()
+    server.model_draft = None
+    server.spec_type = "ngram-simple"
+    server.n_slots = 1
+    server.server_slots = True
+    server.n_ctx = 1024
+    server.n_batch = 512
+    server.n_ubatch = 512
+    server.n_threads = 4
+    server.fa = "off"
+    server.start()
+
+    props = server.make_request("GET", "/props")
+    assert props.status_code == 200, props.body
+
+    eos = server.make_request("POST", "/tokenize", data={
+        "content": props.body["eos_token"],
+        "parse_special": True,
+    })
+    token_x = server.make_request("POST", "/tokenize", data={"content": "x"})
+    token_bos_x = server.make_request("POST", "/tokenize", data={
+        "content": "x",
+        "add_special": True,
+    })
+    assert eos.status_code == 200, eos.body
+    assert token_x.status_code == 200, token_x.body
+    assert token_bos_x.status_code == 200, token_bos_x.body
+    assert len(eos.body["tokens"]) == 1, eos.body
+    assert len(token_x.body["tokens"]) >= 1, token_x.body
+    assert len(token_bos_x.body["tokens"]) >= 2, token_bos_x.body
+
+    id_eos = eos.body["tokens"][0]
+    id_x = token_x.body["tokens"][0]
+    id_bos = token_bos_x.body["tokens"][0]
+
+    calibration = server.make_request("POST", "/completion", data={
+        "prompt": [id_bos, id_x],
+        "cache_prompt": False,
+        "temperature": 0.0,
+        "top_k": 1,
+        "n_predict": 2,
+        "return_tokens": True,
+        "grammar": 'root ::= "a"',
+    })
+    assert calibration.status_code == 200, calibration.body
+    assert len(calibration.body["tokens"]) == 2, calibration.body
+    assert calibration.body["tokens"][-1] == id_eos, calibration.body
+
+    id_a = calibration.body["tokens"][0]
+    prompt_tokens = [id_bos, id_x] + [id_x] * 11 + [id_a] + [id_eos] * 48 + [id_x] * 11
+
+    response = server.make_request("POST", "/completion", data={
+        "prompt": prompt_tokens,
+        "cache_prompt": False,
+        "temperature": 0.0,
+        "top_k": 1,
+        "n_predict": 64,
+        "return_tokens": True,
+        "grammar": 'root ::= "a"',
+    })
+    assert response.status_code == 200, response.body
+
+    slots = server.make_request("GET", "/slots")
+    assert slots.status_code == 200, slots.body
+
+    assert response.body["tokens"] == [id_a, id_eos]
+    assert response.body["stop_type"] == "eos"
+    assert response.body["timings"]["draft_n"] == 48
+    assert response.body["timings"]["draft_n_accepted"] == 0
+    assert slots.body[0]["n_prompt_tokens"] == len(prompt_tokens) + 1
+
+
 def test_slot_ctx_not_exceeded():
     global server
     server.n_ctx = 256


### PR DESCRIPTION
## Overview

Speculative decoding could return accepted draft tokens past an EOG within the accepted draft portion of the result. The server used this untrimmed result to compute draft acceptance, rollback, prompt contents, and model state before `process_token()` stopped generation, leaving client-visible output correct while acceptance statistics and slot state could include post-EOG tokens.

Search the accepted draft portion for its first EOG and truncate the full speculative result at that token before rollback or state updates. For FULL/recurrent memory, restore the checkpoint and replay only the valid prefix before EOG; if that prefix is empty, skip drafting once so the target can resample the terminating token without a replay loop.

## Additional information

The regression test covers the `ngram-simple` 48-EOG draft case and verifies zero accepted drafts and no stale slot tail.
Fixes #28049

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES     Used Codex to review the speculative decoding changes, refine code style, and suggest small implementation improvements around EOG handling and replay logic. I manually reviewed the resulting changes and verified the final behavior with the relevant regression tests and local checks.
