### PR TITLE
rpc : read cached tensor files with fread instead of std::ifstream

### DIFF
--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -1460,12 +1460,27 @@ bool rpc_server::get_cached_file(uint64_t hash, std::vector<uint8_t> & data) {
     if (!fs::exists(cache_file, ec)) {
         return false;
     }
-    std::ifstream ifs(cache_file, std::ios::binary);
-    ifs.seekg(0, std::ios::end);
-    size_t size = ifs.tellg();
-    ifs.seekg(0, std::ios::beg);
+    // read with C stdio instead of std::ifstream: on MSVC, ifstream::read() of a large block
+    // goes through the small filebuf buffer and tops out at ~250 MB/s even from page cache
+    size_t size = fs::file_size(cache_file, ec);
+    if (ec) {
+        return false;
+    }
+#ifdef _WIN32
+    FILE * f = _wfopen(cache_file.c_str(), L"rb");
+#else
+    FILE * f = fopen(cache_file.c_str(), "rb");
+#endif
+    if (!f) {
+        return false;
+    }
     data.resize(size);
-    ifs.read((char *)data.data(), size);
+    size_t n = fread(data.data(), 1, size, f);
+    fclose(f);
+    if (n != size) {
+        data.clear();
+        return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
## Overview

I've noticed that even once the model was supposed to be loaded in memory, it was still slow to respond, exactly as slow as if it was reading again from the disk. I decided to keep digging.

Timing the worker per cached tensor showed that `rpc_server::get_cached_file()` reads a file with a single `std::ifstream::read()`, and on MSVC that runs at about 1 GB/s even when the file is in the page cache. With 22.8 GB of cached tensors that is 23 s of the load spent inside the read call. `fread()` with one large request reads the same files at about 3 GB/s.

This change reads the cache file with `fopen`/`fread` (`_wfopen` on Windows so non-ASCII cache paths keep working) and fails cleanly on a short read instead of returning a partly filled buffer. The write side in `set_tensor` is unchanged.

This is not the only cost in a cached load: on my setup the client-side FNV hashing and the raw transfer of tensors under `HASH_THRESHOLD` take longer than the read phase. Those are separate topics.

## Additional information

Windows 11 worker (`ggml-rpc-server --cache`, Vulkan, Ryzen AI Max+ 395), macOS client, 46 layers of Qwen3-Coder-Next Q4_K_M on the worker, 94 cached tensors / 22.8 GB, files in page cache:

| | read phase | full cached load |
|---|---|---|
| `std::ifstream` (master) | 23.4 s (1.0 GB/s) | 99 s |
| `fread` (this PR) | 7.7 s (3.0 GB/s) | 90 s |

Measured by timing `get_cached_file()` and `ggml_backend_tensor_set()` inside `set_tensor_hash()` on the worker. Loopback test on macOS with Qwen2.5-1.5B Q8_0 writes 45 cache files and reads them back through the new path with correct output.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - an AI coding assistant was used during the investigation and for the first version of the patch; I reviewed and tested the change.
