### PR TITLE
model: keep Qwen3.5 delta-net output projection 2D

### DIFF
--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -452,8 +452,8 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn_linear(
     // Apply gated normalization: self.norm(core_attn_out, z)
     ggml_tensor * attn_out_norm = build_norm_gated(output, model.layers[il].ssm_norm, z_2d, il);
 
-    // Final reshape: [head_dim, n_heads, n_tokens, n_seqs] -> [n_tokens, n_seqs, n_heads * head_dim]
-    ggml_tensor * final_output = ggml_reshape_3d(ctx0, attn_out_norm, head_v_dim * num_v_heads, n_seq_tokens, n_seqs);
+    // Final reshape: [head_dim, n_heads, n_tokens, n_seqs] -> [n_heads * head_dim, n_tokens * n_seqs].
+    ggml_tensor * final_output = ggml_reshape_2d(ctx0, attn_out_norm, head_v_dim * num_v_heads, n_seq_tokens * n_seqs);
     cb(final_output, "final_output", il);
 
     // Output projection

--- a/src/models/qwen35moe.cpp
+++ b/src/models/qwen35moe.cpp
@@ -476,8 +476,8 @@ ggml_tensor * llama_model_qwen35moe::graph::build_layer_attn_linear(
     // Apply gated normalization: self.norm(core_attn_out, z)
     ggml_tensor * attn_out_norm = build_norm_gated(output, model.layers[il].ssm_norm, z_2d, il);
 
-    // Final reshape: [head_dim, n_heads, n_tokens, n_seqs] -> [n_tokens, n_seqs, n_heads * head_dim]
-    ggml_tensor * final_output = ggml_reshape_3d(ctx0, attn_out_norm, head_v_dim * num_v_heads, n_seq_tokens, n_seqs);
+    // Final reshape: [head_dim, n_heads, n_tokens, n_seqs] -> [n_heads * head_dim, n_tokens * n_seqs].
+    ggml_tensor * final_output = ggml_reshape_2d(ctx0, attn_out_norm, head_v_dim * num_v_heads, n_seq_tokens * n_seqs);
     cb(final_output, "final_output", il);
 
     // Output projection


### PR DESCRIPTION
## Overview

The 3D shape makes ssm_out dispatch as n_seqs single-column mat-vecs, re-reading the weight matrix once per sequence. 2D makes it one mat-mul with n_tokens columns. This change gives a speedup for batched decoding (tested on Vulkan and ROCm).

## Additional information

Benchmarks run with `llama-batched-bench -m <model>.gguf -c 12288 -b 2048 -ub 512 -npp 512 -ntg 128 -npl 1,4,8 -fa 1` on a Strix Halo machine on Vulkan and ROCm. I don't have access to other hardware to test the other backends. The ROCm figures include [this patch](https://github.com/kyuz0/amd-strix-halo-toolboxes/blob/main/toolboxes/llama-cpp-25992-rocm-host-buffer.patch) to work around bug #25992. The following tables contain TG figures in t/s. PP did not change, difference was within noise.

### Qwen3.8-27B-Q5_K_S-bartowski.gguf:

**Vulkan (RADV)**
| `-npl` | upstream | + patch | delta |
|---|---|---|---|
| 1 | 10.63 | 10.63 | +0.0% |
| 4 | 32.49 | 34.64 | +6.6% |
| 8 | 44.30 | 48.52 | +9.5% |


**ROCm 10.0**
| `-npl`  | upstream | + patch | delta |
|---|---|---|---|
| 1 | 9.26 | 9.27 | +0.1% |
| 4 | 20.09 | 20.80 | +3.5% |
| 8 | 23.58 | 24.55 | +4.1% |

### Qwen3.6-35B-A3B-UD-Q5_K_S.gguf:

**Vulkan (RADV)**
| `-npl`  | upstream | + patch | delta |
|---|---|---|---|
| 1 | 47.75 | 47.86 | +0.2% |
| 4 | 107.65 | 112.09 | +4.1% |
| 8 | 137.20 | 145.29 | +5.9% |

**ROCm 10.0**
| `-npl`  | upstream | + patch | delta |
|---|---|---|---|
| 1 | 37.98 | 37.73 | -0.7% |
| 4 | 93.27 | 99.01 | +6.2% |
| 8 | 131.06 | 137.84 | +5.2% |

### Correctness

`llama-perplexity -c 512 --chunks 4 -b 2048 -fa on` over ~4200 words of English prose (llama.cpp docs):

| model | backend | upstream | + patch |
|---|---|---|---|
| Qwen3.8-27B | Vulkan | 3.4408 | 3.4408 |
| Qwen3.8-27B | ROCm | 3.4267 | 3.4267 |
| Qwen3.6-35B-A3B | Vulkan | 3.6615 | 3.6498 |
| Qwen3.6-35B-A3B | ROCm | 3.6684 | 3.6684 |

(the same run with `-b 512` on the 35B Vulkan gives 3.6498 for both arms, upstream is the outlier at `-b 2048`)

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, Claude Opus found and implemented this.
