### PR TITLE
vulkan: fix crash on Vulkan-1.1-only devices with extension-provided timeline semaphores

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6333,6 +6333,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
         bool dot2_f16_support = false;
         bool ocp_microscaling_extension = false;
         bool shader_float8_extension = false;
+        bool timeline_semaphore_support = false;
 
         for (const auto& properties : ext_props) {
             if (strcmp("VK_KHR_maintenance4", properties.extensionName) == 0) {
@@ -6401,6 +6402,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 internally_sync_support = true;
             } else if (strcmp("VK_EXT_device_fault", properties.extensionName) == 0) {
                 device->device_fault = true;
+            } else if (strcmp("VK_KHR_timeline_semaphore", properties.extensionName) == 0) {
+                timeline_semaphore_support = true;
             }
         }
 
@@ -6596,12 +6599,12 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device_features2.pNext = nullptr;
         device_features2.features = (VkPhysicalDeviceFeatures)device_features;
 
-        VkPhysicalDeviceVulkan11Features vk11_features;
+        VkPhysicalDeviceVulkan11Features vk11_features{};
         vk11_features.pNext = nullptr;
         vk11_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
         device_features2.pNext = &vk11_features;
 
-        VkPhysicalDeviceVulkan12Features vk12_features;
+        VkPhysicalDeviceVulkan12Features vk12_features{};
         vk12_features.pNext = nullptr;
         vk12_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
         vk11_features.pNext = &vk12_features;
@@ -6617,6 +6620,17 @@ static vk_device ggml_vk_get_device(size_t idx) {
             last_struct->pNext = (VkBaseOutStructure *)&internally_synchronized_queues_features;
             last_struct = (VkBaseOutStructure *)&internally_synchronized_queues_features;
             device_extensions.push_back(VK_KHR_INTERNALLY_SYNCHRONIZED_QUEUES_EXTENSION_NAME);
+        }
+
+        VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timeline_semaphore_features{};
+        timeline_semaphore_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR;
+        timeline_semaphore_features.pNext = nullptr;
+        timeline_semaphore_features.timelineSemaphore = VK_TRUE;
+
+        if (timeline_semaphore_support && !vk12_features.timelineSemaphore) {
+            last_struct->pNext = (VkBaseOutStructure *)&timeline_semaphore_features;
+            last_struct = (VkBaseOutStructure *)&timeline_semaphore_features;
+            device_extensions.push_back("VK_KHR_timeline_semaphore");
         }
 
         VkPhysicalDevicePipelineRobustnessFeaturesEXT pl_robustness_features;
