### PR TITLE
convert: fix LoRA conversion crash for Qwen3.5 V-head reorder

### DIFF
--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -462,6 +462,24 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
         shape = list(tensor.shape)
         if dim < 0:
             dim += len(shape)
+
+        # LoRA tensors (W ≈ B @ A) cannot reshape their row dimension.
+        # Instead, build a permutation index and apply it to A (column
+        # reorder) or B (row reorder) directly.
+        if hasattr(tensor, 'get_lora_A_B'):
+            n = shape[dim]
+            idx = torch.arange(n).reshape(num_k_heads, num_v_per_k, head_dim)
+            idx = idx.permute(1, 0, 2).contiguous().reshape(n)
+            lora_A, lora_B = tensor.get_lora_A_B()
+            if dim == len(shape) - 1:
+                return type(tensor)(lora_A[:, idx], lora_B)
+            elif dim == 0:
+                return type(tensor)(lora_A, lora_B[idx])
+            else:
+                raise NotImplementedError(
+                    f"_reorder_v_heads on dim={dim} not supported for LoRA tensors"
+                )
+
         new_shape = shape[:dim] + [num_k_heads, num_v_per_k, head_dim] + shape[dim + 1:]
         tensor = tensor.reshape(*new_shape)
         perm = list(range(len(new_shape)))

--- a/conversion/qwen.py
+++ b/conversion/qwen.py
@@ -470,7 +470,7 @@ class _LinearAttentionVReorderBase(Qwen3NextModel):
             n = shape[dim]
             idx = torch.arange(n).reshape(num_k_heads, num_v_per_k, head_dim)
             idx = idx.permute(1, 0, 2).contiguous().reshape(n)
-            lora_A, lora_B = tensor.get_lora_A_B()
+            lora_A, lora_B = tensor.get_lora_A_B()  # ty: ignore[call-non-callable]
             if dim == len(shape) - 1:
                 return type(tensor)(lora_A[:, idx], lora_B)
             elif dim == 0:


### PR DESCRIPTION
## Overview

Fix crash in `convert_lora_to_gguf.py` when converting Qwen3.5 LoRA adapters. The `_reorder_v_heads` function uses reshape+permute+reshape to reorder V heads, but `LoraTorchTensor.reshape()` cannot split its row dimension (the A matrix), so it throws `NotImplementedError` on `out_proj` weights.

The fix detects LoRA tensors via `get_lora_A_B()` and applies an equivalent index permutation directly on the A or B matrix instead of going through reshape.

- Column reorder (out_proj): permute A columns
- Row reorder (in_proj_*): permute B rows

Both produce identical results to the full-tensor path — verified with zero-diff tests on random rank-32 matrices matching Qwen3.5-9B dimensions.

Fixes #21125

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - code was written with AI assistance, description written by the contributor