### PR TITLE
mmproj : add --mmproj-evict-draft (swap mmproj and draft weights on demand)

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -2608,6 +2608,18 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_examples(mmproj_examples).set_env("LLAMA_ARG_MMPROJ_OFFLOAD"));
     add_opt(common_arg(
+        {"--mmproj-evict-draft"},
+        {"--no-mmproj-evict-draft"},
+        string_format("EXPERIMENTAL: keep mmproj weights (vision and/or audio encoders) in host RAM and stream each to the "
+                      "compute device on demand, only while encoding that modality, evicting the speculative-decoding "
+                      "draft model's unique weights to host RAM for that window (default: %s)\n"
+                      "requires a draft model to be loaded (--spec-draft-model); without one the flag is a no-op with a warning",
+                      params.mmproj_evict_draft ? "enabled" : "disabled"),
+        [](common_params & params, bool value) {
+            params.mmproj_evict_draft = value;
+        }
+    ).set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_MMPROJ_EVICT_DRAFT"));
+    add_opt(common_arg(
         // note: "-mmdev" must sort after "--rpc" in the preset map, else RPC devices are not registered yet
         {"-mmdev", "--mmproj-device"}, "DEVICE",
         "device to use for multimodal projector (none = don't offload, default: auto)\n"

--- a/common/common.h
+++ b/common/common.h
@@ -594,6 +594,7 @@ struct common_params {
     bool mmproj_use_gpu = true;                 // use GPU for multimodal model
     ggml_backend_dev_t mmproj_device = nullptr; // GPU device to use for multimodal model
     bool no_mmproj = false;                     // explicitly disable multimodal model
+    bool mmproj_evict_draft = false;            // EXPERIMENTAL: keep mmproj weights (vision + audio) in host RAM, stream to VRAM per encode by evicting the draft model (requires a draft model)
     std::vector<std::string> image;             // path to image file(s) ; TODO: change the name to "media"
     int image_min_tokens = -1;
     int image_max_tokens = -1;

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -88,6 +88,21 @@ LLAMA_API int32_t llama_model_n_devices(const struct llama_model * model);
 
 LLAMA_API ggml_backend_dev_t llama_model_get_device(const struct llama_model * model, int i);
 
+// EXPERIMENTAL (--mmproj-evict-draft): runtime-evict/restore the model's unique GPU
+// weight buffers. prepare() is one-time (must run after the model is loaded and before any
+// evict); evict() frees the device weight buffers (a host copy is held); restore() reallocates and
+// refills them. Shared tensors (tok_embd/output borrowed via ctx_other) are not in the model's own
+// buffers and are never touched. evict()/restore() are not all-or-nothing across buffers: a failure
+// partway leaves the model in a partially swapped state (every tensor still points at a valid,
+// filled buffer, so inference stays correct); a later evict()/restore() retries the remaining parts.
+LLAMA_API bool llama_model_weights_swap_prepare(const struct llama_model * model);
+LLAMA_API bool llama_model_weights_swap_evict(const struct llama_model * model);
+LLAMA_API bool llama_model_weights_swap_restore(const struct llama_model * model);
+// Total bytes of the unique, non-shared device weight buffers recorded by
+// llama_model_weights_swap_prepare() (i.e. what an evict moves to host RAM). 0 until prepare() has
+// run, or when no buffer is swappable.
+LLAMA_API size_t llama_model_weights_swap_size(const struct llama_model * model);
+
 LLAMA_API llama_memory_breakdown llama_get_memory_breakdown(const struct llama_context * ctx);
 
 // Set whether the context outputs nextn embeddings or not

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1156,6 +1156,22 @@ struct llama_model::impl {
     // contexts where the model tensors metadata is stored as well as the corresponding buffers:
     std::vector<std::pair<ggml_context_ptr, std::vector<ggml_backend_buffer_ptr>>> ctxs_bufs;
 
+    // --mmproj-evict-draft: runtime eviction/restore of the model's GPU weight buffers.
+    // Each part describes one evictable (non-host, non-mmap) weight buffer and the tensors it backs.
+    struct wswap_part {
+        size_t ctx_idx = 0;
+        size_t buf_idx = 0;
+        ggml_context * ctx = nullptr;
+        ggml_backend_buffer_type_t buft = nullptr;
+        ggml_backend_dev_t dev = nullptr;
+        size_t size = 0;
+        std::vector<std::pair<ggml_tensor *, ptrdiff_t>> tensors; // (tensor, offset) for base + view tensors
+        ggml_backend_buffer_ptr host; // valid only while the part is evicted
+        bool evicted = false;
+    };
+    std::vector<wswap_part> wswap;
+    bool wswap_prepared = false;
+
     buft_list_t cpu_buft_list;
     std::map<ggml_backend_dev_t, buft_list_t> gpu_buft_list;
 
@@ -1899,12 +1915,174 @@ std::map<ggml_backend_buffer_type_t, size_t> llama_model::memory_breakdown() con
             ret[buft] += ggml_backend_alloc_ctx_tensors_from_buft_size(ctx.get(), buft);
         } else {
             for (const auto & buf : bufs) {
-                // GGML_ASSERT(ggml_backend_buffer_get_base(buf.get()) != nullptr); // multi_buffer does not have a defined base
-                ret[ggml_backend_buffer_get_type(buf.get())] += ggml_backend_buffer_get_size(buf.get());
+                if (buf) { // temporarily null while evicted by --mmproj-evict-draft
+                    // GGML_ASSERT(ggml_backend_buffer_get_base(buf.get()) != nullptr); // multi_buffer does not have a defined base
+                    ret[ggml_backend_buffer_get_type(buf.get())] += ggml_backend_buffer_get_size(buf.get());
+                }
             }
         }
     }
     return ret;
+}
+
+// --mmproj-evict-draft ------------------------------------------------------------------------
+
+namespace {
+// re-point every tensor of ctx from one buffer to another, keeping each tensor's absolute
+// offset. Tensor offsets from the ggml allocator are multiples of GGML_MEM_ALIGN (the minimum
+// alignment ggml guarantees) and both buffer bases are aligned to at least GGML_MEM_ALIGN, so
+// to_base + off is a valid, aligned placement in a destination buffer of the same total size.
+// (Same offset-preserving repoint for the mmproj buffers: clip_repoint_ctx, tools/mtmd/clip.cpp)
+static void model_wswap_repoint(ggml_context * ctx, ggml_backend_buffer_t from, ggml_backend_buffer_t to) {
+    auto * from_base = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(from));
+    auto * to_base   = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(to));
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+        if (t->buffer != from) {
+            continue;
+        }
+        if (t->data) {
+            const ptrdiff_t off = reinterpret_cast<uint8_t *>(t->data) - from_base;
+            t->data = to_base + off;
+        }
+        t->buffer = to;
+    }
+}
+} // namespace
+
+bool llama_model::weight_swap_prepare() {
+    if (pimpl->wswap_prepared) {
+        return true;
+    }
+    pimpl->wswap.clear();
+    auto & cb = pimpl->ctxs_bufs;
+    // Invariant: the collected buffers hold only this model's own weights. Tensors borrowed from a
+    // sibling model via ctx_other (e.g. a draft's tok_embd/output shared with the target) are never
+    // allocated into this model's buffers, so evict/restore cannot free or overwrite a buffer the
+    // other model still reads.
+    for (size_t i = 0; i < cb.size(); ++i) {
+        auto & [ctx_ptr, bufs] = cb[i];
+        for (size_t j = 0; j < bufs.size(); ++j) {
+            ggml_backend_buffer_t buf = bufs[j].get();
+            if (ggml_backend_buffer_is_host(buf)) {
+                continue; // CPU weights: nothing to move off the device
+            }
+            if (ggml_backend_buffer_get_base(buf) == nullptr) {
+                continue; // no host-visible base (dummy buffer, private device memory): nothing to copy
+            }
+            // buffers made from a host pointer (mmap/lazy weights on a backend that maps the file
+            // into device-accessible memory, e.g. Metal) own no device memory; their base is
+            // the host pointer, so the check above does not catch them. Evicting them would free
+            // nothing and restore would permanently re-home the weights into VRAM.
+            // Deliberately conservative: if any mapping exists and the device supports from-host-ptr
+            // buffers, ALL device buffers are skipped, including ones not host-backed. Worst case
+            // the swap disarms (or shrinks); it never corrupts.
+            if (!pimpl->mappings.empty()) {
+                ggml_backend_dev_t dev = ggml_backend_buft_get_device(ggml_backend_buffer_get_type(buf));
+                if (dev) {
+                    ggml_backend_dev_props props;
+                    ggml_backend_dev_get_props(dev, &props);
+                    if (props.caps.buffer_from_host_ptr) {
+                        continue;
+                    }
+                }
+            }
+            const size_t size = ggml_backend_buffer_get_size(buf);
+            if (size == 0) {
+                continue;
+            }
+            impl::wswap_part p;
+            p.ctx_idx = i;
+            p.buf_idx = j;
+            p.ctx     = ctx_ptr.get();
+            p.buft    = ggml_backend_buffer_get_type(buf);
+            p.dev     = ggml_backend_buft_get_device(p.buft);
+            p.size    = size;
+            auto * base = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(buf));
+            for (ggml_tensor * t = ggml_get_first_tensor(ctx_ptr.get()); t != nullptr; t = ggml_get_next_tensor(ctx_ptr.get(), t)) {
+                if (t->buffer != buf || t->data == nullptr) {
+                    continue;
+                }
+                p.tensors.emplace_back(t, reinterpret_cast<uint8_t *>(t->data) - base);
+            }
+            if (p.tensors.empty()) {
+                continue;
+            }
+            pimpl->wswap.push_back(std::move(p));
+        }
+    }
+    pimpl->wswap_prepared = !pimpl->wswap.empty();
+    return pimpl->wswap_prepared;
+}
+
+bool llama_model::weight_swap_evict() {
+    if (!pimpl->wswap_prepared) {
+        return false;
+    }
+    for (auto & p : pimpl->wswap) {
+        if (p.evicted) {
+            continue;
+        }
+        auto & bufs = pimpl->ctxs_bufs[p.ctx_idx].second;
+        ggml_backend_buffer_t buf = bufs[p.buf_idx].get();
+
+        p.host.reset(ggml_backend_buft_alloc_buffer(ggml_backend_cpu_buffer_type(), p.size));
+        if (p.host == nullptr) {
+            return false;
+        }
+        ggml_backend_buffer_set_usage(p.host.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+        auto * host_base = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(p.host.get()));
+        for (auto & [t, off] : p.tensors) {
+            if (t->view_src == nullptr) {
+                ggml_backend_tensor_get(t, host_base + off, 0, ggml_nbytes(t)); // D2H
+            }
+        }
+        // the D2H copies above are host-blocking but do not order against the compute stream; the
+        // caller has drained the model's context before this, so no in-flight decode reads the buffer
+        model_wswap_repoint(p.ctx, buf, p.host.get()); // tensors now point at the host copy
+        bufs[p.buf_idx].reset();
+        p.evicted = true;
+    }
+    return true;
+}
+
+bool llama_model::weight_swap_restore() {
+    if (!pimpl->wswap_prepared) {
+        return false;
+    }
+    for (auto & p : pimpl->wswap) {
+        if (!p.evicted) {
+            continue;
+        }
+        auto & bufs = pimpl->ctxs_bufs[p.ctx_idx].second;
+        bufs[p.buf_idx].reset(ggml_backend_buft_alloc_buffer(p.buft, p.size));
+        if (bufs[p.buf_idx] == nullptr) {
+            return false;
+        }
+        ggml_backend_buffer_t buf = bufs[p.buf_idx].get();
+        ggml_backend_buffer_set_usage(buf, GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+        model_wswap_repoint(p.ctx, p.host.get(), buf); // tensors now point back at the device buffer
+        auto * host_base = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(p.host.get()));
+        for (auto & [t, off] : p.tensors) {
+            if (t->view_src == nullptr) {
+                ggml_backend_tensor_set(t, host_base + off, 0, ggml_nbytes(t)); // H2D
+            }
+        }
+        // the H2D copies above are host-blocking, so the host copy is fully read; release it
+        p.host.reset();
+        p.evicted = false;
+    }
+    return true;
+}
+
+size_t llama_model::weight_swap_size() const {
+    if (!pimpl->wswap_prepared) {
+        return 0;
+    }
+    size_t total = 0;
+    for (const auto & p : pimpl->wswap) {
+        total += p.size;
+    }
+    return total;
 }
 
 uint64_t llama_model::n_elements() const {
@@ -3140,6 +3318,22 @@ ggml_backend_dev_t llama_model_get_device(const struct llama_model * model, int 
         return nullptr;
     }
     return model->devices[i].dev;
+}
+
+bool llama_model_weights_swap_prepare(const struct llama_model * model) {
+    return const_cast<struct llama_model *>(model)->weight_swap_prepare();
+}
+
+bool llama_model_weights_swap_evict(const struct llama_model * model) {
+    return const_cast<struct llama_model *>(model)->weight_swap_evict();
+}
+
+bool llama_model_weights_swap_restore(const struct llama_model * model) {
+    return const_cast<struct llama_model *>(model)->weight_swap_restore();
+}
+
+size_t llama_model_weights_swap_size(const struct llama_model * model) {
+    return model->weight_swap_size();
 }
 
 //

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -732,6 +732,13 @@ struct llama_model {
 
     std::map<ggml_backend_buffer_type_t, size_t> memory_breakdown() const;
 
+    // EXPERIMENTAL (--mmproj-evict-draft): snapshot then runtime-evict/restore the model's GPU
+    // weight buffers (host copy held while evicted). prepare() is one-time; evict/restore toggle.
+    bool weight_swap_prepare();
+    bool weight_swap_evict();
+    bool weight_swap_restore();
+    size_t weight_swap_size() const;
+
     // total number of parameters in the model
     uint64_t n_elements() const;
 

--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -157,13 +157,45 @@ struct clip_ctx {
 
     ggml_backend_t backend = nullptr;
     ggml_backend_t backend_cpu = nullptr;
-    ggml_backend_buffer_ptr buf;
+    ggml_backend_buffer_ptr buf; // GPU weight buffer (weights_evict: allocated on demand)
+    ggml_backend_buffer_ptr buf_host; // weights_evict: persistent host copy of the weights
 
 
     int max_nodes = 8192;
     ggml_backend_sched_ptr sched;
     clip_flash_attn_type flash_attn_type = CLIP_FLASH_ATTN_TYPE_AUTO;
     bool is_allocated = false;
+
+    bool weights_evict = false; // weights live in buf_host and are streamed to buf on demand
+    bool weights_on_gpu = false; // true while buf (GPU) is allocated and tensors point at it
+
+    // eval callback, stored so create_sched() can re-attach it after the scheduler is
+    // freed between image requests
+    ggml_backend_sched_eval_callback cb_eval = nullptr;
+    void * cb_eval_user_data = nullptr;
+
+    // (re)create the scheduler (and its compute/activation buffer, reclaimed by free_sched
+    // between image requests when weights_evict is set). The weights live in a separate buffer
+    // (buf/buf_host), so this only touches activation memory, which is rebuilt on every encode.
+    void create_sched() {
+        sched.reset(ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), (int) backend_ptrs.size(), max_nodes, false, true));
+        if (cb_eval != nullptr) {
+            ggml_backend_sched_set_eval_callback(sched.get(), cb_eval, cb_eval_user_data);
+        }
+    }
+    void free_sched() {
+        if (sched) {
+            size_t sz = 0;
+            for (ggml_backend_t b : backend_ptrs) {
+                sz += ggml_backend_sched_get_buffer_size(sched.get(), b);
+            }
+            LOG_DBG("%s: freeing mmproj compute buffer (%.2f MiB); reclaimed until next image encode\n",
+                    __func__, sz / 1024.0 / 1024.0);
+        }
+        sched.reset(); // ggml_backend_sched_free releases the compute buffer
+        is_allocated = false;
+        mem_compute.clear(); // report the freed compute buffer as absent until the next encode
+    }
 
     bool debug_output_embeddings = false;
 
