### PR TITLE
compilation: detect and enable AVX-VNNI compilation on MSVC

### DIFF
--- a/ggml/src/ggml-cpu/cmake/FindSIMD.cmake
+++ b/ggml/src/ggml-cpu/cmake/FindSIMD.cmake
@@ -52,6 +52,16 @@ set(FMA_CODE "
     }
 ")
 
+set(AVX_VNNI_CODE "
+    #include <immintrin.h>
+    int main()
+    {
+        __m256i a = _mm256_setzero_si256();
+        a = _mm256_dpbusd_avx_epi32(a, a, a);
+        return 0;
+    }
+")
+
 macro(check_sse type flags)
     set(__FLAG_I 1)
     set(CMAKE_REQUIRED_FLAGS_SAVE ${CMAKE_REQUIRED_FLAGS})
@@ -90,6 +100,12 @@ if ((NOT ${AVX2_FOUND}) OR (NOT ${FMA_FOUND}))
     set(GGML_AVX2 OFF)
 else()
     set(GGML_AVX2 ON)
+    check_sse("AVX_VNNI" " ;/arch:AVX2")
+    if (NOT ${AVX_VNNI_FOUND})
+        set(GGML_AVX_VNNI OFF)
+    else()
+        set(GGML_AVX_VNNI ON)
+    endif()
 endif()
 
 check_sse("AVX512" " ;/arch:AVX512")


### PR DESCRIPTION
## Overview

Fixes - https://github.com/ggml-org/llama.cpp/issues/28295

While profiling the llama.cpp generation on ggml-org/Qwen3.8-27B-GGUF:Q8_0, I found that llama-cpp is not using AVX-VNNI instruction even if they are available.

This is because AVX-VNNI is not detected automatically in MSVC builds. gcc target -march=native seems to automatically detect this and set __AVXVNNI__.

This change adds detection for AVX-VNNI by compiling and running a test program with _mm256_dpbusd_avx_epi32 intrinsic.

## Additional information

This can be observed by compiling with below command 

```
cmake --build build --config Release -j 2
```

And running as follows

```
llama.exe serve -hf ggml-org/Qwen3.8-27B-GGUF:Q8_0
...
0.00.015.281 I cmn  common_param: system_info: n_threads = 20 (n_threads_batch = 20) / 28 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 |
```

With the patch notice AVX_VNNI is detected (during compilation)
```
llama.exe serve -hf ggml-org/Qwen3.8-27B-GGUF:Q8_0
...
0.00.012.161 I cmn  common_param: system_info: n_threads = 20 (n_threads_batch = 20) / 28 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX_VNNI = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | LLAMAFILE = 1 | OPENMP = 1 | REPACK = 1 |
```


## Requirements

Windows OS
AVX-VNNI supported processor

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES
To study the kernel and to find the file where changes are required. I've handwritten the change to satisfy my excitement :)

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->