### PR TITLE
add gt-asr-1.7b

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -101,6 +101,7 @@ class ModelBase:
     dir_model_card: Path
     remote_hf_model_id: str | None
     target_model_dir: Path | None
+    gt_asr_adapter: Path | None
 
     # subclasses should define this!
     model_arch: gguf.MODEL_ARCH
@@ -129,6 +130,7 @@ class ModelBase:
                  disable_mistral_community_chat_template: bool = False,
                  sentence_transformers_dense_modules: bool = False,
                  target_model_dir: Path | None = None,
+                 gt_asr_adapter: Path | None = None,
                  fuse_gate_up_exps: bool = False,
                  fp8_as_q8: bool = False,
                  fuse_qkv: bool = False):
@@ -151,6 +153,7 @@ class ModelBase:
         self.remote_hf_model_id = remote_hf_model_id
         self.sentence_transformers_dense_modules = sentence_transformers_dense_modules
         self.target_model_dir = target_model_dir
+        self.gt_asr_adapter = gt_asr_adapter
         self.fuse_gate_up_exps = fuse_gate_up_exps
         self._gate_exp_buffer: dict[int, Tensor] = {}
         self._up_exp_buffer: dict[int, Tensor] = {}

--- a/conversion/qwen3vl.py
+++ b/conversion/qwen3vl.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 import json
+import hashlib
 
+from pathlib import Path
 from typing import Any, Callable, Iterable, TYPE_CHECKING
+
+import torch
 
 if TYPE_CHECKING:
     from torch import Tensor
@@ -11,6 +15,174 @@ from .base import MmprojModel, ModelBase, gguf, logger
 
 from .qwen import Qwen3Model, Qwen3MoeModel
 from .qwenvl import Qwen25AudioModel
