### PR TITLE
metal : skip the empty half of the mul_mm_id token tile, load iq2/iq3 codebooks as uint32

### DIFF
--- a/ggml/src/ggml-metal/kernels/mul_mm.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mm.metal
@@ -496,6 +496,13 @@ kernel void kernel_mul_mm_id(
         + args.nb11*i11
         + args.nb10*iy);
 
+    // skip the upper half of the token tile when the expert did not fill it
+    constexpr short NR1H = NR1/2;
+
+    const bool has_hi = nr1 > NR1H;
+
+    const short lb1 = (short) tiitg/NL1; // 0 .. NR1-1, this thread's row of the B tile
+
 #ifndef GGML_METAL_HAS_TENSOR
     S0_8x8 ma[4];
     S1_8x8 mb[2];
@@ -505,15 +512,22 @@ kernel void kernel_mul_mm_id(
     for (short i = 0; i < 8; i++){
         mc[i] = make_filled_simdgroup_matrix<float, 8>(0.f);
     }
+
+    // simdgroups 2,3 own rows NR1H..NR1-1
+    const bool sg_active = has_hi || sgitg < 2;
 #else
-    auto tA = tensor<threadgroup S0, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK,  NR0));
-    auto tB = tensor<threadgroup S1, dextents<int32_t, 2>, tensor_inline>(sb, dextents<int32_t, 2>(NR1, NK ));
+    auto tA  = tensor<threadgroup S0, dextents<int32_t, 2>, tensor_inline>(sa, dextents<int32_t, 2>(NK, NR0));
+
+    // sb is [NR1][NK] row-major
+    auto tB0 = tensor<threadgroup S1, dextents<int32_t, 2>, tensor_inline>(sb,             dextents<int32_t, 2>(NK, NR1H));
+    auto tB1 = tensor<threadgroup S1, dextents<int32_t, 2>, tensor_inline>(sb + NR1H*NK,   dextents<int32_t, 2>(NK, NR1H));
 
     mpp::tensor_ops::matmul2d<
