### PR TITLE
MTMD: Fix qwen3-tts on Vulkan (get_rows index rows)

### DIFF
--- a/tools/mtmd/models/qwen3tts-gen.cpp
+++ b/tools/mtmd/models/qwen3tts-gen.cpp
@@ -2,6 +2,11 @@
 
 #include <string>
 
+// row slice used as a get_rows index, materialized because the Vulkan path needs an aligned offset
+static ggml_tensor * row_ids(ggml_context * ctx0, ggml_tensor * src, int64_t n, int64_t row) {
+    return ggml_cont(ctx0, ggml_view_1d(ctx0, src, n, (size_t) row * src->nb[1]));
+}
+
 // on-device sampling: top-k, top-p, then a random draw
 ggml_tensor * clip_graph_qwen3tts_gen::code_gen::do_sampling(ggml_tensor * logits, ggml_tensor * inp_rand) const {
     logits = ggml_reshape_1d(ctx0, logits, ggml_nelements(logits));
@@ -248,7 +253,7 @@ ggml_tensor * clip_graph_qwen3tts_gen::code_gen::step(
     const int     pos      = step_idx + 1; // new cache row and RoPE position
 
     // embed the previous code via this step's codebook table (rows are already scalars)
-    ggml_tensor * code_in = ggml_view_1d(ctx0, out_code_cache, 1, (size_t) step_idx * out_code_cache->nb[1]);
+    ggml_tensor * code_in = row_ids(ctx0, out_code_cache, 1, step_idx);
 
     ggml_tensor * embd_w = model.gen_code_embd_w; // [n_embd_talker, vocab, n_acoustic]
     ggml_tensor * embd_g = ggml_view_2d(ctx0, embd_w, embd_w->ne[0], embd_w->ne[1], embd_w->nb[1],
@@ -390,7 +395,7 @@ ggml_tensor * clip_graph_qwen3tts_gen::code2wav::quant_decode(ggml_tensor * inp_
 
     // ids for codebook group g over all T frames, [T] I32
     auto group_ids = [&](int g) {
-        return ggml_view_1d(ctx0, inp_codes, T, (size_t) g * inp_codes->nb[1]);
+        return row_ids(ctx0, inp_codes, T, g);
     };
 
     ggml_tensor * sem     = ggml_get_rows(ctx0, c2w.quant_first_cb_w, group_ids(0)); // [256, T]
@@ -719,7 +724,7 @@ ggml_cgraph * clip_graph_qwen3tts_gen::build() {
     // output 2: sum of all 16 codebook embeddings, fed back to the talker for the next frame
     ggml_tensor * out_embd = code0_embd;
     for (int g = 1; g <= n_acoustic; g++) {
-        ggml_tensor * code_g = ggml_view_1d(ctx0, out_code_cache, 1, (size_t) g * out_code_cache->nb[1]);
+        ggml_tensor * code_g = row_ids(ctx0, out_code_cache, 1, g);
 
         ggml_tensor * embd_g = ggml_view_2d(ctx0, model.gen_code_embd_w, model.gen_code_embd_w->ne[0], model.gen_code_embd_w->ne[1],
                                             model.gen_code_embd_w->nb[1], (size_t) (g - 1) * model.gen_code_embd_w->nb[2]);


### PR DESCRIPTION
## Overview

Replaced with #28253: All backends now behave the same, which is much better than patching our graphs for a single one.

Fixes the Vulkan crash in the Qwen3-TTS generator: the gen graph handed GET_ROWS an index tensor that was a view at a few bytes offset, which the Vulkan path rejects.

## Additional information

GET_ROWS on Vulkan requires its tensors at an aligned offset, and the gen graph passed a one element or T element view of the code cache at a byte offset of a few units. Three sites, all in the gen graph: the step index, the codebook sum, and the code2wav group ids. The embedding table views are fine, their offsets are multiples of a full table. CPU and CUDA read the row where it lies and never noticed, so this hits both model sizes and predates the 0.6B work. Materializing those three index views costs three tiny nodes, and the output is bit for bit identical on CPU at a fixed seed, before and after.

Follow-up #26254 and #28231

### Testing

Every clip below was generated on a Vulkan build, which aborted on all of them before this change.

Short sample: "the quick brown fox jumped over the lazy dog".

[qwen3tts-0.6B-clone-short.wav](https://github.com/user-attachments/files/31734535/qwen3tts-0.6B-clone-short.wav)
[qwen3tts-0.6B-tts-short.wav](https://github.com/user-attachments/files/31734538/qwen3tts-0.6B-tts-short.wav)
[qwen3tts-1.7B-clone-short.wav](https://github.com/user-attachments/files/31734540/qwen3tts-1.7B-clone-short.wav)
[qwen3tts-1.7B-tts-short.wav](https://github.com/user-attachments/files/31734543/qwen3tts-1.7B-tts-short.wav)

Long sample: "There was one more problem, this time only on Vulkan. The generator was handing the row gather an index that pointed a few bytes into a larger buffer, and the Vulkan path insists that such offsets line up on a boundary, so it stopped the program outright. Processors and CUDA cards simply read the row where it lies, and never noticed. The fix copies those three index rows into tensors of their own. It costs three tiny operations, and it leaves the audio identical, bit for bit, on every backend."

[qwen3tts-0.6B-clone-long.wav](https://github.com/user-attachments/files/31734533/qwen3tts-0.6B-clone-long.wav)
[qwen3tts-0.6B-tts-long.wav](https://github.com/user-attachments/files/31734536/qwen3tts-0.6B-tts-long.wav)
[qwen3tts-1.7B-clone-long.wav](https://github.com/user-attachments/files/31734539/qwen3tts-1.7B-clone-long.wav)
[qwen3tts-1.7B-tts-long.wav](https://github.com/user-attachments/files/31734542/qwen3tts-1.7B-tts-long.wav)

The plain TTS clips use the model's own default voice, the cloned ones are conditioned on a 17 s reference recording of a real speaker.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
