### PR TITLE
fix: speculative: zero MTP carrier at sequence start

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1537,6 +1537,11 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
                     continue;
                 }
 
+                const int32_t i_first = i_batch_beg[seq_id];
+                if (batch_in.pos[i_first] == 0) {
+                    std::fill(pending_h[seq_id].begin(), pending_h[seq_id].end(), 0.0f);
+                }
+
                 set_h(i_batch_beg[seq_id], pending_h[seq_id].data());
             }
 


### PR DESCRIPTION
## Overview
Identical deterministic requests produced different tokens because of stale MTP carrier presisted between fresh requests.
The change zeroes the carrier at sequence 0.
Repeated request testing confirmed identical output after the fix.  
<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information
Test
```
./build/bin/llama-server \
  -m /path/to/Qwen3.6-27B-MTP.gguf \
  -np 1 -c 8192 -ngl 99 -fa on \
  --spec-type draft-mtp --spec-draft-n-max 2 \
  --port 8090
```

```
head -c 16900 wiki.test.raw > /tmp/mtp-prompt.txt

# Test request
jq -Rs '{
  prompt: .,
  n_predict: 256,
  temperature: 0,
  seed: 1234,
  cache_prompt: false,
  return_tokens: true
}' /tmp/mtp-prompt.txt > /tmp/mtp-request.json

# Init request
jq -n '{
  prompt: "hi",
  n_predict: 1,
  temperature: 0,
  seed: 1234,
  cache_prompt: false,
  return_tokens: true
}' > /tmp/mtp-prime-request.json

curl -fsS http://127.0.0.1:8090/completion \
  -H 'Content-Type: application/json' \
  --data-binary @/tmp/mtp-prime-request.json \
  > /tmp/mtp-prime.json

# 5 runs of test request
for i in 1 2 3 4 5; do
  curl -fsS http://127.0.0.1:8090/completion \
    -H 'Content-Type: application/json' \
    --data-binary @/tmp/mtp-request.json \
    > "/tmp/mtp-$i.json"

  jq -c '{
    content,
    tokens,
    draft_n: .timings.draft_n,
    accepted: .timings.draft_n_accepted
  }' "/tmp/mtp-$i.json" | sha256sum
done
```

* Current result hash (r5)
```
482b8812c4e78ae73a11b4baa64e9ca66dc3515708d94dae81cb73cb4c2f4137  <- different result after init request
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
```

* Patched result hash (r5)
```
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
d6f08b45ab8f5aa4d4b5cecf831c930a7c40e3445e262723c6665a14b9b987cd  -
```

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, debugging, pinpointing this issue 

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
