### PR TITLE
CUDA: fix two flash_attn_ext_vec shared-memory races found by racecheck

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -362,7 +362,17 @@ static __device__ __forceinline__ void quantize_q8_1_to_shared(
         }
     }
 
-    yq32[threadIdx.x] = q32;
+    // Only the first ni lanes own a slot in yq32. For ni < WARP_SIZE (reached for head size 64,
+    // where ni == 16) the surplus lanes would otherwise write their zero padding one element past
+    // the ni-int yq32 region -- which is exactly where the caller places yds (yds = yq32 + ni).
+    // That store races the yds store below (a write/write hazard on the packed d/sum words,
+    // reported by compute-sanitizer racecheck) and violates the __restrict__ contract between
+    // yq32 and yds, so the compiler may order the padding store last, leaving Q_ds read back as 0
+    // and the whole Q block silently dropped from the attention sum. ni is a template parameter,
+    // so the ni == WARP_SIZE instantiations fold this guard away with no codegen change.
+    if (ni == WARP_SIZE || threadIdx.x < ni) {
+        yq32[threadIdx.x] = q32;
+    }
     if (threadIdx.x % QI8_1 == 0 && (ni == WARP_SIZE || threadIdx.x < ni)) {
         if (std::is_same<Tds, half2>::value) {
             ((half2  *) yds)[threadIdx.x/QI8_1] =  make_half2(d, sum);

--- a/ggml/src/ggml-cuda/fattn-vec.cuh
+++ b/ggml/src/ggml-cuda/fattn-vec.cuh
@@ -376,6 +376,18 @@ static __global__ void flash_attn_ext_vec(
             }
 #endif // V_DOT2_F32_F16_AVAILABLE
         }
+
+#ifndef GGML_USE_HIP
+        // Close the loop-carried read->write cycle on the shared KQ scores. The __syncwarp()
+        // above orders this iteration's KQ stores (KQ[j*nthreads + tid] = ...) against its KQ
+        // loads, but nothing orders those loads against the NEXT iteration's stores to the same
+        // slots: with independent thread scheduling (Volta+) a lane can advance through the loop
+        // back-edge and overwrite a KQ slot while a sibling lane is still reading it for the V
+        // accumulation (a warp-local WAR reported by compute-sanitizer racecheck). A warp barrier
+        // suffices because each warp only reads its own 32-score segment; __syncwarp() is
+        // unavailable under HIP (wavefronts execute in lockstep), matching the #ifndef above.
+        __syncwarp();
+#endif // GGML_USE_HIP
     }
 
     if (sinks && blockIdx.y == 0) {


### PR DESCRIPTION
This PR fixes two independent shared-memory data races in the vector Flash Attention kernels, both surfaced by `compute-sanitizer --tool racecheck` and both currently masked only by codegen/scheduling luck. They are logically independent (separate commits) but were found in the same racecheck sweep on `flash_attn_ext_vec`, so I've grouped them; happy to split if you'd prefer.

Environment where the hazards reproduce: CUDA `sm_120`, `test-backend-ops -o FLASH_ATTN_EXT`, with `--tool racecheck`. Fixes verified clean afterwards (full FLASH_ATTN_EXT sweep: 50 → 0 hazard records) and `test-backend-ops -o FLASH_ATTN_EXT` still passes. Both changes are arithmetic-free, so kernel output is bit-identical where it was already correct.

## 1. `quantize_q8_1_to_shared` — write/write hazard at head size 64

`quantize_q8_1_to_shared()` stores `yq32[threadIdx.x]` from all 32 lanes unconditionally. Callers lay `yds` out immediately after an `ni`-int `yq32` region (`yds = yq32 + ni`). When `ni < WARP_SIZE` — reached at head size 64, where the caller passes `ni == 16` — lanes `16..31` write their zero q32 padding onto the `d`/`sum` words that lanes 0 and 8 concurrently store into `yds`. Two lanes, different PCs, no intervening sync → a write/write hazard, plus a `__restrict__` violation between `yq32` and `yds` that lets the compiler order the padding store last and read `Q_ds` back as 0, silently dropping the Q block from the attention sum.

racecheck flags this in every `flash_attn_ext_vec` instantiation pairing head size 64 with quantized K (q8_0, q4_0).

Fix: predicate the store on `lane < ni`, mirroring the `yds` guard just below it. `ni` is a template parameter, so `ni == WARP_SIZE` instantiations (head size ≥ 128) fold the guard away — zero codegen change there. No reader consumes `yq32[ni..31]`.

## 2. `flash_attn_ext_vec` — loop-carried KQ-score WAR

In the main KV loop each thread stores its softmax score `KQ[j*nthreads + tid]`, passes the existing `__syncwarp()`, then reads its warp's whole 32-score segment `KQ[j*nthreads + k]` in the unrolled V accumulation. The `__syncwarp()` orders store→load *within* an iteration, but nothing orders those loads against the *next* iteration's stores to the same slots. With independent thread scheduling (Volta+) a lane can cross the loop back-edge and overwrite a score slot a sibling lane is still loading — a loop-carried write-after-read on every KQ slot.

racecheck reports these as read/write hazards (observed on `sm_120`, head sizes 128 and 256, `ncols == 1`, f16 K/V).

Fix: one `__syncwarp()` at the end of the main-loop body, closing the read→write cycle. Accesses are warp-local (each warp reads only its own 32-score segment), so a warp barrier suffices. Guarded with `#ifndef GGML_USE_HIP` to match the existing `__syncwarp()` — HIP wavefronts execute in lockstep and hipcc provides no `__syncwarp()`.
