### PR TITLE
ggml-cpu(s390x): fix q5_1 uninitialized v_acc

### DIFF
--- a/ggml/src/ggml-cpu/arch/s390/quants.c
+++ b/ggml/src/ggml-cpu/arch/s390/quants.c
@@ -636,7 +636,7 @@ void ggml_vec_dot_q5_1_q8_1(int n, float * GGML_RESTRICT s, size_t bs, const voi
         const float32x4_t v_xyf = vec_float(v_xy);
 
         const float32x4_t v_d = vec_splats(GGML_CPU_FP16_TO_FP32(x0->d) * GGML_CPU_FP16_TO_FP32(y0->d));
-        const float32x4_t v_acc = vec_madd(v_xyf, v_d, v_acc);
+        const float32x4_t v_acc = vec_madd(v_xyf, v_d, vec_splats(0.0f));
 
         sumf += vec_hsum_f32x4(v_acc) + summs;
     }


### PR DESCRIPTION
## Overview

fixes #28281

I forgot to use `vec_splats(0.0f)` when accumulating, and instead used `v_acc`, which was undefined. Quoting @IgorTodorovskiIBM:

> v_acc is declared const inside the loop body and has no prior value, so the third operand of vec_madd is whatever the register happens to hold. The accumulated sumf is therefore garbage, and can be NaN or Inf depending on the residue.

Relatively simple fix, not sure how I overlooked it.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: 没有

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
