### PR TITLE
vulkan-shaders-gen: retry without optimization only on the specific spirv-opt failure

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/vulkan-shaders-gen.cpp
@@ -348,6 +348,10 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
     // disable spirv-opt for bf16 shaders for https://github.com/ggml-org/llama.cpp/issues/15344
     // disable spirv-opt for rope shaders for https://github.com/ggml-org/llama.cpp/issues/16860
     // disable spirv-opt for dot2 shaders (spirv-opt doesn't recognize SPV_VALVE_mixed_float_dot_product capability)
+    // Beyond these known-bad shader families, an older bundled spirv-tools (e.g. some Linux
+    // distro / Termux packages) can still fail to optimize other shaders as new SPIR-V
+    // capabilities are introduced upstream; that's handled generically below by retrying
+    // with -O0 only on that specific failure, instead of guessing more names ahead of time.
     if (!coopmat && name.find("bf16") == std::string::npos && name.find("rope") == std::string::npos && name.find("_dot2") == std::string::npos) {
         cmd.push_back("-O");
     }
@@ -384,6 +388,27 @@ void string_to_spv_func(std::string name, std::string in_path, std::string out_p
         // std::cout << std::endl;
 
         int exit_code = execute_command(cmd, stdout_str, stderr_str);
+
+        // Some spirv-tools/shaderc builds are too old to optimize certain SPIR-V capabilities
+        // emitted by newer shaders (fails with e.g. "Invalid capability operand: N" / "failed
+        // to optimize"). Retry once without optimization rather than hard-coding which shader
+        // names are affected -- that list has already had to grow multiple times (coopmat,
+        // bf16, rope, dot2 above) as new shaders were added.
+        if ((exit_code != 0 || !stderr_str.empty()) &&
+            stderr_str.find("failed to optimize") != std::string::npos) {
+            auto it = std::find(cmd.begin(), cmd.end(), "-O");
+            if (it != cmd.end()) {
+                *it = "-O0";
+                std::string retry_stdout, retry_stderr;
+                int retry_exit_code = execute_command(cmd, retry_stdout, retry_stderr);
+                if (retry_exit_code == 0 && retry_stderr.empty()) {
+                    exit_code = retry_exit_code;
+                    stdout_str = retry_stdout;
+                    stderr_str = retry_stderr;
+                }
+            }
+        }
+
         if (exit_code != 0 || !stderr_str.empty()) {
             std::cerr << "cannot compile " << name << " (exit code " << exit_code << ")\n\n";
             for (const auto& part : cmd) {


### PR DESCRIPTION
## What

`string_to_spv_func` already carries a per-shader-family exclusion list (coopmat, bf16, rope, dot2) for shaders whose SPIR-V an older bundled spirv-tools/shaderc can't optimize (fails with `Invalid capability operand: N` / `"failed to optimize"`). That list has had to grow every time a new shader hit the same failure on some environment's older toolchain, and until a name is added upstream, anyone on that toolchain gets a hard build failure ("cannot compile ...") rather than a working (if slightly less optimized) binary.

## Fix

When `execute_command`'s stderr contains `"failed to optimize"`, retry the exact same compile once with `-O0` instead of `-O`. Any other failure (a real syntax/semantic error, glslc itself failing, missing include, etc.) is unaffected and still fails the build immediately, since the retry is gated on that specific error string.

## Testing

Built with Termux's bundled shaderc (glslc 2026.3, internal spirv-tools 1.4.350.1) targeting a Mali-G78 device. With the existing exclusion list alone, the build still failed on:
- coopmat2 (`_cm2`) shaders -- not covered by the exclusion list's `coopmat` bool parameter, since `string_to_spv` passes the `coopmat` (v1) flag rather than `coopmat2`, so e.g. `flash_attn_cm2.comp` variants still went through `-O` and hit `Invalid capability operand: 5447`.
- several `mul_mat_vec` subgroup/OCP-FP4 (mxfp4/nvfp4) variants, hitting `Invalid capability operand: 4229`.

With this patch, both fall back to `-O0` and the build completes; every other shader still gets normally optimized.

Co-authored with Claude Sonnet 5 (Anthropic) during the debugging session that found this.