### PR TITLE
server : avoid repeated mmproj memory margin addition on sleep/resume

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1061,7 +1061,8 @@ private:
         }
 
         // optionally get the memory usage of mmproj
-        if (has_mmproj && params_base.fit_params) {
+        // on resume params_base already holds the margin from the first load
+        if (has_mmproj && params_base.fit_params && !is_resume) {
             int64_t t_start = ggml_time_us();
             auto mmproj_mem = mtmd_get_memory_usage(mmproj_path.c_str(), mparams);
             int64_t t_elapsed = ggml_time_us() - t_start;

--- a/tools/server/tests/unit/test_sleep.py
+++ b/tools/server/tests/unit/test_sleep.py
@@ -1,4 +1,7 @@
+import os
 import pytest
+import re
+import tempfile
 import time
 from utils import *
 
@@ -125,3 +128,34 @@ def test_server_sleep_metrics_buckets():
     assert res.status_code == 200
     assert is_sleeping(server) == False
     assert get_metric(fetch_metrics(server), "predicted_tokens_seconds") == 0
+
+
+def test_server_sleep_mmproj_memory_target():
+    global server
+    server = ServerPreset.tinygemma3()
+    server.sleep_idle_seconds = 1
+    server.debug = True
+    fd, server.log_path = tempfile.mkstemp(suffix='.log')
+    os.close(fd)
+    server.start()
+
+    wait_for_sleep(server)
+
+    # wake up and let the model reload
+    res = server.make_request("POST", "/completion", data={
+        "n_predict": 1,
+        "prompt": "Hello",
+    })
+    assert res.status_code == 200
+
+    with open(server.log_path) as f:
+        log = f.read()
+
+    # the fitting step reports the free memory target it was given, once per device
+    targets = [int(x) for x in re.findall(
+        r"(?:will leave \d+ >= |cannot meet free memory target of |free vs\. target of\s+)(\d+)", log)]
+
+    assert len(targets) >= 2 and len(targets) % 2 == 0, f"expected one fit report per load, got {targets}"
+    # the mmproj margin must not accumulate onto the target across a resume
+    half = len(targets) // 2
+    assert targets[:half] == targets[half:], f"free memory target changed across resume: {targets}"

--- a/tools/server/tests/unit/test_sleep.py
+++ b/tools/server/tests/unit/test_sleep.py
@@ -1,7 +1,5 @@
-import os
 import pytest
 import re
-import tempfile
 import time
 from utils import *
 
@@ -130,32 +128,34 @@ def test_server_sleep_metrics_buckets():
     assert get_metric(fetch_metrics(server), "predicted_tokens_seconds") == 0
 
 
-def test_server_sleep_mmproj_memory_target():
+def test_server_sleep_mmproj_memory_target(tmp_path):
     global server
     server = ServerPreset.tinygemma3()
     server.sleep_idle_seconds = 1
     server.debug = True
-    fd, server.log_path = tempfile.mkstemp(suffix='.log')
-    os.close(fd)
+    server.log_path = str(tmp_path / "mmproj-memory-target.log")
     server.start()
 
-    wait_for_sleep(server)
-
-    # wake up and let the model reload
-    res = server.make_request("POST", "/completion", data={
-        "n_predict": 1,
-        "prompt": "Hello",
-    })
-    assert res.status_code == 200
-
     with open(server.log_path) as f:
-        log = f.read()
+        previous_log = f.read()
+    assert "[mtmd] adding " in previous_log, "cold load did not add an mmproj margin"
+    target_pattern = re.compile(
+        r"(?:will leave \d+ >= |cannot meet free memory target of |free vs\. target of\s+)(\d+)")
+    cold_targets = target_pattern.findall(previous_log)
+    assert cold_targets, "cold load did not report a free memory target"
 
-    # the fitting step reports the free memory target it was given, once per device
-    targets = [int(x) for x in re.findall(
-        r"(?:will leave \d+ >= |cannot meet free memory target of |free vs\. target of\s+)(\d+)", log)]
+    for _ in range(3):
+        wait_for_sleep(server)
+        res = server.make_request("POST", "/completion", data={
+            "n_predict": 1,
+            "prompt": "Hello",
+        })
+        assert res.status_code == 200
 
-    assert len(targets) >= 2 and len(targets) % 2 == 0, f"expected one fit report per load, got {targets}"
-    # the mmproj margin must not accumulate onto the target across a resume
-    half = len(targets) // 2
-    assert targets[:half] == targets[half:], f"free memory target changed across resume: {targets}"
+        with open(server.log_path) as f:
+            log = f.read()
+        resume_log = log[len(previous_log):]
+        targets = target_pattern.findall(resume_log)
+        assert targets == cold_targets, f"free memory target changed across resume: {cold_targets} vs {targets}"
+        assert "[mtmd] adding " not in resume_log, "mmproj margin was added again on resume"
+        previous_log = log


### PR DESCRIPTION
## Overview

### Problem

On a cold load, `load_model(params)` copies `params` into `params_base`, and the mmproj memory estimate adds its margin once:

```cpp
params_base.fit_params_target[i] += size;
```

After the initial load, `params_base.fit_params_target` therefore contains the CLI target plus the mmproj margin.

On resume, the server calls `load_model(params_base)`. Inside the function, `params` refers to `params_base` itself, so `params_base = params` is a self-assignment and does not restore the original CLI target. The mmproj block then runs again and adds the same margin a second time, causing the effective free-memory target to grow on each resume.

`is_resume` is derived from the server's `sleeping` state, so it is false on the cold-load path and true on resume. There are two entry paths into `server_context_impl::load_model`: the cold-load path passes the original `params`, while the resume path passes `params_base`, which already contains the mmproj margin. 

### Fix

Skip the mmproj estimation block on resume:

```cpp
has_mmproj && params_base.fit_params && !is_resume
```

On cold load, this block behaves as before: the mmproj estimate still runs and adds the margin once. The same function already uses `!is_resume` guards in two other places, so this follows the existing resume-handling pattern.

## Regression test

I ran the same regression-test harness against an unpatched `43d87ff` tree and the patched tree:

```text
unpatched: cold [1025] -> resume [1027]
pytest:    assert [1025] == [1027]

patched:   cold [1025] -> resume [1025]
```

The test asserts on the effective free-memory target rather than `n_ctx`. On the CPU-only validation machine, `n_ctx` remains 131072 for both cold load and resume even when the bug is present, so an `n_ctx` assertion would pass and fail to catch the accumulation.

## Validation

- New regression test: FAILED on the unpatched tree -> PASSED on the patched tree; the patched test passed 3 consecutive runs.
- Non-slow suite: 348 passed / 12 failed unpatched -> 349 passed / 11 failed patched. The 11 pre-existing failures and 11 errors were identical in both runs.

## Regression-test follow-up (2026-09-08)

The earlier test could accept unchanged targets without confirming that the cold load actually added an mmproj margin. The test now requires the cold-load margin, compares each of three resume reports against the cold target, and uses pytest's `tmp_path` for log cleanup.

- Updated test on the native CPU server: **1 passed**, covering three resumes; targets were **1025, 1025, 1025, 1025 MiB**, with the margin added once.
- A synthetic missing-margin run passes the old test and fails the updated test at the new precondition. This checks the test's detection ability; it is not a native-server performance result.
- Validation reused the existing CPU server build with unchanged C++ sources. A local fixture selected the tiny model, two CPU threads, and a separate loopback port, without preloading unrelated model presets.
- `git diff --check`: clean.

This follow-up changes only the existing regression test. AI assistance was used for the test audit and validation.

## Prior work

#24475 reported the same underlying issue: `fit_params_target` grows across sleep/resume cycles. It later went stale and was closed as not planned.

#24498 was an earlier implementation for #24475. It stored a baseline, restored it on reload, and then re-applied the margins. That matched the code at the time, when more than one path could modify `fit_params_target`.

Current master is simpler: draft/MTP models now participate in fitting through `common_fit_extra_model` and no longer modify `fit_params_target` directly, leaving mmproj as the remaining accumulation point. Skipping that block on resume is sufficient for the current code.

## Impact

Fixes #26401, which reports that after resume, the increased target can reduce `n_gpu_layers`, causing more of the model to be offloaded to CPU and slowing inference. #24475 reported another symptom of the same accumulation: unnecessary context shrink.

Validation for this PR was performed on a CPU-only machine, so neither downstream symptom was reproduced directly.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. I used Codex to make the code changes and ChatGPT to discuss the approach. I reviewed the implementation and ran every validation reported above, and I am responsible for the submitted changes.
