### PR TITLE
vulkan: support type-aligned GET_ROWS

### DIFF
--- a/ggml/src/ggml-openvino/ggml-openvino.cpp
+++ b/ggml/src/ggml-openvino/ggml-openvino.cpp
@@ -1091,6 +1091,10 @@ static ggml_openvino_op_support is_op_supported_case(const ggml_tensor * op) {
         if (op->ne[3] != 1) {
             return {false, "GET_ROWS/SET_ROWS with ne[3] != 1 (ne[3]=" + std::to_string(op->ne[3]) + ") is not supported"};
         }
+        if (op->op == GGML_OP_GET_ROWS && ggml_is_quantized(op->src[0]->type) &&
+            op->src[0]->view_src != nullptr && op->src[0]->view_offs != 0) {
+            return {false, "GET_ROWS with a nonzero quantized src0 view offset is not supported"};
+        }
         if (op->op == GGML_OP_GET_ROWS && ggml_openvino_get_device_name() == "GPU" &&
             op->src[0]->type == GGML_TYPE_BF16) {
             return {false, "GET_ROWS with BF16 src0 is not supported on GPU"};

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2493,6 +2493,18 @@ static uint32_t get_misalign_bytes(const ggml_backend_vk_context * ctx, const gg
     return ((vk_tensor_offset(t) + t->view_offs) & (ctx->device->properties.limits.minStorageBufferOffsetAlignment - 1));;
 }
 
+static uint32_t ggml_vk_get_adjusted_misalign(const ggml_backend_vk_context * ctx, const ggml_tensor * t)
+{
+    const size_t offset = vk_tensor_offset(t) + t->view_offs;
+    const size_t align = ctx->device->properties.limits.minStorageBufferOffsetAlignment;
+    const size_t ts = ggml_type_size(t->type);
+    size_t misalign = offset & (align - 1);
+    while (misalign > 0 && misalign % ts != 0) {
+        misalign += align;
+    }
+    return (uint32_t)misalign;
+}
+
 static uint32_t ggml_vk_concat_unit_size(ggml_type type) {
     const uint32_t type_size = ggml_type_size(type);
 
@@ -8205,16 +8217,19 @@ static vk_subbuffer ggml_vk_tensor_subbuffer(
     if (!buffer) {
         auto buf_ctx = (ggml_backend_vk_buffer_context *)tensor->buffer->context;
         buffer = buf_ctx->dev_buffer;
-        offset = vk_tensor_offset(tensor);
         if (use_view_offs) {
-            offset += tensor->view_offs;
+            offset = vk_tensor_offset(tensor) + tensor->view_offs;
+        } else {
+            const size_t target = vk_tensor_offset(tensor) + tensor->view_offs;
+            const size_t misalign = ggml_vk_get_adjusted_misalign(ctx, tensor);
+            offset = target - misalign;
         }
     }
     GGML_ASSERT(buffer != nullptr);
 
     size_t size = ggml_nbytes(tensor);
-    if (!use_view_offs && tensor->view_src != nullptr) {
-        size += tensor->view_offs;
+    if (!use_view_offs) {
+        size += ggml_vk_get_adjusted_misalign(ctx, tensor);
     }
 
     size_t misalign_bytes = offset & (ctx->device->properties.limits.minStorageBufferOffsetAlignment - 1);
@@ -12104,9 +12119,9 @@ template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk
 }
 
 template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk_op_binary_push_constants &p, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * src2, const ggml_tensor * src3, ggml_tensor * dst) {
-    const uint32_t a_offset = src0->view_offs / ggml_type_size(src0->type);
-    const uint32_t b_offset = src1 != nullptr ? src1->view_offs / ggml_type_size(src1->type) : 0;
-    const uint32_t d_offset = dst->view_offs / ggml_type_size(dst->type);
+    const uint32_t a_offset = ggml_vk_get_adjusted_misalign(ctx, src0) / ggml_type_size(src0->type);
+    const uint32_t b_offset = src1 != nullptr ? ggml_vk_get_adjusted_misalign(ctx, src1) / ggml_type_size(src1->type) : 0;
+    const uint32_t d_offset = ggml_vk_get_adjusted_misalign(ctx, dst) / ggml_type_size(dst->type);
 
     GGML_ASSERT(a_offset <= 0xFFFF);
     GGML_ASSERT(b_offset <= 0xFF);
@@ -12114,7 +12129,6 @@ template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk
 
     p.misalign_offsets = (a_offset << 16) | (b_offset << 8) | d_offset;
 
-    GGML_UNUSED(ctx);
     GGML_UNUSED(src2);
     GGML_UNUSED(src3);
 }

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -18751,6 +18751,22 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_GET_ROWS:
             {
+                // Vulkan GET_ROWS shader doesn't support tensor offsets that are
+                // misaligned w.r.t. minStorageBufferOffsetAlignment. The shader
+                // push-constant offset init (init_pushconst_tensor_offsets) asserts
+                // (a_offset == 0 && b_offset == 0 && d_offset == 0) when the
+                // backing-buffer offset + view_offs produces a misalignment.
+                // Fall back to CPU in that case instead of crashing.
+                // Repro: Qwen3-TTS (uses ggml_view + ggml_get_rows in its graph).
+                const auto misaligned = [&](const ggml_tensor * t) -> bool {
+                    if (!t) return false;
+                    const size_t align = device->properties.limits.minStorageBufferOffsetAlignment;
+                    if (align == 0) return false;
+                    return ((vk_tensor_offset(t) + t->view_offs) & (align - 1)) != 0;
+                };
+                if (misaligned(op->src[0]) || misaligned(op->src[1]) || misaligned(op)) {
+                    return false;
+                }
                 switch (op->src[0]->type) {
                     case GGML_TYPE_F32:
                     case GGML_TYPE_F16:

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2488,14 +2488,24 @@ static uint64_t vk_tensor_offset(const ggml_tensor * tensor) {
     return (uint8_t *) tensor->data - (uint8_t *) vk_ptr_base;
 }
 
+static size_t ggml_vk_tensor_physical_offset(const ggml_backend_vk_context * ctx, const ggml_tensor * t) {
+    if (ctx->device->uma) {
+        vk_buffer buf = nullptr;
+        size_t off = 0;
+        ggml_vk_host_get(ctx->device, t->data, buf, off);
+        return off;
+    }
+    return (size_t)(vk_tensor_offset(t) + t->view_offs);
+}
+
 static uint32_t get_misalign_bytes(const ggml_backend_vk_context * ctx, const ggml_tensor * t)
 {
-    return ((vk_tensor_offset(t) + t->view_offs) & (ctx->device->properties.limits.minStorageBufferOffsetAlignment - 1));;
+    return (ggml_vk_tensor_physical_offset(ctx, t) & (ctx->device->properties.limits.minStorageBufferOffsetAlignment - 1));
 }
 
 static uint32_t ggml_vk_get_adjusted_misalign(const ggml_backend_vk_context * ctx, const ggml_tensor * t)
 {
-    const size_t offset = vk_tensor_offset(t) + t->view_offs;
+    const size_t offset = ggml_vk_tensor_physical_offset(ctx, t);
     const size_t align = ctx->device->properties.limits.minStorageBufferOffsetAlignment;
     const size_t ts = ggml_type_size(t->type);
     size_t misalign = offset & (align - 1);
@@ -8217,13 +8227,17 @@ static vk_subbuffer ggml_vk_tensor_subbuffer(
     if (!buffer) {
         auto buf_ctx = (ggml_backend_vk_buffer_context *)tensor->buffer->context;
         buffer = buf_ctx->dev_buffer;
-        if (use_view_offs) {
+    }
+
+    if (use_view_offs) {
+        if (!ctx->device->uma) {
             offset = vk_tensor_offset(tensor) + tensor->view_offs;
-        } else {
-            const size_t target = vk_tensor_offset(tensor) + tensor->view_offs;
-            const size_t misalign = ggml_vk_get_adjusted_misalign(ctx, tensor);
-            offset = target - misalign;
         }
+    } else {
+        const size_t physical = ggml_vk_tensor_physical_offset(ctx, tensor);
+        const size_t misalign = ggml_vk_get_adjusted_misalign(ctx, tensor);
+        GGML_ASSERT(physical >= misalign);
+        offset = physical - misalign;
     }
     GGML_ASSERT(buffer != nullptr);
 

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1895,7 +1895,7 @@ struct vk_op_rwkv_wkv7_push_constants {
 };
 struct vk_op_gated_linear_attn_push_constants {
     uint32_t B;
-    uint32_t T;
+    uint32_t T;const auto misaligned 
     uint32_t C;
     uint32_t H;
     float scale;
@@ -18751,13 +18751,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_GET_ROWS:
             {
-                // Vulkan GET_ROWS shader doesn't support tensor offsets that are
-                // misaligned w.r.t. minStorageBufferOffsetAlignment. The shader
-                // push-constant offset init (init_pushconst_tensor_offsets) asserts
-                // (a_offset == 0 && b_offset == 0 && d_offset == 0) when the
-                // backing-buffer offset + view_offs produces a misalignment.
-                // Fall back to CPU in that case instead of crashing.
-                // Repro: Qwen3-TTS (uses ggml_view + ggml_get_rows in its graph).
+                // GET_ROWS shader asserts on misaligned tensor offsets (see init_pushconst_tensor_offsets)
                 const auto misaligned = [&](const ggml_tensor * t) -> bool {
                     if (!t) return false;
                     const size_t align = device->properties.limits.minStorageBufferOffsetAlignment;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -12102,8 +12102,6 @@ template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk
     const uint32_t b_offset = get_misalign_bytes(ctx, src1) / ggml_type_size(src1->type);
     const uint32_t d_offset = get_misalign_bytes(ctx, dst) / ggml_type_size(dst->type);
 
-    GGML_ASSERT(dst->op != GGML_OP_GET_ROWS || (a_offset == 0 && b_offset == 0 && d_offset == 0));
-
     p.misalign_offsets = (a_offset << 16) | (b_offset << 8) | d_offset;
 
     GGML_UNUSED(src2);
@@ -18751,16 +18749,6 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
             }
         case GGML_OP_GET_ROWS:
             {
-                // GET_ROWS shader asserts on misaligned tensor offsets (see init_pushconst_tensor_offsets)
-                const auto misaligned = [&](const ggml_tensor * t) -> bool {
-                    if (!t) return false;
-                    const size_t align = device->properties.limits.minStorageBufferOffsetAlignment;
-                    if (align == 0) return false;
-                    return ((vk_tensor_offset(t) + t->view_offs) & (align - 1)) != 0;
-                };
-                if (misaligned(op->src[0]) || misaligned(op->src[1]) || misaligned(op)) {
-                    return false;
-                }
                 switch (op->src[0]->type) {
                     case GGML_TYPE_F32:
                     case GGML_TYPE_F16:

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -1895,7 +1895,7 @@ struct vk_op_rwkv_wkv7_push_constants {
 };
 struct vk_op_gated_linear_attn_push_constants {
     uint32_t B;
-    uint32_t T;const auto misaligned 
+    uint32_t T;
     uint32_t C;
     uint32_t H;
     float scale;

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -8195,7 +8195,7 @@ static void ggml_vk_host_get(const vk_device& device, const void * ptr, vk_buffe
 }
 
 static vk_subbuffer ggml_vk_tensor_subbuffer(
-    const ggml_backend_vk_context * ctx, const ggml_tensor * tensor, bool allow_misalign = false) {
+    const ggml_backend_vk_context * ctx, const ggml_tensor * tensor, bool allow_misalign = false, bool use_view_offs = true) {
 
     vk_buffer buffer = nullptr;
     size_t offset = 0;
@@ -8205,11 +8205,17 @@ static vk_subbuffer ggml_vk_tensor_subbuffer(
     if (!buffer) {
         auto buf_ctx = (ggml_backend_vk_buffer_context *)tensor->buffer->context;
         buffer = buf_ctx->dev_buffer;
-        offset = vk_tensor_offset(tensor) + tensor->view_offs;
+        offset = vk_tensor_offset(tensor);
+        if (use_view_offs) {
+            offset += tensor->view_offs;
+        }
     }
     GGML_ASSERT(buffer != nullptr);
 
     size_t size = ggml_nbytes(tensor);
+    if (!use_view_offs && tensor->view_src != nullptr) {
+        size += tensor->view_offs;
+    }
 
     size_t misalign_bytes = offset & (ctx->device->properties.limits.minStorageBufferOffsetAlignment - 1);
     // The shader must support misaligned offsets when indexing into the buffer
@@ -12098,12 +12104,17 @@ template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk
 }
 
 template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk_op_binary_push_constants &p, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * src2, const ggml_tensor * src3, ggml_tensor * dst) {
-    const uint32_t a_offset = get_misalign_bytes(ctx, src0) / ggml_type_size(src0->type);
-    const uint32_t b_offset = get_misalign_bytes(ctx, src1) / ggml_type_size(src1->type);
-    const uint32_t d_offset = get_misalign_bytes(ctx, dst) / ggml_type_size(dst->type);
+    const uint32_t a_offset = src0->view_offs / ggml_type_size(src0->type);
+    const uint32_t b_offset = src1 != nullptr ? src1->view_offs / ggml_type_size(src1->type) : 0;
+    const uint32_t d_offset = dst->view_offs / ggml_type_size(dst->type);
+
+    GGML_ASSERT(a_offset <= 0xFFFF);
+    GGML_ASSERT(b_offset <= 0xFF);
+    GGML_ASSERT(d_offset <= 0xFF);
 
     p.misalign_offsets = (a_offset << 16) | (b_offset << 8) | d_offset;
 
+    GGML_UNUSED(ctx);
     GGML_UNUSED(src2);
     GGML_UNUSED(src3);
 }
@@ -12186,11 +12197,12 @@ static void ggml_vk_op_f32(ggml_backend_vk_context * ctx, vk_context& subctx, co
 
     ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
 
-    vk_subbuffer src0_buf = ggml_vk_tensor_subbuffer(ctx, src0, true);
-    vk_subbuffer src1_buf = use_src1 ? ggml_vk_tensor_subbuffer(ctx, src1, true) : vk_subbuffer{};
-    vk_subbuffer src2_buf = use_src2 ? ggml_vk_tensor_subbuffer(ctx, src2, true) : vk_subbuffer{};
-    vk_subbuffer src3_buf = use_src3 ? ggml_vk_tensor_subbuffer(ctx, src3, true) : vk_subbuffer{};
-    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst, true);
+    constexpr bool is_binary = std::is_same_v<std::remove_cv_t<std::remove_reference_t<PC>>, vk_op_binary_push_constants>;
+    vk_subbuffer src0_buf = ggml_vk_tensor_subbuffer(ctx, src0, true, !is_binary);
+    vk_subbuffer src1_buf = use_src1 ? ggml_vk_tensor_subbuffer(ctx, src1, true, !is_binary) : vk_subbuffer{};
+    vk_subbuffer src2_buf = use_src2 ? ggml_vk_tensor_subbuffer(ctx, src2, true, !is_binary) : vk_subbuffer{};
+    vk_subbuffer src3_buf = use_src3 ? ggml_vk_tensor_subbuffer(ctx, src3, true, !is_binary) : vk_subbuffer{};
+    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst, true, !is_binary);
 
     // Compute misalignment offset for descriptors and store it in in push constants.
     init_pushconst_tensor_offsets(ctx, pc, src0, src1, src2, src3, dst);

--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2488,31 +2488,38 @@ static uint64_t vk_tensor_offset(const ggml_tensor * tensor) {
     return (uint8_t *) tensor->data - (uint8_t *) vk_ptr_base;
 }
 
-static size_t ggml_vk_tensor_physical_offset(const ggml_backend_vk_context * ctx, const ggml_tensor * t) {
+static void ggml_vk_host_get(const vk_device& device, const void * ptr, vk_buffer& buf, size_t& buf_offset);
+
+static size_t ggml_vk_tensor_buffer_offset(const ggml_backend_vk_context * ctx, const ggml_tensor * t) {
+    // vk_tensor_offset() is relative to vk_ptr_base, but mapped host tensors need an offset relative to their Vulkan buffer.
     if (ctx->device->uma) {
         vk_buffer buf = nullptr;
         size_t off = 0;
         ggml_vk_host_get(ctx->device, t->data, buf, off);
-        return off;
+        if (buf) {
+            return off;
+        }
     }
     return (size_t)(vk_tensor_offset(t) + t->view_offs);
 }
 
-static uint32_t get_misalign_bytes(const ggml_backend_vk_context * ctx, const ggml_tensor * t)
-{
-    return (ggml_vk_tensor_physical_offset(ctx, t) & (ctx->device->properties.limits.minStorageBufferOffsetAlignment - 1));
+static size_t ggml_vk_descriptor_offset(size_t tensor_offset, size_t alignment, size_t type_size) {
+    // Move the descriptor back until its distance to the tensor is divisible by the tensor type size.
+    size_t descriptor_offset = tensor_offset & ~(alignment - 1);
+    while ((tensor_offset - descriptor_offset) % type_size != 0) {
+        GGML_ASSERT(descriptor_offset >= alignment);
+        descriptor_offset -= alignment;
+    }
+
+    return descriptor_offset;
 }
 
-static uint32_t ggml_vk_get_adjusted_misalign(const ggml_backend_vk_context * ctx, const ggml_tensor * t)
-{
-    const size_t offset = ggml_vk_tensor_physical_offset(ctx, t);
-    const size_t align = ctx->device->properties.limits.minStorageBufferOffsetAlignment;
-    const size_t ts = ggml_type_size(t->type);
-    size_t misalign = offset & (align - 1);
-    while (misalign > 0 && misalign % ts != 0) {
-        misalign += align;
-    }
-    return (uint32_t)misalign;
+static uint32_t get_misalign_bytes(const ggml_backend_vk_context * ctx, const ggml_tensor * t) {
+    const size_t tensor_offset = ggml_vk_tensor_buffer_offset(ctx, t);
+    const size_t descriptor_offset = ggml_vk_descriptor_offset(
+        tensor_offset, ctx->device->properties.limits.minStorageBufferOffsetAlignment, ggml_type_size(t->type));
+    GGML_ASSERT(tensor_offset - descriptor_offset <= UINT32_MAX);
+    return tensor_offset - descriptor_offset;
 }
 
 static uint32_t ggml_vk_concat_unit_size(ggml_type type) {
@@ -8217,7 +8224,7 @@ static void ggml_vk_host_get(const vk_device& device, const void * ptr, vk_buffe
 }
 
 static vk_subbuffer ggml_vk_tensor_subbuffer(
-    const ggml_backend_vk_context * ctx, const ggml_tensor * tensor, bool allow_misalign = false, bool use_view_offs = true) {
+    const ggml_backend_vk_context * ctx, const ggml_tensor * tensor, bool allow_misalign = false) {
 
     vk_buffer buffer = nullptr;
     size_t offset = 0;
@@ -8227,29 +8234,18 @@ static vk_subbuffer ggml_vk_tensor_subbuffer(
     if (!buffer) {
         auto buf_ctx = (ggml_backend_vk_buffer_context *)tensor->buffer->context;
         buffer = buf_ctx->dev_buffer;
-    }
-
-    if (use_view_offs) {
-        if (!ctx->device->uma) {
-            offset = vk_tensor_offset(tensor) + tensor->view_offs;
-        }
-    } else {
-        const size_t physical = ggml_vk_tensor_physical_offset(ctx, tensor);
-        const size_t misalign = ggml_vk_get_adjusted_misalign(ctx, tensor);
-        GGML_ASSERT(physical >= misalign);
-        offset = physical - misalign;
+        offset = vk_tensor_offset(tensor) + tensor->view_offs;
     }
     GGML_ASSERT(buffer != nullptr);
 
     size_t size = ggml_nbytes(tensor);
-    if (!use_view_offs) {
-        size += ggml_vk_get_adjusted_misalign(ctx, tensor);
-    }
 
-    size_t misalign_bytes = offset & (ctx->device->properties.limits.minStorageBufferOffsetAlignment - 1);
+    const size_t descriptor_offset = ggml_vk_descriptor_offset(
+        offset, ctx->device->properties.limits.minStorageBufferOffsetAlignment, ggml_type_size(tensor->type));
+    const size_t misalign_bytes = offset - descriptor_offset;
     // The shader must support misaligned offsets when indexing into the buffer
     GGML_ASSERT(allow_misalign || misalign_bytes == 0);
-    offset &= ~misalign_bytes;
+    offset = descriptor_offset;
     size += misalign_bytes;
 
     return vk_subbuffer{buffer, offset, size};
@@ -12133,9 +12129,9 @@ template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk
 }
 
 template <> void init_pushconst_tensor_offsets(ggml_backend_vk_context * ctx, vk_op_binary_push_constants &p, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * src2, const ggml_tensor * src3, ggml_tensor * dst) {
-    const uint32_t a_offset = ggml_vk_get_adjusted_misalign(ctx, src0) / ggml_type_size(src0->type);
-    const uint32_t b_offset = src1 != nullptr ? ggml_vk_get_adjusted_misalign(ctx, src1) / ggml_type_size(src1->type) : 0;
-    const uint32_t d_offset = ggml_vk_get_adjusted_misalign(ctx, dst) / ggml_type_size(dst->type);
+    const uint32_t a_offset = get_misalign_bytes(ctx, src0) / ggml_type_size(src0->type);
+    const uint32_t b_offset = get_misalign_bytes(ctx, src1) / ggml_type_size(src1->type);
+    const uint32_t d_offset = get_misalign_bytes(ctx, dst) / ggml_type_size(dst->type);
 
     GGML_ASSERT(a_offset <= 0xFFFF);
     GGML_ASSERT(b_offset <= 0xFF);
@@ -12225,12 +12221,11 @@ static void ggml_vk_op_f32(ggml_backend_vk_context * ctx, vk_context& subctx, co
 
     ggml_pipeline_request_descriptor_sets(ctx, pipeline, 1);
 
-    constexpr bool is_binary = std::is_same_v<std::remove_cv_t<std::remove_reference_t<PC>>, vk_op_binary_push_constants>;
-    vk_subbuffer src0_buf = ggml_vk_tensor_subbuffer(ctx, src0, true, !is_binary);
-    vk_subbuffer src1_buf = use_src1 ? ggml_vk_tensor_subbuffer(ctx, src1, true, !is_binary) : vk_subbuffer{};
-    vk_subbuffer src2_buf = use_src2 ? ggml_vk_tensor_subbuffer(ctx, src2, true, !is_binary) : vk_subbuffer{};
-    vk_subbuffer src3_buf = use_src3 ? ggml_vk_tensor_subbuffer(ctx, src3, true, !is_binary) : vk_subbuffer{};
-    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst, true, !is_binary);
+    vk_subbuffer src0_buf = ggml_vk_tensor_subbuffer(ctx, src0, true);
+    vk_subbuffer src1_buf = use_src1 ? ggml_vk_tensor_subbuffer(ctx, src1, true) : vk_subbuffer{};
+    vk_subbuffer src2_buf = use_src2 ? ggml_vk_tensor_subbuffer(ctx, src2, true) : vk_subbuffer{};
+    vk_subbuffer src3_buf = use_src3 ? ggml_vk_tensor_subbuffer(ctx, src3, true) : vk_subbuffer{};
+    vk_subbuffer dst_buf = ggml_vk_tensor_subbuffer(ctx, dst, true);
 
     // Compute misalignment offset for descriptors and store it in in push constants.
     init_pushconst_tensor_offsets(ctx, pc, src0, src1, src2, src3, dst);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/get_rows_quant.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/get_rows_quant.comp
@@ -27,10 +27,10 @@ void main() {
             const uint i11 = gid_z / p.ne12;
             const uint i12 = gid_z % p.ne12;
 
-            const uint i01 = data_b[i10*p.nb10 + i11*p.nb11 + i12*p.nb12];
+            const uint i01 = data_b[get_boffset() + i10*p.nb10 + i11*p.nb11 + i12*p.nb12];
 
-            const uint a_offset = i01*p.nb01 + i11*p.nb02 + i12*p.nb03;
-            const uint d_offset = i10*p.nb21 + i11*p.nb22 + i12*p.nb23;
+            const uint a_offset = get_aoffset() + i01*p.nb01 + i11*p.nb02 + i12*p.nb03;
+            const uint d_offset = get_doffset() + i10*p.nb21 + i11*p.nb22 + i12*p.nb23;
 
             const uint ib = a_offset + i00/QUANT_K; // block index
             const uint iqs = (i00%QUANT_K)/QUANT_R; // quant index

--- a/ggml/src/ggml-webgpu/ggml-webgpu.cpp
+++ b/ggml/src/ggml-webgpu/ggml-webgpu.cpp
@@ -4323,13 +4323,21 @@ static bool ggml_backend_webgpu_device_supports_op(ggml_backend_dev_t dev, const
                             op->type == GGML_TYPE_Q4_0) &&
                            src0->type == GGML_TYPE_F32 && (src1->type == GGML_TYPE_I64 || src1->type == GGML_TYPE_I32));
             break;
-        case GGML_OP_GET_ROWS:
+        case GGML_OP_GET_ROWS: {
+            const size_t storage_alignment =
+                ctx->webgpu_global_ctx->capabilities.limits.minStorageBufferOffsetAlignment;
+            const size_t src_address_unit =
+                src0->type == GGML_TYPE_F32 && op->ne[0] % 4 == 0 ? 4 * sizeof(float) : ggml_type_size(src0->type);
+            if (ggml_webgpu_tensor_misalignment(src0, storage_alignment) % src_address_unit != 0) {
+                break;
+            }
             if (src0->type == GGML_TYPE_F32 || src0->type == GGML_TYPE_F16 || ggml_webgpu_supported_qtype(src0->type)) {
                 supports_op = (op->type == GGML_TYPE_F32);
             } else if (src0->type == GGML_TYPE_I32) {
                 supports_op = op->type == GGML_TYPE_I32;
             }
             break;
+        }
         case GGML_OP_MUL_MAT:
             {
                 switch (src1->type) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2309,7 +2309,7 @@ struct test_get_rows : public test_case {
     const int be1; // batch size
     const int be2; // batch size
     const bool v; // view (non-contiguous src1)
-    const bool vs0; // view src0 (non-zero view_offs -> misaligned tensor offsets)
+    const bool vs0; // view src0
 
     std::string vars() override {
         if (vs0) {
@@ -2324,9 +2324,6 @@ struct test_get_rows : public test_case {
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * in;
         if (vs0) {
-            // Allocate a larger tensor and view into it with a non-zero row offset
-            // to produce view_offs > 0, which triggers misaligned storage buffer offsets
-            // (mimics KV cache view scenarios in Qwen3-TTS and Qwen3-VL).
             const int padded_m = m + 3;
             ggml_tensor * in_padded = ggml_new_tensor_4d(ctx, type, n, padded_m, be1, be2);
             ggml_set_name(in_padded, "in_padded");
@@ -2361,7 +2358,7 @@ struct test_get_rows : public test_case {
     void initialize_tensors(ggml_context * ctx) override {
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
             if (vs0 && ggml_is_view_op(t->op) && std::string(ggml_get_name(t)) == "in_view") {
-                continue; // skip view, initialize in_padded instead
+                continue;
             }
             if (t->type == GGML_TYPE_I32) {
                 if (ggml_is_view_op(t->op)) { continue; }
@@ -8661,8 +8658,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v));
         }
     }
-    // view_src0=true cases: exercise non-zero view_offs on src0 to cover misaligned
-    // storage buffer offsets in both get_rows.comp and get_rows_quant.comp paths.
     for (ggml_type type : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K, GGML_TYPE_Q8_0, GGML_TYPE_I32}) {
         for (bool v : {false, true}) {
             test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, 1, 1, v, /*vs0=*/true));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2327,12 +2327,9 @@ struct test_get_rows : public test_case {
             // Allocate a larger tensor and view into it with a non-zero row offset
             // to produce view_offs > 0, which triggers misaligned storage buffer offsets
             // (mimics KV cache view scenarios in Qwen3-TTS and Qwen3-VL).
-            const int padded_m = m + 3; // extra rows so view_offs is non-trivial
+            const int padded_m = m + 3;
             ggml_tensor * in_padded = ggml_new_tensor_4d(ctx, type, n, padded_m, be1, be2);
             ggml_set_name(in_padded, "in_padded");
-            // View starting at row 3 (non-zero offset)
-            // Note: ggml_view_4d takes (ctx, a, ne0, ne1, ne2, ne3, nb1, nb2, nb3, offset)
-            //   nb0 is implicit (= ggml_type_size * ne0 elem), so do not pass nb[0]
             in = ggml_view_4d(ctx, in_padded, n, m, be1, be2,
                               in_padded->nb[1], in_padded->nb[2], in_padded->nb[3],
                               3 * in_padded->nb[1]);
@@ -8664,9 +8661,8 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v));
         }
     }
-    // Tests with view_src0=true: non-zero view_offs on src0 triggers misaligned storage
-    // buffer offsets (mimics KV cache view patterns in Qwen3-TTS / Qwen3-VL).
-    // Covers both non-quantized (get_rows.comp path) and quantized (get_rows_quant.comp path) types.
+    // view_src0=true cases: exercise non-zero view_offs on src0 to cover misaligned
+    // storage buffer offsets in both get_rows.comp and get_rows_quant.comp paths.
     for (ggml_type type : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K, GGML_TYPE_Q8_0, GGML_TYPE_I32}) {
         for (bool v : {false, true}) {
             test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, 1, 1, v, /*vs0=*/true));

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2309,17 +2309,38 @@ struct test_get_rows : public test_case {
     const int be1; // batch size
     const int be2; // batch size
     const bool v; // view (non-contiguous src1)
+    const bool vs0; // view src0 (non-zero view_offs -> misaligned tensor offsets)
 
     std::string vars() override {
+        if (vs0) {
+            return VARS_TO_STR8(type, n, m, r, be1, be2, v, vs0);
+        }
         return VARS_TO_STR7(type, n, m, r, be1, be2, v);
     }
 
-    test_get_rows(ggml_type type = GGML_TYPE_F32, int n = 10, int m = 5, int r = 3, int be1 = 1, int be2 = 1, bool v = false)
-        : type(type), n(n), m(m), r(r), be1(be1), be2(be2), v(v) {}
+    test_get_rows(ggml_type type = GGML_TYPE_F32, int n = 10, int m = 5, int r = 3, int be1 = 1, int be2 = 1, bool v = false, bool vs0 = false)
+        : type(type), n(n), m(m), r(r), be1(be1), be2(be2), v(v), vs0(vs0) {}
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
-        ggml_tensor * in = ggml_new_tensor_4d(ctx, type, n, m, be1, be2);
-        ggml_set_name(in, "in");
+        ggml_tensor * in;
+        if (vs0) {
+            // Allocate a larger tensor and view into it with a non-zero row offset
+            // to produce view_offs > 0, which triggers misaligned storage buffer offsets
+            // (mimics KV cache view scenarios in Qwen3-TTS and Qwen3-VL).
+            const int padded_m = m + 3; // extra rows so view_offs is non-trivial
+            ggml_tensor * in_padded = ggml_new_tensor_4d(ctx, type, n, padded_m, be1, be2);
+            ggml_set_name(in_padded, "in_padded");
+            // View starting at row 3 (non-zero offset)
+            // Note: ggml_view_4d takes (ctx, a, ne0, ne1, ne2, ne3, nb1, nb2, nb3, offset)
+            //   nb0 is implicit (= ggml_type_size * ne0 elem), so do not pass nb[0]
+            in = ggml_view_4d(ctx, in_padded, n, m, be1, be2,
+                              in_padded->nb[1], in_padded->nb[2], in_padded->nb[3],
+                              3 * in_padded->nb[1]);
+            ggml_set_name(in, "in_view");
+        } else {
+            in = ggml_new_tensor_4d(ctx, type, n, m, be1, be2);
+            ggml_set_name(in, "in");
+        }
 
         ggml_tensor * rows = ggml_new_tensor_3d(ctx, GGML_TYPE_I32, r, be1, be2);
         ggml_set_name(rows, "rows");
@@ -2342,6 +2363,9 @@ struct test_get_rows : public test_case {
 
     void initialize_tensors(ggml_context * ctx) override {
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            if (vs0 && ggml_is_view_op(t->op) && std::string(ggml_get_name(t)) == "in_view") {
+                continue; // skip view, initialize in_padded instead
+            }
             if (t->type == GGML_TYPE_I32) {
                 if (ggml_is_view_op(t->op)) { continue; }
                 // rows
@@ -8638,6 +8662,14 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     for (int b : {1, 7}) {
         for (bool v : {false, true}) {
             test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v));
+        }
+    }
+    // Tests with view_src0=true: non-zero view_offs on src0 triggers misaligned storage
+    // buffer offsets (mimics KV cache view patterns in Qwen3-TTS / Qwen3-VL).
+    // Covers both non-quantized (get_rows.comp path) and quantized (get_rows_quant.comp path) types.
+    for (ggml_type type : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K, GGML_TYPE_Q8_0, GGML_TYPE_I32}) {
+        for (bool v : {false, true}) {
+            test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, 1, 1, v, /*vs0=*/true));
         }
     }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2324,12 +2324,13 @@ struct test_get_rows : public test_case {
     ggml_tensor * build_graph(ggml_context * ctx) override {
         ggml_tensor * in;
         if (vs0) {
-            const int padded_m = m + 3;
+            const int offset_rows = 3;
+            const int padded_m = m + offset_rows;
             ggml_tensor * in_padded = ggml_new_tensor_4d(ctx, type, n, padded_m, be1, be2);
             ggml_set_name(in_padded, "in_padded");
             in = ggml_view_4d(ctx, in_padded, n, m, be1, be2,
                               in_padded->nb[1], in_padded->nb[2], in_padded->nb[3],
-                              3 * in_padded->nb[1]);
+                              offset_rows * in_padded->nb[1]);
             ggml_set_name(in, "in_view");
         } else {
             in = ggml_new_tensor_4d(ctx, type, n, m, be1, be2);
@@ -2343,7 +2344,7 @@ struct test_get_rows : public test_case {
             ggml_set_name(rows, "view_of_rows");
         }
 
-        const bool grad_supported = ggml_is_matrix(in) && ggml_is_vector(rows);
+        const bool grad_supported = !vs0 && ggml_is_matrix(in) && ggml_is_vector(rows);
         if (grad_supported) {
             ggml_set_param(in);
             // rows is a constant input -> no gradients
@@ -8658,9 +8659,16 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v));
         }
     }
-    for (ggml_type type : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q4_K, GGML_TYPE_Q8_0, GGML_TYPE_I32}) {
+    for (ggml_type type : all_types) {
+        for (int b : {1, 7}) {
+            for (bool v : {false, true}) {
+                test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, b, 1, v, /*vs0=*/true));
+            }
+        }
+    }
+    for (int b : {1, 7}) {
         for (bool v : {false, true}) {
-            test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, 1, 1, v, /*vs0=*/true));
+            test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v, /*vs0=*/true));
         }
     }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -2308,14 +2308,11 @@ struct test_get_rows : public test_case {
     const int r; // rows to get
     const int be1; // batch size
     const int be2; // batch size
-    const bool v; // view (non-contiguous src1)
+    const bool v; // view src1
     const bool vs0; // view src0
 
     std::string vars() override {
-        if (vs0) {
-            return VARS_TO_STR8(type, n, m, r, be1, be2, v, vs0);
-        }
-        return VARS_TO_STR7(type, n, m, r, be1, be2, v);
+        return VARS_TO_STR8(type, n, m, r, be1, be2, v, vs0);
     }
 
     test_get_rows(ggml_type type = GGML_TYPE_F32, int n = 10, int m = 5, int r = 3, int be1 = 1, int be2 = 1, bool v = false, bool vs0 = false)
@@ -2337,10 +2334,10 @@ struct test_get_rows : public test_case {
             ggml_set_name(in, "in");
         }
 
-        ggml_tensor * rows = ggml_new_tensor_3d(ctx, GGML_TYPE_I32, r, be1, be2);
+        ggml_tensor * rows = ggml_new_tensor_3d(ctx, GGML_TYPE_I32, v ? r + 1 : r, be1, be2);
         ggml_set_name(rows, "rows");
         if (v) {
-            rows = ggml_view_3d(ctx, rows, r/2, be1, be2, rows->nb[1], rows->nb[2], 0);
+            rows = ggml_view_3d(ctx, rows, r/2, be1, be2, rows->nb[1], rows->nb[2], rows->nb[0]);
             ggml_set_name(rows, "view_of_rows");
         }
 
@@ -2358,17 +2355,16 @@ struct test_get_rows : public test_case {
 
     void initialize_tensors(ggml_context * ctx) override {
         for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
-            if (vs0 && ggml_is_view_op(t->op) && std::string(ggml_get_name(t)) == "in_view") {
+            if (ggml_is_view_op(t->op)) {
                 continue;
             }
             if (t->type == GGML_TYPE_I32) {
-                if (ggml_is_view_op(t->op)) { continue; }
                 // rows
-                std::vector<int> data(r*be1*be2);
-                for (int i = 0; i < r*be1*be2; i++) {
+                std::vector<int> data(ggml_nelements(t));
+                for (size_t i = 0; i < data.size(); i++) {
                     data[i] = rand() % m;
                 }
-                ggml_backend_tensor_set(t, data.data(), 0, r * be1 * be2 * sizeof(int));
+                ggml_backend_tensor_set(t, data.data(), 0, data.size() * sizeof(int));
             } else {
                 init_tensor_uniform(t);
             }
@@ -8650,25 +8646,17 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     for (ggml_type type : all_types) {
         for (int b : {1, 7}) {
             for (bool v : {false, true}) {
-                test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, b, 1, v));
+                for (bool vs0 : {false, true}) {
+                    test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, b, 1, v, vs0));
+                }
             }
         }
     }
     for (int b : {1, 7}) {
         for (bool v : {false, true}) {
-            test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v));
-        }
-    }
-    for (ggml_type type : all_types) {
-        for (int b : {1, 7}) {
-            for (bool v : {false, true}) {
-                test_cases.emplace_back(new test_get_rows(type, 256, 5, 4, b, 1, v, /*vs0=*/true));
+            for (bool vs0 : {false, true}) {
+                test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v, vs0));
             }
-        }
-    }
-    for (int b : {1, 7}) {
-        for (bool v : {false, true}) {
-            test_cases.emplace_back(new test_get_rows(GGML_TYPE_I32, 256, 5, 4, b, 1, v, /*vs0=*/true));
         }
     }
 


### PR DESCRIPTION
## Overview

Fix GET_ROWS to compute an appropriate misalignment offset so it can handle scalar/block-aligned tensors.

This replaces/finishes #26854.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, used codex to help.
