### PR TITLE
CUDA: use radix TOP_K when CUB DeviceTopK is unavailable

### DIFF
--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -10,6 +10,12 @@ using namespace cub;
 #    endif  // CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2
 #endif      // GGML_CUDA_USE_CUB
 
+// Exact radix top-k selection when CUB DeviceTopK is unavailable (CCCL < 3.2):
+// O(nrows) temp instead of the O(ncols*nrows) full-argsort fallback. Selects the same set.
+#if !defined(CUB_TOP_K_AVAILABLE)
+#define GGML_CUDA_TOP_K_RADIX
+#endif
+
 #ifdef CUB_TOP_K_AVAILABLE
 
 static void top_k_cub(ggml_cuda_pool & pool,
@@ -36,7 +42,7 @@ static void top_k_cub(ggml_cuda_pool & pool,
                          ncols, k, env));
 }
 
-#elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+#elif defined(GGML_CUDA_USE_CUB) && !defined(GGML_CUDA_TOP_K_RADIX)  // CUB_TOP_K_AVAILABLE
 
 static int next_power_of_2(int x) {
     int n = 1;
@@ -48,7 +54,7 @@ static int next_power_of_2(int x) {
 
 #endif                            // CUB_TOP_K_AVAILABLE
 
-#if !defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP)
+#if defined(GGML_CUDA_TOP_K_RADIX) || (!defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP))
 
 static __device__ __forceinline__ uint32_t top_k_float_to_ordered(float value) {
     const uint32_t bits = __float_as_uint(value);
@@ -231,6 +237,17 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     // TODO: investigate if there exists a point where parallelized argsort is faster than sequential top-k
     for (int i = 0; i < nrows; i++) {
         top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+    }
+#elif defined(GGML_CUDA_TOP_K_RADIX)
+    // exact radix selection: ~nrows*blocks*256 ints of temp (MBs, not 100s of MBs)
+    if (ncols > 1024) {
+        top_k_radix_cuda(pool, src0_d, dst_d, (int) ncols, (int) nrows, (int) k, stream);
+    } else {
+        ggml_cuda_pool_alloc<int> temp_dst_alloc(pool, ncols * nrows);
+        int *                     tmp_dst = temp_dst_alloc.get();
+        argsort_f32_i32_cuda_bitonic(src0_d, tmp_dst, ncols, nrows, GGML_SORT_ORDER_DESC, stream);
+        CUDA_CHECK(cudaMemcpy2DAsync(dst_d, k * sizeof(int), tmp_dst, ncols * sizeof(int), k * sizeof(int), nrows,
+                                     cudaMemcpyDeviceToDevice, stream));
     }
 #elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
     // Fall back to argsort + copy

--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -10,10 +10,11 @@ using namespace cub;
 #    endif  // CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2
 #endif      // GGML_CUDA_USE_CUB
 
-// Exact radix top-k selection when CUB DeviceTopK is unavailable (CCCL < 3.2):
+// Exact radix top-k selection when CUB DeviceTopK is unavailable:
 // O(nrows) temp instead of the O(ncols*nrows) full-argsort fallback. Selects the same set.
-#if !defined(CUB_TOP_K_AVAILABLE)
-#define GGML_CUDA_TOP_K_RADIX
+// Set on CUDA without a new-enough CUB, or on HIP without CUB at all.
+#if !defined(CUB_TOP_K_AVAILABLE) || (!defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP))
+#define GGML_CUDA_USE_TOP_K_RADIX
 #endif
 
 #ifdef CUB_TOP_K_AVAILABLE
@@ -42,7 +43,7 @@ static void top_k_cub(ggml_cuda_pool & pool,
                          ncols, k, env));
 }
 
-#elif defined(GGML_CUDA_USE_CUB) && !defined(GGML_CUDA_TOP_K_RADIX)  // CUB_TOP_K_AVAILABLE
+#elif defined(GGML_CUDA_USE_CUB) && !defined(GGML_CUDA_USE_TOP_K_RADIX)  // CUB_TOP_K_AVAILABLE
 
 static int next_power_of_2(int x) {
     int n = 1;
@@ -54,7 +55,7 @@ static int next_power_of_2(int x) {
 
 #endif                            // CUB_TOP_K_AVAILABLE
 
-#if defined(GGML_CUDA_TOP_K_RADIX) || (!defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP))
+#if defined(GGML_CUDA_USE_TOP_K_RADIX)
 
 static __device__ __forceinline__ uint32_t top_k_float_to_ordered(float value) {
     const uint32_t bits = __float_as_uint(value);
@@ -238,7 +239,7 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     for (int i = 0; i < nrows; i++) {
         top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
     }
-#elif defined(GGML_CUDA_TOP_K_RADIX)
+#elif defined(GGML_CUDA_USE_TOP_K_RADIX)
     // exact radix selection: ~nrows*blocks*256 ints of temp (MBs, not 100s of MBs)
     if (ncols > 1024) {
         top_k_radix_cuda(pool, src0_d, dst_d, (int) ncols, (int) nrows, (int) k, stream);


### PR DESCRIPTION
## Overview

CUDA builds with CCCL < 3.2 have no `cub::DeviceTopK`, so `ggml_cuda_op_top_k` falls back to a full argsort + copy at ~12 bytes of temp per cell. On long-context sparse-attention top-k that kills small cards: my 10 GB card (about 600 MB free) died in `cuMemCreate` on QSA top-k over ~200K cols x 128 rows. That's 190+ MB of temp per layer.

This PR reuses the radix selection from #27466 (merged for HIP) on CUDA when `CUB_TOP_K_AVAILABLE` is off. New `GGML_CUDA_TOP_K_RADIX` gate. Temp drops to O(nrows): per-row state plus `nrows x blocks_per_row x 256` histogram ints, single-digit MBs. Same set out (ordered-bit radix; ties break either way in both paths, and downstream reads the indices as a set plus mask). Also gated `next_power_of_2`, unused on that path now.

Nothing changes when `CUB_TOP_K_AVAILABLE` is set (that branch is untouched and still wins), or on HIP (same guards, extended).

## Additional information

What I checked:
- TU builds clean under nvcc 12.4 + CUB 2.5, radix branch taken, radix kernels in the object.
- With CCCL 3.3 headers the `DeviceTopK` branch still wins (`MaxPairs` present), radix compiled out.
- Full runtime of this exact branch on my box (10 GB cards, 200K ctx) still pending; kernels are unchanged from #27466. Sibling data point: real `DeviceTopK` through newer CCCL headers on the same CUDA 12.4 toolchain gave +9% prefill (220.9 vs 202.0 tok/s) at 207K context against the argsort fallback.

Related: #27466.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - patch drafted with an AI coding assistant; all measurements come from real runs on my own hardware, and I reviewed and take responsibility for the change.