### PR TITLE
vulkan: use shared-memory reduction for dequant mul_mat_vec on Imagination PowerVR

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -5297,8 +5297,12 @@ static void ggml_vk_load_shaders(vk_device& device, vk_pipeline requested) {
     uint32_t rm_iq = 2 * rm_kq;
 
     const bool use_subgroups = device->subgroup_arithmetic;
+    // The Imagination proprietary compiler rejects the subgroup-only dequant mul_mat_vec
+    // shaders that require a subgroup size >= 16; fall back to shared-memory reduction.
+    const bool is_imagination_proprietary =
+        device->driver_id == vk::DriverId::eImaginationProprietary;
     // Ensure a subgroup size >= 16 is available
-    const bool use_subgroups16 = use_subgroups && subgroup_min_size_16;
+    const bool use_subgroups16 = use_subgroups && subgroup_min_size_16 && !is_imagination_proprietary;
 
     const uint32_t subgroup_size = (device->vendor_id == VK_VENDOR_ID_INTEL && device->subgroup_size_control && device->subgroup_min_size <= 16 && device->subgroup_max_size >= 16) ? 16 : device->subgroup_size;
     const uint32_t subgroup_size16 = std::max(subgroup_size, 16u);


### PR DESCRIPTION
## Overview

Imagination's proprietary Vulkan compiler cannot compile the subgroup-only reduction variants of the dequant `mul_mat_vec` shaders. `vkCreateComputePipelines` returns `VK_ERROR_UNKNOWN`, `ggml_vk_create_pipeline_func` rethrows, and the process dies with an uncaught `vk::SystemError` on the first generated token. Prompt processing runs first and succeeds, so the failure looks like a hang partway into generation.

This affects every type that goes through `reduc16`: Q2_K through Q6_K, TQ2_0, the IQ types, MXFP4 and NVFP4. The legacy quants use the plain subgroup reduction and compile fine, so the subgroup path itself is not the problem.

Falling back to the shared-memory reduction for those shaders fixes it.

## Additional information

### Device

Pixel 11 Pro, PowerVR C-Series CXTP-48-1536 MC1, `VK_DRIVER_ID_IMAGINATION_PROPRIETARY`, driver 1.662.3024, Vulkan 1.4.317. Subgroup size 128, min 32, max 128. 32 KB shared memory, no cooperative matrix, no integer dot product.

The failing pipeline is created with `require_full_subgroups=1`, `requiredSubgroupSize=128`, `wg_denoms=[2,1,1]`, specialization constants `[128,2,1]`, 17320 bytes of SPIR-V.

### What I ruled out

None of these help; the compile still fails:

- dropping `VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT`
- dropping the `VkPipelineShaderStageRequiredSubgroupSizeCreateInfoEXT` pNext
- dropping both
- forcing the subgroup size to 64
- forcing it to 32

So it is the shader body, not the pipeline flags or the subgroup width.

### Why not the hybrid variant

#20565 proposed hybrid reduction for the same vendor on a Pixel 10. Hybrid does compile here and is correct, but it costs 27% of token throughput on this device:

| reduction | pp128 | tg32 |
|---|---|---|
| shared memory | 21.41 t/s | 5.20 t/s |
| hybrid | 21.41 t/s | 3.78 t/s |

Qwen3.5-2B-Q4_K_M, `-ngl 99 -p 128 -n 32 -r 3`.

### Testing

`test-backend-ops` against the CPU reference, on device:

| type | before | after |
|---|---|---|
| Q2_K | pipeline compile fails | 11/11 |
| Q3_K | pipeline compile fails | 11/11 |
| Q4_K | pipeline compile fails | 26/26 |
| Q5_K | pipeline compile fails | 11/11 |
| Q6_K | pipeline compile fails | 11/11 |

Q4_K and Q6_K repeated four times each, same result every run. `llama-bench` on Qwen3.5-2B-Q4_K_M runs end to end after the change; before it aborts at the first generated token.

Gated on `driver_id` rather than `vendor_id` because the evidence is for the proprietary Android driver only. I have not tested Mesa's PowerVR driver.

Related: #28214 (other problems on the same device, not addressed here), #20565.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used to help create this PR, including the on-device investigation.
