### PR TITLE
api : mark `llama_context_params.ctx_other` as `const`

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -415,7 +415,7 @@ extern "C" {
 
         // a source/target/parent context
         // can be utilized in various ways, for example by sharing results or llama_memory between 2 contexts
-        struct llama_context * ctx_other;
+        const struct llama_context * ctx_other;
     };
 
     struct llama_model_tensor_override {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -4324,6 +4324,6 @@ llama_memory_breakdown llama_get_memory_breakdown(const struct llama_context * c
     return ctx->memory_breakdown();
 }
 
-llama_context * llama_get_ctx_other(struct llama_context * ctx) {
+const llama_context * llama_get_ctx_other(struct llama_context * ctx) {
     return ctx->get_cparams().ctx_other;
 }

--- a/src/llama-cparams.h
+++ b/src/llama-cparams.h
@@ -63,5 +63,5 @@ struct llama_cparams {
     ggml_backend_sched_eval_callback cb_eval;
     void * cb_eval_user_data;
 
-    llama_context * ctx_other;
+    const llama_context * ctx_other;
 };

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -114,7 +114,7 @@ LLAMA_API void llama_set_embeddings_layer_inp(struct llama_context * ctx, uint32
 // LLAMA_API float * llama_get_embeddings(struct llama_context * ctx);
 LLAMA_API float * llama_get_embeddings_layer_inp(struct llama_context * ctx, uint32_t lid);
 
-LLAMA_API llama_context * llama_get_ctx_other(struct llama_context * ctx);
+LLAMA_API const llama_context * llama_get_ctx_other(struct llama_context * ctx);
 
 //
 // model/context data extraction


### PR DESCRIPTION
## Overview

This allows consumers to rely on the `llama_context` not being mutated while inside another `llama_context`, which is useful for ensuring thread-safety and correctness.

CC @ngxson, dunno who else it'd make sense to ping about this?

## Additional information

Similar to https://github.com/ggml-org/llama.cpp/pull/28307.

Would be useful in https://github.com/utilityai/llama-cpp-rs/pull/1122.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
