### PR TITLE
fix the msvc clang compile test backend ops mismatch 

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -78,7 +78,7 @@ struct ggml_compute_params {
 #if defined(__ARM_NEON)
 
 // ref: https://github.com/ggml-org/llama.cpp/pull/5404
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define ggml_vld1q_u32(w,x,y,z) { ((w) + ((uint64_t)(x) << 32)), ((y) + ((uint64_t)(z) << 32)) }
 #else
 #define ggml_vld1q_u32(w,x,y,z) { (w), (x), (y), (z) }


### PR DESCRIPTION
## Overview

When building with MSVC but with clang, we should still use the 4 initializers in this macro. This fix allows test-backend-ops to pass for builds with -DGGML_CUDA and building with MSVC + clang. 

## Additional information

`ggml_vld1q_u32(w,x,y,z)` builds a 128-bit vector of four uint32 lanes from four scalars. It's written as a brace initializer, and it has two forms because uint32x4_t is a genuinely different type on MSVC than on clang/gcc.

On MSVC it is a union whose first member is `unsigned __int64 n128_u64[2]` so brace-initialization would be to feed it two u64 values
```
typedef union __declspec(intrin_type) _ADVSIMD_ALIGN(16) __n128 {
     unsigned __int64   n128_u64[2];      // <-- first member
     unsigned __int32   n128_u32[4];
     ...
} __n128;
typedef __n128 uint32x4_t;
```
Whereas in clang/gcc, `uint32x4_t` is a native vector type, so it needs four initializers.
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used to locate the issue. 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