+
+
+_GT_ASR_CONFIG = {
+    "attentive_utterance_evidence": False,
+    "convolution_kernel_size": 5,
+    "dropout": 0.1,
+    "encoder_dim": 1024,
+    "eos_prior_strength": 2.0,
+    "frame_evidence_hidden_dim": 128,
+    "global_zero_anchor": True,
+    "hidden_dim": 256,
+    "local_fusion": True,
+    "local_uncertainty_gate": True,
+    "masked_reconstruction_probability": 0.15,
+    "maximum_residual_scale": 0.25,
+    "nonlinear_frame_evidence": True,
+    "probabilistic_null_mixture": True,
+    "text_dim": 2048,
+    "transformer_ffn_dim": 1024,
+    "transformer_heads": 4,
+    "utterance_evidence_hidden_dim": 128,
+}
+
+_GT_ASR_TENSOR_SHAPES = {
+    "local_scale_raw": (),
+    "global_scale_raw": (),
+    "upm.mask_token": (1024,),
+    "upm.input_norm.weight": (1024,),
+    "upm.input_norm.bias": (1024,),
+    "upm.temporal.0.weight": (256, 1024, 5),
+    "upm.temporal.0.bias": (256,),
+    "upm.temporal.2.weight": (256, 256, 5),
+    "upm.temporal.2.bias": (256,),
+    "upm.context.layers.0.self_attn.in_proj_weight": (768, 256),
+    "upm.context.layers.0.self_attn.in_proj_bias": (768,),
+    "upm.context.layers.0.self_attn.out_proj.weight": (256, 256),
+    "upm.context.layers.0.self_attn.out_proj.bias": (256,),
+    "upm.context.layers.0.linear1.weight": (1024, 256),
+    "upm.context.layers.0.linear1.bias": (1024,),
+    "upm.context.layers.0.linear2.weight": (256, 1024),
+    "upm.context.layers.0.linear2.bias": (256,),
+    "upm.context.layers.0.norm1.weight": (256,),
+    "upm.context.layers.0.norm1.bias": (256,),
+    "upm.context.layers.0.norm2.weight": (256,),
+    "upm.context.layers.0.norm2.bias": (256,),
+    "upm.output_norm.weight": (256,),
+    "upm.output_norm.bias": (256,),
+    "upm.frame_confidence_head.weight": (1, 256),
+    "upm.frame_confidence_head.bias": (1,),
+    "upm.global_uncertainty_head.weight": (1, 256),
+    "upm.global_uncertainty_head.bias": (1,),
+    "upm.speech_presence_head.weight": (1, 256),
+    "upm.speech_presence_head.bias": (1,),
+    "upm.reconstruction_head.weight": (1024, 256),
+    "upm.reconstruction_head.bias": (1024,),
+    "upm.frame_evidence_head.0.weight": (128, 256),
+    "upm.frame_evidence_head.0.bias": (128,),
+    "upm.frame_evidence_head.3.weight": (1, 128),
+    "upm.frame_evidence_head.3.bias": (1,),
+    "local_projection.weight": (2048, 256),
+    "local_projection.bias": (2048,),
+    "global_projection.0.weight": (256, 1),
+    "global_projection.0.bias": (256,),
+    "global_projection.2.weight": (2048, 256),
+    "global_projection.2.bias": (2048,),
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as input_file:
+        for chunk in iter(lambda: input_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_gt_asr_adapter(adapter_dir: Path) -> tuple[dict[str, Any], dict[str, Tensor]]:
+    manifest_path = adapter_dir / "uncertainty_adapter.json"
+    if not manifest_path.is_file():
+        raise ValueError(f"GT-ASR manifest not found: {manifest_path}")
+    with manifest_path.open("r", encoding="utf-8") as manifest_file:
+        manifest = json.load(manifest_file)
+
+    if manifest.get("schema_version") != 1 or manifest.get("stage") != 2:
+        raise ValueError("Only stage-2 GT-ASR adapter schema version 1 is supported")
+    config = manifest.get("config")
+    if config != _GT_ASR_CONFIG:
+        raise ValueError("GT-ASR adapter config does not match the supported contract")
+
+    weights_name = manifest.get("weights")
+    if not isinstance(weights_name, str) or Path(weights_name).name != weights_name:
+        raise ValueError("GT-ASR manifest contains an invalid weights filename")
+    weights_path = adapter_dir / weights_name
+    if not weights_path.is_file():
+        raise ValueError(f"GT-ASR weights not found: {weights_path}")
+    expected_hash = manifest.get("weights_sha256")
+    actual_hash = _sha256(weights_path)
+    if expected_hash != actual_hash:
+        raise ValueError(f"GT-ASR weights SHA-256 mismatch: expected {expected_hash}, got {actual_hash}")
+
+    state = torch.load(weights_path, map_location="cpu", weights_only=True)
+    if not isinstance(state, dict) or not all(
+        isinstance(name, str) and isinstance(value, torch.Tensor)
+        for name, value in state.items()
+    ):
+        raise ValueError("GT-ASR weights must be a tensor state dict")
+    missing = sorted(set(_GT_ASR_TENSOR_SHAPES) - set(state))
+    extra = sorted(set(state) - set(_GT_ASR_TENSOR_SHAPES))
+    if missing or extra:
+        raise ValueError(f"GT-ASR tensor names differ from the supported contract; missing={missing}, extra={extra}")
+    for name, shape in _GT_ASR_TENSOR_SHAPES.items():
+        if tuple(state[name].shape) != shape:
+            raise ValueError(f"GT-ASR tensor {name!r} has shape {tuple(state[name].shape)}, expected {shape}")
+        if not state[name].is_floating_point():
+            raise ValueError(f"GT-ASR tensor {name!r} must be floating point")
+    return manifest, state
+
+
+def _gt_asr_tensors(state: dict[str, Tensor]) -> Iterable[tuple[str, Tensor]]:
+    direct = {
+        "local_scale_raw": "a.gt_asr.local_scale_raw",
+        "global_scale_raw": "a.gt_asr.global_scale_raw",
+        "upm.input_norm.weight": "a.gt_asr.input_norm.weight",
+        "upm.input_norm.bias": "a.gt_asr.input_norm.bias",
+        "upm.temporal.0.weight": "a.gt_asr.temporal.0.weight",
+        "upm.temporal.0.bias": "a.gt_asr.temporal.0.bias",
+        "upm.temporal.2.weight": "a.gt_asr.temporal.1.weight",
+        "upm.temporal.2.bias": "a.gt_asr.temporal.1.bias",
+        "upm.context.layers.0.self_attn.out_proj.weight": "a.gt_asr.blk.0.attn_out.weight",
+        "upm.context.layers.0.self_attn.out_proj.bias": "a.gt_asr.blk.0.attn_out.bias",
+        "upm.context.layers.0.linear1.weight": "a.gt_asr.blk.0.ffn_up.weight",
+        "upm.context.layers.0.linear1.bias": "a.gt_asr.blk.0.ffn_up.bias",
+        "upm.context.layers.0.linear2.weight": "a.gt_asr.blk.0.ffn_down.weight",
+        "upm.context.layers.0.linear2.bias": "a.gt_asr.blk.0.ffn_down.bias",
+        "upm.context.layers.0.norm1.weight": "a.gt_asr.blk.0.attn_norm.weight",
+        "upm.context.layers.0.norm1.bias": "a.gt_asr.blk.0.attn_norm.bias",
+        "upm.context.layers.0.norm2.weight": "a.gt_asr.blk.0.ffn_norm.weight",
+        "upm.context.layers.0.norm2.bias": "a.gt_asr.blk.0.ffn_norm.bias",
+        "upm.output_norm.weight": "a.gt_asr.output_norm.weight",
+        "upm.output_norm.bias": "a.gt_asr.output_norm.bias",
+        "upm.frame_confidence_head.weight": "a.gt_asr.frame_confidence.weight",
+        "upm.frame_confidence_head.bias": "a.gt_asr.frame_confidence.bias",
+        "upm.global_uncertainty_head.weight": "a.gt_asr.global_uncertainty.weight",
+        "upm.global_uncertainty_head.bias": "a.gt_asr.global_uncertainty.bias",
+        "upm.frame_evidence_head.0.weight": "a.gt_asr.frame_evidence.0.weight",
+        "upm.frame_evidence_head.0.bias": "a.gt_asr.frame_evidence.0.bias",
+        "upm.frame_evidence_head.3.weight": "a.gt_asr.frame_evidence.1.weight",
+        "upm.frame_evidence_head.3.bias": "a.gt_asr.frame_evidence.1.bias",
+        "local_projection.weight": "a.gt_asr.local_projection.weight",
+        "local_projection.bias": "a.gt_asr.local_projection.bias",
+        "global_projection.0.weight": "a.gt_asr.global_projection.0.weight",
+        "global_projection.0.bias": "a.gt_asr.global_projection.0.bias",
+        "global_projection.2.weight": "a.gt_asr.global_projection.1.weight",
+        "global_projection.2.bias": "a.gt_asr.global_projection.1.bias",
+    }
+    for source, target in direct.items():
+        tensor = state[source].detach().float().contiguous()
+        if tensor.ndim == 0:
+            tensor = tensor.reshape(1)
+        yield target, tensor
+
+    qkv_weight = state["upm.context.layers.0.self_attn.in_proj_weight"].detach().float()
+    qkv_bias = state["upm.context.layers.0.self_attn.in_proj_bias"].detach().float()
+    for index, projection in enumerate(("q", "k", "v")):
+        start = index * 256
+        end = (index + 1) * 256
+        yield f"a.gt_asr.blk.0.attn_{projection}.weight", qkv_weight[start:end].contiguous()
+        yield f"a.gt_asr.blk.0.attn_{projection}.bias", qkv_bias[start:end].contiguous()
 
 
 @ModelBase.register("Qwen3VLForConditionalGeneration", "Qwen3VLMoeForConditionalGeneration", "Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration")
@@ -223,6 +395,58 @@ class Qwen3OmniMmprojModel(Qwen3VLVisionModel, Qwen25AudioModel):
 class Qwen3ASRMmprojModel(Qwen3OmniMmprojModel):
     has_audio_encoder = True
     has_vision_encoder = False
+
+    def __init__(self, *args, **kwargs):
+        # Keep the stock Qwen3-ASR metadata unchanged unless the adapter is present.
+        if kwargs.get("gt_asr_adapter") is not None and kwargs.get("model_name") is None:
+            kwargs["model_name"] = "gt-asr-1.7b"
+        super().__init__(*args, **kwargs)
+        self.gt_asr_manifest: dict[str, Any] | None = None
+        self.gt_asr_state: dict[str, Tensor] | None = None
+        if self.gt_asr_adapter is not None:
+            self.gt_asr_manifest, self.gt_asr_state = _load_gt_asr_adapter(self.gt_asr_adapter)
+
+    def set_gguf_parameters(self):
+        super().set_gguf_parameters()
+        if self.gt_asr_manifest is None:
+            return
+        config = self.gt_asr_manifest["config"]
+        writer = self.gguf_writer
+        writer.add_bool("clip.audio.gt_asr.enabled", True)
+        writer.add_uint32("clip.audio.gt_asr.schema_version", self.gt_asr_manifest["schema_version"])
+        writer.add_uint32("clip.audio.gt_asr.stage", self.gt_asr_manifest["stage"])
+        writer.add_uint32("clip.audio.gt_asr.encoder_dim", config["encoder_dim"])
+        writer.add_uint32("clip.audio.gt_asr.text_dim", config["text_dim"])
+        writer.add_uint32("clip.audio.gt_asr.hidden_dim", config["hidden_dim"])
+        writer.add_uint32("clip.audio.gt_asr.conv_kernel_size", config["convolution_kernel_size"])
+        writer.add_uint32("clip.audio.gt_asr.head_count", config["transformer_heads"])
+        writer.add_uint32("clip.audio.gt_asr.feed_forward_dim", config["transformer_ffn_dim"])
+        writer.add_float32("clip.audio.gt_asr.layer_norm_epsilon", 1.0e-5)
+        writer.add_float32("clip.audio.gt_asr.maximum_residual_scale", config["maximum_residual_scale"])
+        writer.add_bool("clip.audio.gt_asr.local_fusion", config["local_fusion"])
+        writer.add_bool("clip.audio.gt_asr.local_uncertainty_gate", config["local_uncertainty_gate"])
+        writer.add_bool("clip.audio.gt_asr.nonlinear_frame_evidence", config["nonlinear_frame_evidence"])
+        writer.add_bool("clip.audio.gt_asr.global_zero_anchor", config["global_zero_anchor"])
+        writer.add_bool("clip.audio.gt_asr.probabilistic_null_mixture", config["probabilistic_null_mixture"])
+        writer.add_array("clip.audio.gt_asr.eos_token_ids", [151643, 151645])
+        writer.add_string("clip.audio.gt_asr.weights_sha256", self.gt_asr_manifest["weights_sha256"])
+        writer.add_string("clip.audio.gt_asr.program_contract_sha256", self.gt_asr_manifest["program_contract_sha256"])
+
+    def generate_extra_tensors(self) -> Iterable[tuple[str, Tensor]]:
+        yield from super().generate_extra_tensors()
+        if self.gt_asr_state is not None:
+            yield from _gt_asr_tensors(self.gt_asr_state)
+
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        if name.startswith("a.gt_asr."):
+            yield name, data_torch
+            return
+        yield from super().modify_tensors(data_torch, name, bid)
+
+    def tensor_force_quant(self, name, new_name, bid, n_dims):
+        if name.startswith("a.gt_asr."):
+            return gguf.GGMLQuantizationType.F32
+        return super().tensor_force_quant(name, new_name, bid, n_dims)
 
 
 @ModelBase.register("Glm4vForConditionalGeneration", "Glm4vMoeForConditionalGeneration", "GlmOcrForConditionalGeneration")

--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -118,6 +118,10 @@ def parse_args() -> argparse.Namespace:
         help="Export multimodal projector (mmproj) for vision models. This will only work on some vision models. An 'mmproj-' prefix will be added to the output file name.",
     )
     parser.add_argument(
+        "--gt-asr-adapter", type=Path,
+        help="GT-ASR adapter directory to embed in a Qwen3-ASR mmproj GGUF.",
+    )
+    parser.add_argument(
         "--mtp", action="store_true",
         help="Export only the multi-token prediction (MTP) head as a separate GGUF, suitable for use as a speculative draft. An 'mtp-' prefix will be added to the output file name.",
     )
@@ -173,6 +177,8 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
     if not args.print_supported_models and args.model is None:
         parser.error("the following arguments are required: model")
+    if args.gt_asr_adapter is not None and not args.mmproj:
+        parser.error("--gt-asr-adapter requires --mmproj")
     return args
 
 
@@ -262,6 +268,12 @@ def main() -> None:
             from conversion.mistral import MistralModel
             model_class = MistralModel
 
+        if args.gt_asr_adapter is not None and (
+            is_mistral_format or model_architecture != "Qwen3ASRForConditionalGeneration"
+        ):
+            logger.error("--gt-asr-adapter is only supported for Qwen3-ASR")
+            sys.exit(1)
+
         if sum((args.mtp, args.no_mtp, args.dspark)) > 1:
             logger.error("--mtp, --no-nextn, and --dspark are mutually exclusive")
             sys.exit(1)
@@ -292,6 +304,7 @@ def main() -> None:
                                      remote_hf_model_id=hf_repo_id, disable_mistral_community_chat_template=disable_mistral_community_chat_template,
                                      sentence_transformers_dense_modules=args.sentence_transformers_dense_modules,
                                      target_model_dir=Path(args.target_model_dir) if args.target_model_dir else None,
+                                     gt_asr_adapter=args.gt_asr_adapter,
                                      fuse_gate_up_exps=args.fuse_gate_up_exps,
                                      fp8_as_q8=args.fp8_as_q8,
                                      fuse_qkv=args.fuse_qkv,

--- a/tools/mtmd/clip-impl.h
+++ b/tools/mtmd/clip-impl.h
@@ -86,6 +86,23 @@
 #define KEY_A_PROJ_WINDOW_SIZE     "clip.audio.projector.window_size"
 #define KEY_A_PROJ_DOWNSAMPLE_RATE "clip.audio.projector.downsample_rate"
 #define KEY_A_PROJ_HEAD_COUNT      "clip.audio.projector.head_count"
+#define KEY_A_GT_ASR_ENABLED       "clip.audio.gt_asr.enabled"
+#define KEY_A_GT_ASR_SCHEMA        "clip.audio.gt_asr.schema_version"
+#define KEY_A_GT_ASR_STAGE         "clip.audio.gt_asr.stage"
+#define KEY_A_GT_ASR_ENCODER_DIM   "clip.audio.gt_asr.encoder_dim"
+#define KEY_A_GT_ASR_TEXT_DIM      "clip.audio.gt_asr.text_dim"
+#define KEY_A_GT_ASR_HIDDEN_DIM    "clip.audio.gt_asr.hidden_dim"
+#define KEY_A_GT_ASR_CONV_KERNEL   "clip.audio.gt_asr.conv_kernel_size"
+#define KEY_A_GT_ASR_HEAD_COUNT    "clip.audio.gt_asr.head_count"
+#define KEY_A_GT_ASR_FFN_DIM       "clip.audio.gt_asr.feed_forward_dim"
+#define KEY_A_GT_ASR_NORM_EPS      "clip.audio.gt_asr.layer_norm_epsilon"
+#define KEY_A_GT_ASR_MAX_SCALE     "clip.audio.gt_asr.maximum_residual_scale"
+#define KEY_A_GT_ASR_LOCAL         "clip.audio.gt_asr.local_fusion"
+#define KEY_A_GT_ASR_LOCAL_GATE    "clip.audio.gt_asr.local_uncertainty_gate"
+#define KEY_A_GT_ASR_FRAME_HEAD    "clip.audio.gt_asr.nonlinear_frame_evidence"
+#define KEY_A_GT_ASR_ZERO_ANCHOR   "clip.audio.gt_asr.global_zero_anchor"
+#define KEY_A_GT_ASR_NULL_MIXTURE  "clip.audio.gt_asr.probabilistic_null_mixture"
+#define KEY_A_GT_ASR_EOS_IDS       "clip.audio.gt_asr.eos_token_ids"
 #define KEY_A_RVQ_NUM_QUANTIZERS   "clip.audio.rvq.num_quantizers"   // mimo-audio-tokenizer
 #define KEY_A_RVQ_CODEBOOK_SIZE    "clip.audio.rvq.codebook_size"    // mimo-audio-tokenizer: per-quantizer bin count
 #define KEY_A_WA_PATTERN_MODE      "clip.audio.wa_pattern_mode"      // mimo-audio-tokenizer, per-layer -1 (full) / 0 (windowed)
@@ -194,6 +211,7 @@
 #define TN_CONV_OUT     "a.conv_out.%s"
 #define TN_MM_AUDIO_MLP "mm.a.mlp.%d.%s"
 #define TN_MM_AUDIO_FC  "mm.a.fc.%s" // fully connected layer
+#define TN_A_GT_ASR     "a.gt_asr.%s"
 #define TN_MM_NORM_PRE  "mm.a.norm_pre.%s"
 #define TN_MM_NORM_MID  "mm.a.norm_mid.%s"
 
@@ -686,9 +704,19 @@ struct clip_image_f32 {
     int nx() const { return nx_; }
     int ny() const { return ny_; }
 
+    int audio_n_frames() const {
+        return audio_n_frames_ > 0 ? audio_n_frames_ : nx_;
+    }
+
+    void set_audio_n_frames(int n_frames) {
+        GGML_ASSERT(n_frames > 0 && n_frames <= nx_);
+        audio_n_frames_ = n_frames;
+    }
+
     void set_size(clip_image_size size, bool is_placeholder, bool is_audio) {
         nx_ = size.width;
         ny_ = size.height;
+        audio_n_frames_ = 0;
         if (is_placeholder) {
             buf.clear();
         } else {
@@ -754,6 +782,7 @@ struct clip_image_f32 {
     std::vector<float> buf;
     int nx_ = 0;
     int ny_ = 0;
+    int audio_n_frames_ = 0;
 
     size_t n_pixels() const {
         return (size_t) nx_ * (size_t) ny_;

--- a/tools/mtmd/clip-model.h
+++ b/tools/mtmd/clip-model.h
@@ -131,6 +131,24 @@ struct clip_hparams {
     int32_t audio_proj_downsample_rate = 0;
     int32_t audio_proj_head_count      = 0;
 
+    bool gt_asr_enabled                = false;
+    int32_t gt_asr_schema_version      = 0;
+    int32_t gt_asr_stage               = 0;
+    int32_t gt_asr_encoder_dim         = 0;
+    int32_t gt_asr_text_dim            = 0;
+    int32_t gt_asr_hidden_dim          = 0;
+    int32_t gt_asr_conv_kernel_size    = 0;
+    int32_t gt_asr_head_count          = 0;
+    int32_t gt_asr_ffn_dim             = 0;
+    float gt_asr_norm_eps              = 1e-5f;
+    float gt_asr_max_residual_scale    = 0.0f;
+    bool gt_asr_local_fusion           = false;
+    bool gt_asr_local_uncertainty_gate = false;
+    bool gt_asr_nonlinear_frame_head   = false;
+    bool gt_asr_global_zero_anchor     = false;
+    bool gt_asr_null_mixture           = false;
+    std::vector<int32_t> gt_asr_eos_token_ids;
+
     // audio-to-mel preprocessor params
     int32_t audio_chunk_len   = -1; // in seconds
     int32_t audio_sample_rate = -1;
@@ -768,6 +786,26 @@ struct clip_model {
     ggml_tensor * conv2d_2_b = nullptr;
     ggml_tensor * conv2d_3_w = nullptr;
     ggml_tensor * conv2d_3_b = nullptr;
+
+    ggml_tensor * gt_asr_input_norm_w = nullptr;
+    ggml_tensor * gt_asr_input_norm_b = nullptr;
+    std::array<ggml_tensor *, 2> gt_asr_temporal_w = {nullptr};
+    std::array<ggml_tensor *, 2> gt_asr_temporal_b = {nullptr};
+    clip_layer gt_asr_context;
+    ggml_tensor * gt_asr_output_norm_w = nullptr;
+    ggml_tensor * gt_asr_output_norm_b = nullptr;
+    ggml_tensor * gt_asr_frame_confidence_w = nullptr;
+    ggml_tensor * gt_asr_frame_confidence_b = nullptr;
+    ggml_tensor * gt_asr_global_uncertainty_w = nullptr;
+    ggml_tensor * gt_asr_global_uncertainty_b = nullptr;
+    std::array<ggml_tensor *, 2> gt_asr_frame_evidence_w = {nullptr};
+    std::array<ggml_tensor *, 2> gt_asr_frame_evidence_b = {nullptr};
+    ggml_tensor * gt_asr_local_projection_w = nullptr;
+    ggml_tensor * gt_asr_local_projection_b = nullptr;
+    std::array<ggml_tensor *, 2> gt_asr_global_projection_w = {nullptr};
+    std::array<ggml_tensor *, 2> gt_asr_global_projection_b = {nullptr};
+    ggml_tensor * gt_asr_local_scale_raw = nullptr;
+    ggml_tensor * gt_asr_global_scale_raw = nullptr;
 
     // qwen3tts speaker encoder (ECAPA-TDNN)
     // reused tensors: stem conv is conv1d_1_w/b, feature aggregation is conv_out_w/b, output proj is mm_fc_w/b

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -1783,6 +1783,51 @@ struct clip_model_loader {
                         hparams.audio_n_fft        = 400;
                         hparams.audio_window_len   = 400;
                         hparams.audio_hop_len      = 160;
+
+                        if (model.proj_type == PROJECTOR_TYPE_QWEN3A) {
+                            get_bool(KEY_A_GT_ASR_ENABLED, hparams.gt_asr_enabled, false);
+                            if (hparams.gt_asr_enabled) {
+                                get_u32(KEY_A_GT_ASR_SCHEMA,      hparams.gt_asr_schema_version);
+                                get_u32(KEY_A_GT_ASR_STAGE,       hparams.gt_asr_stage);
+                                get_u32(KEY_A_GT_ASR_ENCODER_DIM, hparams.gt_asr_encoder_dim);
+                                get_u32(KEY_A_GT_ASR_TEXT_DIM,    hparams.gt_asr_text_dim);
+                                get_u32(KEY_A_GT_ASR_HIDDEN_DIM,  hparams.gt_asr_hidden_dim);
+                                get_u32(KEY_A_GT_ASR_CONV_KERNEL, hparams.gt_asr_conv_kernel_size);
+                                get_u32(KEY_A_GT_ASR_HEAD_COUNT,  hparams.gt_asr_head_count);
+                                get_u32(KEY_A_GT_ASR_FFN_DIM,     hparams.gt_asr_ffn_dim);
+                                get_f32(KEY_A_GT_ASR_NORM_EPS,    hparams.gt_asr_norm_eps);
+                                get_f32(KEY_A_GT_ASR_MAX_SCALE,   hparams.gt_asr_max_residual_scale);
+                                get_bool(KEY_A_GT_ASR_LOCAL,       hparams.gt_asr_local_fusion);
+                                get_bool(KEY_A_GT_ASR_LOCAL_GATE,  hparams.gt_asr_local_uncertainty_gate);
+                                get_bool(KEY_A_GT_ASR_FRAME_HEAD,  hparams.gt_asr_nonlinear_frame_head);
+                                get_bool(KEY_A_GT_ASR_ZERO_ANCHOR, hparams.gt_asr_global_zero_anchor);
+                                get_bool(KEY_A_GT_ASR_NULL_MIXTURE, hparams.gt_asr_null_mixture);
+                                std::vector<int> gt_asr_eos_token_ids;
+                                get_arr_int(KEY_A_GT_ASR_EOS_IDS, gt_asr_eos_token_ids);
+                                hparams.gt_asr_eos_token_ids.assign(
+                                    gt_asr_eos_token_ids.begin(), gt_asr_eos_token_ids.end());
+
+                                const bool supported =
+                                    hparams.gt_asr_schema_version == 1 &&
+                                    hparams.gt_asr_stage == 2 &&
+                                    hparams.gt_asr_encoder_dim == 1024 &&
+                                    hparams.gt_asr_text_dim == 2048 &&
+                                    hparams.gt_asr_hidden_dim == 256 &&
+                                    hparams.gt_asr_conv_kernel_size == 5 &&
+                                    hparams.gt_asr_head_count == 4 &&
+                                    hparams.gt_asr_ffn_dim == 1024 &&
+                                    hparams.gt_asr_local_fusion &&
+                                    hparams.gt_asr_local_uncertainty_gate &&
+                                    hparams.gt_asr_nonlinear_frame_head &&
+                                    hparams.gt_asr_global_zero_anchor &&
+                                    hparams.gt_asr_null_mixture &&
+                                    hparams.gt_asr_eos_token_ids.size() == 2;
+                                if (!supported) {
+                                    throw std::runtime_error("unsupported Qwen3-ASR GT-ASR contract");
+                                }
+                                LOG_INF("%s: Qwen3-ASR GT-ASR stage %d enabled\n", __func__, hparams.gt_asr_stage);
+                            }
+                        }
                     } break;
                 case PROJECTOR_TYPE_MIMO_AUDIO:
                     {
@@ -2861,6 +2906,50 @@ struct clip_model_loader {
                     model.mm_1_b = get_tensor(string_format(TN_MM_AUDIO_MLP, 1, "bias"));
                     model.mm_2_w = get_tensor(string_format(TN_MM_AUDIO_MLP, 2, "weight"));
                     model.mm_2_b = get_tensor(string_format(TN_MM_AUDIO_MLP, 2, "bias"));
+
+                    if (hparams.gt_asr_enabled) {
+                        model.gt_asr_input_norm_w = get_tensor(string_format(TN_A_GT_ASR, "input_norm.weight"));
+                        model.gt_asr_input_norm_b = get_tensor(string_format(TN_A_GT_ASR, "input_norm.bias"));
+                        for (int i = 0; i < 2; ++i) {
+                            model.gt_asr_temporal_w[i] = get_tensor(string_format(TN_A_GT_ASR, string_format("temporal.%d.weight", i).c_str()));
+                            model.gt_asr_temporal_b[i] = get_tensor(string_format(TN_A_GT_ASR, string_format("temporal.%d.bias", i).c_str()));
+                        }
+
+                        auto & layer = model.gt_asr_context;
+                        layer.q_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_q.weight"));
+                        layer.q_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_q.bias"));
+                        layer.k_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_k.weight"));
+                        layer.k_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_k.bias"));
+                        layer.v_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_v.weight"));
+                        layer.v_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_v.bias"));
+                        layer.o_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_out.weight"));
+                        layer.o_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_out.bias"));
+                        layer.ln_1_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_norm.weight"));
+                        layer.ln_1_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.attn_norm.bias"));
+                        layer.ff_up_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.ffn_up.weight"));
+                        layer.ff_up_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.ffn_up.bias"));
+                        layer.ff_down_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.ffn_down.weight"));
+                        layer.ff_down_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.ffn_down.bias"));
+                        layer.ln_2_w = get_tensor(string_format(TN_A_GT_ASR, "blk.0.ffn_norm.weight"));
+                        layer.ln_2_b = get_tensor(string_format(TN_A_GT_ASR, "blk.0.ffn_norm.bias"));
+
+                        model.gt_asr_output_norm_w = get_tensor(string_format(TN_A_GT_ASR, "output_norm.weight"));
+                        model.gt_asr_output_norm_b = get_tensor(string_format(TN_A_GT_ASR, "output_norm.bias"));
+                        model.gt_asr_frame_confidence_w = get_tensor(string_format(TN_A_GT_ASR, "frame_confidence.weight"));
+                        model.gt_asr_frame_confidence_b = get_tensor(string_format(TN_A_GT_ASR, "frame_confidence.bias"));
+                        model.gt_asr_global_uncertainty_w = get_tensor(string_format(TN_A_GT_ASR, "global_uncertainty.weight"));
+                        model.gt_asr_global_uncertainty_b = get_tensor(string_format(TN_A_GT_ASR, "global_uncertainty.bias"));
+                        for (int i = 0; i < 2; ++i) {
+                            model.gt_asr_frame_evidence_w[i] = get_tensor(string_format(TN_A_GT_ASR, string_format("frame_evidence.%d.weight", i).c_str()));
+                            model.gt_asr_frame_evidence_b[i] = get_tensor(string_format(TN_A_GT_ASR, string_format("frame_evidence.%d.bias", i).c_str()));
+                            model.gt_asr_global_projection_w[i] = get_tensor(string_format(TN_A_GT_ASR, string_format("global_projection.%d.weight", i).c_str()));
+                            model.gt_asr_global_projection_b[i] = get_tensor(string_format(TN_A_GT_ASR, string_format("global_projection.%d.bias", i).c_str()));
+                        }
+                        model.gt_asr_local_projection_w = get_tensor(string_format(TN_A_GT_ASR, "local_projection.weight"));
+                        model.gt_asr_local_projection_b = get_tensor(string_format(TN_A_GT_ASR, "local_projection.bias"));
+                        model.gt_asr_local_scale_raw = get_tensor(string_format(TN_A_GT_ASR, "local_scale_raw"));
+                        model.gt_asr_global_scale_raw = get_tensor(string_format(TN_A_GT_ASR, "global_scale_raw"));
+                    }
                 } break;
             case PROJECTOR_TYPE_MIMO_AUDIO:
                 {
@@ -4252,7 +4341,12 @@ int clip_n_output_tokens(const clip_ctx * ctx, const clip_image_f32 * img) {
                 // chunk_size=100 frames --> 3x stride-2 conv2d --> 13 tokens per chunk
                 const int chunk_size       = 100;
                 const int tokens_per_chunk = 13;
-                n_patches = (img->nx() / chunk_size) * tokens_per_chunk;
+                const int n_frames = ctx->model.hparams.gt_asr_enabled ? img->audio_n_frames() : img->nx();
+                const int tail_frames = n_frames % chunk_size;
+                n_patches = (n_frames / chunk_size) * tokens_per_chunk;
+                if (tail_frames > 0) {
+                    n_patches += (tail_frames + 7) / 8;
+                }
             } break;
         case PROJECTOR_TYPE_GLMA:
             {
@@ -4395,11 +4489,12 @@ bool clip_image_encode(struct clip_ctx * ctx, int n_threads, const clip_image_f3
     return clip_image_batch_encode(ctx, n_threads, &imgs, out_vec);
 }
 
-bool clip_image_batch_encode(clip_ctx * ctx, int n_threads, const clip_image_f32_batch * imgs_c_ptr, std::vector<float> & out_batch_embd) {
+bool clip_image_batch_encode(clip_ctx * ctx, int n_threads, const clip_image_f32_batch * imgs_c_ptr, std::vector<float> & out_batch_embd, float * out_speech_probability) {
     clip_encode_params params;
     params.imgs = imgs_c_ptr;
     params.n_threads = n_threads;
     params.out_embd = &out_batch_embd;
+    params.out_speech_probability = out_speech_probability;
 
     return clip_encode(ctx, &params);
 }
@@ -5781,6 +5876,15 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
         }
     }
 
+    if (params->out_speech_probability != nullptr) {
+        ggml_tensor * probability = ggml_graph_get_tensor(gf, "gt_asr_speech_probability");
+        if (probability == nullptr || ggml_nelements(probability) != 1) {
+            LOG_ERR("%s: GT-ASR speech probability output is missing or invalid\n", __func__);
+            return false;
+        }
+        ggml_backend_tensor_get(probability, params->out_speech_probability, 0, sizeof(float));
+    }
+
     //
     // for audio gen models
     //
@@ -6022,6 +6126,14 @@ bool clip_has_vision_encoder(const struct clip_ctx * ctx) {
 
 bool clip_has_audio_encoder(const struct clip_ctx * ctx) {
     return ctx->model.modality == CLIP_MODALITY_AUDIO;
+}
+
+bool clip_has_speech_probability(const struct clip_ctx * ctx) {
+    return ctx->model.hparams.gt_asr_enabled;
+}
+
+const std::vector<int32_t> & clip_get_speech_probability_eos_token_ids(const struct clip_ctx * ctx) {
+    return ctx->model.hparams.gt_asr_eos_token_ids;
 }
 
 bool clip_support_batch(const struct clip_ctx * ctx) {

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -85,7 +85,7 @@ int clip_n_mmproj_embd(const struct clip_ctx * ctx);
 
 // TODO: remove clip_image_encode() and always use batched version
 bool clip_image_encode      (struct clip_ctx * ctx, int n_threads, const clip_image_f32 * img, std::vector<float> & out_vec);
-bool clip_image_batch_encode(struct clip_ctx * ctx, int n_threads, const struct clip_image_f32_batch * imgs, std::vector<float> & out_batch_embd);
+bool clip_image_batch_encode(struct clip_ctx * ctx, int n_threads, const struct clip_image_f32_batch * imgs, std::vector<float> & out_batch_embd, float * out_speech_probability = nullptr);
 
 enum clip_gen_process_type {
     CLIP_GEN_PROCESS_GEN_UNKNOWN,
@@ -96,6 +96,7 @@ struct clip_encode_params {
     int n_threads = 1;
     const clip_image_f32_batch * imgs = nullptr;
     std::vector<float> * out_embd = nullptr;
+    float * out_speech_probability = nullptr;
 
     // for audio gen, imgs has exactly one entry: hidden state from backbone (GEN_CODE) or unused (GEN_WAV)
     clip_gen_process_type gen_process = CLIP_GEN_PROCESS_GEN_UNKNOWN;
@@ -125,6 +126,8 @@ bool clip_is_llava(const struct clip_ctx * ctx);
 
 bool clip_has_vision_encoder(const struct clip_ctx * ctx);
 bool clip_has_audio_encoder(const struct clip_ctx * ctx);
+bool clip_has_speech_probability(const struct clip_ctx * ctx);
+const std::vector<int32_t> & clip_get_speech_probability_eos_token_ids(const struct clip_ctx * ctx);
 
 bool clip_support_batch(const struct clip_ctx * ctx);
 

--- a/tools/mtmd/models/qwen3a.cpp
+++ b/tools/mtmd/models/qwen3a.cpp
@@ -1,5 +1,7 @@
 #include "models.h"
 
+#include <cstdlib>
+
 ggml_cgraph * clip_graph_qwen3a::build() {
     // Ref implementation: https://github.com/QwenLM/Qwen3-ASR/blob/main/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py
 
@@ -10,8 +12,13 @@ ggml_cgraph * clip_graph_qwen3a::build() {
     const int64_t n_mel      = inp->ne[1]; // 128
     const int64_t chunk_size = 100;        // n_window * 2 (n_window=50 from model config)
     const int64_t n_chunks   = n_frames / chunk_size;
+    const int64_t n_valid_frames = hparams.gt_asr_enabled ? img.audio_n_frames() : n_frames;
+    const int64_t n_tail_frames = n_valid_frames % chunk_size;
+    const int64_t n_valid_tokens =
+        (n_valid_frames / chunk_size) * 13 + (n_tail_frames > 0 ? (n_tail_frames + 7) / 8 : 0);
 
     GGML_ASSERT(n_frames % chunk_size == 0); // preprocessor should already pad the input
+    GGML_ASSERT(n_valid_frames > 0 && n_valid_frames <= n_frames);
     GGML_ASSERT(inp->type == GGML_TYPE_F32);
 
     // View mel spectrogram as batched 100-frame chunks: [chunk_size, n_mel, 1, n_chunks]
@@ -55,25 +62,57 @@ ggml_cgraph * clip_graph_qwen3a::build() {
     }
     cb(inp, "after_conv_out", -1);
 
-    const int64_t n_pos = inp->ne[1]; // 25 * n_chunks
+    const int64_t n_pos_padded = inp->ne[1];
 
     // Per-chunk positional embeddings: repeat pos[0:13] for each chunk
     // (position indices reset 0..12 per chunk, not sequential across chunks)
     {
-        const int64_t tokens_per_chunk = n_pos / n_chunks; // 13
+        const int64_t tokens_per_chunk = n_pos_padded / n_chunks; // 13
         ggml_tensor * pos_tmp = ggml_view_2d(ctx0, model.position_embeddings,
             model.position_embeddings->ne[0], tokens_per_chunk,
             model.position_embeddings->nb[1], 0);
         ggml_tensor * tgt = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32,
-            model.position_embeddings->ne[0], n_pos);
+            model.position_embeddings->ne[0], n_pos_padded);
         inp = ggml_add(ctx0, inp, ggml_repeat(ctx0, pos_tmp, tgt));
+    }
+
+    int64_t n_pos = n_pos_padded;
+    if (hparams.gt_asr_enabled) {
+        GGML_ASSERT(n_valid_tokens > 0 && n_valid_tokens <= n_pos_padded);
+        n_pos = n_valid_tokens;
+        if (n_pos != n_pos_padded) {
+            inp = ggml_cont(ctx0, ggml_view_2d(ctx0, inp, inp->ne[0], n_pos, inp->nb[1], 0));
+        }
+    }
+
+    const bool gt_asr_debug = hparams.gt_asr_enabled &&
+        std::getenv("MTMD_GT_ASR_DEBUG_DIR") != nullptr;
+    auto keep_gt_asr_debug_output = [&](ggml_tensor * tensor) {
+        if (gt_asr_debug) {
+            ggml_set_output(tensor);
+        }
+    };
+    if (gt_asr_debug) {
+        ggml_tensor * debug_transformer_input = ggml_dup(ctx0, inp);
+        cb(debug_transformer_input, "audio_transformer_input", -1);
+        ggml_set_output(debug_transformer_input);
+        ggml_build_forward_expand(gf, debug_transformer_input);
     }
 
     ggml_tensor * cur = build_vit(inp, n_pos,
         NORM_TYPE_NORMAL, hparams.ffn_op,
         nullptr,  // pos embd already added above
         nullptr);
-    cb(cur, "after_transformer", -1);
+    if (gt_asr_debug) {
+        ggml_tensor * debug_encoder_states = ggml_dup(ctx0, cur);
+        cb(debug_encoder_states, "after_transformer", -1);
+        ggml_set_output(debug_encoder_states);
+        ggml_build_forward_expand(gf, debug_encoder_states);
+    } else {
+        cb(cur, "after_transformer", -1);
+    }
+
+    ggml_tensor * encoder_states = cur;
 
     // MLP projector
     cur = build_ffn(cur,
@@ -82,6 +121,186 @@ ggml_cgraph * clip_graph_qwen3a::build() {
         model.mm_2_w, model.mm_2_b,
         FFN_GELU_ERF, -1);
     cb(cur, "projected", -1);
+    keep_gt_asr_debug_output(cur);
+
+    if (hparams.gt_asr_enabled) {
+        const int64_t n_tokens = encoder_states->ne[1];
+        const int64_t hidden_dim = hparams.gt_asr_hidden_dim;
+        const int64_t head_dim = hidden_dim / hparams.gt_asr_head_count;
+        const auto & layer = model.gt_asr_context;
+
+        auto linear = [&](ggml_tensor * x, ggml_tensor * weight, ggml_tensor * bias) {
+            x = build_mm(weight, x);
+            return bias ? ggml_add(ctx0, x, bias) : x;
+        };
+
+        ggml_tensor * features = ggml_reshape_2d(ctx0, encoder_states, hparams.gt_asr_encoder_dim, n_tokens);
+        features = build_norm(
+            features,
+            model.gt_asr_input_norm_w,
+            model.gt_asr_input_norm_b,
+            NORM_TYPE_NORMAL,
+            hparams.gt_asr_norm_eps,
+            -1);
+
+        features = ggml_cont(ctx0, ggml_transpose(ctx0, features));
+        features = ggml_reshape_3d(ctx0, features, n_tokens, hparams.gt_asr_encoder_dim, 1);
+        for (int i = 0; i < 2; ++i) {
+            features = ggml_conv_1d(
+                ctx0,
+                model.gt_asr_temporal_w[i],
+                features,
+                1,
+                hparams.gt_asr_conv_kernel_size / 2,
+                1);
+            features = ggml_add(
+                ctx0,
+                features,
+                ggml_reshape_3d(ctx0, model.gt_asr_temporal_b[i], 1, hidden_dim, 1));
+            features = ggml_gelu_erf(ctx0, features);
+        }
+        features = ggml_reshape_2d(ctx0, features, n_tokens, hidden_dim);
+        features = ggml_cont(ctx0, ggml_transpose(ctx0, features));
+        cb(features, "gt_asr_after_temporal", -1);
+        keep_gt_asr_debug_output(features);
+
+        ggml_tensor * residual = features;
+        ggml_tensor * normalized = build_norm(
+            features,
+            layer.ln_1_w,
+            layer.ln_1_b,
+            NORM_TYPE_NORMAL,
+            hparams.gt_asr_norm_eps,
+            -1);
+        ggml_tensor * q = linear(normalized, layer.q_w, layer.q_b);
+        ggml_tensor * k = linear(normalized, layer.k_w, layer.k_b);
+        ggml_tensor * v = linear(normalized, layer.v_w, layer.v_b);
+        q = ggml_reshape_4d(ctx0, q, head_dim, hparams.gt_asr_head_count, n_tokens, 1);
+        k = ggml_reshape_4d(ctx0, k, head_dim, hparams.gt_asr_head_count, n_tokens, 1);
+        v = ggml_reshape_4d(ctx0, v, head_dim, hparams.gt_asr_head_count, n_tokens, 1);
+        features = build_attn(
+            layer.o_w,
+            layer.o_b,
+            q,
+            k,
+            v,
+            nullptr,
+            1.0f / std::sqrt((float) head_dim),
+            -1);
+        features = ggml_add(ctx0, features, residual);
+
+        residual = features;
+        features = build_norm(
+            features,
+            layer.ln_2_w,
+            layer.ln_2_b,
+            NORM_TYPE_NORMAL,
+            hparams.gt_asr_norm_eps,
+            -1);
+        features = build_ffn(
+            features,
+            layer.ff_up_w,
+            layer.ff_up_b,
+            nullptr,
+            nullptr,
+            layer.ff_down_w,
+            layer.ff_down_b,
+            FFN_GELU_ERF,
+            -1);
+        features = ggml_add(ctx0, features, residual);
+        features = build_norm(
+            features,
+            model.gt_asr_output_norm_w,
+            model.gt_asr_output_norm_b,
+            NORM_TYPE_NORMAL,
+            hparams.gt_asr_norm_eps,
+            -1);
+        cb(features, "gt_asr_features", -1);
+        keep_gt_asr_debug_output(features);
+
+        ggml_tensor * frame_confidence = linear(
+            features,
+            model.gt_asr_frame_confidence_w,
+            model.gt_asr_frame_confidence_b);
+        frame_confidence = ggml_sigmoid(ctx0, frame_confidence);
+        cb(frame_confidence, "gt_asr_frame_confidence", -1);
+        keep_gt_asr_debug_output(frame_confidence);
+
+        ggml_tensor * pooled = ggml_cont(ctx0, ggml_transpose(ctx0, features));
+        pooled = ggml_mean(ctx0, pooled);
+        pooled = ggml_cont(ctx0, ggml_transpose(ctx0, pooled));
+        ggml_tensor * global_uncertainty = linear(
+            pooled,
+            model.gt_asr_global_uncertainty_w,
+            model.gt_asr_global_uncertainty_b);
+        global_uncertainty = ggml_sigmoid(ctx0, global_uncertainty);
+        cb(global_uncertainty, "gt_asr_global_uncertainty", -1);
+        keep_gt_asr_debug_output(global_uncertainty);
+
+        ggml_tensor * frame_evidence = linear(
+            features,
+            model.gt_asr_frame_evidence_w[0],
+            model.gt_asr_frame_evidence_b[0]);
+        frame_evidence = ggml_gelu_erf(ctx0, frame_evidence);
+        frame_evidence = linear(
+            frame_evidence,
+            model.gt_asr_frame_evidence_w[1],
+            model.gt_asr_frame_evidence_b[1]);
+        cb(frame_evidence, "gt_asr_frame_evidence", -1);
+        keep_gt_asr_debug_output(frame_evidence);
+        frame_evidence = ggml_cont(ctx0, ggml_transpose(ctx0, frame_evidence));
+        ggml_tensor * speech_probability = ggml_sigmoid(ctx0, ggml_mean(ctx0, frame_evidence));
+        ggml_set_name(speech_probability, "gt_asr_speech_probability");
+        ggml_set_output(speech_probability);
+        ggml_build_forward_expand(gf, speech_probability);
+
+        auto global_projection = [&](ggml_tensor * uncertainty) {
+            ggml_tensor * projected = linear(
+                uncertainty,
+                model.gt_asr_global_projection_w[0],
+                model.gt_asr_global_projection_b[0]);
+            projected = ggml_gelu_erf(ctx0, projected);
+            return linear(
+                projected,
+                model.gt_asr_global_projection_w[1],
+                model.gt_asr_global_projection_b[1]);
+        };
+        ggml_tensor * global_delta = global_projection(global_uncertainty);
+        ggml_tensor * global_zero = global_projection(ggml_scale(ctx0, global_uncertainty, 0.0f));
+        global_delta = ggml_sub(ctx0, global_delta, global_zero);
+        ggml_tensor * global_scale = ggml_scale(
+            ctx0,
+            ggml_tanh(ctx0, model.gt_asr_global_scale_raw),
+            hparams.gt_asr_max_residual_scale);
+        global_delta = ggml_mul(ctx0, global_delta, global_scale);
+        cb(global_delta, "gt_asr_global_delta", -1);
+        keep_gt_asr_debug_output(global_delta);
+        global_delta = ggml_repeat(ctx0, global_delta, cur);
+
+        ggml_tensor * local_gate = ggml_scale(ctx0, frame_confidence, -1.0f);
+        ggml_tensor * local_gate_one = ggml_fill(
+            ctx0,
+            ggml_dup(ctx0, frame_confidence),
+            1.0f);
+        local_gate = ggml_add(ctx0, local_gate, local_gate_one);
+        ggml_tensor * local_delta = linear(
+            features,
+            model.gt_asr_local_projection_w,
+            model.gt_asr_local_projection_b);
+        local_gate = ggml_repeat(ctx0, local_gate, local_delta);
+        local_delta = ggml_mul(ctx0, local_delta, local_gate);
+        ggml_tensor * local_scale = ggml_scale(
+            ctx0,
+            ggml_tanh(ctx0, model.gt_asr_local_scale_raw),
+            hparams.gt_asr_max_residual_scale);
+        local_delta = ggml_mul(ctx0, local_delta, local_scale);
+        cb(local_delta, "gt_asr_local_delta", -1);
+        keep_gt_asr_debug_output(local_delta);
+
+        cur = ggml_add(ctx0, cur, ggml_add(ctx0, global_delta, local_delta));
+        cb(cur, "gt_asr_fused", -1);
+        keep_gt_asr_debug_output(cur);
+    }
 
     ggml_build_forward_expand(gf, cur);
     return gf;

--- a/tools/mtmd/mtmd-audio.cpp
+++ b/tools/mtmd/mtmd-audio.cpp
@@ -2,6 +2,7 @@
 
 #define _USE_MATH_DEFINES // for M_PI
 #include <cmath>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <thread>
@@ -646,6 +647,21 @@ bool mtmd_audio_preprocessor_qwen3a::preprocess(const float *                 sa
     GGML_ASSERT(!cache.cos_vals.empty());
     GGML_ASSERT(!cache.filters.data.empty());
 
+    const bool gt_asr_enabled = hparams.gt_asr_enabled;
+    const char * gt_asr_debug_dir = gt_asr_enabled ? std::getenv("MTMD_GT_ASR_DEBUG_DIR") : nullptr;
+    if (gt_asr_debug_dir != nullptr) {
+        const std::string base = std::string(gt_asr_debug_dir) + "/mel_filters";
+        std::ofstream data_file(base + ".f32", std::ios::binary);
+        if (data_file.is_open()) {
+            data_file.write(
+                reinterpret_cast<const char *>(cache.filters.data.data()),
+                cache.filters.data.size() * sizeof(float));
+        }
+        std::ofstream shape_file(base + ".shape");
+        shape_file << (hparams.audio_n_fft / 2 + 1) << " "
+                   << hparams.n_mel_bins << " 1 1\n";
+    }
+
     // Reflection-pad n_fft/2 samples at each end, matching WhisperFeatureExtractor center=True
     const int pad = hparams.audio_n_fft / 2; // = 200
 
@@ -670,6 +686,9 @@ bool mtmd_audio_preprocessor_qwen3a::preprocess(const float *                 sa
     params.sample_rate      = hparams.audio_sample_rate;
     params.no_padding       = true; // reflection padding already applied above
     params.use_natural_log  = false; // log10
+    if (gt_asr_enabled) {
+        params.mel_floor = 1.0e-10f; // WhisperFeatureExtractor clamp minimum
+    }
 
     mtmd_audio_mel mel_full;
     bool ok = log_mel_spectrogram(padded.data(), (int)padded.size(), 4, params, cache, mel_full);
@@ -677,28 +696,52 @@ bool mtmd_audio_preprocessor_qwen3a::preprocess(const float *                 sa
         return false;
     }
 
-    // Whisper-style normalization: clamp to (max - 8), scale to [-1, 1]
-    {
+    int64_t n_eff;
+    if (gt_asr_enabled) {
+        // torch.stft(center=True) produces one terminal frame that Whisper drops
+        // before the mel projection. Keep the same effective frame count here.
+        n_eff = std::min(
+            mel_full.n_len,
+            (int64_t)(n_samples / hparams.audio_hop_len));
+
+        // The dropped terminal frame must not influence normalization.
         double mmax = -1e20;
-        for (float v : mel_full.data) {
-            if (v > mmax) mmax = v;
+        for (int64_t m = 0; m < mel_full.n_mel; ++m) {
+            for (int64_t t = 0; t < n_eff; ++t) {
+                mmax = std::max(
+                    mmax,
+                    (double)mel_full.data[(size_t)m * mel_full.n_len + t]);
+            }
         }
         mmax -= 8.0;
-        for (float & v : mel_full.data) {
-            v = (std::max((double)v, mmax) + 4.0) / 4.0;
+        for (int64_t m = 0; m < mel_full.n_mel; ++m) {
+            for (int64_t t = 0; t < n_eff; ++t) {
+                float & value = mel_full.data[(size_t)m * mel_full.n_len + t];
+                value = (std::max((double)value, mmax) + 4.0) / 4.0;
+            }
         }
+    } else {
+        double mmax = -1e20;
+        for (float value : mel_full.data) {
+            mmax = std::max(mmax, (double)value);
+        }
+        mmax -= 8.0;
+        for (float & value : mel_full.data) {
+            value = (std::max((double)value, mmax) + 4.0) / 4.0;
+        }
+
+        n_eff = std::min(
+            mel_full.n_len,
+            (int64_t)(n_samples / hparams.audio_hop_len) + 1);
+    }
+    if (n_eff <= 0) {
+        return false;
     }
 
-    // The effective frame count: center-padded STFT gives ~n_samples/hop_length frames.
-    // We take min(mel_full.n_len, n_samples/hop + 1) to avoid including excess frames.
-    const int64_t n_eff = std::min(mel_full.n_len,
-                               (int64_t)(n_samples / hparams.audio_hop_len) + 1);
-
-    // Split into inference windows matching n_window_infer=800 from model config.
-    // Each window is padded to the next multiple of chunk_size for the cgraph.
-    // The mtmd caller loops over output entries, so long audio is handled automatically.
-    const int chunk_size  = 100; // conv sub-chunk size (n_window * 2, n_window=50)
-    const int window_size = 800; // mel frames per forward pass (n_window_infer=800)
+    // Stock inference uses separate 800-frame windows. GT-ASR keeps one packed
+    // utterance so its adapter sees the same sequence as the PyTorch runtime.
+    const int chunk_size = 100; // conv sub-chunk size (n_window * 2, n_window=50)
+    const int64_t window_size = gt_asr_enabled ? n_eff : 800;
 
     for (int64_t off = 0; off < n_eff; off += window_size) {
         const int64_t win_eff  = std::min((int64_t)window_size, n_eff - off);
@@ -717,6 +760,18 @@ bool mtmd_audio_preprocessor_qwen3a::preprocess(const float *                 sa
                           mel_full.data.begin() + (size_t)m * mel_full.n_len + off + copy_len,
                           out.data.begin()      + (size_t)m * out.n_len);
             }
+        }
+        if (gt_asr_debug_dir != nullptr) {
+            const std::string base = std::string(gt_asr_debug_dir) +
+                "/mel_input_" + std::to_string(off / window_size);
+            std::ofstream data_file(base + ".f32", std::ios::binary);
+            if (data_file.is_open()) {
+                data_file.write(
+                    reinterpret_cast<const char *>(out.data.data()),
+                    out.data.size() * sizeof(float));
+            }
+            std::ofstream shape_file(base + ".shape");
+            shape_file << out.n_len << " " << out.n_mel << " 1 1\n";
         }
         output.push_back(std::move(out));
     }

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -420,6 +420,8 @@ struct mtmd_batch {
     mtmd_context * ctx;
     std::vector<const mtmd_input_chunk *> entries;
     std::vector<float> output_embd; // aggregated output embedding for the whole batch
+    float output_speech_probability = 0.0f;
+    bool has_output_speech_probability = false;
     mtmd_batch(mtmd_context * ctx): ctx(ctx) {}
     int32_t n_tokens() const {
         int32_t n = 0;
@@ -1796,7 +1798,11 @@ static int32_t mtmd_encode_impl(mtmd_context * ctx, const mtmd_image_tokens * im
     return ok ? 0 : 1;
 }
 
-static int32_t mtmd_encode_chunk_impl(mtmd_context * ctx, const mtmd_input_chunk * chunk, std::vector<float> & out_embd) {
+static int32_t mtmd_encode_chunk_impl(
+        mtmd_context * ctx,
+        const mtmd_input_chunk * chunk,
+        std::vector<float> & out_embd,
+        float * out_speech_probability = nullptr) {
     if (chunk->type == MTMD_INPUT_CHUNK_TYPE_TEXT) {
         LOG_WRN("mtmd_encode_chunk has no effect for text chunks\n");
         return 0;
@@ -1833,7 +1839,8 @@ static int32_t mtmd_encode_chunk_impl(mtmd_context * ctx, const mtmd_input_chunk
             ctx->ctx_a,
             ctx->n_threads,
             &chunk->tokens_audio->batch_f32,
-            out_embd);
+            out_embd,
+            out_speech_probability);
         return ok ? 0 : 1;
     }
 
@@ -2131,15 +2138,24 @@ static int32_t mtmd_batch_encode_impl(mtmd_batch * batch) {
 
     LOG_DBG("%s: encoding batch with %zu entries and total %zu tokens\n",
             __func__, batch->entries.size(), mtmd_input_chunk_get_n_tokens(batch_chunk.get()));
+    batch->has_output_speech_probability = mtmd_support_speech_probability(batch->ctx);
     int32_t res = mtmd_encode_chunk_impl(
         batch->ctx,
         batch_chunk.get(),
-        batch->output_embd);
+        batch->output_embd,
+        batch->has_output_speech_probability ? &batch->output_speech_probability : nullptr);
+    if (res != 0) {
+        batch->has_output_speech_probability = false;
+    }
     return res;
 }
 
 int32_t mtmd_batch_encode(mtmd_batch * batch) {
     try {
+        if (mtmd_support_speech_probability(batch->ctx) && batch->entries.size() != 1) {
+            LOG_ERR("%s: speech-probability models require exactly one audio chunk per batch\n", __func__);
+            return 1;
+        }
         return mtmd_batch_encode_impl(batch);
     } catch (const std::exception & e) {
         LOG_ERR("%s: error: %s\n", __func__, e.what());
@@ -2165,6 +2181,23 @@ float * mtmd_batch_get_output_embd(mtmd_batch * batch, const mtmd_input_chunk * 
         }
     }
     return nullptr; // not found
+}
+
+bool mtmd_batch_get_output_speech_probability(
+        mtmd_batch * batch,
+        const mtmd_input_chunk * chunk,
+        struct mtmd_speech_probability * output) {
+    if (!batch->has_output_speech_probability ||
+        output == nullptr ||
+        batch->entries.size() != 1 ||
+        batch->entries[0] != chunk) {
+        return false;
+    }
+    const auto & eos_token_ids = clip_get_speech_probability_eos_token_ids(batch->ctx->ctx_a);
+    output->value = batch->output_speech_probability;
+    output->eos_token_ids = eos_token_ids.data();
+    output->n_eos_token_ids = eos_token_ids.size();
+    return true;
 }
 
 bool mtmd_decode_use_non_causal(const mtmd_context * ctx, const mtmd_input_chunk * chunk) {
@@ -2195,6 +2228,10 @@ bool mtmd_support_vision(const mtmd_context * ctx) {
 
 bool mtmd_support_audio(const mtmd_context * ctx) {
     return ctx->ctx_a != nullptr;
+}
+
+bool mtmd_support_speech_probability(const mtmd_context * ctx) {
+    return ctx->ctx_a && clip_has_speech_probability(ctx->ctx_a);
 }
 
 int mtmd_get_audio_sample_rate(const mtmd_context * ctx) {

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -66,6 +66,12 @@ struct mtmd_input_chunk;
 struct mtmd_input_chunks;
 struct mtmd_batch;
 
+struct mtmd_speech_probability {
+    float value;
+    const int32_t * eos_token_ids;
+    size_t n_eos_token_ids;
+};
+
 struct mtmd_input_text {
     const char * text;
     size_t text_len;
@@ -148,6 +154,9 @@ MTMD_API bool mtmd_support_vision(const mtmd_context * ctx);
 
 // whether the current model supports audio input
 MTMD_API bool mtmd_support_audio(const mtmd_context * ctx);
+
+// Whether audio encoding produces a speech probability for first-token sampling.
+MTMD_API bool mtmd_support_speech_probability(const mtmd_context * ctx);
 
 // get audio sample rate in Hz, for example 16000 for Whisper
 // return -1 if audio is not supported
@@ -349,6 +358,10 @@ MTMD_API int32_t mtmd_batch_add_chunk(mtmd_batch * batch, const mtmd_input_chunk
 // returns 1 on generic error
 MTMD_API int32_t mtmd_batch_encode(mtmd_batch * batch);
 MTMD_API float * mtmd_batch_get_output_embd(mtmd_batch * batch, const mtmd_input_chunk * chunk);
+MTMD_API bool mtmd_batch_get_output_speech_probability(
+    mtmd_batch * batch,
+    const mtmd_input_chunk * chunk,
+    struct mtmd_speech_probability * output);
 
 
 // Set callback for all future logging events.

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -18,6 +18,7 @@
 #include "mtmd-helper.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cinttypes>
 #include <exception>
@@ -26,6 +27,7 @@
 #include <random>
 #include <utility>
 #include <fstream>
+#include <limits>
 
 // fix problem with std::min and std::max
 #if defined(_WIN32)
@@ -287,6 +289,10 @@ struct server_slot {
     bool has_new_line   = false;
     bool truncated      = false;
 
+    bool has_speech_probability = false;
+    float speech_probability = 0.0f;
+    std::vector<llama_token> speech_probability_eos_token_ids;
+
     stop_type stop;
 
     std::string stopping_word;
@@ -387,6 +393,9 @@ struct server_slot {
         generated_tokens.clear();
         generated_token_probs.clear();
         json_schema = json();
+        has_speech_probability = false;
+        speech_probability = 0.0f;
+        speech_probability_eos_token_ids.clear();
 
         task_prev = std::move(task);
         task.reset();
@@ -468,7 +477,7 @@ struct server_slot {
     }
 
     bool can_speculate() const {
-        return !!spec;
+        return !!spec && !(mctx && mtmd_support_speech_probability(mctx));
     }
 
     void add_token(const completion_token_output & token) {
@@ -728,6 +737,9 @@ struct server_slot {
         other.i_batch = i_batch;
 
         other.stats = stats;
+        other.has_speech_probability = has_speech_probability;
+        other.speech_probability = speech_probability;
+        other.speech_probability_eos_token_ids = speech_probability_eos_token_ids;
 
         other.prompt = prompt.clone();
         other.init_sampler();
@@ -739,7 +751,7 @@ struct server_slot {
 // note: this is not a member of server_slot because we want to run it inside yield_to_queue
 //       slot is passed as const to avoid accidental modification of the slot state
 //       some pointers are allowed to be used, they are not used by to_json()
-static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch, size_t idx, size_t & n_tokens_out) {
+static int process_mtmd_chunk(server_slot & slot, mtmd::batch_ptr & mbatch, size_t idx, size_t & n_tokens_out) {
     GGML_ASSERT(slot.mctx);
     const auto & mctx = slot.mctx;
     const auto & input_tokens = slot.task->tokens;
@@ -750,8 +762,25 @@ static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch
         if (mbatch) {
             float * embd = mtmd_batch_get_output_embd(mbatch.get(), chunk.get());
             if (embd) {
-                void * cb_data = slot.spec;
+                struct mtmd_speech_probability probability;
+                if (mtmd_batch_get_output_speech_probability(mbatch.get(), chunk.get(), &probability)) {
+                    if (slot.has_speech_probability) {
+                        SLT_ERR(slot, "%s", "multiple GT-ASR audio inputs in one request are not supported\n");
+                        return -1;
+                    }
+                    slot.has_speech_probability = true;
+                    slot.speech_probability = probability.value;
+                    slot.speech_probability_eos_token_ids.assign(
+                        probability.eos_token_ids,
+                        probability.eos_token_ids + probability.n_eos_token_ids);
+                    SLT_DBG(slot, "GT-ASR speech probability = %.6f\n", slot.speech_probability);
+                }
+
+                void * cb_data = slot.can_speculate() ? slot.spec : nullptr;
                 static auto cb = [](llama_batch batch, void * user_data) {
+                    if (user_data == nullptr) {
+                        return 0;
+                    }
                     common_speculative * spec = static_cast<common_speculative *>(user_data);
                     if (!common_speculative_process(spec, batch)) {
                         return 1;
@@ -1790,6 +1819,9 @@ private:
             const bool need_pre_sample_logits = task.params.sampling.n_probs > 0 && !task.params.post_sampling_probs;
 
             bool use_backend_sampling = task.params.sampling.backend_sampling;
+
+            // GT-ASR needs to adjust the first-token logits after the audio encoder runs.
+            use_backend_sampling &= !(mctx && mtmd_support_speech_probability(mctx));
 
             // TODO: getting pre sampling logits is not yet supported with backend sampling
             use_backend_sampling &= !need_pre_sample_logits;
@@ -3837,6 +3869,68 @@ private:
             llama_token id;
             {
                 scoped_timer timer(t_sampl, n_sampl);
+                if (slot.stats.n_gen == 0 && slot.has_speech_probability) {
+                    if (slot.speech_probability_eos_token_ids.empty()) {
+                        throw std::runtime_error("GT-ASR speech probability has no EOS token IDs");
+                    }
+                    llama_synchronize(slot.ctx_tgt);
+                    float * logits = llama_get_logits_ith(slot.ctx_tgt, tok_idx);
+                    if (logits == nullptr) {
+                        throw std::runtime_error("GT-ASR first-token logits are unavailable");
+                    }
+                    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+                    const char * gt_asr_debug_logits_dir = std::getenv("GT_ASR_DEBUG_LOGITS_DIR");
+                    auto dump_gt_asr_logits = [&](const char * name) {
+                        if (gt_asr_debug_logits_dir == nullptr) {
+                            return;
+                        }
+                        const std::string base = std::string(gt_asr_debug_logits_dir) + "/" + name;
+                        std::ofstream data_file(base + ".f32", std::ios::binary);
+                        if (!data_file.is_open()) {
+                            SRV_ERR("cannot open GT-ASR debug logits output %s.f32\n", base.c_str());
+                            return;
+                        }
+                        data_file.write(
+                            reinterpret_cast<const char *>(logits),
+                            (size_t) n_vocab * sizeof(float));
+                        std::ofstream shape_file(base + ".shape");
+                        shape_file << n_vocab << " 1 1 1\n";
+                    };
+                    dump_gt_asr_logits("first_token_logits_raw");
+
+                    const float probability = std::clamp(
+                        slot.speech_probability,
+                        1.0e-7f,
+                        1.0f - 1.0e-7f);
+                    float max_logit = -std::numeric_limits<float>::infinity();
+                    for (int32_t i = 0; i < n_vocab; ++i) {
+                        max_logit = std::max(max_logit, logits[i]);
+                    }
+                    double sum_exp = 0.0;
+                    for (int32_t i = 0; i < n_vocab; ++i) {
+                        sum_exp += std::exp((double) logits[i] - max_logit);
+                    }
+                    const float log_normalizer = max_logit + std::log(sum_exp);
+                    const float speech_log_probability = std::log(probability);
+                    const float null_log_probability =
+                        std::log1p(-probability) -
+                        std::log((float) slot.speech_probability_eos_token_ids.size());
+                    for (int32_t i = 0; i < n_vocab; ++i) {
+                        logits[i] = logits[i] - log_normalizer + speech_log_probability;
+                    }
+                    for (llama_token eos_token_id : slot.speech_probability_eos_token_ids) {
+                        if (eos_token_id < 0 || eos_token_id >= n_vocab) {
+                            continue;
+                        }
+                        const float a = logits[eos_token_id];
+                        const float b = null_log_probability;
+                        const float maximum = std::max(a, b);
+                        logits[eos_token_id] = std::isinf(maximum)
+                            ? maximum
+                            : maximum + std::log(std::exp(a - maximum) + std::exp(b - maximum));
+                    }
+                    dump_gt_asr_logits("first_token_logits_adjusted");
+                }
                 id = common_sampler_sample(slot.smpl.get(), slot.ctx_tgt, tok_idx);
             }
 


### PR DESCRIPTION
## Overview
<!-- Describe what this PR does and why. Be concise but complete -->
Add GT-ASR adapter conversion parameters to `convert_hf_to_gguf.py`.
During conversion, checks are performed on the adapter manifest, SHA-256 hashes, tensor names, shapes, and dtypes.
Adapter tensors are written into GGUF, and GT-ASR metadata is persisted.
mtmd determines whether to enable the enhanced path based on GT-ASR metadata.
The enhanced path includes uncertainty, context, and fusion bypasses, and outputs speech probability.
The server adjusts first-token logits using the speech/null mixture.
If GT-ASR metadata is absent, vanilla Qwen3-ASR follows the original processing pipeline without entering the enhanced logic.
Speculative decoding and backend sampling are disabled for the GT-ASR path to ensure stable inference behavior for this model.

## Additional information
<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
Python compilation checks have been performed on the relevant conversion scripts.
Ruff has been used to lint the Python files.
Passed `git diff --check`.
`pytest -q gguf-py/tests`: all 7 tests passed.
The CUDA builds of `llama-mtmd-cli` and `llama-server` were completed successfully.
Comparative inference tests were carried out using vanilla Qwen3-ASR and GT-ASR.
Full testing is incomplete due to missing `appium` and `wget` in the environment.
No model files, build directories or log files were committed to the repository.

## Requirements
<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI assisted with code implementation, debugging and testing support, and I confirm that I have reviewed the code, understand the changes, and take responsibility for maintenance.
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
