### PR TITLE
server : encode images on the GPU by borrowing the idle compute buffers

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2608,6 +2608,15 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ_OFFLOAD"));
     add_opt(common_arg(
+        {"--mmproj-vram-swap"},
+        string_format("encode images on the GPU even when the projector does not fit alongside the model: "
+                "release the idle compute buffers for the duration of the encode, then reclaim them "
+                "(default: %s, requires --no-mmproj-offload)", params.mmproj_vram_swap ? "enabled" : "disabled"),
+        [](common_params & params) {
+            params.mmproj_vram_swap = true;
+        }
+    ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ_VRAM_SWAP"));
+    add_opt(common_arg(
         // note: "-mmdev" must sort after "--rpc" in the preset map, else RPC devices are not registered yet
         {"-mmdev", "--mmproj-device"}, "DEVICE",
         "device to use for multimodal projector (none = don't offload, default: auto)\n"

--- a/common/common.h
+++ b/common/common.h
@@ -593,6 +593,11 @@ struct common_params {
     struct common_params_model mmproj;
     bool mmproj_use_gpu = true;                 // use GPU for multimodal model
     ggml_backend_dev_t mmproj_device = nullptr; // GPU device to use for multimodal model
+    // Encode images on the GPU even when the projector does not fit alongside
+    // the model: hand the LLM's idle compute buffers back for the duration of
+    // the encode (llama_sched_release()), run the projector there, then give
+    // the memory straight back. Only meaningful with mmproj_use_gpu = false.
+    bool mmproj_vram_swap = false;
     bool no_mmproj = false;                     // explicitly disable multimodal model
     std::vector<std::string> image;             // path to image file(s) ; TODO: change the name to "media"
     int image_min_tokens = -1;

--- a/include/llama.h
+++ b/include/llama.h
@@ -1026,6 +1026,14 @@ extern "C" {
     // and is not necessary to call it explicitly in most cases
     LLAMA_API void llama_synchronize(struct llama_context * ctx);
 
+    // Release the compute-graph scheduler and hand its buffers back to the
+    // backend allocator. Those buffers hold only per-ubatch scratch, which is
+    // idle between requests and can be gigabytes at a large context, so this
+    // lets another consumer - a vision encoder, say - borrow the VRAM.
+    // The next llama_encode() / llama_decode() re-reserves from the same
+    // worst-case graph; no weights or KV cache are touched.
+    LLAMA_API void llama_sched_release(struct llama_context * ctx);
+
     // Token logits obtained from the last call to llama_decode()
     // The logits for which llama_batch.logits[i] != 0 are stored contiguously
     // in the order they have appeared in the batch.

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -579,6 +579,38 @@ void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint3
     }
 }
 
+void llama_context::sched_release() {
+    if (!sched) {
+        return;
+    }
+
+    // Hand the compute buffers back. The scheduler owns them through its
+    // graph allocator, so freeing it is the only way to release the
+    // per-ubatch scratch - on a large context that is gigabytes (here:
+    // ~2.4 GiB of FlashAttention F16 scratch plus ~0.6 GiB of activations at
+    // n_ctx = 150k, n_ubatch = 1024), and it sits idle between requests.
+    //
+    // Nothing is lost: sched_reserve() runs at the top of both encode() and
+    // decode(), so the next call rebuilds the scheduler from the same
+    // worst-case graph. The caller only pays the reserve, not a reload.
+    synchronize();
+
+    const size_t n_bufs = backend_ptrs.size();
+    size_t released = 0;
+    for (size_t i = 0; i < n_bufs; i++) {
+        released += ggml_backend_sched_get_buffer_size(sched.get(), backend_ptrs[i]);
+    }
+
+    gf_res_prev.reset();
+    gf_res_reserve.reset();
+    sched.reset();
+
+    sched_need_reserve = true;
+
+    LLAMA_LOG_INFO("%s: released %.2f MiB of compute buffers\n",
+            __func__, released / (1024.0 * 1024.0));
+}
+
 void llama_context::sched_reserve() {
     if (!sched_need_reserve) {
         return;
@@ -3844,6 +3876,10 @@ void llama_set_warmup(llama_context * ctx, bool warmup) {
 
 void llama_synchronize(llama_context * ctx) {
     ctx->synchronize();
+}
+
+void llama_sched_release(llama_context * ctx) {
+    ctx->sched_release();
 }
 
 float * llama_get_logits(llama_context * ctx) {

--- a/src/llama-context.h
+++ b/src/llama-context.h
@@ -55,6 +55,10 @@ struct llama_context {
     //   - etc.
     void sched_reserve();
 
+    // release the backend scheduler and hand its compute buffers back to the
+    // backend allocator; the next encode()/decode() re-reserves them
+    void sched_release();
+
     void synchronize();
 
     const llama_model   & get_model()   const;

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -2167,6 +2167,14 @@ float * mtmd_batch_get_output_embd(mtmd_batch * batch, const mtmd_input_chunk * 
     return nullptr; // not found
 }
 
+void mtmd_batch_set_ctx(mtmd_batch * batch, mtmd_context * ctx) {
+    GGML_ASSERT(batch != nullptr);
+    GGML_ASSERT(ctx   != nullptr);
+    GGML_ASSERT(batch->ctx->n_embd_out() == ctx->n_embd_out() &&
+            "mtmd_batch_set_ctx: contexts disagree on the embedding width");
+    batch->ctx = ctx;
+}
+
 bool mtmd_decode_use_non_causal(const mtmd_context * ctx, const mtmd_input_chunk * chunk) {
     auto proj_type = ctx->proj_type_v();
     if (chunk && chunk->type == MTMD_INPUT_CHUNK_TYPE_AUDIO) {

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -350,6 +350,15 @@ MTMD_API int32_t mtmd_batch_add_chunk(mtmd_batch * batch, const mtmd_input_chunk
 MTMD_API int32_t mtmd_batch_encode(mtmd_batch * batch);
 MTMD_API float * mtmd_batch_get_output_embd(mtmd_batch * batch, const mtmd_input_chunk * chunk);
 
+// Re-point an already-encoded batch at a different context of the same mmproj
+// model. mtmd_batch_encode() leaves its result in host memory owned by the
+// batch, so the context that produced it is only needed for the embedding
+// width afterwards; re-pointing lets that context be freed while the batch
+// stays usable. Intended for handing GPU memory back between an encode and
+// the decode that consumes it - see llama_sched_release().
+// Both contexts must come from the same mmproj file.
+MTMD_API void mtmd_batch_set_ctx(mtmd_batch * batch, mtmd_context * ctx);
+
 
 // Set callback for all future logging events.
 // If this is not called, or NULL is supplied, everything is output on stderr.

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -25,6 +25,7 @@
 #include <filesystem>
 #include <random>
 #include <utility>
+#include <functional>
 #include <fstream>
 
 // fix problem with std::min and std::max
@@ -734,12 +735,23 @@ struct server_slot {
     }
 };
 
+// Lets the caller lend the LLM's compute buffers to the vision encoder for the
+// duration of one encode. acquire() releases those buffers and returns a
+// GPU-resident mmproj context, or nullptr to encode on the host as before;
+// release() gives the context - and with it the VRAM - straight back.
+// See llama_sched_release() and mtmd_batch_set_ctx().
+struct mtmd_vram_swap {
+    std::function<mtmd_context *()>     acquire;
+    std::function<void(mtmd_context *)> release;
+};
+
 // returns 0 on success
 // caller need to update prompt.tokens after a successful call to keep track of the processing progress
 // note: this is not a member of server_slot because we want to run it inside yield_to_queue
 //       slot is passed as const to avoid accidental modification of the slot state
 //       some pointers are allowed to be used, they are not used by to_json()
-static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch, size_t idx, size_t & n_tokens_out) {
+static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch, size_t idx, size_t & n_tokens_out,
+        const mtmd_vram_swap * swap) {
     GGML_ASSERT(slot.mctx);
     const auto & mctx = slot.mctx;
     const auto & input_tokens = slot.task->tokens;
@@ -793,9 +805,37 @@ static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch
         return res;
     }
 
+
     // otherwise, the batch is either uninitialized or is used up
     // we need to create & encode a new batch
-    mbatch.reset(mtmd_batch_init(mctx));
+    //
+    // If the caller offered a swap, encode on a GPU-resident projector: its
+    // memory comes from the LLM's per-ubatch scratch, which is idle until the
+    // decode below. Guard it so an error path cannot leak the borrowed VRAM.
+    struct borrowed_ctx {
+        const mtmd_vram_swap * swap = nullptr;
+        mtmd_context *         ctx  = nullptr;
+
+        void give_back() {
+            if (ctx != nullptr) {
+                swap->release(ctx);
+                ctx = nullptr;
+            }
+        }
+
+        ~borrowed_ctx() { give_back(); }
+    } gpu;
+
+    mtmd_context * enc_ctx = mctx;
+    if (swap != nullptr && swap->acquire && swap->release) {
+        gpu.swap = swap;
+        gpu.ctx  = swap->acquire();
+        if (gpu.ctx != nullptr) {
+            enc_ctx = gpu.ctx;
+        }
+    }
+
+    mbatch.reset(mtmd_batch_init(enc_ctx));
     res = mtmd_batch_add_chunk(mbatch.get(), chunk.get());
     GGML_ASSERT(res == 0); // we should never have an empty batch
 
@@ -818,6 +858,18 @@ static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch
     SLT_TRC(slot, "encoding mtmd batch from idx = %zu, n_chunks = %d\n", idx, n_added);
 
     res = mtmd_batch_encode(mbatch.get());
+
+    if (gpu.ctx != nullptr) {
+        // The result is host memory owned by the batch, so the borrowed
+        // context is only needed for the embedding width from here on.
+        // Re-point the batch at the persistent projector and return the VRAM
+        // now: try_decode() below re-reserves the compute buffers, and the two
+        // must not be resident at the same time. Unconditional, so a failed
+        // encode cannot leave the batch pointing at a freed context.
+        mtmd_batch_set_ctx(mbatch.get(), mctx);
+        gpu.give_back();
+    }
+
     if (res != 0) {
         SLT_ERR(slot, "failed to encode mtmd batch for chunk idx = %zu, res = %d\n", idx, res);
         return -1;
@@ -843,6 +895,63 @@ public:
     // note: video_params.ffmpeg_bin_dir points into params_base, which outlives this struct
     mtmd_helper_init_opt init_opt = mtmd_helper_init_opt_default();
     const llama_vocab * vocab = nullptr;
+
+    // Hooks for --mmproj-vram-swap. The projector is kept on the host, where it
+    // costs only RAM; for the duration of one encode we hand the LLM's
+    // per-ubatch compute buffers back (idle at that moment, and gigabytes at a
+    // large context) and load a GPU-resident projector into that space. No
+    // weights move between devices: the transient context reads the same mmproj
+    // file, which is in the page cache after the first request.
+    mtmd_vram_swap mmproj_vram_swap_hooks() {
+        mtmd_vram_swap swap;
+
+        swap.acquire = [this]() -> mtmd_context * {
+            if (params_base.mmproj.path.empty() || params_base.mmproj_use_gpu) {
+                return nullptr; // nothing to swap, or already resident
+            }
+
+            const int64_t t_start = ggml_time_us();
+
+            llama_sched_release(ctx_tgt);
+            if (ctx_dft) {
+                llama_sched_release(ctx_dft);
+            }
+
+            mtmd_context_params mp = mtmd_context_params_default();
+            mp.use_gpu          = true;
+            mp.device           = params_base.mmproj_device;
+            mp.print_timings    = false;
+            mp.warmup           = false; // one-shot: a warmup encode would double the cost
+            mp.n_threads        = params_base.cpuparams.n_threads;
+            mp.flash_attn_type  = params_base.flash_attn_type;
+            mp.image_min_tokens = params_base.image_min_tokens;
+            mp.image_max_tokens = params_base.image_max_tokens;
+            mp.batch_max_tokens = params_base.mtmd_batch_max_tokens;
+            mp.media_marker     = get_media_marker();
+
+            mtmd_context * gpu = mtmd_init_from_file(params_base.mmproj.path.c_str(), model_tgt, mp);
+            if (gpu == nullptr) {
+                // The compute buffers are already gone, which costs nothing:
+                // the next decode re-reserves them. Fall back to the host
+                // projector for this request.
+                SRV_WRN("%s", "mmproj vram swap: could not place the projector on the GPU, encoding on the host\n");
+                return nullptr;
+            }
+
+            SRV_INF("mmproj vram swap: projector on GPU after %.0f ms\n",
+                    (ggml_time_us() - t_start) / 1000.0);
+            return gpu;
+        };
+
+        swap.release = [](mtmd_context * gpu) {
+            const int64_t t_start = ggml_time_us();
+            mtmd_free(gpu);
+            SRV_DBG("mmproj vram swap: projector released after %.0f ms\n",
+                    (ggml_time_us() - t_start) / 1000.0);
+        };
+
+        return swap;
+    }
 
     server_queue    queue_tasks;
     server_response queue_results;
@@ -1180,6 +1289,16 @@ private:
                 params_base.n_cache_reuse = 0;
                 SRV_WRN("%s\n", "cache_reuse is not supported by multimodal, it will be disabled");
             }
+
+            if (params_base.mmproj_vram_swap && params_base.mmproj_use_gpu) {
+                params_base.mmproj_vram_swap = false;
+                SRV_WRN("%s\n", "--mmproj-vram-swap is redundant when the projector is offloaded, it will be disabled");
+            }
+        }
+
+        if (!has_mmproj && params_base.mmproj_vram_swap) {
+            params_base.mmproj_vram_swap = false;
+            SRV_WRN("%s\n", "--mmproj-vram-swap needs a projector, it will be disabled");
         }
 
         if (!llama_memory_can_shift(llama_get_memory(ctx_tgt))) {
@@ -3477,7 +3596,9 @@ private:
                         size_t n_tokens_out = 0;
                         int32_t res = 0;
                         queue_tasks.yield_to_queue([&]() {
-                            res = process_mtmd_chunk(slot, slot.mbatch, cur_token_idx, n_tokens_out);
+                            const mtmd_vram_swap swap = mmproj_vram_swap_hooks();
+                            res = process_mtmd_chunk(slot, slot.mbatch, cur_token_idx, n_tokens_out,
+                                    params_base.mmproj_vram_swap ? &swap : nullptr);
                         });
 
                         if (res != 0) {


### PR DESCRIPTION
When the projector does not fit alongside the model, the only option is `--no-mmproj-offload`, which puts the vision encoder on the CPU. The memory for it is in fact available — it is just spoken for. The per-ubatch compute buffers are worst-case scratch and sit idle for the whole duration of an image encode, so lend them out and take them straight back.

Measured on this branch, 2x Tesla V100-SXM2-16GB, Qwen3.8-27B-abliterated-Q6_K with mmproj-F16 (885 MiB), `-sm tensor -ts 1,1 -fa on`, `n_ctx 150016`, `n_ubatch 1024`. Same build, same prompt, flag flipped in between:

| 1048-token image prompt | prompt eval |
|---|---|
| flag absent, encoder on the CPU | 22 371 ms |
| `--mmproj-vram-swap` | **3 619 ms** |

Context unchanged, no layers moved, no second GPU. Both runs answered correctly.

## What it does

Per image batch:

1. release the compute buffers
2. load a GPU-resident projector into that space
3. encode
4. free the projector
5. the decode that follows re-reserves the buffers

Step 5 needs no new code — `sched_reserve()` already runs at the top of `encode()` and `decode()`, so the rebuild is lazy and automatic. Two additions carry the rest.

**`llama_sched_release(ctx)`** frees the scheduler, and with it the graph allocator's buffers, then sets `sched_need_reserve`. No weights and no KV cache are touched; those live in their own buffers. In the configuration above the released scratch is 2401 MiB of FlashAttention F16 workspace plus 632 MiB of activations.

**`mtmd_batch_set_ctx(batch, ctx)`** re-points an encoded batch at another context of the same mmproj file. `mtmd_batch_encode()` leaves its result in `output_embd` owned by the batch, i.e. host memory, so the context that produced it is only needed for the embedding width afterwards. Re-pointing is what lets the projector be freed *before* the decode consumes the embeddings — the two must never be resident at the same time. The decode path itself only reads metadata from the context (`llama_model_n_embd_inp`, `mtmd_decode_use_mrope`, the position helpers), never the projector graph.

The server keeps the host projector loaded exactly as before. Nothing migrates between devices: the transient context reads the same file, which is in the page cache after the first request.

## Cost

| | |
|---|---|
| `mtmd_init_from_file` for the transient context | 1 504 ms |
| everything else | 2 115 ms |

The second row is dominated by the model prefilling 1048 embedding positions — the same work as 1048 text tokens, and irreducible. The vision encode itself is a small part of it; on the CPU it was around 20 s of the total.

That makes the projector load the next thing worth attacking. 885 MiB over PCIe 3.0 x16 is roughly 90 ms of copy, so most of the 1.5 s looks like GGUF open, parse and buffer allocation rather than transfer. Retaining the parsed model between requests should bring it close to the prefill floor. Not in this PR.

## Behaviour

- Opt-in via `--mmproj-vram-swap`; ignored with a warning when the projector is already offloaded or absent.
- Falls back to a host encode if the GPU load fails. The already-released buffers cost nothing in that case, since the next decode re-reserves them either way.
- VRAM peaked at 16071 of 16384 MiB per GPU during the swap, low water mark 13969 MiB.
- Text turns, prompt caching and tool calls unaffected: a text turn directly after an image answers correctly, and a repeated 10582-token prompt still reports `prompt_n = 1`.

## Not covered

Splitting the projector across devices would not help here — the encoder is not compute-bound and `mtmd_context_params` takes a single `device`. Swapping *model layers* out instead (#20246) is strictly more invasive and is not what this does.
