### PR TITLE
server: fail initialization on async compute errors (#27309)

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1596,6 +1596,12 @@ common_context_seq_rm_type common_context_can_seq_rm(llama_context * ctx) {
     tmp.push_back(0);
 
     int ret = llama_decode(ctx, llama_batch_get_one(tmp.data(), tmp.size()));
+    if (ret == 0) {
+        // llama_decode does not wait; async backend errors appear at synchronize
+        llama_synchronize(ctx);
+        llama_memory_clear(mem, true);
+        ret = llama_decode(ctx, llama_batch_get_one(tmp.data(), tmp.size()));
+    }
     if (ret != 0) {
         COM_ERR("llama_decode() failed: %d\n", ret);
         res = COMMON_CONTEXT_SEQ_RM_TYPE_NO;

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1238,6 +1238,10 @@ private:
         slots.clear();
 
         ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
+        if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO && llama_get_memory(ctx_tgt) != nullptr) {
+            SRV_ERR("%s", "failed to evaluate the context during initialization\n");
+            return false;
+        }
         if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             SRV_WRN("%s", "speculative decoding not supported by this context\n");
         }


### PR DESCRIPTION
## Overview

Fixes #27309.

A compute failure during context initialization can happen asynchronously. In that case, the initial `llama_decode()` may succeed, with the error only appearing when the backend is synchronized. The server could then print `model loaded` and report itself as ready, while requests later fail with `Compute error.`

Probe once more after synchronization so the backend error is caught, and fail initialization when the target context cannot evaluate.

## Additional information

Tested on Metal with and without warmup.

- An oversized context that hits OOM now fails during initialization.
- Normal context loading and completion still work.
- No-memory embedding models still load and serve embeddings.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Cursor was used during investigation and testing. I reviewed the change and verified the behavior manually.