### PR TITLE
CUDA/HIP: use hardware v_perm_b32 for Q1_0 vec_dot on AMD (+110% decode on gfx1201)

### DIFF
--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -675,6 +675,19 @@ static __device__ __forceinline__ float vec_dot_q6_K_q8_1_impl_mmq(
     return d6 * sumf_d;
 }
 
+#if defined(GGML_USE_HIP)
+// 4 Q1_0 sign bits (nibble j of q) -> one int holding weights 4j..4j+3 as int8 (-1 / +1)
+// in byte lanes 0..3. n * 0x00204081 lands bit i at position 8i, so the mask leaves one
+// sign bit per byte; 0x0D - spread selects the v_perm_b32 byte constant 0xFF (sel 0x0D)
+// or 0x00 (sel 0x0C), and the spread bit is OR'd back in.
+static __device__ __forceinline__ int q1_0_unpack4_hip(const uint32_t q, const int j) {
+    const uint32_t n      = (q >> (4 * j)) & 0x0Fu;
+    const uint32_t spread = (n * 0x00204081u) & 0x01010101u;
+    const uint32_t sel    = 0x0D0D0D0Du - spread;
+    return (int) (__builtin_amdgcn_perm(0u, 0u, sel) | spread);
+}
+#endif // defined(GGML_USE_HIP)
+
 static __device__ __forceinline__ float vec_dot_q1_0_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
 
@@ -700,6 +713,17 @@ static __device__ __forceinline__ float vec_dot_q1_0_q8_1(
         const int u2 = get_int_b4(bq8_1_chunk->qs, j*4+2);
         const int u3 = get_int_b4(bq8_1_chunk->qs, j*4+3);
 
+#if defined(GGML_USE_HIP)
+        // HIP implements __byte_perm as a software routine, so the 8-call chain below is
+        // expensive. Spread the sign bits directly instead: for nibble n, n * 0x00204081
+        // lands bit i at position 8i, so the mask leaves one sign bit per byte. Then
+        // 0x0D - spread selects the v_perm_b32 constant 0xFF (sel 0x0D) or 0x00 (sel 0x0C)
+        // per byte, and the spread bit is OR'd back to give -1 / +1 as int8.
+        const int v0 = q1_0_unpack4_hip((uint32_t) q, 0);
+        const int v1 = q1_0_unpack4_hip((uint32_t) q, 1);
+        const int v2 = q1_0_unpack4_hip((uint32_t) q, 2);
+        const int v3 = q1_0_unpack4_hip((uint32_t) q, 3);
+#else
         // unpack crumbs into nibble indices
         const int n0 = __byte_perm(0x11100100, 0x11100100, q >> 0); // [0, 1, 4, 5] [ 8,  9, 12, 13]
         const int n1 = __byte_perm(0x11100100, 0x11100100, q >> 2); // [2, 3, 6, 7] [10, 11, 14, 15]
@@ -713,6 +737,7 @@ static __device__ __forceinline__ float vec_dot_q1_0_q8_1(
         const int v1 = __byte_perm(s0, s1, 0x7632);
         const int v2 = __byte_perm(s2, s3, 0x5410);
         const int v3 = __byte_perm(s2, s3, 0x7632);
+#endif // defined(GGML_USE_HIP)
 
         sumi = ggml_cuda_dp4a(v0, u0, sumi);
         sumi = ggml_cuda_dp4a(v1, u1, sumi);


### PR DESCRIPTION
## Overview

Follows the same approach as #26753, which did this for `Q2_0`.

HIP has no hardware `__byte_perm`; it lowers to a software routine. The current `Q1_0` unpack calls it **20 times per 32-element chunk** -- 2 for the nibble indices, 4 for the byte values, 4 to unshuffle, twice per block. That makes `Q1_0` decode VALU-bound on AMD rather than bandwidth-bound.

This spreads the sign bits arithmetically and selects the byte constants with one hardware `v_perm_b32` per nibble:

- `n * 0x00204081` lands bit `i` at position `8i`, so `& 0x01010101` leaves one sign bit per byte
- `0x0D - spread` selects the `v_perm_b32` byte constant `0xFF` (sel `0x0D`) or `0x00` (sel `0x0C`)
- OR the spread bit back in to get `-1` / `+1` as int8

One helper plus an `#if defined(GGML_USE_HIP)` / `#else`. **The non-HIP branch is unchanged**, so CUDA behaviour is identical.

### Measured

1x Radeon AI PRO R9700 (gfx1201), ROCm/TheRock 7.13, Bonsai-27B `Q1_0` (3.53 GiB), `-p 0 -n 64 -r 5`, interleaved against a clean build of the same base commit:

| build | tg64 |
|---|---|
| master | 29.69 / 29.11 t/s |
| master + this patch | 61.97 / 61.34 t/s |

**mean 29.402 -> 61.657 t/s (+109.7%)**

### Correctness

- **Exhaustive**: all 65536 possible `q` values, both paths compiled for gfx1201, all 4 nibbles each -- **bit-identical** to the `__byte_perm` reference. The change cannot alter numerics.
- `test-backend-ops -o MUL_MAT`: all 11 `q1_0` cases pass (n=1..9, k=256 and 4096).

### Caveats

- Tested on one model and one GPU (gfx1201). No other RDNA/CDNA parts available to me.
- **No NVIDIA hardware**, so the CUDA path is unverified by measurement. It is unchanged code inside the `#else`, but it has not been run.
- `Q1_0` still will not beat `Q2_0` on this hardware even with this fix -- that appears to be a property of sub-2-bpw formats rather than of any implementation (cf. ik_llama.cpp#45 on RTX-4080, and #19743's RTX 4090 Vulkan numbers). This removes an AMD-specific software-lowering penalty; it does not change the format's ceiling.

## Additional information

Context and further measurements in #27127, including a note on why the figure there was originally reported as +16% (that was measured against a fork where other changes already masked most of the loss, not against master).

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: **YES.** The unpack algorithm itself is my own prior work from my fork, not AI-generated. An AI agent (Claude) was used to: port that helper onto current master and adapt it to the surrounding upstream code; write the exhaustive 65536-value equivalence harness; build both the baseline and patched trees and run the interleaved benchmarks and `test-backend-ops`; and draft this description. I have reviewed the diff and am responsible for it.