### PR TITLE
cuda : fix CUB argsort corruption caused by in-place keys

### DIFF
--- a/ggml/src/ggml-cuda/argsort.cu
+++ b/ggml/src/ggml-cuda/argsort.cu
@@ -51,9 +51,13 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
                               cudaStream_t     stream) {
     ggml_cuda_pool_alloc<int>   temp_indices_alloc(pool, ncols * nrows);
     ggml_cuda_pool_alloc<float> temp_keys_alloc(pool, ncols * nrows);
+    // the one-shot DeviceRadixSort API does not support in-place keys: the internal
+    // double-buffer ping-pong requires distinct input and output key buffers
+    ggml_cuda_pool_alloc<float> temp_keys_out_alloc(pool, ncols * nrows);
 
     int *   temp_indices = temp_indices_alloc.get();
     float * temp_keys    = temp_keys_alloc.get();
+    float * temp_keys_out = temp_keys_out_alloc.get();
 
     static const int block_size = 256;
     const dim3 grid_size((ncols + block_size - 1) / block_size, nrows);
@@ -85,18 +89,18 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
 
     if (order == GGML_SORT_ORDER_ASC) {
         if (nrows == 1) {
-            CUDA_CHECK(DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes, temp_keys, temp_keys,  // keys (in-place)
+            CUDA_CHECK(DeviceRadixSort::SortPairs(nullptr, temp_storage_bytes, temp_keys, temp_keys_out,  // keys in, keys out
                                                   temp_indices, dst,  // values (indices)
                                                   ncols, 0, sizeof(float) * 8, stream));
         } else if (is_capturing) {
             CUDA_CHECK(DeviceSegmentedRadixSort::SortPairs(
-                nullptr, temp_storage_bytes, temp_keys, temp_keys,  // keys (in-place)
+                nullptr, temp_storage_bytes, temp_keys, temp_keys_out,  // keys in, keys out
                 temp_indices, dst,                                  // values (indices)
                 ncols * nrows, nrows,                               // num items, num segments
                 offset_iterator, offset_iterator + 1, 0, sizeof(float) * 8, stream));
         } else {
             CUDA_CHECK(DeviceSegmentedSort::SortPairs(nullptr, temp_storage_bytes, temp_keys,
-                                                      temp_keys,             // keys (in-place)
+                                                      temp_keys_out, // keys out
                                                       temp_indices, dst,     // values (indices)
                                                       ncols * nrows, nrows,  // num items, num segments
                                                       offset_iterator, offset_iterator + 1, stream));
@@ -104,15 +108,15 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
     } else {
         if (nrows == 1) {
             CUDA_CHECK(DeviceRadixSort::SortPairsDescending(nullptr, temp_storage_bytes, temp_keys,
-                                                            temp_keys,          // keys (in-place)
+                                                            temp_keys_out, // keys out
                                                             temp_indices, dst,  // values (indices)
                                                             ncols, 0, sizeof(float) * 8, stream));
         } else if (is_capturing) {
             CUDA_CHECK(DeviceSegmentedRadixSort::SortPairsDescending(
-                nullptr, temp_storage_bytes, temp_keys, temp_keys, temp_indices, dst, ncols * nrows, nrows,
+                nullptr, temp_storage_bytes, temp_keys, temp_keys_out, temp_indices, dst, ncols * nrows, nrows,
                 offset_iterator, offset_iterator + 1, 0, sizeof(float) * 8, stream));
         } else {
-            CUDA_CHECK(DeviceSegmentedSort::SortPairsDescending(nullptr, temp_storage_bytes, temp_keys, temp_keys,
+            CUDA_CHECK(DeviceSegmentedSort::SortPairsDescending(nullptr, temp_storage_bytes, temp_keys, temp_keys_out,
                                                                 temp_indices, dst, ncols * nrows, nrows,
                                                                 offset_iterator, offset_iterator + 1, stream));
         }
@@ -124,31 +128,31 @@ void argsort_f32_i32_cuda_cub(ggml_cuda_pool & pool,
     if (order == GGML_SORT_ORDER_ASC) {
         if (nrows == 1) {
             CUDA_CHECK(DeviceRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, temp_keys,
-                                                  temp_keys,          // keys (in-place)
+                                                  temp_keys_out, // keys out
                                                   temp_indices, dst,  // values (indices)
                                                   ncols, 0, sizeof(float) * 8, stream));
         } else if (is_capturing) {
-            CUDA_CHECK(DeviceSegmentedRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, temp_keys, temp_keys,
+            CUDA_CHECK(DeviceSegmentedRadixSort::SortPairs(d_temp_storage, temp_storage_bytes, temp_keys, temp_keys_out,
                                                            temp_indices, dst, ncols * nrows, nrows, offset_iterator,
                                                            offset_iterator + 1, 0, sizeof(float) * 8, stream));
         } else {
-            CUDA_CHECK(DeviceSegmentedSort::SortPairs(d_temp_storage, temp_storage_bytes, temp_keys, temp_keys,
+            CUDA_CHECK(DeviceSegmentedSort::SortPairs(d_temp_storage, temp_storage_bytes, temp_keys, temp_keys_out,
                                                       temp_indices, dst, ncols * nrows, nrows, offset_iterator,
                                                       offset_iterator + 1, stream));
         }
     } else {
         if (nrows == 1) {
             CUDA_CHECK(DeviceRadixSort::SortPairsDescending(d_temp_storage, temp_storage_bytes, temp_keys,
-                                                            temp_keys,          // keys (in-place)
+                                                            temp_keys_out, // keys out
                                                             temp_indices, dst,  // values (indices)
                                                             ncols, 0, sizeof(float) * 8, stream));
         } else if (is_capturing) {
             CUDA_CHECK(DeviceSegmentedRadixSort::SortPairsDescending(
-                d_temp_storage, temp_storage_bytes, temp_keys, temp_keys, temp_indices, dst, ncols * nrows, nrows,
+                d_temp_storage, temp_storage_bytes, temp_keys, temp_keys_out, temp_indices, dst, ncols * nrows, nrows,
                 offset_iterator, offset_iterator + 1, 0, sizeof(float) * 8, stream));
         } else {
             CUDA_CHECK(DeviceSegmentedSort::SortPairsDescending(d_temp_storage, temp_storage_bytes, temp_keys,
-                                                                temp_keys, temp_indices, dst, ncols * nrows, nrows,
+                                                                temp_keys_out, temp_indices, dst, ncols * nrows, nrows,
                                                                 offset_iterator, offset_iterator + 1, stream));
         }
     }


### PR DESCRIPTION
## Overview

`argsort_f32_i32_cuda_cub()` calls the one-shot CUB radix-sort API with `d_keys_in == d_keys_out`. That API is not in-place: it ping-pongs double buffers internally, and aliasing its ends lets it overwrite its own input mid-pass, corrupting the permutation on sm_50 with CCCL 2.x. The fix allocates a distinct keys-out scratch buffer at all six call sites.

## Problem

`argsort_f32_i32_cuda_cub()` (ggml/src/ggml-cuda/argsort.cu) calls the one-shot `DeviceRadixSort::SortPairs` / `SortPairsDescending` API with `d_keys_in == d_keys_out`: the same scratch buffer (`temp_keys`) is passed as both key input and key output at every CUB call site (size query + actual sort, ASC + DESC, `nrows == 1` + segmented variants).

The one-shot API is not an in-place sort: internally it runs a double-buffer ping-pong, and with the two ends aliased it partially overwrites its own input mid-pass (observed with CCCL 2.x on Maxwell). The result is a corrupted permutation: a mixture of valid indices and stale values from the keys buffer.

## How it manifests

Two properties make this rare in practice:

- normal sampling argsorts on the CPU, so the CUDA CUB path is only exercised by ops that sort on the GPU (e.g. `GGML_OP_TOP_K` in backend sampling);
- the CUB path only runs when `ncols > 1024` (smaller inputs take the bitonic path).

Observed failure: backend `top_k` over a 248,320-column vocab (DFlash speculative decoding on Qwen3.8-27B) on Maxwell (sm_50, CUDA 12.5, CCCL 2.x). The corrupted indices were fed to `get_rows`, which gathered with a garbage row id -> illegal memory access -> `CUDA error: an illegal memory access` (Xid 31, sticky context error). Non-deterministic across runs (depends on key values and scheduling).

Evidence from debugging the repro:

- compute-sanitizer memcheck pinned the fault to `k_get_rows_float` reading an unmapped address ~2.1 GB below the nearest allocation;
- bounds-check instrumentation on the `get_rows` ids input showed the `top_k` output containing float bit patterns instead of indices, and an A/B test (aliased vs distinct keys-out) localized the corruption to the argsort.

## Fix

Allocate a distinct keys-out scratch buffer (`temp_keys_out`) from the same transient pool and pass it as `d_keys_out` at all 6 CUB call sites. Peak memory grows by at most one chunk (~64 MB) of transient scratch during the sort.

## Testing

- Repro that crashed within 3 tokens (`top_k` ncols = 248320, temp 0.8, 4-way GPU split) now completes full generation; with instrumentation re-enabled, all `top_k` outputs validated as in-bounds indices (69/69 calls in a 40-token run).
- 3/3 stress runs (3 seeds x 200 tokens each) complete with zero CUDA errors and zero MMU faults.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — an AI assistant helped with sanitizer/log analysis and polishing this description; the diagnosis, fix, and every test result are the author's own and were verified hands-on against the repro.
