### PR TITLE
fix edge case for repetition count threshold

### DIFF
--- a/src/llama-grammar.cpp
+++ b/src/llama-grammar.cpp
@@ -492,7 +492,7 @@ const char * llama_grammar_parser::parse_sequence(
             total_rules = min_times;
         }
 
-        if (n_prev_rules * total_rules >= MAX_REPETITION_THRESHOLD) {
+        if (n_prev_rules * total_rules > MAX_REPETITION_THRESHOLD) {
             throw std::runtime_error("number of rules that are going to be repeated multiplied by the new repetition exceeds sane defaults, please reduce the number of repetitions or rule complexity");
         }
 

--- a/tests/test-grammar-parser.cpp
+++ b/tests/test-grammar-parser.cpp
@@ -139,6 +139,13 @@ static void verify_failure(const char * grammar_bytes) {
     assert(result.rules.empty() && "should have failed");
 }
 
+static void verify_success(const char * grammar_bytes) {
+    fprintf(stderr, "Testing expected success:%s\n", grammar_bytes);
+    llama_grammar_parser result;
+    result.parse(grammar_bytes);
+    assert(!result.rules.empty() && "should have parsed");
+}
+
 int main()
 {
     verify_failure(R"""(
@@ -163,6 +170,18 @@ int main()
 
     verify_failure(R"""(
         root ::= "a"{5000,6000}
+    )""");
+
+    verify_success(R"""(
+        root ::= "a"{0,2000}
+    )""");
+
+    verify_success(R"""(
+        root ::= "a"{2000}
+    )""");
+
+    verify_failure(R"""(
+        root ::= ("a"{0,50}){0,50}
     )""");
 
     verify_parsing(R"""(


### PR DESCRIPTION
## Overview

Fixes an edge case where a repetition count of exactly 2000 was rejected by the parser, despite values above 2000 being handled as unbounded. Repetition counts equal to the threshold of 2000 are now accepted, while nested repetitions exceeding the expansion limit remain restricted.

## Additional information

This PR revisits the fix from #27177 (which stalled in Draft due to template and AI disclosure requirements) and presents the solution along with tests.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Codex assisted with implementation and test preparation; I reviewed the change and ran the parser test locally.
