### PR TITLE
ui : don't use npx inside package.json script

### DIFF
--- a/tools/ui/package.json
+++ b/tools/ui/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "npm run build-pwa-assets && vite build",
-		"build-pwa-assets": "npx @vite-pwa/assets-generator --root . --config pwa-assets.config.ts && npx @vite-pwa/assets-generator --root . --config pwa-assets-dark.config.ts && node scripts/make-icons-circular.js",
+		"build-pwa-assets": "pwa-assets-generator --root . --config pwa-assets.config.ts && pwa-assets-generator --root . --config pwa-assets-dark.config.ts && node scripts/make-icons-circular.js",
 		"dev": "bash scripts/dev.sh",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Don't use `npx` inside of a package.json script. It's not necessary, and can potentially install an unexpected version of the package if `npm ci` hasn't already been run.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - Sol found this and wrote the (extremely trivial) diff, as part of an old supply-chain-security audit, although it's more of a cleanup at than any real risk.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
