### PR TITLE
Cuda mmq moe oob fix

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -138,7 +138,8 @@ void ggml_cuda_mul_mat_q(
         ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), nbytes_src1_q8_1);
         ggml_cuda_pool_alloc<float> src1_scale(ctx.pool());
         if (src0->type == GGML_TYPE_NVFP4 && use_native_fp4) {
-            src1_scale.alloc(ne13*ne12*ne11);
+            // The stream-k fixup reads y_scale for a full J-wide tile, pad for columns past the valid ones:
+            src1_scale.alloc(ne13*ne12*ne11 + 128);
         }
 
         {
@@ -207,7 +208,8 @@ void ggml_cuda_mul_mat_q(
     ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), nbytes_src1_q8_1);
     ggml_cuda_pool_alloc<float> src1_scale(ctx.pool());
     if (src0->type == GGML_TYPE_NVFP4 && use_native_fp4) {
-        src1_scale.alloc(ne12*n_expert_used);
+        // The stream-k fixup reads y_scale for a full J-wide tile, pad for columns past the valid ones:
+        src1_scale.alloc(ne12*n_expert_used + 128);
     }
 
     const int64_t ne11_flat = ne12*n_expert_used;

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1031,7 +1031,9 @@ static __global__ void mul_mat_q(
                     break;
                 }
 
-                ids_dst_shared[j] = ids_dst[col_low + jt*J + j];
+                // The ids buffer only has col_diff valid entries for this expert, do not read past them.
+                const int jj = jt*J + j;
+                ids_dst_shared[j] = jj < col_diff ? ids_dst[col_low + jj] : 0;
             }
             __syncthreads();
         }
@@ -1125,7 +1127,9 @@ static __global__ void mul_mat_q(
                     break;
                 }
 
-                ids_dst_shared[j] = ids_dst[col_low + jt*J + j];
+                // The ids buffer only has col_diff valid entries for this expert, do not read past them.
+                const int jj = jt*J + j;
+                ids_dst_shared[j] = jj < col_diff ? ids_dst[col_low + jj] : 0;
             }
             __syncthreads();
         }
@@ -1347,7 +1351,9 @@ static __global__ void mul_mat_q_stream_k_fixup(
     const int col_diff = col_high - col_low;
 
     for (int j = threadIdx.y*warp_size + threadIdx.x; j < J; j += nwarps*warp_size) {
-        ids_dst_shared[j] = ids_dst[col_low + jt*J + j];
+        // The ids buffer only has col_diff valid entries for this expert, do not read past them.
+        const int jj = jt*J + j;
+        ids_dst_shared[j] = jj < col_diff ? ids_dst[col_low + jj] : 0;
     }
     __syncthreads();
 

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -371,7 +371,14 @@ static __host__ int ggml_cuda_mmq_get_J_max(const ggml_type type, const bool fal
             return ret;
         }
     }
-    return ret;
+    // There is no valid J <= ne11, return the smallest valid J instead.
+    // This is used to calculate buffer padding, MMQ never reads further than one J-wide tile.
+    for (int J = 8; J <= 128; J += 8) {
+        if (ggml_cuda_mmq_get_config(type, J, fallback, cc).type != GGML_TYPE_COUNT) {
+            return J;
+        }
+    }
+    return 0;
 }
 
 static constexpr __device__ int ggml_cuda_mmq_get_rows_per_warp(ggml_type type, int J, bool fallback) {

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -899,6 +899,9 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
     constexpr int sz = sizeof(block_q8_1_mmq) / sizeof(int);
 
+    // Rows past tile_y_max_j are unused, the y buffer can end inside the tile, do not read them.
+    const int tile_y_max_l = (tile_y_max_j + 1)*MMQ_TILE_Y_K;
+
     for (int kb0 = kb0_start; kb0 < kb0_stop; kb0 += blocks_per_iter) {
         load_tiles(x, tile_x, offset_x + kb0, tile_x_max_i, stride_row_x);
         {
@@ -907,7 +910,7 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
             for (int l0 = 0; l0 < J * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
                 int l = l0 + threadIdx.y*warp_size + threadIdx.x;
 
-                tile_y[l] = by0[l];
+                tile_y[l] = l < tile_y_max_l ? by0[l] : 0;
             }
         }
 
@@ -923,7 +926,7 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
             for (int l0 = 0; l0 < J * MMQ_TILE_Y_K; l0 += nwarps * warp_size) {
                 int l = l0 + threadIdx.y*warp_size + threadIdx.x;
 
-                tile_y[l] = by0[l];
+                tile_y[l] = l < tile_y_max_l ? by0[l] : 0;
             }
         }
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -5026,6 +5026,39 @@ struct test_mul_mat_id : public test_case {
     }
 };
 
