### PR TITLE
CUDA/HIP: derive MMVQ nwarps from kernel launch bounds

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -920,12 +920,28 @@ static __global__ void mul_mat_vec_q_moe(
     }
 }
 
-template<ggml_type type>
+// The host cannot infer the device arch macros from cc, because the driver may load a generic
+// code object that sets different ones. Read nwarps back from the kernel instead.
+template<ggml_type type, int c_ncols_dst, bool small_k, bool halve_iters>
+static int calc_nwarps_from_kernel(const int device, const int warp_size) {
+    static int nwarps_cached[GGML_CUDA_MAX_DEVICES] = { 0 }; // 0 == not queried yet
+    if (nwarps_cached[device] == 0) {
+        cudaFuncAttributes attr = {};
+        // has_fusion does not change calc_nwarps, so the non-fusion kernel is enough to probe.
+        CUDA_CHECK(cudaFuncGetAttributes(&attr, reinterpret_cast<const void *>(
+                        &mul_mat_vec_q<type, c_ncols_dst, /*has_fusion =*/ false, small_k, halve_iters>)));
+        nwarps_cached[device] = attr.maxThreadsPerBlock / warp_size;
+    }
+    return nwarps_cached[device];
+}
+
+template<ggml_type type, int c_ncols_dst, bool small_k = false, bool halve_iters = false>
 static std::pair<dim3, dim3> calc_launch_params(
-        const int ncols_dst, const int nrows_x, const int nchannels_dst, const int nsamples_or_ntokens,
-        const int warp_size, const mmvq_parameter_table_id table_id, const bool small_k = false, const bool halve_iters = false) {
-    const int nwarps = calc_nwarps(type, ncols_dst, table_id, small_k, halve_iters);
-    const int rpb = calc_rows_per_block(ncols_dst, table_id, small_k, nwarps);
+        const int nrows_x, const int nchannels_dst, const int nsamples_or_ntokens,
+        const int device, const int warp_size, const mmvq_parameter_table_id table_id) {
+    const int nwarps = calc_nwarps_from_kernel<type, c_ncols_dst, small_k, halve_iters>(device, warp_size);
+    // calc_rows_per_block only varies across the RDNA split, which no code object straddles.
+    const int rpb = calc_rows_per_block(c_ncols_dst, table_id, small_k, nwarps);
     const int64_t nblocks = (nrows_x + rpb - 1) / rpb;
     const dim3 block_nums(nblocks, nchannels_dst, nsamples_or_ntokens);
     const dim3 block_dims(warp_size, nwarps, 1);
@@ -1112,8 +1128,8 @@ static void mul_mat_vec_q_switch_ncols_dst(
 
                 constexpr bool c_halve_iters = decltype(halve_iters_tag)::value && c_promoted;
 
-                const std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst,
-                                                                              nsamples_dst, warp_size, table_id, c_small_k, c_halve_iters);
+                const std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst, c_small_k, c_halve_iters>(
+                                                                              nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
                 mul_mat_vec_q_switch_fusion<type, c_ncols_dst, c_small_k, c_halve_iters>(
                     vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                     channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst, sample_ratio_fd,
@@ -1131,7 +1147,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 2: {
             constexpr int c_ncols_dst = 2;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
+            std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst>(nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
             mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                  channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
                  sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
@@ -1139,7 +1155,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 3: {
             constexpr int c_ncols_dst = 3;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
+            std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst>(nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
             mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                  channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
                  sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
@@ -1147,7 +1163,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 4: {
             constexpr int c_ncols_dst = 4;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
+            std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst>(nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
             mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                  channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
                  sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
@@ -1155,7 +1171,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 5: {
             constexpr int c_ncols_dst = 5;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
+            std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst>(nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
             mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                  channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
                  sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
@@ -1163,7 +1179,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 6: {
             constexpr int c_ncols_dst = 6;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
+            std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst>(nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
             mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                  channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
                  sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
@@ -1171,7 +1187,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 7: {
             constexpr int c_ncols_dst = 7;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
+            std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst>(nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
             mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                  channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
                  sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,
@@ -1179,7 +1195,7 @@ static void mul_mat_vec_q_switch_ncols_dst(
         } break;
         case 8: {
             constexpr int c_ncols_dst = 8;
-            std::pair<dim3, dim3> dims = calc_launch_params<type>(c_ncols_dst, nrows_x, nchannels_dst, nsamples_dst, warp_size, table_id);
+            std::pair<dim3, dim3> dims = calc_launch_params<type, c_ncols_dst>(nrows_x, nchannels_dst, nsamples_dst, device, warp_size, table_id);
             mul_mat_vec_q_switch_fusion<type, c_ncols_dst>(vx, vy, ids, fusion, dst, ncols_x, nchannels_y_fd, stride_row_x, stride_col_y, stride_col_dst,
                  channel_ratio_fd, stride_channel_x, stride_channel_y, stride_channel_dst,
                  sample_ratio_fd, stride_sample_x, stride_sample_y, stride_sample_dst,

--- a/ggml/src/ggml-cuda/vendors/hip.h
+++ b/ggml/src/ggml-cuda/vendors/hip.h
@@ -145,6 +145,8 @@
 #define cudaOccupancyMaxActiveBlocksPerMultiprocessor hipOccupancyMaxActiveBlocksPerMultiprocessor
 #define cudaFuncSetAttribute hipFuncSetAttribute
 #define cudaFuncAttributeMaxDynamicSharedMemorySize hipFuncAttributeMaxDynamicSharedMemorySize
+#define cudaFuncGetAttributes hipFuncGetAttributes
+#define cudaFuncAttributes hipFuncAttributes
 #define __trap() do { abort(); __builtin_unreachable(); } while(0)
 #define CUBLAS_STATUS_SUCCESS HIPBLAS_STATUS_SUCCESS
 #define CUBLAS_STATUS_NOT_INITIALIZED HIPBLAS_STATUS_NOT_INITIALIZED


### PR DESCRIPTION
Fixes #25620

## Overview

mmvq.cu sets nwarps twice; device-side from arch macros + host-side from runtime cc. It is assumed these agree but breaks on a generic code object - gfx11-generic on RDNA3.5 sets __GFX11__ but not __gfx115x__, so the device gets RDNA3_0 (nwarps=8) & the host gets RDNA3_5 (nwarps=1). The reduction then reads unwritten shared memory, outputs NaN at ncols_dst=1. 

Instead, this PR reads nwarps back from the compiled kernel via cudaFuncGetAttributes in place of recomputing host-side.

Tested: gfx11-generic went 10 FAIL to 0 FAIL on n=1 (all NaN/-inf); gfx1151-native stayed 48/48. test-backend-ops -o MUL_MAT, type_a=q4_0, llama.cpp 7798007, ROCm 7.2.4, Strix Halo gfx1151. This bug only reproduces on AMD, and the fix has only been tested on AMD.

Original patch is by @talhaHavadar - who requested this PR in #25620 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI was used in testing this issue, consulted for solution implementation, and provided support throughout. This PR message, commit and code contribution are attributable to the human responsible, myself.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
