### PR TITLE
server : fix context checkpoint eviction on prompts shorter than checkpoint_min_step

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2300,8 +2300,11 @@ private:
 
         // evict checkpoints within min-step of a previous checkpoint, unless they were
         // created by the current task
+        // only when the list is full, otherwise short prompts keep just the oldest checkpoint
         int64_t last = -1;
-        for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end(); ) {
+        for (auto it = slot.prompt.checkpoints.begin();
+                slot.prompt.checkpoints.size() + 1 >= (size_t) params_base.n_ctx_checkpoints &&
+                it != slot.prompt.checkpoints.end(); ) {
             if (it->id_task != id_task && last >= 0 && it->n_tokens <= last + params_base.checkpoint_min_step) {
                 SLT_TRC(slot, "erasing context checkpoint too close to an earlier one (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
                         it->pos_min, it->pos_max, it->n_tokens, (float) it->size() / 1024 / 1024);
@@ -2322,6 +2325,19 @@ private:
                     cur.pos_min, cur.pos_max, cur.n_tokens, (float) cur.size() / 1024 / 1024);
 
             slot.prompt.checkpoints.erase(slot.prompt.checkpoints.begin());
+        }
+
+        // replace an existing checkpoint at the same n_tokens instead of appending a duplicate
+        {
+            const int64_t n_tokens_new = slot.prompt.n_tokens() - n_tokens_cur;
+            for (auto it = slot.prompt.checkpoints.begin(); it != slot.prompt.checkpoints.end(); ) {
+                if (it->n_tokens == n_tokens_new) {
+                    SLT_TRC(slot, "superseding context checkpoint at n_tokens = %" PRId64 "\n", it->n_tokens);
+                    it = slot.prompt.checkpoints.erase(it);
+                } else {
+                    ++it;
+                }
+            }
         }
 
         auto & cur = slot.prompt.checkpoints.emplace_back();


### PR DESCRIPTION
## Overview

This fixes `create_checkpoint()` deleting the checkpoint a later rewind needs whenever the prompt is shorter than `checkpoint_min_step`.

`create_checkpoint()` currently runs a spacing eviction before appending the new checkpoint. Walking from the oldest entry, it removes checkpoints from another task whose `n_tokens` is within `checkpoint_min_step` (8192 by default) of the previous surviving checkpoint. On prompts shorter than 8192 tokens, effectively every checkpoint falls within that range, so only the oldest one survives.

This removes the recent checkpoint that the prompt-fill loop placed near the end of the prompt at `n_tokens - 4` (`checkpoint_offsets = {4 + n_ubatch, 4}`, #20288). For hybrid/recurrent models, whose recurrent state cannot simply be rolled back, that recent checkpoint is the useful one when a later request rewinds the conversation.

The functional change is about ten lines: apply the spacing rule only once the checkpoint list has reached `n_ctx_checkpoints`, which already provides a hard capacity bound, and replace an existing checkpoint at the same `n_tokens` instead of appending a duplicate.

I found this while replaying a coding-agent transcript on `Tiel-Coder-35B-A3B-MTP-UD-IQ3_XXS.gguf` (HF: `peculiar-ragdoll/Tiel-Coder-35B-A3B-GGUF-MTP`), a dynamic UD-IQ3_XXS re-quantization of Ornith-1.5-35B-A3B. It is a hybrid GDN MoE: 30 of its 40 trunk layers use Gated DeltaNet recurrent state and only 10 use full attention with a KV cache, so rewinding requires restoring the recurrent state from a checkpoint.

The symptom was that reopening each session caused a few hundred already-cached tokens to be processed again, while the server log repeatedly printed `erasing context checkpoint too close`.

**When it shows.** Normal linear chat is unaffected: each turn resumes from the checkpoint created by the previous request before that checkpoint can be evicted. Switching between conversations is also unaffected because the prompt cache saves and restores the slot together with its checkpoints.

The problem appears when a request rewinds within a conversation after it has already advanced: editing or branching an earlier turn, agent harnesses that retry or compact a session, or reopening a session at an earlier point.

Tested on my 14inch MacBook Pro M5 24 GB and my 16inch MacBook Pro M1 Pro 32 GB.

## Additional information

**Stock Qwen3.5-9B Q4_K_M (Unsloth), `upstream/master = 7798007`, M5**, using 6 turns of ~150 tokens after a 390-token system prompt, then editing turn 4, continuing for two more turns, and finally regenerating the last answer. Generation was greedy with 120-token replies. `prompt_n` is the number of tokens `llama-server` actually processed:

| step                     | master `prompt_n` | master prompt ms | PR `prompt_n` | PR prompt ms |
| ------------------------ | ----------------: | ---------------: | ------------: | -----------: |
| turns 2-6, each          |           144-154 |          440-448 |       144-154 |      440-451 |
| edit turn 4 after turn 6 |               702 |             1459 |            26 |          229 |
| turns 5-6 again          |           145-149 |              448 |       145-149 |      449-451 |
| regenerate last answer   |                 4 |               69 |             4 |           67 |
| total, 9 warm requests   |              1753 |             4647 |          1077 |         3407 |

Both sides produced the same greedy output.

**Same scenario on the M1 Pro**, run as master, PR, then master again as an ordering control:

| step                                                       | master            | PR              | master again      |
| ---------------------------------------------------------- | ----------------- | --------------- | ----------------- |
| turns 2-6, prompt ms per turn                              | 840-1176          | 831-846         | 840-851           |
| edit turn 4 after turn 6                                   | 704 tok / 3355 ms | 26 tok / 264 ms | 704 tok / 3323 ms |
| regenerate last answer                                     | 4 tok / 102 ms    | 4 tok / 101 ms  | 4 tok / 101 ms    |
| `erasing context checkpoint too close` lines in server log | 23                | 0               | 23                |

The ordering control reproduces the original behavior after the PR run, which makes the edit-turn difference unlikely to be explained by thermal state or cache warming.

**Tiel-Coder-35B-A3B-MTP-UD-IQ3_XXS (Ornith-1.5-35B-A3B, hybrid GDN MoE), `b10488` tree, M5**, using a fixed replay of a 3-session coding-agent transcript, 13 generations, and a ~5.6K-token system prompt, measured as the mean of 3 warm repetitions. Each repetition reopens the sessions at turn 1, which exercises the rewind case.

The three session openers re-processed 260/254/272 tokens before the patch and 40/34/52 after it. Total warm re-processed tokens per repetition dropped from 2436 to 1776, and warm wall time from 18.25 to 17.12 s (−6.2%). In the same plain-chat edit-turn-4 scenario used above, re-processed tokens dropped from 715 to 26.

**Memory.** Master effectively retains 2 to 4 checkpoints on short prompts because the spacing pass removes the rest. After this change, a slot may retain up to `n_ctx_checkpoints` checkpoints before the existing capacity rule starts evicting them.

At the default limit of 32, that means up to 32 times the model's checkpoint state size: about 74 MiB per checkpoint on Tiel and 50 MiB on Qwen3.5-9B. The highest observed usage in the agent replay was 8 live checkpoints / 596 MiB after duplicate positions were removed, and the Qwen3.5-9B chat reached 13 live checkpoints.

`--ctx-checkpoints` already provides an explicit bound. A byte-based budget in addition to the count would be a reasonable follow-up, but I would prefer to keep that separate from this eviction fix unless maintainers want it included here.

An alternative would be to keep applying the spacing rule on every call but choose the most redundant checkpoint, for example the one closest to its neighbours, instead of allowing the oldest checkpoint to dominate the surviving set. I went with the smaller change here, but I am happy to reshape the policy if that is preferred.

Related: #22929 introduced `checkpoint_min_step`; its discussion includes a report of prompt-cache performance dropping for sub-1000-token requests after the merge. #24055 ("context checkpoints always invalidated on hybrid/recurrent models", open) appears to describe the same underlying mechanism. See also #22384 and #20225 for earlier restore-path fixes.

### Test methodology

* Multi-turn script against `llama-server` using `/v1/chat/completions`, `temperature 0`, `top_k 1`, and `seed 0`, recording `timings.prompt_n` and `timings.prompt_ms` for every request. Master and PR were built from the same tree and build directory, with `CMAKE_BUILD_TYPE=Release` confirmed on both.
* Server config: `--ctx-size 16384 --batch-size 512 --ubatch-size 256 --flash-attn on --cache-type-k q8_0 --cache-type-v q8_0 --parallel 1 --jinja`, with the defaults for `--ctx-checkpoints` (32), `--checkpoint-min-step` (8192), and prompt caching.
* This is a server-only change, so it does not affect model arithmetic. The agent replay's perplexity canary remained unchanged at 3.3969.

## Requirements

* I have read and agree with the contributing guidelines.
* AI usage disclosure: YES, AI was used during the implementation and profiling, guided and reviewed by me.
