### PR TITLE
ggml-cpu : add OS XSAVE checks to x86 CPU feature scoring.

### DIFF
--- a/ggml/src/ggml-cpu/arch/x86/cpu-feats.cpp
+++ b/ggml/src/ggml-cpu/arch/x86/cpu-feats.cpp
@@ -86,6 +86,8 @@ struct cpuid_x86 {
     bool AMX_INT8(void) { return f_7_edx[25]; }
     bool AMX_FP16(void) { return f_7_1_eax[21]; }
     bool AMX_BF16(void) { return f_7_edx[22]; }
+    bool OS_AVX(void) { return (xcr0 & 0x6) == 0x6; }
+    bool OS_AVX512(void) { return (xcr0 & 0xe6) == 0xe6; }
 
 #ifdef _MSC_VER
     static void cpuid(int cpu_info[4], int eax) {
@@ -93,6 +95,9 @@ struct cpuid_x86 {
     }
     static void cpuidex(int cpu_info[4], int eax, int ecx) {
         __cpuidex(cpu_info, eax, ecx);
+    }
+    static uint64_t xgetbv(unsigned int index) {
+        return _xgetbv(index);
     }
 #else
     static void cpuid(int cpu_info[4], int eax) {
@@ -106,6 +111,12 @@ struct cpuid_x86 {
             "cpuid"
             : "=a"(cpu_info[0]), "=b"(cpu_info[1]), "=c"(cpu_info[2]), "=d"(cpu_info[3])
             : "a"(eax), "c"(ecx));
+    }
+    static uint64_t xgetbv(unsigned int index) {
+        uint32_t eax;
+        uint32_t edx;
+        __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
+        return (static_cast<uint64_t>(edx) << 32) | eax;
     }
 #endif
 
@@ -150,6 +161,11 @@ struct cpuid_x86 {
             f_7_1_eax = cpui[0];
         }
 
+        // capture OS-enabled XSAVE state, if supported
+        if (OSXSAVE()) {
+            xcr0 = xgetbv(0);
+        }
+
         // calling __cpuid with 0x80000000 as the function_id argument
         // gets the number of the highest valid extended ID.
         cpuid(cpui.data(), 0x80000000);
@@ -189,6 +205,7 @@ struct cpuid_x86 {
     std::bitset<32> f_7_1_eax;
     std::bitset<32> f_81_ecx;
     std::bitset<32> f_81_edx;
+    uint64_t xcr0 = 0;
 };
 
 #if 0
@@ -257,12 +274,12 @@ void test_x86_is() {
     printf("amx_int8: %d\n", is.AMX_INT8());
     printf("amx_fp16: %d\n", is.AMX_FP16());
     printf("amx_bf16: %d\n", is.AMX_BF16());
+    printf("OS_AVX: %d\n", is.OS_AVX());
+    printf("OS_AVX512: %d\n", is.OS_AVX512());
 }
 #endif
 
 static int ggml_backend_cpu_x86_score() {
-    // FIXME: this does not check for OS support
-
     int score = 1;
     cpuid_x86 is;
 
@@ -283,19 +300,19 @@ static int ggml_backend_cpu_x86_score() {
     score += 1<<3;
 #endif
 #ifdef GGML_AVX
-    if (!is.AVX()) { return 0; }
+    if (!is.AVX() || !is.OS_AVX()) { return 0; }
     score += 1<<4;
 #endif
 #ifdef GGML_AVX2
-    if (!is.AVX2()) { return 0; }
+    if (!is.AVX2() || !is.OS_AVX()) { return 0; }
     score += 1<<5;
 #endif
 #ifdef GGML_AVX_VNNI
-    if (!is.AVX_VNNI()) { return 0; }
+    if (!is.AVX_VNNI() || !is.OS_AVX()) { return 0; }
     score += 1<<6;
 #endif
 #ifdef GGML_AVX512
-    if (!is.AVX512F()) { return 0; }
+    if (!is.AVX512F() || !is.OS_AVX512()) { return 0; }
     if (!is.AVX512CD()) { return 0; }
     if (!is.AVX512VL()) { return 0; }
     if (!is.AVX512DQ()) { return 0; }
@@ -303,18 +320,19 @@ static int ggml_backend_cpu_x86_score() {
     score += 1<<7;
 #endif
 #ifdef GGML_AVX512_VBMI
-    if (!is.AVX512_VBMI()) { return 0; }
+    if (!is.AVX512_VBMI() || !is.OS_AVX512()) { return 0; }
     score += 1<<8;
 #endif
 #ifdef GGML_AVX512_BF16
-    if (!is.AVX512_BF16()) { return 0; }
+    if (!is.AVX512_BF16() || !is.OS_AVX512()) { return 0; }
     score += 1<<9;
 #endif
 #ifdef GGML_AVX512_VNNI
-    if (!is.AVX512_VNNI()) { return 0; }
+    if (!is.AVX512_VNNI() || !is.OS_AVX512()) { return 0; }
     score += 1<<10;
 #endif
 #ifdef GGML_AMX_INT8
+    // FIXME: This doesn't include OS support
     if (!is.AMX_INT8()) { return 0; }
     score += 1<<11;
 #endif


### PR DESCRIPTION
## Overview

Adds checks for OS support of instructions to the x86 ggml-cpu score function. This avoids Illegal Instructions when a VM is running an OS that doesn't enable XSAVE for instructions that CPUID advertises.


## Additional information

- Fixes #28328 
- No regressions tests are included as XCR0 cannot be changed from userspace.
- Verified with test-backend-ops in a QEMU/KVM guest booted with clearcpuid=xsave: SIGILL inside libggml-cpu-haswell.so before the fix, passes after (falls back to libggml-cpu-sse42.so).

<details><summary>Logs</summary>

```
debian@debian:~/llama.cpp$ ./prober
XSAVE=1 OSXSAVE=0 AVX2=1 XCR0=0x0
debian@debian:~/llama.cpp$ gdb -batch -ex run -ex bt ./build/bin/test-backend-ops 2>&1 | tail -20
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-x64.so score: 1
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-cooperlake.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-sandybridge.so score: 21
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-piledriver.so score: 24
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-icelake.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-haswell.so score: 64
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-ivybridge.so score: 23

Program received signal SIGILL, Illegal instruction.
ggml_compute_fp16_to_fp32 (h=0) at /home/debian/llama.cpp/ggml/src/./ggml-impl.h:391
391	   const float exp_scale = 0x1.0p-112f;
#0  ggml_compute_fp16_to_fp32 (h=0) at /home/debian/llama.cpp/ggml/src/./ggml-impl.h:391
#1  0x00007ffff742cb1b in ggml_cpu_init () at /home/debian/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.c:3881
#2  0x00007ffff742f125 in ggml_backend_cpu_reg () at /home/debian/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp:701
#3  0x00007ffff742f137 in ggml_backend_init () at /home/debian/llama.cpp/ggml/src/ggml-cpu/ggml-cpu.cpp:712
#4  0x00007ffff7fad25c in ggml_backend_registry::load_backend (this=0x7ffff7fbe1a0 <get_reg()::reg>, path=filesystem::path "/home/debian/llama.cpp/build/bin/libggml-cpu-haswell.so" = {...}, silent=false) at /home/debian/llama.cpp/ggml/src/ggml-backend-reg.cpp:245
#5  0x00007ffff7fab74d in ggml_backend_load_best (name=0x7ffff7fb57c2 "cpu", silent=false, user_search_path=0x0) at /home/debian/llama.cpp/ggml/src/ggml-backend-reg.cpp:559
#6  0x00007ffff7fabbf2 in ggml_backend_load_all_from_path (dir_path=0x0) at /home/debian/llama.cpp/ggml/src/ggml-backend-reg.cpp:587
#7  0x00007ffff7faba68 in ggml_backend_load_all () at /home/debian/llama.cpp/ggml/src/ggml-backend-reg.cpp:563
#8  0x00005555555d5d6e in main (argc=1, argv=0x7fffffffe3c8) at /home/debian/llama.cpp/tests/test-backend-ops.cpp:11417


After the fix:

debian@debian:~/llama.cpp$ gdb -batch -ex run -ex bt ./build/bin/test-backend-ops 2>&1 | tail -20
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-sapphirerapids.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-skylakex.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-x64.so score: 1
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-cooperlake.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-sandybridge.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-piledriver.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-icelake.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-haswell.so score: 0
ggml_backend_load_best: /home/debian/llama.cpp/build/bin/libggml-cpu-ivybridge.so score: 0
load_backend: loaded CPU backend from /home/debian/llama.cpp/build/bin/libggml-cpu-sse42.so
register_backend: registered backend CPU (1 devices)
register_device: registered device CPU (Intel(R) Core(TM) i5-10210U CPU @ 1.60GHz)
Testing 1 devices

Backend 1/1: CPU
  Skipping CPU backend
1/1 backends passed
OK
[Inferior 1 (process 1375) exited normally]
No stack.
``` 

</details> 

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Used OpenCode agents to review the code and find the exact relevant pages in the Intel documentation. Also as help to replicate the error. I take full responsibility for all code.