@@ -6806,7 +6820,7 @@ static vk_device ggml_vk_get_device(size_t idx) {
                             getenv("GGML_VK_DISABLE_MULTI_ADD") == nullptr;
 
         device->shader_int64 = device_features2.features.shaderInt64;
-        device->buffer_device_address = vk12_features.bufferDeviceAddress;
+        device->buffer_device_address = vk12_features.bufferDeviceAddress && device->properties.apiVersion >= VK_API_VERSION_1_2;
         device->vulkan_memory_model = vk12_features.vulkanMemoryModel;
 
         if (device->subgroup_size_control) {
@@ -7059,6 +7073,8 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device_create_info.setPNext(&device_features2);
         device->device = device->physical_device.createDevice(device_create_info);
 
+        ggml_vk_default_dispatcher().init(device->device);
+
         if (device->device_fault) {
             device->pfn_vkGetDeviceFaultInfoEXT = (PFN_vkGetDeviceFaultInfoEXT)
                 vkGetDeviceProcAddr(device->device, "vkGetDeviceFaultInfoEXT");
@@ -7308,12 +7324,12 @@ static void ggml_vk_print_gpu_info(size_t idx) {
     device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
     device_features2.pNext = nullptr;
 
-    VkPhysicalDeviceVulkan11Features vk11_features;
+    VkPhysicalDeviceVulkan11Features vk11_features{};
     vk11_features.pNext = nullptr;
     vk11_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     device_features2.pNext = &vk11_features;
 
-    VkPhysicalDeviceVulkan12Features vk12_features;
+    VkPhysicalDeviceVulkan12Features vk12_features{};
     vk12_features.pNext = nullptr;
     vk12_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
     vk11_features.pNext = &vk12_features;
@@ -19482,7 +19498,7 @@ static bool ggml_vk_device_is_supported(const vk::PhysicalDevice & vkdev) {
     VkPhysicalDeviceFeatures2 device_features2;
     device_features2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
 
-    VkPhysicalDeviceVulkan11Features vk11_features;
+    VkPhysicalDeviceVulkan11Features vk11_features{};
     vk11_features.pNext = nullptr;
     vk11_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
     device_features2.pNext = &vk11_features;


### PR DESCRIPTION
## What

Fixes a null-function-pointer crash (SIGSEGV in `ggml_backend_vk_device_event_synchronize` -> `vk::Device::waitSemaphores`) that happens unconditionally on any GPU-offloaded model load (`-ngl >= 1`) on a device that reports Vulkan **1.1** but supports timeline semaphores only via the `VK_KHR_timeline_semaphore` extension (not core-promoted).

Reproduced on: **Galaxy S21 Ultra (Exynos 2100), Mali-G78 MP14**, ARM proprietary driver r38p0, Vulkan **1.1.213**, running Qwen3.5-4B (Q4_K_M) under Termux.

## Root cause

`ggml_backend_vk_device_event_synchronize()` calls `device->device.waitSemaphores(...)`, which resolves through vulkan.hpp's dynamic dispatcher to the **core Vulkan 1.2** `vkWaitSemaphores` entry point. vulkan.hpp's `DispatchLoaderDynamic::init()` does have KHR-to-core aliasing for this (`if (!vkWaitSemaphores) vkWaitSemaphores = vkWaitSemaphoresKHR;`), but that only helps if `vkGetDeviceProcAddr` actually returns the KHR function -- which in turn requires `VK_KHR_timeline_semaphore` to have been requested at `vkCreateDevice` time. This backend never requests it (it assumes timeline semaphores come for free from a Vulkan >= 1.2 device), so on a 1.1-only device the pointer is null and the call segfaults.

Two adjacent issues surfaced while tracking this down, on the same device/code path:

- Several `VkPhysicalDeviceVulkan11Features`/`VkPhysicalDeviceVulkan12Features` locals are declared without an initializer, so any field the driver's `vkGetPhysicalDeviceFeatures2` call doesn't touch is read back as indeterminate memory rather than `false`. This driver doesn't populate the aggregate `..Vulkan12Features` struct for 1.1-era extension functionality (e.g. `timelineSemaphore`), so those reads were relying on whatever happened to be on the stack.
- `device->buffer_device_address` was set purely from `vk12_features.bufferDeviceAddress` (subject to the same garbage-read risk above), even though actually using it also requires `VK_KHR_buffer_device_address` to be requested, which isn't done here either. Gated it on `apiVersion >= VK_API_VERSION_1_2` as well, so a <1.2 device never enables it regardless of what that field reads back as.
- The dynamic dispatcher's device-level function table was never explicitly initialized after `vkCreateDevice` -- added `ggml_vk_default_dispatcher().init(device->device)` right after device creation, which is also what makes the KHR-aliasing in `init()` actually run for a freshly-created device.

## Fix

Detect `VK_KHR_timeline_semaphore` in the device's supported extension list, and explicitly request it (extension name + `VkPhysicalDeviceTimelineSemaphoreFeaturesKHR{ .timelineSemaphore = VK_TRUE }`) whenever the aggregate `vk12_features.timelineSemaphore` came back false. Zero-initialize the feature-query structs. Gate `buffer_device_address` on the reported API version.

## Testing

- `test-backend-ops -b Vulkan0`: `ADD`, `MUL`, `CPY` all pass. (Note: a handful of pre-existing `MUL_MAT` correctness failures remain for some small-`m` synthetic shapes on this device -- unrelated to this patch, not touched here, and not reproducible in real model inference below.)
- `llama-cli`/`llama-server` with the real Qwen3.5-4B model: previously crashed unconditionally on model load with `-ngl >= 1`; now loads and generates correct output at `-ngl` 1 through 32 (full offload).
- `llama-bench` (`-ngl 0` vs `-ngl 32`, warmup + 3 reps): pp32 0.38 -> 0.48 tok/s, tg32 0.55 -> 2.25 tok/s on this device, confirming the offloaded path is both correct and functional end-to-end, not just non-crashing.

Built as a fully static binary (`-DBUILD_SHARED_LIBS=OFF`) to rule out an unrelated library-loading issue also present in this environment; not relevant to this fix itself.

Co-authored with Claude Sonnet 5 (Anthropic) during the debugging session that found this.