### PR TITLE
openvino: serve GET_ROWS on a weight view from the base Constant

### DIFF
--- a/ggml/src/ggml-openvino/ggml-decoder.cpp
+++ b/ggml/src/ggml-openvino/ggml-decoder.cpp
@@ -972,6 +972,11 @@ void GgmlOvDecoder::compute_model_inputs() {
             if (m_model_weights.find(src_name) != m_model_weights.end()) {
                 continue;
             }
+            // A view over a weight is served by the base tensor's Constant, never by a Parameter.
+            if (src->view_src != nullptr &&
+                m_model_weights.find(get_tensor_ov_name(m_cgraph, src->view_src)) != m_model_weights.end()) {
+                continue;
+            }
 
             bool is_intermediate_node = false;
             for (const auto & node_info : m_node_info_list) {
@@ -1107,19 +1112,19 @@ std::map<std::string, std::shared_ptr<ov::Node>> GgmlOvDecoder::create_weight_no
                 continue;
             }
 
-            std::string src_name = get_tensor_ov_name(cgraph, src);
-            if (is_rope_freqs_weight(src, node)) {
+            // A view over a weight is served by the base tensor's Constant.
+            ggml_tensor * base = src->view_src ? src->view_src : src;
+            std::string src_name = get_tensor_ov_name(cgraph, base);
+            if (is_rope_freqs_weight(base, node)) {
                 src_name = "rope_freqs.weight";
             }
-            if (!src->view_src) {
-                ggml_backend_buffer * buffer = src->buffer;
-                if (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS || ggml_is_quantized(src->type) ||
-                    is_mul_mat_id_expert_weight(node, i)) {
-                    if (model_weights.find(src_name) == model_weights.end()) {
-                        auto weight_node = create_weight_node(src, naive);
-                        weight_node->set_friendly_name(src_name);
-                        model_weights[src_name] = weight_node;
-                    }
+            ggml_backend_buffer * buffer = base->buffer;
+            if (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS || ggml_is_quantized(base->type) ||
+                is_mul_mat_id_expert_weight(node, i)) {
+                if (model_weights.find(src_name) == model_weights.end()) {
+                    auto weight_node = create_weight_node(base, naive);
+                    weight_node->set_friendly_name(src_name);
+                    model_weights[src_name] = weight_node;
                 }
             }
         }
@@ -1148,15 +1153,14 @@ std::set<std::string> GgmlOvDecoder::collect_weight_names(ggml_cgraph * cgraph) 
             if (src == nullptr) {
                 continue;
             }
-            std::string src_name(src->name);
-            if (is_rope_freqs_weight(src, node)) {
+            const ggml_tensor * base = src->view_src ? src->view_src : src;
+            std::string src_name(base->name);
+            if (is_rope_freqs_weight(base, node)) {
                 src_name = "rope_freqs.weight";
             }
-            if (!src->view_src) {
-                ggml_backend_buffer * buffer = src->buffer;
-                if (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS || ggml_is_quantized(src->type)) {
-                    names.insert(src_name);
-                }
+            ggml_backend_buffer * buffer = base->buffer;
+            if (buffer->usage == GGML_BACKEND_BUFFER_USAGE_WEIGHTS || ggml_is_quantized(base->type)) {
+                names.insert(src_name);
             }
         }
     }

--- a/ggml/src/ggml-openvino/openvino/op/get_rows.cpp
+++ b/ggml/src/ggml-openvino/openvino/op/get_rows.cpp
@@ -5,6 +5,7 @@
 #include <climits>
 #include <openvino/core/node.hpp>
 #include <openvino/core/node_output.hpp>
+#include <openvino/op/add.hpp>
 #include <openvino/op/broadcast.hpp>
 #include <openvino/op/concat.hpp>
 #include <openvino/op/constant.hpp>
@@ -24,7 +25,23 @@ OutputVector translate_get_rows(const NodeContext & context) {
     num_inputs_check(context, 2, 2);
 
     Output<Node> res;
-    auto data = process_view_input_new(context, 0);
+    Output<Node> data;
+    int64_t row_offset = 0;
+    if (context.get_view_input_size(0) > 0 && context.get_input(0).get_partial_shape().rank() == 2) {
+        // A row range view over a 2D weight Constant folds into the gather indices,
+        // which keeps the dequantization subgraph intact for the plugins.
+        const auto view_shape = context.get_view_input_ggml_shape(0, 0);
+        const auto view_stride = context.get_view_input_stride(0, 0);
+        const size_t view_offset = context.get_view_input_offset(0, 0);
+        const size_t row_bytes = view_stride[2];
+        data = context.get_input(0);
+        FRONT_END_OP_CONVERSION_CHECK(row_bytes > 0 && view_offset % row_bytes == 0 &&
+                                          data.get_partial_shape()[1].compatible(view_shape[3]),
+                                      "GET_ROWS: view over a weight must be a row range");
+        row_offset = static_cast<int64_t>(view_offset / row_bytes);
+    } else {
+        data = process_view_input_new(context, 0);
+    }
 
     auto op_case = context.get_op_case();
     ov::Output<ov::Node> indices;
@@ -51,6 +68,10 @@ OutputVector translate_get_rows(const NodeContext & context) {
     // data[x,y] ind[1,1,1,x'] normal case
     indices =
         std::make_shared<ov::op::v0::Squeeze>(indices, ov::op::v0::Constant::create(ov::element::i64, {2}, {0, 1}));
+    if (row_offset != 0) {
+        indices = std::make_shared<ov::op::v1::Add>(
+            indices, ov::op::v0::Constant::create(indices.get_element_type(), {}, {row_offset}));
+    }
     if (data.get_partial_shape().rank() == 4) {
         if (!(data.get_partial_shape()[1].is_dynamic()) && data.get_partial_shape()[1].get_length() == 1) {
             // Work-around for a bug in ov cpu plugin for test-backend-ops


### PR DESCRIPTION
## Overview

This fixes the GET_ROWS failures that #28253 exposes on the OpenVINO runner, a view over a quantized weight was registered as a dynamic typed Parameter instead of being served by the base Constant, so the weight collection now resolves view_src and the row offset is folded into the gather indices, validated locally on the CPU device with the CI toolkit (50/50 GET_ROWS, 3919/3919 full suite).

## Additional information

Resolve view_src when collecting weight Constants so a view over a quantized weight no longer becomes a dynamic typed Parameter, and fold the row offset of the view into the gather indices instead of slicing the dequantization subgraph.

### Test

Tested on the CPU device with the CI 2026.3.1 toolkit, which reproduces the same 8 failures as the GPU runner, GET_ROWS goes from 42/50 to 50/50 and the full suite passes 3919/3919.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES Fable 5.1 MCP loop on rootless container with Nvidia GPU

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
