### PR TITLE
graph : keep the backend sampling subgraph static across ubatches also helps fix CI issue

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1390,7 +1390,7 @@ common_init_result::common_init_result(common_params & params, bool model_only) 
         pimpl->samplers_seq_config[i] = { i, common_sampler_get(pimpl->samplers[i].get()) };
     }
 
-    if (params.sampling.backend_sampling) {
+    if (params.sampling.backend_sampling && !cparams.embeddings) {
         cparams.samplers   = pimpl->samplers_seq_config.data();
         cparams.n_samplers = pimpl->samplers_seq_config.size();
     }

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -2330,24 +2330,12 @@ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
         }
     }
 
-    uint32_t n_sampling_nodes = 0;
-    uint32_t n_sampling_nodes_max = 0;
+    const uint32_t n_chains_per_seq = cparams.n_sampling_chains_per_seq();
+
     for (const auto & [seq_id, sampler] : sampling.samplers) {
-        const uint32_t n_nodes = llama_sampler_backend_n_nodes(sampler);
-        n_sampling_nodes += n_nodes;
-        if (cparams.n_outputs_max_per_seq > 1) {
-            n_sampling_nodes_max = std::max(n_sampling_nodes_max, n_nodes);
-        }
+        res += n_chains_per_seq * llama_sampler_backend_n_nodes(sampler);
     }
 
-    const uint32_t n_sampling_outputs_max = std::min<uint64_t>(
-            std::min(n_tokens, cparams.n_outputs_max),
-            (uint64_t) cparams.n_seq_max * cparams.n_outputs_max_per_seq);
-
-    res += n_sampling_nodes;
-    if (n_sampling_outputs_max > 1) {
-        res += (n_sampling_outputs_max - 1) * n_sampling_nodes_max;
-    }
     return res;
 }
 

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -2,6 +2,7 @@
 
 #include "llama.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <vector>
 
