### PR TITLE
qwen4exp : enable sparse flash attention in build_attn_qsa

### DIFF
--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -744,10 +744,7 @@ ggml_tensor * llama_model_qwen4exp::graph::build_attn_qsa(
     ggml_tensor * k = mctx_cur->get_k(ctx0, il);
     ggml_tensor * v = mctx_cur->get_v(ctx0, il);
 
-    // TODO: enable sparse attention when we are ready
-    // ref: https://github.com/ggml-org/llama.cpp/pull/27970
-    //ggml_tensor * cur = build_attn_mha(q, k, v, nullptr, kq_mask_top_k, nullptr, nullptr, top_k->ne[0], kq_scale, il);
-    ggml_tensor * cur = build_attn_mha(q, k, v, nullptr, kq_mask_top_k, nullptr, nullptr, 0, kq_scale, il);
+    ggml_tensor * cur = build_attn_mha(q, k, v, nullptr, kq_mask_top_k, nullptr, nullptr, top_k->ne[0], kq_scale, il);
     cb(cur, "kqv_out", il);
 
     // the rotation is its own inverse, so undo it on the value side of the output


### PR DESCRIPTION
## Overview

Pass the indexer top-k width as `n_kv_max` in `build_attn_qsa`, so backends with a sparse FA path (#27970 CUDA, #28098 Metal) gather the selected KV rows instead of masking the full cache. Same call as the MLA sparse path in `llama-graph.cpp`.

The mask is `set_rows` over the top-k indices plus the causal mask, so each row has at most `top_k->ne[0]` finite entries, which is the bound `ggml_flash_attn_ext_set_n_kv_max` requires.

M5 Max, Qwen3.8-Flash-Next IQ4_XS, q8_0 KV, `-ub 2048 -b 2048`, `llama-bench -fa 1 -r 2`:

| test             | master      | PR          |
|------------------|-------------|-------------|
| pp2048 @ d65536  | 388.1 ± 3.6 | 702.2 ± 9.0 |
| pp2048 @ d131072 | 340.0 ± 4.8 | 588.7 ± 1.6 |
| tg32 @ d16384    | 35.0 ± 5.2  | 39.4 ± 0.2  |
| tg32 @ d32768    | 34.5 ± 0.5  | 35.1 ± 0.3  |
| tg32 @ d65536    | 28.3 ± 0.2  | 28.7 ± 0.1  |
| tg32 @ d131072   | 20.6 ± 0.1  | 20.7 ± 0.1  |

llama-server cold prefill, three ~33k prompts: **664 -> 760 t/s**. Greedy output over a 36k prompt matched master.

Measured on master + #27836 (MTP), which does not touch this path. CUDA not tested here. Its gate falls back to dense below 4096 KV, and CPU and Vulkan ignore the hint.

## Additional information

Removes the TODO from #28098. The change is the one @am17an suggested in https://github.com/ggml-org/llama.cpp/pull/27970#issuecomment-5477575647, with the Metal numbers in https://github.com/ggml-org/llama.cpp/pull/28098#issuecomment-5532762692.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, Claude (Fable 5.1) ran the benchmarks, checked the mask bound, and drafted the patch. Reviewed and rewritten by me.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
