### PR TITLE
ui: add close button to UI toasts

### DIFF
--- a/tools/ui/src/routes/+layout.svelte
+++ b/tools/ui/src/routes/+layout.svelte
@@ -332,7 +332,7 @@
 
 	<ModeWatcher />
 
-	<Toaster richColors />
+	<Toaster richColors closeButton />
 </Tooltip.Provider>
 
 <!-- PWA update prompt + version -->


### PR DESCRIPTION
## Overview

This PR tweaks the `Toaster` element to include a close button.

These toasts often cover other UI elements like the model selector, and this change avoids having to wait for them to disappear on their own (e.g. after a load failure).

<img width="1228" height="217" alt="image" src="https://github.com/user-attachments/assets/47252b09-e343-4b2e-a9c1-f168c522f777" />

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
