### PR TITLE
convert : skip bias_vl tensor in DeepSeek-V4 DSpark conversion

### DIFF
--- a/conversion/deepseek.py
+++ b/conversion/deepseek.py
@@ -1007,6 +1007,13 @@ class DeepseekV4DSparkModel(DeepseekV4Model):
             return self._DSPARK_ROOT_MAP[name]
         return super()._map_dsv4_tensor_name(name, bid)
 
+    def modify_tensors(self, data_torch: Tensor, name: str, bid: int | None) -> Iterable[tuple[str, Tensor]]:
+        # the DFlash draft uses the plain exp-probs bias (ffn.gate.bias -> FFN_EXP_PROBS_B);
+        # the mtmd-only hash routing tensors (bias_vl, tid2eid) are not part of the DFLASH arch
+        if name.endswith(".ffn.gate.bias_vl"):
+            return []
+        return super().modify_tensors(data_torch, name, bid)
+
     def set_vocab(self):
         if self.target_model_dir is None:
             raise ValueError("DeepSeek-V4 DSpark requires --target-model-dir with the target tokenizer")

--- a/conversion/deepseek.py
+++ b/conversion/deepseek.py
@@ -1011,8 +1011,8 @@ class DeepseekV4DSparkModel(DeepseekV4Model):
         # the DFlash draft uses the plain exp-probs bias (ffn.gate.bias -> FFN_EXP_PROBS_B);
         # the mtmd-only hash routing tensors (bias_vl, tid2eid) are not part of the DFLASH arch
         if name.endswith(".ffn.gate.bias_vl"):
-            return []
-        return super().modify_tensors(data_torch, name, bid)
+            return
+        yield from super().modify_tensors(data_torch, name, bid)
 
     def set_vocab(self):
         if self.target_model_dir is None:


### PR DESCRIPTION
## Overview

cont #28133 https://github.com/ggml-org/llama.cpp/pull/28133#issuecomment-5514628446

Fix DSpark conversion for the new https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-Vision-Exp.

GGUFs: https://huggingface.co/ggml-org/DeepSeek-V4-Flash-Vision-Exp-GGUF

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. pi:llama.cpp/DeepSeek-V4-Flash-0731

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