+// Like test_mul_mat_id but with a skewed expert distribution (hot experts),
+// closer to a real MoE router than a uniform shuffle.
+struct test_mul_mat_id_skew : public test_mul_mat_id {
+    using test_mul_mat_id::test_mul_mat_id;
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "MUL_MAT_ID_SKEW";
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        // init weights etc. as usual, then overwrite ids with a skewed distribution:
+        init_mul_mat_id_tensors(ctx, n_mats);
+        std::random_device rd;
+        std::default_random_engine rng(rd());
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != NULL; t = ggml_get_next_tensor(ctx, t)) {
+            if (t->type != GGML_TYPE_I32 || ggml_is_view_op(t->op)) { continue; }
+            for (int64_t r = 0; r < ggml_nrows(t); r++) {
+                std::vector<int32_t> pool(n_mats - 2);
+                for (int i = 0; i < n_mats - 2; i++) { pool[i] = 2 + i; }
+                std::shuffle(pool.begin(), pool.end(), rng);
+                std::vector<int32_t> data(t->ne[0]);
+                for (int i = 0; i < t->ne[0]; i++) {
+                    if (i == 0)      data[i] = 0;   // hot expert: every token
+                    else if (i == 1) data[i] = 1;   // hot expert: every token
+                    else             data[i] = pool[i - 2]; // distinct per row, like real top-k
+                }
+                ggml_backend_tensor_set(t, data.data(), r * t->nb[1], t->ne[0] * sizeof(int32_t));
+            }
+        }
+    }
+};
+
 // GGML_OP_MUL_MAT_ID + GGML_OP_ADD or GGML_OP_MUL
 struct test_mul_mat_id_fusion : public test_case {
     const ggml_type type_a;
@@ -9952,6 +9985,19 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     // per-expert base offset, which k == 256 alone leaves untested
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_TQ1_0, GGML_TYPE_F32, 28, 10, false, 1024, 1, 4096));
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_TQ1_0, GGML_TYPE_F32, 128, 8, false, 1024, 1, 2048));
+
+    // DeepSeek-V4-Flash (deepseek4) expert shapes: 256 experts, top-6, m=2048, k=4096
+    for (int bs : {129, 160, 200, 231, 256, 300, 400, 512, 743}) {
+        test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_MXFP4, GGML_TYPE_F32, 256, 6, false, 2048, bs, 4096));
+    }
+    for (int bs : {129, 160, 200, 231, 256, 300, 400, 512, 743}) {
+        test_cases.emplace_back(new test_mul_mat_id_skew(GGML_TYPE_MXFP4, GGML_TYPE_F32, 256, 6, false, 2048, bs, 4096));
+    }
+    // Broadcast activations (ne11 == 1), as used by real MoE gate/up projections (dedup_bcast path)
+    for (int bs : {129, 160, 200, 231, 256, 300, 400, 512, 743}) {
+        test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_MXFP4, GGML_TYPE_F32, 256, 6, true, 2048, bs, 4096));
+        test_cases.emplace_back(new test_mul_mat_id_skew(GGML_TYPE_MXFP4, GGML_TYPE_F32, 256, 6, true, 2048, bs, 4096));
+    }
 
     for (ggml_type type_a : all_types) {
         test_cases.emplace_back(new test_mul_mat_id(type_a, GGML_TYPE_F32, 4, 2, false, 64, 16, 3*ggml_blck_size(type_a)));


### PR DESCRIPTION
What is not working:
Fresh server > first request (web UI vision chat, system prompt + one 1024×1536 PNG + short prompt: 743 prompt tokens) dies instantly.
```
E ggml_cuda_compute_forward: SWIGLU_CLAMP failed
E CUDA error: an illegal memory access was encountered
E   current device: 1, ... at ggml-cuda.cu:2417
```

Bug hunting:
SWIGLU_CLAMP is a sticky-error misattribution (async kernels; first checkpoint after the fault reports it).
CUDA_LAUNCH_BLOCKING=1 > names MUL_MAT_ID as the faulting op cuda-gdb with CUDA_DEVICE_WAITS_ON_EXCEPTION=1 > fault at mmq.cuh:926, tile_y[l] = by0[l], CUDA_EXCEPTION_30 Warp MMU Fault = global MMU fault, not shared memory.

`mul_mat_q_process_tile` staging loop copies a full J-wide tile from the y buffer regardless of valid columns.
When a MoE expert's rows end at the buffer end, the read walks past the mapped region > `Warp MMU Fault` > sticky illegal-memory-access. Values past `col_diff` are never used, so it's a silent overread unless it crosses the pool's 2 MiB VMM mapping boundary.

Proposed fixes:
- clamp staging reads to valid columns
- clamp `ids_dst` reads including stream-k fixup
- `get_J_max` floor for `ne11 < 8` (the intended host-side tail ggml_cuda_mmq_get_J_max(...)*sizeof(block_q8_1_mmq) returns 0 for ne11 == 1 (broadcast MoE gate/up) > no tail at all)
- NVFP4 `y_scale` tail

Verified:
10/10 pre-fix crashes, now 7/7 clean
`test-backend-ops` 3464/3464 (RTX 4090) and 2199/2199 (RTX 5090)
perf neutral-to-positive (386 > 360 microseconds on the n=512 case)

Environment:

| Item         | Value                                                                                                                                                                                                       |
| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| OS / driver  | Arch Linux, driver 610.57.04, CUDA 13.3                                                                                                                                                                     |
| GPU0         | RTX 5090, 32 GB, sm_120                                                                                                                                                                                     |
| GPU1         | RTX 4090, 24 GB, sm_89                                                                                                                                                                                      |
| llama.cpp    | master `c5a5535e6` (build 10792, tag b10792)                                                                                                                                                                |
| Build        | `cmake -B build -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="120;89"` + `cmake --build build --config Release`                                                                                                |
| Model        | `DeepSeek-V4-Flash-Vision-Exp` - only FP8 converted to Q8_0, MXFP4 and other weigths are intact.                                                                                                            |
| Server flags | `--device CUDA0,CUDA1 --split-mode layer --n-gpu-layers all --tensor-split 1,0 --override-tensor "blk\.3[0-5]\..*_exps=CUDA0,blk\.(3[6-9]\|4[0-2])\..*_exps=CUDA1,ffn_.*_exps=CPU" --mmproj /path_to_model` |


## Additional information
I found two stale-closed reports for the likely the same cause: **#24174** and **#25721**
You unable to reproduce the #25721 because it is layout-dependence mechanism. The pool/layout state need to be produced by the model load and the specific allocation sequence of this request's ubatches. For example, with default `--ubatch-size 512`, the 743-token prefill splits into ubatches 512 + 231 and 231-token ubatch crashes.
Staging loop is shared by the Blackwell native-FP4 path and the dense ne11 < 8 path.
## Requirements

- I have read and agree with the [[contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, assisted with GLM-5.3, investigation/debugging sessions.