@@ -64,4 +65,9 @@ struct llama_cparams {
     void * cb_eval_user_data;
 
     llama_context * ctx_other;
+
+    uint32_t n_sampling_chains_per_seq() const {
+        const uint32_t n_chains = std::min({ n_outputs_max_per_seq, n_outputs_max, n_ubatch });
+        return std::max<uint32_t>(1, n_chains);
+    }
 };

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -3732,8 +3732,7 @@ void llm_graph_context::build_sampling() const {
     // res->t_logits will contain logits for all tokens that want the logits calculated (logits=1 or output=1)
     GGML_ASSERT(res->t_logits != nullptr && "missing t_logits tensor");
 
-    // add a dummy row to keep the single-output graph static regardless of active samplers
-    // multi-output graphs can still vary with the number of output rows
+    // add a dummy row to keep the graph static regardless of active samplers
     ggml_tensor * logits_t = ggml_pad(ctx0, res->t_logits, 0, 1, 0, 0);
 
     for (const auto & entry : samplers) {
@@ -3742,18 +3741,26 @@ void llm_graph_context::build_sampling() const {
         }
     }
 
-    static const std::vector<uint32_t> dummy_row = { 0 };
+    static const std::vector<uint32_t> no_rows;
+
+    const uint32_t n_chains_per_seq = cparams.n_sampling_chains_per_seq();
 
     for (const auto & [seq_id, sampler] : samplers) {
         const auto it = sampling_rows.find(seq_id);
 
-        // inactive samplers always work on the first row
-        const bool active = it != sampling_rows.end();
-        const auto & rows = active ? it->second : dummy_row;
-        const int i_out   = active ? 1          : 0;
+        const auto & rows = it != sampling_rows.end() ? it->second : no_rows;
 
-        for (uint32_t i = 0; i < rows.size(); ++i) {
-            ggml_tensor * logits_seq = ggml_view_1d(ctx0, logits_t, logits_t->ne[0], rows[i] * logits_t->nb[1]);
+        const uint32_t n_rows_seq = (uint32_t) rows.size();
+
+        GGML_ASSERT(n_rows_seq <= n_chains_per_seq && "more sampled rows than the per-sequence output limit");
+
+        for (uint32_t i = 0; i < n_chains_per_seq; ++i) {
+            // inactive samplers always work on the first row and their results are dropped
+            const bool     active = i < n_rows_seq;
+            const uint32_t row    = active ? rows[i] : 0;
+            const int      i_out  = active ? 1       : 0;
+
+            ggml_tensor * logits_seq = ggml_view_1d(ctx0, logits_t, logits_t->ne[0], row * logits_t->nb[1]);
             ggml_format_name(logits_seq, "logits_seq_%d_%u", seq_id, i);
 
             struct llama_sampler_data data = {
@@ -3768,7 +3775,7 @@ void llm_graph_context::build_sampling() const {
 
             if (data.sampled != nullptr) {
                 if (active) {
-                    res->t_sampled[rows[i]] = data.sampled;
+                    res->t_sampled[row] = data.sampled;
                 }
                 outs[1] = data.sampled;
                 ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
@@ -3776,7 +3783,7 @@ void llm_graph_context::build_sampling() const {
 
             if (data.probs != nullptr) {
                 if (active) {
-                    res->t_sampled_probs[rows[i]] = data.probs;
+                    res->t_sampled_probs[row] = data.probs;
                 }
                 outs[1] = data.probs;
                 ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
@@ -3784,7 +3791,7 @@ void llm_graph_context::build_sampling() const {
 
             if (data.logits != nullptr) {
                 if (active) {
-                    res->t_sampled_logits[rows[i]] = data.logits;
+                    res->t_sampled_logits[row] = data.logits;
                 }
                 outs[1] = data.logits;
                 ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);
@@ -3792,7 +3799,7 @@ void llm_graph_context::build_sampling() const {
 
             if (data.candidates != nullptr) {
                 if (active) {
-                    res->t_candidates[rows[i]] = data.candidates;
+                    res->t_candidates[row] = data.candidates;
                 }
                 outs[1] = data.candidates;
                 ggml_build_forward_select(gf, outs.data(), outs.size(), i_out);


### PR DESCRIPTION
## Overview

This PR proposes a solution to CI failure:  https://github.com/ggml-org/llama.cpp/actions/runs/33469748435/job/99736916399. 
With backend sampling enabled at ubatch which has more than 1 row sampled per sequence can trigger unexpected graph reallocation. For Specdec the verify step samples the full accepted draft window. Sampling is part of the graph and the nodes added for sampling are counted in the graph. build_sampling adds chain for every row it samples, so graph changes based on the number of rows sampled. ggml-alloc reuses its memory plan whenever the node count matches but let say for a later step with more token and same node count which doesn't fit in the plan forces a realloc.
Under -DGGML_SCHED_NO_REALLOC=ON, which is set in CI workflow, this results in this error

`/home/ggml/runner/_work/llama.cpp/llama.cpp/ggml/src/ggml-backend.cpp:1633: ggml_backend_sched_alloc_splits: unexpected graph reallocation (graph size = 443, nodes = 443, leafs = 84), debug_realloc = 1`

This change makes build_sampling() always emit a fixed number of chains per sequence and drop the results of the unused ones. Inactive chains read row 0 and are excluded from computation , so the topology and every tensor shape stay constant regardless of how many rows the ubatch actually sample.

The one thing to keep in mind with this approach is token-generation graph carries the full per-sequence chain count at all times, which cost extra nodes

## Additional information

Some instances 
https://github.com/ggml-org/llama.cpp/actions/runs/33469748435/job/99736916399
https://github.com/ggml-org/llama.cpp/actions/runs/33490164618/job/99799511589
https://github.com/ggml-org/llama.cpp/actions/runs/33497050057/job/99821531802
https://github.com/ggml-org/llama.cpp/actions/runs/33535152050/job/99947544090
https://github.com/ggml-org/llama.cpp/actions/runs/33542635485/job/99972378975

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, to root cause and analyze the failure

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