-        mpp::tensor_ops::matmul2d_descriptor(NR1, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
+        mpp::tensor_ops::matmul2d_descriptor(NR1H, NR0, NK, false, true, false, mpp::tensor_ops::matmul2d_descriptor::mode::multiply_accumulate),
         execution_simdgroups<4>> mm;
 
-    auto cT = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB), float>();
+    auto cT0 = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB0), float>();
+    auto cT1 = mm.get_destination_cooperative_tensor<decltype(tA), decltype(tB1), float>();
 #endif
 
     for (int loop_k = 0; loop_k < args.ne00; loop_k += NK) {
@@ -656,37 +670,45 @@ kernel void kernel_mul_mm_id(
         threadgroup_barrier(mem_flags::mem_threadgroup);
 
 #ifndef GGML_METAL_HAS_TENSOR
-        // load matrices from threadgroup memory and conduct outer products
-        threadgroup const S0 * lsma = (sa + 4*64*(sgitg%2));
-        threadgroup const S1 * lsmb = (sb + 2*64*(sgitg/2));
+        if (sg_active) {
+            // load matrices from threadgroup memory and conduct outer products
+            threadgroup const S0 * lsma = (sa + 4*64*(sgitg%2));
+            threadgroup const S1 * lsmb = (sb + 2*64*(sgitg/2));
 
-        FOR_UNROLL (short ik = 0; ik < NK/8; ik++) {
-            simdgroup_barrier(mem_flags::mem_none);
+            FOR_UNROLL (short ik = 0; ik < NK/8; ik++) {
+                simdgroup_barrier(mem_flags::mem_none);
 
-            FOR_UNROLL (short i = 0; i < 4; i++) {
-                simdgroup_load(ma[i], lsma + 64*i, 8, 0, false);
+                FOR_UNROLL (short i = 0; i < 4; i++) {
+                    simdgroup_load(ma[i], lsma + 64*i, 8, 0, false);
+                }
+
+                simdgroup_barrier(mem_flags::mem_none);
+
+                FOR_UNROLL (short i = 0; i < 2; i++) {
+                    simdgroup_load(mb[i], lsmb + 64*i, 8, 0, false);
+                }
+
+                simdgroup_barrier(mem_flags::mem_none);
+
+                FOR_UNROLL (short i = 0; i < 8; i++){
+                    simdgroup_multiply_accumulate(mc[i], mb[i/4], ma[i%4], mc[i]);
+                }
+
+                lsma += 8*64;
+                lsmb += 4*64;
             }
-
-            simdgroup_barrier(mem_flags::mem_none);
-
-            FOR_UNROLL (short i = 0; i < 2; i++) {
-                simdgroup_load(mb[i], lsmb + 64*i, 8, 0, false);
-            }
-
-            simdgroup_barrier(mem_flags::mem_none);
-
-            FOR_UNROLL (short i = 0; i < 8; i++){
-                simdgroup_multiply_accumulate(mc[i], mb[i/4], ma[i%4], mc[i]);
-            }
-
-            lsma += 8*64;
-            lsmb += 4*64;
         }
 #else
-        auto sA = tA.slice(0, 0);
-        auto sB = tB.slice(0, 0);
+        auto sA  = tA.slice(0, 0);
+        auto sB0 = tB0.slice(0, 0);
 
-        mm.run(sB, sA, cT);
+        mm.run(sB0, sA, cT0);
+
+        if (has_hi) {
+            auto sB1 = tB1.slice(0, 0);
+
+            mm.run(sB1, sA, cT1);
+        }
 #endif
     }
 
@@ -694,13 +716,20 @@ kernel void kernel_mul_mm_id(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
 #ifdef GGML_METAL_HAS_TENSOR
-    auto tC = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(sc, dextents<int32_t, 2>(NR0, NR1));
-    cT.store(tC);
-#else
-    threadgroup float * temp_str = ((threadgroup float *) shmem) + 32*(sgitg&1) + (16*(sgitg >> 1))*NR0;
+    auto tC0 = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(sc,             dextents<int32_t, 2>(NR0, NR1H));
+    cT0.store(tC0);
 
-    for (short i = 0; i < 8; i++) {
-        simdgroup_store(mc[i], temp_str + 8*(i%4) + 8*NR0*(i/4), NR0, 0, false);
+    if (has_hi) {
+        auto tC1 = tensor<threadgroup float, dextents<int32_t, 2>, tensor_inline>(sc + NR1H*NR0, dextents<int32_t, 2>(NR0, NR1H));
+        cT1.store(tC1);
+    }
+#else
+    if (sg_active) {
+        threadgroup float * temp_str = ((threadgroup float *) shmem) + 32*(sgitg&1) + (16*(sgitg >> 1))*NR0;
+
+        for (short i = 0; i < 8; i++) {
+            simdgroup_store(mc[i], temp_str + 8*(i%4) + 8*NR0*(i/4), NR0, 0, false);
+        }
     }
 #endif
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -1227,6 +1227,11 @@ struct test_case {
         }
     }
 
+    // re-draw data-dependent inputs between timed perf iterations
+    virtual void reinit_perf_iter(ggml_context * ctx) {
+        GGML_UNUSED(ctx);
+    }
+
     virtual size_t op_size(ggml_tensor * t) {
         size_t size = ggml_nbytes(t);
         // add source tensors
@@ -1661,6 +1666,9 @@ struct test_case {
             total_time_us += end_time - start_time;
             total_mem += mem;
             total_runs += n_runs;
+
+            // re-draw any data-dependent inputs (expert ids) outside the timed region
+            reinit_perf_iter(ctx.get());
         } while (total_time_us < 1000*1000); // run for at least 1 second
 
         // Create test result
@@ -4741,25 +4749,31 @@ struct test_mul_mat_hadamard : public test_mul_mat {
     }
 };
 
-static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
+static void init_mul_mat_id_ids(ggml_context * ctx, int n_mats) {
     std::random_device rd;
     std::default_random_engine rng(rd());
     for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
-        if (t->type == GGML_TYPE_I32) {
-            if (ggml_is_view_op(t->op)) { continue; }
-            // ids
-            for (int64_t r = 0; r < ggml_nrows(t); r++) {
-                std::vector<int32_t> data(t->ne[0]);
-                for (int i = 0; i < t->ne[0]; i++) {
-                    data[i] = i % n_mats;
-                }
-                std::shuffle(data.begin(), data.end(), rng);
-                ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
+        if (t->type != GGML_TYPE_I32 || ggml_is_view_op(t->op)) {
+            continue;
+        }
+        for (int64_t r = 0; r < ggml_nrows(t); r++) {
+            std::vector<int32_t> data(t->ne[0]);
+            for (int i = 0; i < t->ne[0]; i++) {
+                data[i] = i % n_mats;
             }
-        } else {
+            std::shuffle(data.begin(), data.end(), rng);
+            ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
+        }
+    }
+}
+
+static void init_mul_mat_id_tensors(ggml_context * ctx, int n_mats) {
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+        if (t->type != GGML_TYPE_I32) {
             init_tensor_uniform(t);
         }
     }
+    init_mul_mat_id_ids(ctx, n_mats);
 }
 
 // GGML_OP_MUL_MAT_ID
@@ -4825,6 +4839,10 @@ struct test_mul_mat_id : public test_case {
 
     void initialize_tensors(ggml_context * ctx) override {
         init_mul_mat_id_tensors(ctx, n_mats);
+    }
+
+    void reinit_perf_iter(ggml_context * ctx) override {
+        init_mul_mat_id_ids(ctx, n_mats);
     }
 };
 
@@ -9522,6 +9540,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_BF16, GGML_TYPE_F32, 16, 16, 256, {2, 3}, {1, 1}, {0, 2, 1, 3}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_BF16, GGML_TYPE_F32, 16, 16, 256, {2, 3}, {1, 1}, {0, 1, 3, 2}));
     test_cases.emplace_back(new test_mul_mat(GGML_TYPE_BF16, GGML_TYPE_F32, 16, 16, 256, {2, 3}, {1, 1}, {0, 3, 2, 1}));
+
+    // token-tile boundary coverage. With n_used == n_mats every token routes to every expert, so
+    // each expert receives exactly n rows, with no dependence on the random draw. mul_mm_id is used
+    // from 32 tokens up: n = 32, 33, 47, 48, 49 reach it, leaving a last tile of 32, 1, 15, 16 and
+    // 17 rows - 16 and 17 straddle the point where the upper half stops being skipped. The smaller
+    // n cover the same row counts on the mat-vec path.
+    for (ggml_type type_a : {GGML_TYPE_Q4_K, GGML_TYPE_IQ2_XS, GGML_TYPE_F16}) {
+        for (int n : {1, 15, 16, 17, 31, 32, 33, 47, 48, 49}) {
+            test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 4, false, 512, n, 256));
+        }
+        // experts that receive no rows at all
+        test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 8, 1, false, 512, 1, 256));
+    }
 
     for (ggml_type type_a : other_types) {
         for (ggml_type type_b : {GGML_TYPE_F32}) {


### PR DESCRIPTION
## Overview

`kernel_mul_mm_id` works on 32 routed token rows at a time. An expert often receives fewer than 32 rows, but the unused rows are still multiplied and discarded.

This splits the token tile into two `NR1H = 16` halves and skips the upper half when `nr1 <= NR1H`.

On the tensor-ops path, each half gets its own `matmul2d` call. On the simdgroup path, the two simdgroups responsible for rows 16..31 are disabled through `sg_active` when the upper half is not needed.

`nr1` is the number of rows remaining in the current tile. An expert with 33 routed rows therefore gets one full tile and a 1-row tail, and the tail skips its upper half.

The `tB` extents are also corrected for the split tile. They were `(NR1, NK)` for a `[NR1][NK]` row-major tile, which was harmless while both dimensions were 32.

For reference, mean rows per expert are:

```text
ubatch * n_expert_used / n_expert
```

A 256-expert top-8 model therefore averages 8 rows per expert at `-ub 256` and 16 at `-ub 512`.

`mul_mm_id` is used from 32 tokens up. Below that, MoE uses `mul_mv_id`, so this kernel is not reached.

The IQ codebook and padding-staging changes from the first revision have been removed. This PR now contains only the tile split, the `tB` extent fix, and the related tests/benchmark hook.


## Performance

Apple M5, against master `5a4d0feca`. Four paired runs per case. Negative is faster.

### Tensor ops

```sh
./build/bin/test-backend-ops perf -o MUL_MAT_ID -b MTL0 \
  -p "type_a=(q4_0|q4_K|iq2_xs|iq2_s|iq3_xxs),.*,n=(64|128|256|512|1024|2048),"
```

| n | q4_0 | q4_K | iq2_xs | iq2_s | iq3_xxs |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 64 | -4.5% | -11.4% | -18.1% | -16.5% | -15.2% |
| 128 | -5.4% | -8.7% | -13.7% | -13.5% | -11.3% |
| 256 | -4.0% | -3.8% | -7.6% | -6.9% | -5.8% |
| 512 | -3.0% | -0.8% | -4.4% | -4.6% | -3.4% |
| 1024 | -3.4% | -2.0% | -3.9% | -4.0% | -1.8% |
| 2048 | +0.2% | +1.2% | +0.3% | -0.7% | +0.6% |

The largest regression is +1.2% for `q4_K` at `n = 2048`. At smaller batch sizes, where experts receive fewer rows, the gain is larger.

`iq2_s`, `iq3_xxs`, and `n > 512` are not in the upstream perf set. I added them locally for these measurements; the test change is not part of this PR.

<details>
<summary>Measurement-only test-backend-ops change</summary>

```diff
@@ static std::vector<std::unique_ptr<test_case>> make_test_cases_perf() {
     // qwen3-30b-a3b
-    for (int bs : {1, 4, 8, 32, 64, 128, 256, 512}) {
-        for (ggml_type type_a : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0, GGML_TYPE_Q4_K, GGML_TYPE_Q6_K, GGML_TYPE_IQ2_XS}) {
+    for (int bs : {1, 4, 8, 32, 64, 128, 256, 512, 1024, 2048}) {
+        for (ggml_type type_a : {GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0, GGML_TYPE_Q4_K, GGML_TYPE_Q6_K, GGML_TYPE_IQ2_XS, GGML_TYPE_IQ2_S, GGML_TYPE_IQ3_XXS}) {
             for (ggml_type type_b : {GGML_TYPE_F32}) {
                 test_cases.emplace_back(new test_mul_mat_id(type_a, type_b, 128, 8, false, 768, bs, 2048));
```

The same change was made to the `32, 4, false, 1792` loop below it.

</details>

### Simdgroup path

```sh
GGML_METAL_TENSOR_DISABLE=1 ./build/bin/test-backend-ops perf -o MUL_MAT_ID -b MTL0 \
  -p "type_a=(q4_0|q4_K|iq2_xs),.*,n=(32|64|128|256|512),"
```

| mean rows per expert | 2 | 4 | 8 | 16 | 32 | 64 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| change | -41.2% | -40.8% | -40.6% | -22.6% | -12.0% | -8.8% |

Median over `q4_0`, `q4_K`, and `iq2_xs`.

All 30 case medians improve. 119 of 120 paired runs are faster.

The gain is larger on this path because all four simdgroups otherwise run `simdgroup_multiply_accumulate` over the full tile regardless of `nr1`.

## End to end

`Tiel-Coder-35B-A3B` IQ3_XXS, 256 experts top-8, Apple M5, against the same master.

```sh
./build/bin/llama-bench -m <model>.gguf \
  -p 512 -n 0 -fa 1 -r 5 -ub 256,512

./build/bin/llama-batched-bench -m <model>.gguf \
  -c 16384 -b 512 -ub 256 -fa on \
  -npp 128 -ntg 32 -npl 1,8,32,64
```

| test | throughput change | runs faster |
| --- | ---: | ---: |
| pp512, `-ub 256` | +5.1% | 8/8 |
| pp512, `-ub 512` | +2.9% | 8/8 |
| tg64, batch 1 | +0.00% | 3/6 |
| batched decode, `npl = 8` | -0.3% | 1/4 |
| batched decode, `npl = 32` | +3.6% | 3/4 |
| batched decode, `npl = 64` | +2.6% | 4/4 |

Positive is faster.

Batch-1 decode is unchanged, as expected, because it uses `mul_mv_id`.

The batched cases start using `mul_mm_id` at 32 tokens, which is also where the gain appears.

## Testing

```sh
./build/bin/test-backend-ops -o MUL_MAT_ID -b MTL0
./build/bin/test-backend-ops -o MUL_MAT    -b MTL0

GGML_METAL_TENSOR_DISABLE=1 ./build/bin/test-backend-ops -o MUL_MAT_ID -b MTL0
GGML_METAL_TENSOR_DISABLE=1 ./build/bin/test-backend-ops -o MUL_MAT    -b MTL0
```

On `5bda51bf`:

- `MUL_MAT_ID`: 843/843 passed, 78 not supported
- `MUL_MAT`: 1265/1265 passed, 417 not supported

Both pass with tensor ops enabled and disabled.

This PR adds 33 test cases across `q4_K`, `iq2_xs`, and `f16`.

Thirty use `n_used == n_mats == 4`, so every token routes to every expert and each expert receives exactly `n` rows.

The new `mul_mm_id` cases cover the split boundary and tail sizes directly:

| n | final tile |
| ---: | ---: |
| 32 | 32 rows |
| 33 | 1 row |
| 47 | 15 rows |
| 48 | 16 rows |
| 49 | 17 rows |

The 16- and 17-row cases cover the point where the upper half starts running again.

`n = 1, 15, 16, 17, 31` cover the `mul_mv_id` path. Three additional cases use eight experts with one selected to cover empty experts.

`test_mul_mat_id` also redraws expert IDs between timed perf iterations through `reinit_perf_iter`, so perf runs do not repeatedly use the same routing assignment.

## Related

#25377, #27370 and #26223 touch nearby code. #26223 changes the same B-tile staging code, so whichever lands second will need a small merge.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, AI was used during implementation and profiling, guided and reviewed by me.