@@ -181,6 +213,7 @@ struct clip_ctx {
     clip_ctx(clip_context_params & ctx_params) {
         flash_attn_type = ctx_params.flash_attn_type;
         no_alloc = ctx_params.no_alloc;
+        weights_evict = ctx_params.weights_evict;
         backend_cpu = ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr);
         if (!backend_cpu) {
             throw std::runtime_error("failed to initialize CPU backend");
@@ -217,13 +250,9 @@ struct clip_ctx {
         backend_ptrs.push_back(backend_cpu);
         backend_buft.push_back(ggml_backend_get_default_buffer_type(backend_cpu));
 
-        sched.reset(
-            ggml_backend_sched_new(backend_ptrs.data(), backend_buft.data(), backend_ptrs.size(), 8192, false, true)
-        );
-
-        if (ctx_params.cb_eval != nullptr) {
-            ggml_backend_sched_set_eval_callback(sched.get(), ctx_params.cb_eval, ctx_params.cb_eval_user_data);
-        }
+        cb_eval           = ctx_params.cb_eval;
+        cb_eval_user_data = ctx_params.cb_eval_user_data;
+        create_sched();
 
         debug_output_embeddings = std::getenv("MTMD_DEBUG_EMBEDDINGS") != nullptr;
     }
@@ -2148,7 +2177,12 @@ struct clip_model_loader {
                 loaded_tensor_names.insert(name);
                 cur = data_tensor;
                 // add to weight memory counter
-                ctx_clip.mem_usage[ggml_backend_get_device(ctx_clip.backend)] += ggml_nbytes(cur);
+                // weights_evict: the weights are host-resident, so attribute them to the host
+                // device (not the compute device) for the -fit worst-case estimate
+                const ggml_backend_dev_t mem_dev = ctx_clip.weights_evict
+                    ? ggml_backend_get_device(ctx_clip.backend_cpu)
+                    : ggml_backend_get_device(ctx_clip.backend);
+                ctx_clip.mem_usage[mem_dev] += ggml_nbytes(cur);
             }
             return cur;
         };
@@ -3598,9 +3632,21 @@ struct clip_model_loader {
             }
 
             // alloc memory and offload data
-            ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(ctx_clip.backend);
-            ctx_clip.buf.reset(ggml_backend_alloc_ctx_tensors_from_buft(ctx_clip.ctx_data.get(), buft));
-            ggml_backend_buffer_set_usage(ctx_clip.buf.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+            // --mmproj-evict-draft: keep the weights in a persistent host buffer and stream them
+            // to the compute backend's GPU buffer only while an encode is in flight
+            const bool evict = ctx_clip.weights_evict && !ctx_clip.no_alloc;
+            ggml_backend_buffer_type_t buft;
+            if (evict) {
+                buft = ggml_backend_get_default_buffer_type(ctx_clip.backend_cpu);
+                ctx_clip.buf_host.reset(ggml_backend_alloc_ctx_tensors_from_buft(ctx_clip.ctx_data.get(), buft));
+                ggml_backend_buffer_set_usage(ctx_clip.buf_host.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+                ctx_clip.weights_on_gpu = false;
+            } else {
+                buft = ggml_backend_get_default_buffer_type(ctx_clip.backend);
+                ctx_clip.buf.reset(ggml_backend_alloc_ctx_tensors_from_buft(ctx_clip.ctx_data.get(), buft));
+                ggml_backend_buffer_set_usage(ctx_clip.buf.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+                ctx_clip.weights_on_gpu = true;
+            }
             // read the weight from file
             if (!ctx_clip.no_alloc) {
                 size_t data_loaded = 0;
@@ -3972,7 +4018,9 @@ struct clip_init_result clip_init(const char * fname, struct clip_context_params
             loader.load_hparams(ctx_vision->model, CLIP_MODALITY_VISION);
             loader.load_tensors(*ctx_vision);
             loader.init_ctx(*ctx_vision);
-            if (ctx_params.warmup) {
+            // skip the warmup when weights are evicted: it is deferred to the first encode,
+            // which runs after the weights have been streamed to the GPU buffer
+            if (ctx_params.warmup && !ctx_params.weights_evict) {
                 loader.warmup(*ctx_vision);
             }
 
@@ -3986,7 +4034,8 @@ struct clip_init_result clip_init(const char * fname, struct clip_context_params
             loader.load_hparams(ctx_audio->model, CLIP_MODALITY_AUDIO);
             loader.load_tensors(*ctx_audio);
             loader.init_ctx(*ctx_audio);
-            if (ctx_params.warmup) {
+            // skip the warmup when weights are evicted (deferred to the first encode), same as vision
+            if (ctx_params.warmup && !ctx_params.weights_evict) {
                 loader.warmup(*ctx_audio);
             }
         }
@@ -4422,6 +4471,12 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
     if (!ctx->support_batch && n_batch_cur > clip_model_n_temporal_merge(ctx)) {
         LOG_ERR("%s: batch size %d exceeds maximum supported batch/temporal-merge size %d\n", __func__, n_batch_cur, clip_model_n_temporal_merge(ctx));
         return false;
+    }
+
+    // weights_evict: the scheduler (and its compute buffer) is freed on the exit path to
+    // reclaim VRAM, so recreate it here if it is gone; the warmup below re-reserves it.
+    if (ctx->sched == nullptr) {
+        ctx->create_sched();
     }
 
     // if buffers are not allocated, we need to do a warmup run to allocate them
@@ -6061,6 +6116,66 @@ std::map<ggml_backend_dev_t, size_t> clip_get_mem_usage(const struct clip_ctx * 
         result[dev] += size;
     }
     return result;
+}
+
+// re-point every tensor of ctx from one buffer to another, keeping each tensor's absolute
+// offset. Tensor offsets from the ggml allocator are multiples of GGML_MEM_ALIGN (the minimum
+// alignment ggml guarantees) and both buffer bases are aligned to at least GGML_MEM_ALIGN, so
+// to_base + off is a valid, aligned placement in a destination buffer of the same total size.
+// (Same offset-preserving repoint for the draft model buffers: model_wswap_repoint, src/llama-model.cpp)
+static void clip_repoint_ctx(ggml_context * ctx, ggml_backend_buffer_t from, ggml_backend_buffer_t to) {
+    auto * from_base = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(from));
+    auto * to_base   = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(to));
+    for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+        if (t->buffer != from) {
+            continue;
+        }
+        if (t->data) {
+            const ptrdiff_t off = reinterpret_cast<uint8_t *>(t->data) - from_base;
+            t->data = to_base + off;
+        }
+        t->buffer = to;
+    }
+}
+
+bool clip_weights_set_gpu(clip_ctx * ctx, bool on_gpu) {
+    if (!ctx->weights_evict) {
+        return true; // weights are statically on the compute backend; nothing to swap
+    }
+    if (on_gpu == ctx->weights_on_gpu) {
+        return true; // already in the requested state
+    }
+    if (on_gpu) {
+        const auto buft = ggml_backend_get_default_buffer_type(ctx->backend);
+        const size_t size = ggml_backend_buffer_get_size(ctx->buf_host.get());
+        ctx->buf.reset(ggml_backend_buft_alloc_buffer(buft, size));
+        if (ctx->buf == nullptr) {
+            LOG_ERR("%s: failed to allocate %zu byte GPU weight buffer\n", __func__, size);
+            return false;
+        }
+        clip_repoint_ctx(ctx->ctx_data.get(), ctx->buf_host.get(), ctx->buf.get());
+        auto * host_base = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(ctx->buf_host.get()));
+        auto * gpu_base  = reinterpret_cast<uint8_t *>(ggml_backend_buffer_get_base(ctx->buf.get()));
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx->ctx_data.get()); t != nullptr; t = ggml_get_next_tensor(ctx->ctx_data.get(), t)) {
+            if (t->buffer == ctx->buf.get() && t->view_src == nullptr && t->data) {
+                const ptrdiff_t off = reinterpret_cast<uint8_t *>(t->data) - gpu_base;
+                ggml_backend_tensor_set(t, host_base + off, 0, ggml_nbytes(t));
+            }
+        }
+        ggml_backend_buffer_set_usage(ctx->buf.get(), GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+        ggml_backend_synchronize(ctx->backend);
+        ctx->weights_on_gpu = true;
+    } else {
+        clip_repoint_ctx(ctx->ctx_data.get(), ctx->buf.get(), ctx->buf_host.get());
+        ctx->buf.reset(); // free the GPU buffer; the host copy remains the source of truth
+        ctx->weights_on_gpu = false;
+        // reclaim the compute/activation buffer too: the scheduler owns it, and it is only
+        // needed while an image encode is running. It is recreated and re-reserved on the
+        // next encode. Without this the mmproj compute memory would stay resident for the
+        // whole session after the first image.
+        ctx->free_sched();
+    }
+    return true;
 }
 
 //

--- a/tools/mtmd/clip.h
+++ b/tools/mtmd/clip.h
@@ -58,6 +58,10 @@ struct clip_context_params {
     bool no_alloc;
     mtmd_progress_callback progress_callback;
     void * progress_callback_user_data;
+    // EXPERIMENTAL (--mmproj-evict-draft): keep weights in a host buffer and move them to the
+    // compute backend's GPU buffer only while an encode is in flight. Skips the load-time warmup
+    // (compute buffers are reserved lazily on the first encode, after weights are on GPU).
+    bool weights_evict;
 };
 
 struct clip_init_result {
@@ -131,6 +135,12 @@ bool clip_support_batch(const struct clip_ctx * ctx);
 int clip_model_n_temporal_merge(const struct clip_ctx * ctx); // TODO @ngxson : remove, refactor this
 
 std::map<ggml_backend_dev_t, size_t> clip_get_mem_usage(const struct clip_ctx * ctx);
+
+// --mmproj-evict-draft: move the weight buffer between the persistent host buffer and the
+// compute backend's GPU buffer. Only valid when the ctx was created with weights_evict.
+// on_gpu=true: allocate the GPU buffer, host->device copy, tensors point at GPU.
+// on_gpu=false: free the GPU buffer, tensors point back at the host buffer.
+bool clip_weights_set_gpu(struct clip_ctx * ctx, bool on_gpu);
 
 struct clip_cap {
     bool has_vision;

--- a/tools/mtmd/mtmd.cpp
+++ b/tools/mtmd/mtmd.cpp
@@ -465,6 +465,7 @@ mtmd_context_params mtmd_context_params_default() {
         /* media_marker      */ mtmd_default_marker(),
         /* flash_attn_type   */ LLAMA_FLASH_ATTN_TYPE_AUTO,
         /* warmup            */ true,
+        /* weights_evict     */ false,
         /* image_min_tokens  */ -1,
         /* image_max_tokens  */ -1,
         /* cb_eval           */ nullptr,
@@ -577,6 +578,7 @@ struct mtmd_context {
             /* no_alloc          */ no_alloc,
             /* progress_callback */ ctx_params.progress_callback,
             /* progress_callback_user_data */ ctx_params.progress_callback_user_data,
+            /* weights_evict     */ ctx_params.weights_evict,
         };
 
         auto res = clip_init(mmproj_fname, ctx_clip_params);
@@ -2728,4 +2730,16 @@ std::map<ggml_backend_dev_t, size_t> mtmd_get_memory_usage(const char * mmproj_f
         LOG_ERR("%s: error: %s\n", __func__, e.what());
         return {};
     }
+}
+
+bool mtmd_set_mmproj_modality_weights_gpu(mtmd_context * ctx, enum mtmd_mmproj_modality mod, bool on_gpu) {
+    struct clip_ctx * c = mod == MTMD_MMPROJ_MOD_AUDIO ? ctx->ctx_a : ctx->ctx_v;
+    if (c == nullptr) {
+        return true; // modality not present in this mmproj
+    }
+    return clip_weights_set_gpu(c, on_gpu);
+}
+
+bool mtmd_has_gen_audio(mtmd_context * ctx) {
+    return ctx != nullptr && ctx->ctx_gen_a != nullptr;
 }

--- a/tools/mtmd/mtmd.h
+++ b/tools/mtmd/mtmd.h
@@ -103,6 +103,7 @@ struct mtmd_context_params {
     const char * media_marker;
     enum llama_flash_attn_type flash_attn_type;
     bool warmup; // whether to run a warmup encode pass after initialization
+    bool weights_evict; // EXPERIMENTAL (--mmproj-evict-draft): keep mmproj weights in host RAM, stream to GPU per encode
 
     // limit number of image tokens, only for vision models with dynamic resolution
     int image_min_tokens; // minimum number of tokens for image input (default: read from metadata)
@@ -452,6 +453,22 @@ MTMD_API mtmd_input_chunks * mtmd_test_create_input_chunks(void);
 MTMD_API std::map<ggml_backend_dev_t, size_t> mtmd_get_memory_usage(
     const char * mmproj_fname,
     struct mtmd_context_params ctx_params);
+
+// EXPERIMENTAL (--mmproj-evict-draft): true if the mmproj also carries a TTS generation pipeline.
+// Its weights are never streamed to the GPU by the swap, so TTS generation runs on host weights.
+MTMD_API bool mtmd_has_gen_audio(mtmd_context * ctx);
+
+// EXPERIMENTAL (--mmproj-evict-draft): which mmproj weight set to stream. A single mmproj file may
+// hold several independent encoders (vision, audio) in separate clip contexts.
+enum mtmd_mmproj_modality {
+    MTMD_MMPROJ_MOD_VISION,
+    MTMD_MMPROJ_MOD_AUDIO,
+};
+
+// EXPERIMENTAL (--mmproj-evict-draft): stream a single modality's mmproj weights to the compute
+// device's buffer (on_gpu=true) or back to the host buffer (on_gpu=false). No-op (returns true)
+// if that modality's encoder is absent, or if the context was not created with weights_evict.
+MTMD_API bool mtmd_set_mmproj_modality_weights_gpu(mtmd_context * ctx, enum mtmd_mmproj_modality mod, bool on_gpu);
 #endif
 
 //

--- a/tools/server/CMakeLists.txt
+++ b/tools/server/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(${TARGET} STATIC
     server-mcp.h
     server-schema.cpp
     server-schema.h
+    mmproj-evict-draft.cpp
+    mmproj-evict-draft.h
 )
 
 if (BUILD_SHARED_LIBS)

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -181,6 +181,7 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-mmu, --mmproj-url URL` | URL to a multimodal projector file. see tools/mtmd/README.md<br/>(env: LLAMA_ARG_MMPROJ_URL) |
 | `--mmproj-auto, --no-mmproj, --no-mmproj-auto` | whether to use multimodal projector file (if available), useful when using -hf (default: enabled)<br/>(env: LLAMA_ARG_MMPROJ_AUTO) |
 | `--mmproj-offload, --no-mmproj-offload` | whether to enable GPU offloading for multimodal projector (default: enabled)<br/>(env: LLAMA_ARG_MMPROJ_OFFLOAD) |
+| `--mmproj-evict-draft, --no-mmproj-evict-draft` | EXPERIMENTAL: keep mmproj weights in host RAM and stream them to VRAM per encode by evicting the draft model (requires a draft model; default: disabled)<br/>(env: LLAMA_ARG_MMPROJ_EVICT_DRAFT) |
 | `-mmdev, --mmproj-device DEVICE` | device to use for multimodal projector (none = don't offload, default: auto)<br/>use --list-devices to see a list of available devices<br/>(env: MTMD_BACKEND_DEVICE) |
 | `--image-min-tokens N` | minimum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)<br/>(env: LLAMA_ARG_IMAGE_MIN_TOKENS) |
 | `--image-max-tokens N` | maximum number of tokens each image can take, only used by vision models with dynamic resolution (default: read from model)<br/>(env: LLAMA_ARG_IMAGE_MAX_TOKENS) |

--- a/tools/server/mmproj-evict-draft.cpp
+++ b/tools/server/mmproj-evict-draft.cpp
@@ -1,0 +1,106 @@
+#include "mmproj-evict-draft.h"
+
+#include "log.h"
+
+#include "mtmd.h"
+
+#include "llama.h"
+#include "../src/llama-ext.h"
+
+#include <chrono>
+
+namespace server {
+
+bool mmproj_evict_draft_swap::init(mtmd_context * mctx_, llama_model * model_dft_, llama_context * ctx_dft_) {
+    // the caller has already verified the draft has swappable GPU weights (llama_model_weights_swap_prepare)
+    if (mctx_ == nullptr || model_dft_ == nullptr) {
+        return false;
+    }
+    mctx      = mctx_;
+    model_dft = model_dft_;
+    ctx_dft   = ctx_dft_;
+    ready     = true;
+    LOG_INF("mmproj_evict_draft : swap armed (draft weight buffers recorded for evict/restore)\n");
+    return true;
+}
+
+bool mmproj_evict_draft_swap::enter_mtmd(enum mtmd_mmproj_modality mod) {
+    std::lock_guard<std::mutex> lock(mu);
+    if (!ready) {
+        return true; // swap disabled; nothing to do
+    }
+    const bool first_overall = (vision_depth + audio_depth) == 0;
+    int & mod_depth = (mod == MTMD_MMPROJ_MOD_AUDIO) ? audio_depth : vision_depth;
+    const bool first_mod   = (mod_depth == 0);
+    ++mod_depth;
+
+    auto t0 = std::chrono::steady_clock::now();
+    // Evict the draft's unique weights (free its VRAM) before streaming the modality's weights,
+    // so the new GPU buffer can reuse that space with no transient VRAM growth. Done once per
+    // window, when the first modality enters.
+    if (first_overall) {
+        // wait for the last draft decode to finish before freeing its device buffer; the D2H copies
+        // in weight_swap_evict are host-blocking but do not order against the compute stream
+        if (ctx_dft) {
+            llama_synchronize(ctx_dft);
+        }
+        if (!llama_model_weights_swap_evict(model_dft)) {
+            llama_model_weights_swap_restore(model_dft); // roll back the partially evicted buffers
+            --mod_depth;
+            LOG_ERR("mmproj_evict_draft : failed to evict draft before entering %s mode\n", mod_name(mod));
+            return false;
+        }
+    }
+    // Stream the requested modality's weights to GPU (once per window for that modality; a no-op
+    // if the encoder is absent from the mmproj).
+    if (first_mod && !mtmd_set_mmproj_modality_weights_gpu(mctx, mod, true)) {
+        if (first_overall) {
+            llama_model_weights_swap_restore(model_dft);
+        }
+        --mod_depth;
+        LOG_ERR("mmproj_evict_draft : failed to stream %s mmproj weights to GPU; rolling back\n", mod_name(mod));
+        return false;
+    }
+    if (first_mod) {
+        const double ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+        LOG_INF("mmproj_evict_draft : enter %s mode: %s in %.1f ms\n", mod_name(mod),
+                first_overall ? "draft evict + weights -> GPU" : "weights -> GPU", ms);
+    }
+    return true;
+}
+
+bool mmproj_evict_draft_swap::exit_mtmd(enum mtmd_mmproj_modality mod) {
+    std::lock_guard<std::mutex> lock(mu);
+    if (!ready) {
+        return true;
+    }
+    int & mod_depth = (mod == MTMD_MMPROJ_MOD_AUDIO) ? audio_depth : vision_depth;
+    if (mod_depth <= 0) {
+        LOG_WRN("mmproj_evict_draft : unbalanced exit_mtmd(%s), nothing to do\n", mod_name(mod));
+        return true;
+    }
+    --mod_depth;
+    const bool last_mod     = (mod_depth == 0);
+    const bool last_overall = (vision_depth + audio_depth) == 0;
+
+    auto t0 = std::chrono::steady_clock::now();
+    // Move the modality's weights back to host (free its VRAM) once the last encode of that
+    // modality exits, then restore the draft when the last encode of any modality exits.
+    bool ok = true;
+    if (last_mod) {
+        ok = mtmd_set_mmproj_modality_weights_gpu(mctx, mod, false) && ok;
+    }
+    if (last_overall) {
+        ok = llama_model_weights_swap_restore(model_dft) && ok;
+    }
+    const double ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+    if (!ok) {
+        LOG_ERR("mmproj_evict_draft : failed to exit %s mode\n", mod_name(mod));
+    } else if (last_mod) {
+        LOG_INF("mmproj_evict_draft : exit %s mode: weights -> host%s in %.1f ms\n", mod_name(mod),
+                last_overall ? " + draft restore" : "", ms);
+    }
+    return ok;
+}
+
+} // namespace server

--- a/tools/server/mmproj-evict-draft.h
+++ b/tools/server/mmproj-evict-draft.h
@@ -1,0 +1,66 @@
+#pragma once
+
+// --mmproj-evict-draft (EXPERIMENTAL)
+//
+// Keeps each mmproj modality encoder (vision, audio) weights resident in host RAM and streams
+// them to the compute device on demand, only while encoding that modality, evicting the
+// speculative-decoding draft model's unique weights to host RAM for that window, then restoring
+// them.
+//
+// The mmproj side and the draft side are each swappable weight units:
+//   - mmproj: one ggml_backend_buffer per modality encoder (clip_ctx::buf), backed by a persistent
+//             host copy when weights_evict is set (mtmd_set_mmproj_modality_weights_gpu).
+//   - draft : the tensors the draft gguf actually contains (tok_embd / output are shared with the
+//             target via ctx_other and are NOT in the draft's buffers, so the draft buffers are
+//             exactly the unique weights that are safe to evict; llama_model_weights_swap_*).
+
+#include <mutex>
+
+#include "mtmd.h"
+
+struct llama_model;
+struct llama_context;
+
+namespace server {
+
+// Depth-tracked, mutex-guarded controller for the mmproj/draft weight swap; the media-decode path
+// uses it to enter/exit "media mode" per modality (mmproj on GPU, draft evicted). All depths 0 =
+// "decode mode" (draft weights on GPU, every mmproj modality on host); any depth > 0 = "media
+// mode". A single mmproj may hold several modality encoders (vision, audio), tracked
+// independently so only the modalities in use are streamed. The draft is evicted once when the
+// first modality enters and restored once when the last modality exits; nested encodes of the
+// same modality are depth-tracked, so overlapping encodes from multiple slots serialize safely.
+class mmproj_evict_draft_swap {
+public:
+    static const char * mod_name(enum mtmd_mmproj_modality mod) {
+        return mod == MTMD_MMPROJ_MOD_AUDIO ? "audio" : "vision";
+    }
+
+    // Arm the controller. The caller must have already run llama_model_weights_swap_prepare
+    // successfully (the swap is only armed in that case) and loaded the mmproj with weights_evict
+    // (host-resident weights). ctx_dft is the draft context; it is drained (llama_synchronize)
+    // before the first evict so an in-flight draft decode cannot read the freed device buffer.
+    // Returns false only on null inputs.
+    bool init(mtmd_context * mctx, llama_model * model_dft, llama_context * ctx_dft);
+
+    bool active() const { return ready; }
+
+    // Stream the given mmproj modality's weights to GPU and evict the draft's unique weights
+    // (the draft is evicted once, when the first modality enters). Idempotent w.r.t. nested
+    // encodes of the same modality.
+    bool enter_mtmd(enum mtmd_mmproj_modality mod);
+    // Move the given mmproj modality's weights back to host and restore the draft (the draft is
+    // restored once, when the last modality exits).
+    bool exit_mtmd(enum mtmd_mmproj_modality mod);
+
+private:
+    mtmd_context * mctx = nullptr;
+    llama_model * model_dft = nullptr;
+    llama_context * ctx_dft = nullptr;
+    bool ready = false;
+    int vision_depth = 0;
+    int audio_depth  = 0;
+    std::mutex mu;
+};
+
+}

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -11,11 +11,13 @@
 #include "common.h"
 #include "fit.h"
 #include "llama.h"
+#include "../src/llama-ext.h"
 #include "log.h"
 #include "sampling.h"
 #include "speculative.h"
 #include "mtmd.h"
 #include "mtmd-helper.h"
+#include "mmproj-evict-draft.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -734,12 +736,36 @@ struct server_slot {
     }
 };
 
+// RAII guard for the --mmproj-evict-draft media window. enter() streams the given mmproj
+// modality's weights to GPU and evicts the draft; the destructor restores decode mode on every
+// path out of the encode (success, error, exception), so the draft is never left evicted if the
+// encode path throws. If enter fails it has already rolled back, so entered stays false.
+struct mmproj_media_guard {
+    server::mmproj_evict_draft_swap * swap;
+    enum mtmd_mmproj_modality mod;
+    bool entered = false;
+    mmproj_media_guard(server::mmproj_evict_draft_swap * s, enum mtmd_mmproj_modality m) : swap(s), mod(m) {}
+    bool enter() {
+        if (swap == nullptr) {
+            return true;
+        }
+        entered = swap->enter_mtmd(mod);
+        return entered;
+    }
+    ~mmproj_media_guard() {
+        if (entered) {
+            swap->exit_mtmd(mod);
+        }
+    }
+};
+
 // returns 0 on success
 // caller need to update prompt.tokens after a successful call to keep track of the processing progress
 // note: this is not a member of server_slot because we want to run it inside yield_to_queue
 //       slot is passed as const to avoid accidental modification of the slot state
 //       some pointers are allowed to be used, they are not used by to_json()
-static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch, size_t idx, size_t & n_tokens_out) {
+static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch, size_t idx, size_t & n_tokens_out,
+                              server::mmproj_evict_draft_swap * swap) {
     GGML_ASSERT(slot.mctx);
     const auto & mctx = slot.mctx;
     const auto & input_tokens = slot.task->tokens;
@@ -795,6 +821,20 @@ static int process_mtmd_chunk(const server_slot & slot, mtmd::batch_ptr & mbatch
 
     // otherwise, the batch is either uninitialized or is used up
     // we need to create & encode a new batch
+    // --mmproj-evict-draft: the encode needs the mmproj weights for this chunk's modality on the
+    // compute device; evict the draft's unique weights for this window. A batch is modality-
+    // homogeneous (can_batch_with rejects mixed types), so routing by the first chunk suffices.
+    // The guard restores decode mode on every exit path, so a throw in the encode setup below
+    // cannot leave the draft evicted.
+    const enum mtmd_mmproj_modality mod = (mtmd_input_chunk_get_type(chunk.get()) == MTMD_INPUT_CHUNK_TYPE_AUDIO)
+                                          ? MTMD_MMPROJ_MOD_AUDIO
+                                          : MTMD_MMPROJ_MOD_VISION;
+    mmproj_media_guard media_guard(swap, mod);
+    if (!media_guard.enter()) {
+        SLT_ERR(slot, "mmproj_evict_draft: failed to enter %s media mode (id %d); aborting chunk\n",
+                server::mmproj_evict_draft_swap::mod_name(mod), slot.id);
+        return -1;
+    }
     mbatch.reset(mtmd_batch_init(mctx));
     res = mtmd_batch_add_chunk(mbatch.get(), chunk.get());
     GGML_ASSERT(res == 0); // we should never have an empty batch
@@ -844,6 +884,8 @@ public:
     mtmd_helper_init_opt init_opt = mtmd_helper_init_opt_default();
     const llama_vocab * vocab = nullptr;
 
+    server::mmproj_evict_draft_swap evict_swap; // --mmproj-evict-draft
+
     server_queue    queue_tasks;
     server_response queue_results;
 
@@ -887,6 +929,9 @@ private:
 
     llama_model   * model_dft = nullptr;
     llama_context * ctx_dft   = nullptr;
+    // --mmproj-evict-draft: total mmproj bytes from the -fit probe (weight-only in the evict case, where the
+    // probe skips warmup); used to warn when -fit underestimates the encode window's VRAM
+    size_t mmproj_fit_total = 0;
 
     common_speculative_init_result_ptr spec_init;
 
@@ -1055,6 +1100,10 @@ private:
             mparams.image_max_tokens = params_base.image_max_tokens;
             mparams.batch_max_tokens = params_base.mtmd_batch_max_tokens;
             mparams.media_marker     = get_media_marker();
+            // the -fit probe below measures the mmproj weight footprint; run it in weights_evict mode
+            // (when the feature will stream it) so -fit counts the mmproj against the host. The real
+            // load re-decides weights_evict from the arming state further below.
+            mparams.weights_evict    = params_base.mmproj_evict_draft && params_base.speculative.has_dft();
             // progress callback
             mparams.progress_callback           = load_progress_callback;
             mparams.progress_callback_user_data = &load_progress_mmproj;
@@ -1070,6 +1119,7 @@ private:
                 for (auto & [dev, size] : mmproj_mem) {
                     total += size;
                 }
+                mmproj_fit_total = total;
                 SRV_TRC("[mtmd] estimated worst-case memory usage of mmproj is %.2f MiB (took %.2f ms)\n", total / (1024.0 * 1024.0), t_elapsed / 1000.0);
                 GGML_ASSERT(!params_base.fit_params_target.empty());
                 for (auto & [dev, size] : mmproj_mem) {
@@ -1150,6 +1200,8 @@ private:
             load_progress_callback(1.0f, &load_progress_spec);
         }
 
+        bool dft_swap_prepared = false;
+
         if (has_mmproj) {
             if (callback_state) {
                 callback_state(SERVER_STATE_LOADING, {{"stage", "mmproj_model"}});
@@ -1159,6 +1211,17 @@ private:
                 mtmd_helper_log_set(common_log_default_callback, nullptr);
             }
 
+            if (params_base.mmproj_evict_draft) {
+                // arm the swap only if it can actually be: without a draft model, or when the draft has no
+                // swappable GPU weights (CPU-only draft, mmap'd on a backend without device buffers), the
+                // flag is a no-op and the mmproj weights stay on the compute device
+                if (params_base.speculative.has_dft() && model_dft != nullptr
+                    && (dft_swap_prepared = llama_model_weights_swap_prepare(model_dft))) {
+                    mparams.weights_evict = true;
+                } else {
+                    mparams.weights_evict = false; // swap disarmed; override the probe's flag-based value above
+                }
+            }
             mctx = mtmd_init_from_file(mmproj_path.c_str(), model_tgt, mparams);
             if (mctx == nullptr) {
                 SRV_ERR("failed to load multimodal model, '%s'\n", mmproj_path.c_str());
@@ -1179,6 +1242,36 @@ private:
             if (params_base.n_cache_reuse) {
                 params_base.n_cache_reuse = 0;
                 SRV_WRN("%s\n", "cache_reuse is not supported by multimodal, it will be disabled");
+            }
+        }
+
+        if (params_base.mmproj_evict_draft) {
+            if (mctx == nullptr) {
+                SRV_WRN("%s\n", "--mmproj-evict-draft is set but no multimodal projector is loaded; ignoring the flag");
+            } else if (!params_base.speculative.has_dft() || ctx_dft == nullptr) {
+                SRV_WRN("%s\n", "--mmproj-evict-draft requires a draft model (--spec-draft-model); ignoring the flag");
+            } else if (!dft_swap_prepared || !evict_swap.init(mctx, model_dft, ctx_dft)) {
+                SRV_WRN("%s\n", "--mmproj-evict-draft: no swappable draft GPU weights; the swap is disabled (mmproj weights stay on the compute device)");
+            } else if (mtmd_has_gen_audio(mctx)) {
+                SRV_WRN("%s\n", "--mmproj-evict-draft: the mmproj carries a TTS generation pipeline; its weights stay on host RAM (TTS generation runs at host speed)");
+            }
+
+            // with -fit, the host-residency assumption can mislead -fit: when the swap is armed the mmproj may
+            // not fit in the VRAM freed by evicting the draft; when it is disarmed -fit counted the mmproj
+            // against the host but it loads on the compute device
+            if (params_base.fit_params) {
+                if (evict_swap.active()) {
+                    const size_t dft_swap_size = llama_model_weights_swap_size(model_dft);
+                    if (mmproj_fit_total > dft_swap_size) {
+                        SRV_WRN("--mmproj-evict-draft: mmproj weights (%.0f MiB; sum of all modalities) exceed the "
+                                 "evicted draft weights (%.0f MiB); with -fit the encode window can exceed the VRAM "
+                                 "ceiling (weights only; the compute buffer scales with image resolution)\n",
+                                 mmproj_fit_total / (1024.0 * 1024.0), dft_swap_size / (1024.0 * 1024.0));
+                    }
+                } else if (params_base.speculative.has_dft() && mmproj_fit_total > 0) {
+                    SRV_WRN("%s\n", "--mmproj-evict-draft: warning, -fit may under-estimate VRAM usage "
+                                    "(the swap is disabled, so the mmproj is on the compute device, not the host)");
+                }
             }
         }
 
@@ -3477,7 +3570,7 @@ private:
                         size_t n_tokens_out = 0;
                         int32_t res = 0;
                         queue_tasks.yield_to_queue([&]() {
-                            res = process_mtmd_chunk(slot, slot.mbatch, cur_token_idx, n_tokens_out);
+                            res = process_mtmd_chunk(slot, slot.mbatch, cur_token_idx, n_tokens_out, &evict_swap);
                         });
 
                         if (res != 0) {


### PR DESCRIPTION
## Overview

This patch reduces VRAM burden by dynamically swapping draft model weights out of VRAM and mmproj weights into VRAM when a multimedia encode request is processed, then restoring them to resume normal operation with the speculative draft model engaged and the mmproj weights back in host memory. This allows for a "best of both words", where a user can enjoy fast GPU mmproj compute without raising the VRAM high-water mark. In practice, this means that the mmproj is "free", and users will not have to sacrifice context size or slow cpu-bound mmproj execution, which is a common practice currently.

### Function:
Keep each mmproj modality encoder (vision, audio) resident in host RAM and stream it to the compute device on demand, only while encoding that modality. For that window, the speculative-decoding draft model's unique weights are evicted to host RAM and restored on exit, so the mmproj weights and the draft never both occupy VRAM at the same time. The draft is evicted once when the first modality enters and restored once when the last exits; nested encodes of a modality are depth-tracked so overlapping encodes from multiple slots serialize safely.

The mmproj side and the draft side are each a swappable weight unit. The audio compute buffer is allocated lazily inside the guard window instead of at startup warmup. The swap is armed only when llama_model_weights_swap_prepare() confirms the draft has swappable GPU weights (a CPU-only or mmap'd draft leaves the mmproj on the compute device); on prepare failure the controller stays disabled with a warning rather than aborting image requests, and a TTS generation pipeline in the mmproj is flagged with a load-time warning. Before evicting, the controller drains the draft context (llama_synchronize), so an in-flight draft decode is not reading the draft's device buffer when it is freed; the restore's H2D copy is host-blocking, so the freed host copy is not read. A failed evict mid-sequence rolls the partially evicted buffers back.

### Interaction with -fit:
With `--mmproj-evict-draft`, the mmproj encoder weights are host-resident, but the worst-case memory estimate (clip_get_mem_usage) previously attributed them to the compute device. That made `-fit` over-reserve the mmproj footprint against the VRAM budget - even though, in evict mode, the mmproj weights and the draft model never occupy VRAM at the same time. We now attribute the weight bytes to the host device when weights_evict is set, so `-fit` no longer reserves VRAM for weights that predominantly reside in system RAM.

To prevent unexpected out-of-memory conditions, I've added startup warnings for two edge cases where `-fit` might undercount VRAM requirements:
- Insufficient Eviction Space: If the mmproj weights are larger than the evicted draft weights, VRAM usage will temporarily spike above the `-fit` ceiling during the encode phase.
- Eviction Disarmed: If the swap fails to arm (e.g., no draft model is loaded), `-fit` will have already counted the mmproj against the host RAM budget, but the weights will actually permanently load into VRAM.

## Additional information

I have NOT tested any audio functionality at this time. Assistance with testing would be appreciated!

This feature ended up being larger than anticipated; particularly audio and `-fit` interactions were not planned for, but seemed appropriate to do for correctness and completeness. I did not devote time to testing this on Vulkan, as when using the Vulkan backend I think using the iGPU as the mmproj inference device achieves similar ends as this feature does for CUDA.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, Qwen3.8 27B assisted with writing the code. Code was reviewed manually by me, as well as several rounds of agent code review by Qwen and Gemini Flash. Testing was done manually by me, and this PR was written and submitted manually.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
