### PR TITLE
webui: recognize audio/ogg MIME type in file uploads

### DIFF
--- a/tools/ui/src/lib/enums/files.enums.ts
+++ b/tools/ui/src/lib/enums/files.enums.ts
@@ -191,6 +191,7 @@ export enum MimeTypeAudio {
 	MP3 = 'audio/mp3',
 	MP3_MPEG = 'audio/mpeg',
 	MP4 = 'audio/mp4',
+	OGG = 'audio/ogg',
 	VND_WAVE = 'audio/vnd.wave',
 	WAV = 'audio/wav',
 	WAVE = 'audio/wave',

--- a/tools/ui/src/lib/utils/file-type.ts
+++ b/tools/ui/src/lib/utils/file-type.ts
@@ -38,6 +38,7 @@ export function getFileTypeCategory(mimeType: string): FileTypeCategory | null {
 		case MimeTypeAudio.MP3_MPEG:
 		case MimeTypeAudio.MP3:
 		case MimeTypeAudio.MP4:
+		case MimeTypeAudio.OGG:
 		case MimeTypeAudio.WAV:
 		case MimeTypeAudio.WAVE:
 		case MimeTypeAudio.X_WAV:


### PR DESCRIPTION
## Overview

Fixes #24164.

`getFileTypeCategory()` in `file-type.ts` only mapped `video/ogg` to a category. There was no `audio/ogg` entry in the `MimeTypeAudio` enum at all. When a browser reports an uploaded `.ogg` audio file as MIME type `audio/ogg` (which is standard), it doesn't match any case in the switch statement, so the file falls through to the plain-text handling path, fails the binary-content check, and gets silently skipped with an "appears to be binary" warning.

This adds `MimeTypeAudio.OGG = 'audio/ogg'` and routes it to `FileTypeCategory.AUDIO`, mirroring how `video/ogg` is already handled. Every other consumer of `MimeTypeAudio` (audio recording, the MCP `read_media` tool, playback format conversion) is intentionally narrower for an unrelated reason: those are constrained by the model's `input_audio` API, which only accepts MP3/WAV, so I left them untouched.

## Additional information

Verified via `svelte-check` (0 errors), `eslint`/`prettier` (clean), and a local test run through the project's vitest config covering the reported case, `video/ogg` staying unaffected, and existing audio types staying unaffected. No test file was added, per AGENTS.md guidance against adding tests for trivial changes.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - I used Claude Code to help investigate the issue and explore possible fixes, but I made the final code changes myself and independently reviewed,tested, and verified the submission.
