### PR TITLE
HIP : add shared-memory tiled transpose fast path for F32 concat on RDNA3.5

### DIFF
--- a/ggml/src/ggml-cuda/concat.cu
+++ b/ggml/src/ggml-cuda/concat.cu
@@ -194,6 +194,104 @@ static void concat_cuda(const ggml_tensor * src0, const ggml_tensor * src1, ggml
     }
 }
 
+static __global__ void __launch_bounds__(256)
+    concat_f32_transpose(
+        const char * src0,
+        const char * src1,
+              char * dst,
+           int64_t   ne00,
+           int64_t   ne10,
+           int64_t   ne1,
+           int64_t   ne2,
+          uint64_t   nb00,
+          uint64_t   nb01,
+          uint64_t   nb02,
+          uint64_t   nb03,
+          uint64_t   nb10,
+          uint64_t   nb11,
+          uint64_t   nb12,
+          uint64_t   nb13,
+          uint64_t   nb0,
+          uint64_t   nb1,
+          uint64_t   nb2,
+          uint64_t   nb3) {
+    constexpr int tile_dim   = 32;
+    constexpr int block_rows = 8;
+
+    __shared__ float tile[tile_dim][tile_dim + 1];
+
+    const int64_t i2 = blockIdx.z % ne2;
+    const int64_t i3 = blockIdx.z / ne2;
+    const int64_t i1 = (int64_t) blockIdx.x * tile_dim + threadIdx.x;
+    const int64_t i0 = (int64_t) blockIdx.y * tile_dim + threadIdx.y;
+
+    ggml_cuda_pdl_sync();
+#pragma unroll
+    for (int j = 0; j < tile_dim; j += block_rows) {
+        if (i0 + j < ne10 && i1 < ne1) {
+            tile[threadIdx.y + j][threadIdx.x] =
+                *(const float *) (src1 + i3*nb13 + i2*nb12 + i1*nb11 + (i0 + j)*nb10);
+        }
+    }
+
+    if (blockIdx.y == 0) {
+        const int tid = threadIdx.y * tile_dim + threadIdx.x;
+        for (int64_t i = tid; i < ne00 * tile_dim; i += tile_dim * block_rows) {
+            const int64_t state   = i % ne00;
+            const int64_t channel = (int64_t) blockIdx.x * tile_dim + i / ne00;
+            if (channel < ne1) {
+                *(float *) (dst + i3*nb3 + i2*nb2 + channel*nb1 + state*nb0) =
+                    *(const float *) (src0 + i3*nb03 + i2*nb02 + channel*nb01 + state*nb00);
+            }
+        }
+    }
+
+    __syncthreads();
+
+    const int64_t dst_i0 = (int64_t) blockIdx.y * tile_dim + threadIdx.x;
+    const int64_t dst_i1 = (int64_t) blockIdx.x * tile_dim + threadIdx.y;
+#pragma unroll
+    for (int j = 0; j < tile_dim; j += block_rows) {
+        if (dst_i0 < ne10 && dst_i1 + j < ne1) {
+            *(float *) (dst + i3*nb3 + i2*nb2 + (dst_i1 + j)*nb1 + (ne00 + dst_i0)*nb0) =
+                tile[threadIdx.x][threadIdx.y + j];
+        }
+    }
+}
+
+static bool concat_try_f32_transpose(
+        const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst, int dim, cudaStream_t stream) {
+    constexpr int     tile_dim  = 32;
+    constexpr int64_t max_grid_z = 65535;
+
+    const int cc = ggml_cuda_info().devices[ggml_cuda_get_device()].cc;
+    if (dim != 0 ||
+        src0->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32 ||
+        !GGML_CUDA_CC_IS_RDNA3_5(cc) ||
+        (src1->ne[0] != 512 && src1->ne[0] != 1024 && src1->ne[0] != 2048) ||
+        !ggml_is_contiguous(src0) || !ggml_is_contiguous(dst) ||
+        src1->nb[1] != sizeof(float) ||
+        src1->nb[0] != (size_t) src1->ne[1] * src1->nb[1] ||
+        src1->nb[2] != (size_t) src1->ne[0] * src1->nb[0] ||
+        src1->nb[3] != (size_t) src1->ne[2] * src1->nb[2] ||
+        dst->ne[2] * dst->ne[3] > max_grid_z) {
+        return false;
+    }
+
+    constexpr int block_rows = 8;
+    const dim3 block_dim(tile_dim, block_rows, 1);
+    const dim3 grid_dim((dst->ne[1] + tile_dim - 1) / tile_dim,
+                        (src1->ne[0] + tile_dim - 1) / tile_dim,
+                        dst->ne[2] * dst->ne[3]);
+    concat_f32_transpose<<<grid_dim, block_dim, 0, stream>>>(
+        (const char *) src0->data, (const char *) src1->data, (char *) dst->data,
+        src0->ne[0], src1->ne[0], dst->ne[1], dst->ne[2],
+        src0->nb[0], src0->nb[1], src0->nb[2], src0->nb[3],
+        src1->nb[0], src1->nb[1], src1->nb[2], src1->nb[3],
+        dst->nb[0], dst->nb[1], dst->nb[2], dst->nb[3]);
+    return true;
+}
+
 void ggml_cuda_op_concat(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0 = dst->src[0];
     const ggml_tensor * src1 = dst->src[1];
@@ -204,6 +302,10 @@ void ggml_cuda_op_concat(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
 
     GGML_ASSERT(src0->type == src1->type);
     GGML_ASSERT(dst->type  == src0->type);
+
+    if (concat_try_f32_transpose(src0, src1, dst, dim, stream)) {
+        return;
+    }
 
     if (ggml_is_quantized(src0->type)) {
         if (dim == 3) {

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6079,7 +6079,7 @@ struct test_concat : public test_case {
     const std::array<int64_t, 4> ne_a;
     const int64_t ne_b_d;
     const int dim;
-    const int v; // view (1 << 0: non-cont a (first 3 dim), 1 << 1: non-cont b (first 3 dim), 1 << 2: non-cont a (last 2 dim), 1 << 3: non-cont b (last 2 dim))
+    const int v; // view (1 << 0: non-cont a (first 3 dim), 1 << 1: non-cont b (first 3 dim), 1 << 2: non-cont a (last 2 dim), 1 << 3: non-cont b (last 2 dim), 1 << 4: transposed b)
 
     std::string vars() override {
         return VARS_TO_STR5(type, ne_a, ne_b_d, dim, v);
@@ -6090,6 +6090,14 @@ struct test_concat : public test_case {
             int64_t ne_b_d = 5,
             int dim = 2, int v = 0)
         : type(type), ne_a(ne_a), ne_b_d(ne_b_d), dim(dim), v(v) {}
+
+    double max_nmse_err() override {
+        return v & 16 ? 0.0 : test_case::max_nmse_err();
+    }
+
+    double err(const float * a, const float * b, size_t n) override {
+        return v & 16 ? (std::memcmp(a, b, n * sizeof(float)) == 0 ? 0.0 : 1.0) : test_case::err(a, b, n);
+    }
 
     ggml_tensor * build_graph(ggml_context * ctx) override {
         auto ne_b = ne_a;
@@ -6128,6 +6136,14 @@ struct test_concat : public test_case {
 
             b = ggml_view_4d(ctx, b, ne_b[0], ne_b[1], ne_b[2], ne_b[3], b->nb[1], b->nb[2], b->nb[3], 0);
             ggml_set_name(b, "view_of_b");
+        } else if (v & 16) {
+            GGML_ASSERT(dim == 0);
+            std::swap(ne_b[0], ne_b[1]);
+            b = ggml_new_tensor(ctx, type, 4, ne_b.data());
+            ggml_set_name(b, "b");
+
+            b = ggml_transpose(ctx, b);
+            ggml_set_name(b, "transpose_of_b");
         } else {
             b = ggml_new_tensor(ctx, type, 4, ne_b.data());
             ggml_set_name(b, "b");
@@ -9953,6 +9969,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             test_cases.emplace_back(new test_concat(GGML_TYPE_I64, {11, 12, 13, 14}, 7, dim, v));
         }
     }
+
+    for (int64_t ne_b_d : { 512, 1024, 2048 }) {
+        for (int64_t channels : { 31, 32, 33, 64 }) {
+            test_cases.emplace_back(new test_concat(GGML_TYPE_F32, {3, channels, 1, 1}, ne_b_d, 0, 16));
+        }
+    }
+    test_cases.emplace_back(new test_concat(GGML_TYPE_F32, {3, 64, 2, 1}, 2048, 0, 16));
+
+    for (int64_t ne_b_d : { 1, 31, 32, 511, 513, 1537 }) {
+        test_cases.emplace_back(new test_concat(GGML_TYPE_F32, {3, 33, 1, 1}, ne_b_d, 0, 16));
+    }
+    test_cases.emplace_back(new test_concat(GGML_TYPE_F32, {3, 64, 1, 1}, 2048, 0, 0));
+    test_cases.emplace_back(new test_concat(GGML_TYPE_F16, {3, 64, 1, 1}, 2048, 0, 16));
 
     for (ggml_type type_a : { GGML_TYPE_Q4_0, GGML_TYPE_Q4_1, GGML_TYPE_Q5_0, GGML_TYPE_Q5_1, GGML_TYPE_Q8_0 }) {
         for (int v : { 0, 4, 8, 12 }) {


### PR DESCRIPTION
## Overview

On AMD RDNA3.5 (gfx1151, HIP backend), `concat` on dim 0 with a transposed F32
`src1` view falls back to the generic non-contiguous, per-element copy path. The
concrete shape seen during transformer prefill input processing is:

```
src0 : [3,    8192]   (contiguous)
src1 : [2048, 8192]   (transposed F32 view)
dst  : [2051, 8192]   = concat(src0, src1) on dim 0
```

Because `src1` is a transposed view, logically adjacent elements are not
physically adjacent, so global-memory access is poorly coalesced — the result is
correct, only slow.

This PR adds a dedicated kernel `concat_f32_transpose` for exactly this case:

- **New kernel.** 256 threads per block (`32 × 8`), one logical `32×32` tile per
  block. `src1` is staged through `__shared__ float tile[32][33]`, transposed in
  shared memory, then written out coalesced. The `[32][33]` padding (one extra
  column) shifts each row's start so transposed reads don't collide on the same
  shared-memory bank — the standard fix for transpose bank conflicts. `src0` is
  contiguous and copied into the first `ne00` elements of each channel only when
  `blockIdx.y == 0`, avoiding redundant copies across vertical tiles.
- **Gate `concat_try_f32_transpose`.** Triggers only when `dim == 0`;
  `src0`/`src1`/`dst` are all F32; the device is RDNA3.5; `src1->ne[0]` is
  512/1024/2048; `src0`/`dst` are contiguous; `src1` has strict transpose
  strides; and `dst->ne[2] * dst->ne[3] <= 65535`. Otherwise it returns false and
  the original implementation runs unchanged — no existing path is deleted or
  rewritten.

Only two files change: `ggml/src/ggml-cuda/concat.cu` and
`tests/test-backend-ops.cpp` (+132 / -1). Related to #21284.

## Additional information

**Why only prefill.** The matching shape (`ne00=3, ne10=2048, ne1=8192,
ne2=1, ne3=1`) only appears in prefill input processing; decode never matches and
falls back:

| workload | fast-path hits |
|---|---:|
| Q4_K_M prefill | 60 |
| BF16 prefill | 60 |
| Q4_K_M decode | 0 |
| BF16 decode | 0 |

**Tests (`test-backend-ops.cpp`).** New `transposed b` layout (`1 << 4`, i.e.
`v & 16`) built with a real `ggml_transpose`, matching the model's layout.
Transposed cases are checked with `std::memcmp` for bit-identical output (the
kernel only copies/reorders F32 — no arithmetic or conversion). Fast-path shapes:
widths 512/1024/2048 × channel counts 31/32/33/64 (tile boundaries) plus a
`ne2 = 2` case. Fallback shapes: non-whitelisted widths 1/31/32/511/513/1537, a
contiguous F32 case, and a transposed F16 case. Result: concat `198/198` pass;
transposed F32 output bit-identical.

**Performance (Windows 11, ROCm 7.1, Radeon 8060S / gfx1151).** A = upstream
master, B = master + this change; A/B build artifacts differ only in
`ggml-hip.dll`. Full GPU offload, Flash Attention, HIP Graph, `p2048`, `b4096`,
`t16`. Order A/B/B/A then extended; 10 samples per version per scenario; medians:

| model / stage | ubatch | A (tok/s) | B (tok/s) | Δ |
|---|---:|---:|---:|---:|
| Q4_K_M prefill | 512  | 985.611  | 1106.050 | **+12.22%** |
| Q4_K_M prefill | 1024 | 1218.855 | 1287.850 | **+5.66%** |
| Q4_K_M prefill | 2048 | 1293.875 | 1426.610 | **+10.26%** |
| BF16 prefill   | 512  | 485.047  | 526.406  | **+8.53%** |
| BF16 prefill   | 1024 | 440.108  | 465.546  | **+5.78%** |
| BF16 prefill   | 2048 | 581.229  | 604.940  | **+4.08%** |
| Q4_K_M decode  | —    | 56.672   | 56.649   | -0.04% |
| BF16 decode    | —    | 27.077   | 27.037   | -0.14% |

All prefill scenarios improve in the same direction (+4.08% .. +12.22%); decode
changes are < 1% (run-to-run noise, not a regression). No thermal throttling; A/B
GPU clock, memory clock, power and temperature ranges overlap. Fixed-input output
hashes match A/B (Q4_K_M `5A2BC481...A45867F846`, BF16
`E8524416...EBB75C683`).

**Known limitation.** The gate restricts width but **not** channel count
(`dst->ne[1]`), so some small-channel shapes can still enter the fast path and
regress. At width 2048, `ne1 = 33` regresses ~ -4.25% and it turns positive from
`ne1 = 64` (the real model width `ne1 = 8192` improves clearly), because for very
small workloads the kernel's launch/sync/tiling overhead can exceed the generic
kernel. This first PR deliberately keeps the narrow 512/1024/2048 whitelist —
those widths are directly validated by the real model with minimal code surface.
A workload/channel gate to widen the range can be added separately if maintainers
prefer.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — this change was produced with substantial AI
  assistance (code analysis, implementation drafting, and test/benchmark
  automation). I have reviewed the diff and understand the transpose indexing,
  the `[32][33]` shared-memory tiling, the `blockIdx.y == 0` single copy of
  `src0`, the tail-block bounds checks, the fallback gating, and the known
  small-channel regression; I take responsibility for maintaining this change.