### PR TITLE
ui : discover download options

### DIFF
--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetails.svelte
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetails.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+	import { ModelsDiscoverDetailsDownloadOptions } from './ModelsDiscoverDetailsDownloadOptions';
 	import ModelsDiscoverDetailsHeader from './ModelsDiscoverDetailsHeader.svelte';
 	import ModelsDiscoverDetailsReadme from './ModelsDiscoverDetailsReadme.svelte';
 	import ModelsDiscoverDetailsSkeleton from './ModelsDiscoverDetailsSkeleton.svelte';
+	import { OTHER_BIT_DEPTH } from '$lib/constants';
 	import { ModelAuxSidecar } from '$lib/enums';
 	import { HuggingFaceService } from '$lib/services';
-	import type { HfModelDetailInfo, HfModelSibling } from '$lib/types';
+	import type { HfModelDetailInfo, HfModelSibling, ModelBitDepthRow } from '$lib/types';
 	import { detectThinkingSupport, detectToolUseSupport } from '$lib/utils';
+	import { SvelteMap } from 'svelte/reactivity';
 
 	interface Props {
 		/** Full HuggingFace model id, e.g. `ggml-org/gemma-3-4b-it-GGUF`. */
@@ -42,6 +45,29 @@
 	let hasVision = $derived(hasMmproj || details?.pipeline_tag === 'image-text-to-text');
 	let hasTools = $derived(detectToolUseSupport(gguf?.chat_template ?? ''));
 	let hasReasoning = $derived(detectThinkingSupport(gguf?.chat_template ?? ''));
+
+	let bitDepthRows = $derived.by<ModelBitDepthRow[]>(() => {
+		const rows = new SvelteMap<number, HfModelSibling[]>();
+
+		for (const file of files) {
+			const meta = HuggingFaceService.extractQuantMeta(file.path);
+
+			// mmproj sidecars are already conveyed by the Vision capability badge;
+			// imatrix ships as a normal chip with its own badge.
+			if (meta?.sidecar === ModelAuxSidecar.MMPROJ) continue;
+
+			const depth = meta?.quant ? HuggingFaceService.getBitDepth(meta.quant) : null;
+			const bucket = depth ?? OTHER_BIT_DEPTH;
+			const list = rows.get(bucket) ?? [];
+
+			list.push(file);
+			rows.set(bucket, list);
+		}
+
+		return Array.from(rows.entries())
+			.map(([bitDepth, rowFiles]) => ({ bitDepth, files: rowFiles }))
+			.sort((a, b) => a.bitDepth - b.bitDepth);
+	});
 </script>
 
 {#if loading}
@@ -62,6 +88,8 @@
 			{licenseTag}
 			{modelId}
 		/>
+
+		<ModelsDiscoverDetailsDownloadOptions {bitDepthRows} {modelId} />
 
 		<ModelsDiscoverDetailsReadme {readme} />
 	</div>

--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptions.svelte
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptions.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+	import { classify, labelFor } from './download-options.utils';
+	import ModelsDiscoverDetailsDownloadOptionsDownloadCommand from './ModelsDiscoverDetailsDownloadOptionsDownloadCommand.svelte';
+	import ModelsDiscoverDetailsDownloadOptionsRow from './ModelsDiscoverDetailsDownloadOptionsRow.svelte';
+	import { DialogConfirmDownload } from '$lib/components/app/dialogs';
+	import { ModelDownloadConfirmAction, ModelSelectableFileKind } from '$lib/enums';
+	import { HuggingFaceService, ModelsService } from '$lib/services';
+	import { modelsStore } from '$lib/stores';
+	import type {
+		ModelBitDepthRow,
+		ModelDownloadEntryState,
+		ModelQuantOption,
+		ModelSelectableFile
+	} from '$lib/types';
+
+	interface Props {
+		/** Full HuggingFace repo id, e.g. `ggml-org/gemma-3-4b-it-GGUF`. */
+		modelId: string;
+		/** GGUF files grouped by bit depth. */
+		bitDepthRows: ModelBitDepthRow[];
+		/** Download state lookup; defaults to the models store status feed. */
+		getDownloadState?: (
+			repoWithTag: string,
+			filePath: string,
+			isSidecar: boolean
+		) => ModelDownloadEntryState;
+	}
+
+	let { bitDepthRows, getDownloadState, modelId }: Props = $props();
+
+	// Destructive chip actions (delete a downloaded model, cancel a download) are
+	// confirmed here rather than inside each chip: a single shared dialog owned by
+	// the options panel, keyed by the repo+tag the user acted on, so one dialog is
+	// mounted for the whole panel instead of one per chip.
+	// The acted-on target is kept after closing so the copy stays rendered through
+	// the dialog's close transition.
+	let pending: { action: ModelDownloadConfirmAction; repoWithTag: string } = $state({
+		action: ModelDownloadConfirmAction.CANCEL,
+		repoWithTag: ''
+	});
+	let confirmOpen = $state(false);
+
+	function requestCancel(repoWithTag: string) {
+		pending = { action: ModelDownloadConfirmAction.CANCEL, repoWithTag };
+		confirmOpen = true;
+	}
+
+	function requestDelete(repoWithTag: string) {
+		pending = { action: ModelDownloadConfirmAction.DELETE, repoWithTag };
+		confirmOpen = true;
+	}
+
+	function stateFor(
+		repoWithTag: string,
+		filePath: string,
+		isSidecar: boolean
+	): ModelDownloadEntryState {
+		if (getDownloadState) return getDownloadState(repoWithTag, filePath, isSidecar);
+
+		const isDownloading = modelsStore.status.isDownloadInProgress(repoWithTag);
+		const isPaused = modelsStore.status.isDownloadPaused(repoWithTag);
+
+		return {
+			// solo downloads register in /v1/models under the tag (args stay empty),
+			// while drafts pulled by a loaded model only show up as its --model-draft
+			isDownloaded:
+				!isDownloading &&
+				(modelsStore.status.isModelDownloaded(repoWithTag) ||
+					(isSidecar && modelsStore.status.isSidecarDownloaded(modelId, filePath))),
+			isDownloading,
+			isFailed: modelsStore.status.hasFailedDownload(repoWithTag),
+			isPaused,
+			// live progress while downloading, else the frozen snapshot of the pause
+			progress:
+				modelsStore.status.getDownloadProgress(repoWithTag) ??
+				modelsStore.status.getPausedDownloadProgress(repoWithTag),
+			repoWithTag
+		};
+	}
+
+	/**
+	 * Every selectable file with its kind and download state, in row order.
+	 * Single source of truth for the chip rows and the command selects.
+	 */
+	let selectableFiles = $derived.by(() => {
+		const files: (ModelSelectableFile & { state: ModelDownloadEntryState })[] = [];
+
+		for (const row of bitDepthRows) {
+			for (const file of row.files) {
+				const meta = HuggingFaceService.extractQuantMeta(file.path);
+				const tag = ModelsService.buildDownloadTag(
+					modelId,
+					meta?.quant ?? null,
+					meta?.sidecar ?? null
+				);
+
+				files.push({
+					...file,
+					kind: classify(file.path),
+					state: stateFor(tag, file.path, Boolean(meta?.sidecar))
+				});
+			}
+		}
+
+		return files;
+	});
+
+	/** Rows for the row component: per-bit-depth files with state attached. */
+	let rows = $derived.by(() =>
+		bitDepthRows.map((row) => {
+			const paths = new Set(row.files.map((f) => f.path));
+
+			return {
+				bitDepth: row.bitDepth,
+				files: selectableFiles.filter((f) => paths.has(f.path))
+			};
+		})
+	);
+
+	function optionFor(file: ModelSelectableFile): ModelQuantOption {
+		return {
+			label: labelFor(file.path),
+			path: file.path
+		};
+	}
+
+	/** Non-draft quants for the command's base select, in row order. */
+	let mainOptions = $derived(
+		selectableFiles.filter((f) => f.kind === ModelSelectableFileKind.MAIN).map(optionFor)
+	);
+
+	/**
+	 * Draft options for the command's draft select, with their sidecar type
+	 * (MTP, DFLASH...) since a repo can ship more than one draft flavour.
+	 */
+	let draftOptions = $derived(
+		selectableFiles
+			.filter((f) => f.kind === ModelSelectableFileKind.DRAFT)
+			.map((f) => ({
+				...optionFor(f),
+				badge: HuggingFaceService.extractQuantMeta(f.path)?.sidecar ?? null
+			}))
+	);
+</script>
+
+{#if bitDepthRows.length}
+	<section class="rounded-3xl border border-border/30 bg-muted/60 shadow-xs dark:border-border/20">
+		<!-- One chip per file, each an independent download action with its own
+			 lifecycle state; nothing here selects anything. -->
+		<div class="flex w-full flex-col divide-y divide-border/50 px-4 pb-1 dark:divide-border/35">
+			{#each rows as row (row.bitDepth)}
+				<ModelsDiscoverDetailsDownloadOptionsRow
+					bitDepth={row.bitDepth}
+					files={row.files}
+					onRequestCancel={requestCancel}
+					onRequestDelete={requestDelete}
+				/>
+			{/each}
+		</div>
+
+		<!-- Terminal command preview, standalone: its picks are not bound to the chips. -->
+		<div class="border-t border-border/50 px-4 pt-3.5 pb-4 dark:border-border/35">
+			<ModelsDiscoverDetailsDownloadOptionsDownloadCommand {draftOptions} {mainOptions} {modelId} />
+		</div>
+	</section>
+{/if}
+
+<DialogConfirmDownload
+	action={pending.action}
+	onClose={() => (confirmOpen = false)}
+	open={confirmOpen}
+	repoWithTag={pending.repoWithTag}
+/>

--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptionsDownloadCommand.svelte
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptionsDownloadCommand.svelte
@@ -1,0 +1,278 @@
+<script lang="ts">
+	import { Check, Copy, Plus, X } from '@lucide/svelte';
+	import * as Select from '$lib/components/ui/select';
+	import {
+		DEFAULT_BASE_BIT_DEPTH,
+		MODEL_ID,
+		type ModelSidecar,
+		OTHER_BIT_DEPTH,
+		SERVE_COMMAND,
+		SPEC_TYPE
+	} from '$lib/constants';
+	import { HuggingFaceService } from '$lib/services';
+	import type { ModelQuantOption } from '$lib/types';
+	import { copyToClipboard } from '$lib/utils';
+
+	interface Props {
+		modelId: string;
+		/** Non-draft quants of the repo, in bit-depth row order. */
+		mainOptions: ModelQuantOption[];
+		/** Draft sidecar files with their sidecar badge; empty when the repo ships none. */
+		draftOptions: (ModelQuantOption & { badge: ModelSidecar | null })[];
+	}
+
+	let { draftOptions, mainOptions, modelId }: Props = $props();
+
+	// Command picks, owned here: nothing two-way binds them to the quant chips.
+	let basePick = $state<string | null>(null);
+	let draftPick = $state<string | null>(null);
+	let draftTypePick = $state<ModelSidecar | null>(null);
+	let withDraft = $state(false);
+
+	function bitDepthOf(path: string): number {
+		const quant = HuggingFaceService.extractQuantMeta(path)?.quant;
+
+		return quant ? (HuggingFaceService.getBitDepth(quant) ?? OTHER_BIT_DEPTH) : OTHER_BIT_DEPTH;
+	}
+
+	/**
+	 * Base file the command points at: the user's pick while it still exists in
+	 * the options, else the 4-bit file, else the lowest bit depth available. A
+	 * stale pick (the details pane switched models) falls back on its own.
+	 */
+	let baseOption = $derived.by(() => {
+		const picked = mainOptions.find((option) => option.path === basePick);
+
+		if (picked) return picked;
+
+		const preferred = mainOptions.find(
+			(option) => bitDepthOf(option.path) === DEFAULT_BASE_BIT_DEPTH
+		);
+
+		if (preferred) return preferred;
+
+		const ranked = [...mainOptions].sort((a, b) => bitDepthOf(a.path) - bitDepthOf(b.path));
+
+		return ranked[0] ?? null;
+	});
+
+	/** Draft sidecar types the repo ships, in option order. */
+	let specTypes = $derived(
+		draftOptions
+			.map((option) => option.badge)
+			.filter((badge): badge is ModelSidecar => badge !== null)
+			.filter((badge, index, all) => all.indexOf(badge) === index)
+	);
+
+	/**
+	 * Draft type the --spec-type select points at: the user's pick while it
+	 * still exists, else the first type the repo ships.
+	 */
+	let draftType = $derived(
+		draftTypePick && specTypes.includes(draftTypePick) ? draftTypePick : (specTypes[0] ?? null)
+	);
+
+	/** Draft files of the picked type; the quant select only offers these. */
+	let typeDraftOptions = $derived(draftOptions.filter((option) => option.badge === draftType));
+
+	/** Draft file the -hfd tag points at: the user's pick, else the first of the type. */
+	let draftOption = $derived(
+		withDraft
+			? (typeDraftOptions.find((option) => option.path === draftPick) ??
+					typeDraftOptions[0] ??
+					null)
+			: null
+	);
+
+	/** Quant of the file the `-hf` tag points at; null when the file carries no quant. */
+	let mainQuant = $derived(
+		baseOption ? (HuggingFaceService.extractQuantMeta(baseOption.path)?.quant ?? null) : null
+	);
+
+	/** Quant of the file the `-hfd` tag points at. */
+	let draftQuant = $derived(
+		draftOption ? (HuggingFaceService.extractQuantMeta(draftOption.path)?.quant ?? null) : null
+	);
+
+	/** `--spec-type` value; null when no draft type resolved. */
+	let specType = $derived(draftType ? SPEC_TYPE[draftType] : null);
+
+	/** The llama serve command, composed from the inline picks. */
+	let command = $derived.by(() => {
+		const parts = [
+			SERVE_COMMAND.BIN,
+			SERVE_COMMAND.SUBCOMMAND,
+			SERVE_COMMAND.MODEL_FLAG,
+			mainQuant ? `${modelId}${MODEL_ID.QUANTIZATION_SEPARATOR}${mainQuant}` : modelId
+		];
+
+		if (draftOption && draftQuant) {
+			parts.push(
+				SERVE_COMMAND.DRAFT_FLAG,
+				`${modelId}${MODEL_ID.QUANTIZATION_SEPARATOR}${draftQuant}`,
+				SERVE_COMMAND.SPEC_TYPE_FLAG,
+				specType ?? ''
+			);
+		}
+
+		return parts.join(' ');
+	});
+
+	let copied = $state(false);
+
+	async function copy() {
+		await copyToClipboard(command);
+		copied = true;
+		setTimeout(() => (copied = false), 1500);
+	}
+</script>
+
+<!-- <div aria-hidden="true" class="flex items-center gap-3 mt-2 mb-4">
+	<span class="h-px flex-1 bg-border/50"></span>
+
+	<span class="text-xs whitespace-nowrap text-muted-foreground"> or run in your terminal </span>
+
+	<span class="h-px flex-1 bg-border/50"></span>
+</div> -->
+
+<div
+	class="relative flex items-center gap-2 overflow-hidden rounded-lg border border-border/40 bg-background py-2.5 pl-4 pr-10 shadow-xs dark:border-border/35 dark:bg-background/50"
+>
+	<!-- Single line: long commands scroll horizontally instead of wrapping. -->
+	<div
+		class="flex min-w-0 flex-1 items-center gap-x-2 overflow-x-auto py-0.5 font-mono text-xs whitespace-nowrap text-foreground/90"
+	>
+		<span class="shrink-0">{SERVE_COMMAND.BIN}</span>
+
+		<span class="shrink-0">{SERVE_COMMAND.SUBCOMMAND}</span>
+
+		<span class="shrink-0">{SERVE_COMMAND.MODEL_FLAG}</span>
+
+		<span class="shrink-0">
+			{modelId}{mainQuant ? MODEL_ID.QUANTIZATION_SEPARATOR : ''}
+		</span>
+
+		<!-- Base quant: always part of the command, the 4-bit file by default. -->
+		{#if baseOption}
+			<Select.Root onValueChange={(v) => v && (basePick = v)} type="single" value={baseOption.path}>
+				<Select.Trigger
+					aria-label="Base model quantization"
+					class="-ml-2 border-primary/15 bg-primary/[0.07] font-mono text-foreground hover:bg-primary/15 focus-visible:border-primary/40 focus-visible:ring-0"
+					size="xs"
+				>
+					{baseOption.label}
+				</Select.Trigger>
+
+				<Select.Content class="font-mono text-xs">
+					{#each mainOptions as option (option.path)}
+						<Select.Item class="text-xs" label={option.label} value={option.path}>
+							{option.label}
+						</Select.Item>
+					{/each}
+				</Select.Content>
+			</Select.Root>
+		{/if}
+
+		<!-- Draft add: a tiny dashed affordance right of the base part; gone once added. -->
+		{#if draftOptions.length && !withDraft}
+			<button
+				aria-label="Add draft model"
+				class="mx-1 inline-flex h-5 shrink-0 cursor-pointer items-center gap-1 rounded-md border border-dashed border-border/60 px-1.5 text-[10px] text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+				onclick={() => (withDraft = true)}
+				type="button"
+			>
+				<Plus class="h-3 w-3" />
+
+				add draft model
+			</button>
+		{/if}
+
+		<!-- Draft segment: quant and spec type of the picked draft flavour. The X
+				 at the end drops the whole segment (the add button is gone once added);
+				 it only appears while hovering the segment, or directly on touch -->
+		{#if draftOption}
+			<span class="group/draft inline-flex shrink-0 items-center gap-x-2">
+				<span>{SERVE_COMMAND.DRAFT_FLAG}</span>
+
+				<span class="shrink-0">
+					{modelId}{draftQuant ? MODEL_ID.QUANTIZATION_SEPARATOR : ''}
+				</span>
+
+				<Select.Root
+					onValueChange={(v) => v && (draftPick = v)}
+					type="single"
+					value={draftOption.path}
+				>
+					<Select.Trigger
+						aria-label="Draft model quantization"
+						class="-ml-2 border-primary/15 bg-primary/[0.07] font-mono text-foreground hover:bg-primary/15 focus-visible:border-primary/40 focus-visible:ring-0"
+						size="xs"
+					>
+						{draftOption.label}
+					</Select.Trigger>
+
+					<Select.Content class="font-mono text-xs">
+						{#each typeDraftOptions as option (option.path)}
+							<Select.Item class="text-xs" label={option.label} value={option.path}>
+								{option.label}
+							</Select.Item>
+						{/each}
+					</Select.Content>
+				</Select.Root>
+
+				{#if draftType}
+					<span>{SERVE_COMMAND.SPEC_TYPE_FLAG}</span>
+
+					<!-- the select only earns its chrome when there is a real choice to make -->
+					{#if specTypes.length > 1}
+						<Select.Root
+							onValueChange={(v) => v && (draftTypePick = v as ModelSidecar)}
+							type="single"
+							value={draftType}
+						>
+							<Select.Trigger
+								aria-label="Draft type"
+								class="border-primary/15 bg-primary/[0.07] font-mono text-foreground hover:bg-primary/15 focus-visible:border-primary/40 focus-visible:ring-0"
+								size="xs"
+							>
+								{SPEC_TYPE[draftType]}
+							</Select.Trigger>
+
+							<Select.Content class="font-mono text-xs">
+								{#each specTypes as type (type)}
+									<Select.Item class="text-xs" label={SPEC_TYPE[type]} value={type}>
+										{SPEC_TYPE[type]}
+									</Select.Item>
+								{/each}
+							</Select.Content>
+						</Select.Root>
+					{:else}
+						<span>{SPEC_TYPE[draftType]}</span>
+					{/if}
+				{/if}
+
+				<button
+					aria-label="Remove draft model"
+					class="shrink-0 cursor-pointer text-muted-foreground/60 opacity-0 transition-[opacity,color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:text-destructive group-hover/draft:opacity-100 [@media(pointer:coarse)]:opacity-100"
+					onclick={() => (withDraft = false)}
+					type="button"
+				>
+					<X class="h-3 w-3" />
+				</button>
+			</span>
+		{/if}
+	</div>
+
+	<button
+		aria-label="Copy command"
+		class="absolute top-1/2 right-2 -translate-y-1/2 cursor-pointer rounded-md p-1.5 text-muted-foreground/70 transition-colors hover:bg-primary/10 hover:text-foreground"
+		onclick={copy}
+		type="button"
+	>
+		{#if copied}
+			<Check class="h-3.5 w-3.5 text-green-500" />
+		{:else}
+			<Copy class="h-3.5 w-3.5" />
+		{/if}
+	</button>
+</div>

--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton.svelte
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+	import DownloadProgressBar from '../../DownloadProgressBar.svelte';
+	import { labelFor } from './download-options.utils';
+	import { Check, Download, Loader2, Pause, Play, RotateCw, X } from '@lucide/svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { HuggingFaceService } from '$lib/services';
+	import { modelsStore } from '$lib/stores';
+	import type { HfModelSibling, ModelDownloadEntryState } from '$lib/types';
+
+	interface Props {
+		/** GGUF file the chip stands for. */
+		file: HfModelSibling;
+		/** Download state of the file, from the parent's status feed. */
+		entry: ModelDownloadEntryState;
+		/**
+		 * Ask the parent to confirm deleting a downloaded model. The chip owns no
+		 * dialog; the parent renders the single confirmation and acts on confirm.
+		 */
+		onRequestDelete?: (repoWithTag: string) => void;
+		/** Ask the parent to confirm cancelling an in-flight download. */
+		onRequestCancel?: (repoWithTag: string) => void;
+	}
+
+	let { entry, file, onRequestCancel, onRequestDelete }: Props = $props();
+
+	// Sidecar kind (mtp, mmproj, ...) tag shown on every chip state; one source so
+	// the idle, in-flight and downloaded variants stay identical.
+	const SIDECAR_BADGE_CLASS =
+		'rounded-md bg-primary px-1 py-0.5 text-[10px] font-semibold tracking-wide text-primary-foreground uppercase';
+
+	/** Queue the download; a failed attempt leaves partial files, drop them first. */
+	async function startDownload() {
+		try {
+			if (entry.isFailed) await modelsStore.status.cancelDownload(entry.repoWithTag);
+
+			await modelsStore.status.downloadModel(entry.repoWithTag);
+		} catch {
+			// the store already toasted the failure
+		}
+	}
+
+	let meta = $derived(HuggingFaceService.extractQuantMeta(file.path));
+	let label = $derived(labelFor(file.path));
+
+	let percent = $derived(
+		entry.progress && entry.progress.totalBytes > 0
+			? Math.round((entry.progress.downloadedBytes / entry.progress.totalBytes) * 100)
+			: null
+	);
+
+	let tooltipText = $derived(
+		entry.isDownloading
+			? 'Pause downloading'
+			: entry.isPaused
+				? 'Resume downloading'
+				: entry.isDownloaded
+					? 'Delete model'
+					: entry.isFailed
+						? `Retry download: ${file.path}`
+						: `Download ${file.path}`
+	);
+</script>
+
+{#if entry.isDownloaded}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			<!-- downloaded chips are delete actions: green check by default, red X on hover -->
+			<button
+				aria-label={tooltipText}
+				class="group relative inline-flex h-auto cursor-pointer items-center gap-1 rounded-md! border px-2 py-1 text-left font-mono text-xs shadow-xs transition-[background-color,border-color,transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97]
+					border-green-600/25 bg-green-500/5 hover:border-destructive/50 hover:bg-destructive/10 dark:border-green-500/30 dark:bg-green-500/10 dark:hover:border-destructive/50 dark:hover:bg-destructive/15"
+				onclick={() => onRequestDelete?.(entry.repoWithTag)}
+				type="button"
+			>
+				{#if meta?.sidecar}
+					<span class={SIDECAR_BADGE_CLASS}>
+						{meta.sidecar}
+					</span>
+				{/if}
+
+				<span class="font-medium">{label}</span>
+
+				<span
+					class="-my-1 mx-0.75 w-px self-stretch bg-green-600/25 transition-colors duration-200 group-hover:bg-destructive/30 dark:bg-green-600/30 dark:group-hover:bg-destructive/30"
+				></span>
+
+				<span>{HuggingFaceService.formatFileSize(file.size ?? 0)}</span>
+
+				<!-- icon slot: crossfade check -> x; touch devices show the delete affordance directly -->
+				<span class="relative inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+					<Check
+						class="absolute h-3.5 w-3.5 text-green-500 transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:scale-75 group-hover:opacity-0 [@media(pointer:coarse)]:hidden"
+					/>
+
+					<X
+						class="absolute h-3.5 w-3.5 scale-75 text-destructive opacity-0 transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:scale-100 group-hover:opacity-100 [@media(pointer:coarse)]:scale-100 [@media(pointer:coarse)]:opacity-100"
+					/>
+				</span>
+			</button>
+		</Tooltip.Trigger>
+
+		<Tooltip.Content>
+			<p>{tooltipText}</p>
+		</Tooltip.Content>
+	</Tooltip.Root>
+{:else if entry.isDownloading || entry.isPaused}
+	<!-- in-flight / paused chips: the chip body pauses / resumes on click, the X
+	     inside the chip cancels (stops and discards the partial files). The X slot
+	     is reserved, so the chip never reflows when the affordance fades in -->
+	<div
+		class="group relative inline-flex h-auto items-center gap-1 overflow-hidden rounded-md! border px-2 py-1 text-left font-mono text-xs shadow-xs transition-[background-color,border-color,transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97]
+			{entry.isPaused
+			? 'border-yellow-600/40 bg-yellow-500/10 hover:bg-yellow-500/20 dark:border-yellow-500/30 dark:bg-yellow-500/10'
+			: 'border-border/30 bg-background hover:bg-muted-foreground/10 dark:border-border/20 dark:bg-muted-foreground/15'}"
+	>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<button
+					aria-label={tooltipText}
+					class="flex h-auto min-w-0 flex-1 cursor-pointer items-center gap-1 text-left"
+					onclick={() => {
+						if (entry.isDownloading) void modelsStore.status.pauseDownload(entry.repoWithTag);
+						else void modelsStore.status.downloadModel(entry.repoWithTag).catch(() => {});
+					}}
+					type="button"
+				>
+					{#if meta?.sidecar}
+						<span class={SIDECAR_BADGE_CLASS}>
+							{meta.sidecar}
+						</span>
+					{/if}
+
+					<span class="font-medium">{label}</span>
+
+					<span class="-my-1 mx-0.75 w-px self-stretch bg-border"></span>
+
+					{#if percent !== null}
+						<span class="mr-1 tabular-nums">{percent}%</span>
+					{:else if entry.isPaused}
+						<span>Paused</span>
+					{:else}
+						<span>{HuggingFaceService.formatFileSize(file.size ?? 0)}</span>
+					{/if}
+
+					{#if entry.isDownloading}
+						<!-- spinner fades into the pause affordance on hover; opacity only, the
+							 spin keyframes own the transform so scale would fight them -->
+						<span class="relative inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+							<Loader2
+								class="absolute h-3.5 w-3.5 animate-spin text-muted-foreground transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:opacity-0 [@media(pointer:coarse)]:hidden"
+							/>
+
+							<Pause
+								class="absolute h-3.5 w-3.5 opacity-0 transition-opacity duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:opacity-100 [@media(pointer:coarse)]:opacity-100"
+							/>
+						</span>
+					{:else}
+						<!-- paused: the play affordance fades in on hover; visible directly on touch -->
+						<span class="relative inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+							<Play
+								class="absolute h-3.5 w-3.5 scale-75 opacity-0 transition-[opacity,transform] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] group-hover:scale-100 group-hover:opacity-100 [@media(pointer:coarse)]:scale-100 [@media(pointer:coarse)]:opacity-100"
+							/>
+						</span>
+					{/if}
+				</button>
+			</Tooltip.Trigger>
+
+			<Tooltip.Content>
+				<p>{tooltipText}</p>
+			</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger class="grid">
+				<!-- cancel slot: same fixed slot and fade as the pause / play affordances
+					 so the two icons line up exactly; the X turns destructive on its hover -->
+				<button
+					aria-label="Cancel downloading"
+					class="relative inline-flex h-3.5 w-3.5 shrink-0 cursor-pointer items-center justify-center text-muted-foreground/70"
+					onclick={() => onRequestCancel?.(entry.repoWithTag)}
+					type="button"
+				>
+					<X
+						class="h-3.5 w-3.5 transition-[opacity,transform,color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] text-destructive [@media(pointer:coarse)]:scale-100 [@media(pointer:coarse)]:opacity-100"
+					/>
+				</button>
+			</Tooltip.Trigger>
+
+			<Tooltip.Content>
+				<p>Cancel downloading</p>
+			</Tooltip.Content>
+		</Tooltip.Root>
+
+		{#if percent !== null}
+			<DownloadProgressBar
+				downloadedBytes={entry.progress?.downloadedBytes ?? 0}
+				overlay
+				totalBytes={entry.progress?.totalBytes ?? 0}
+			/>
+		{/if}
+	</div>
+{:else}
+	<Tooltip.Root>
+		<Tooltip.Trigger>
+			<!-- idle chips download on click (retry when the last attempt failed) -->
+			<button
+				aria-label={tooltipText}
+				class="group relative inline-flex h-auto cursor-pointer items-center gap-1 overflow-hidden rounded-md! border px-2 py-1 text-left font-mono text-xs shadow-xs transition-[background-color,border-color,transform] duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97]
+					border-border/30 bg-background hover:bg-muted-foreground/10 dark:border-border/20 dark:bg-muted-foreground/15 dark:text-secondary-foreground dark:hover:bg-muted-foreground/25
+					{entry.isFailed ? 'border-destructive!' : ''}"
+				onclick={() => void startDownload()}
+				type="button"
+			>
+				{#if entry.isFailed}
+					<span
+						class="rounded-md bg-destructive px-1 py-0.5 text-[10px] font-semibold tracking-wide text-destructive-foreground uppercase"
+					>
+						Failed
+					</span>
+				{/if}
+
+				{#if meta?.sidecar}
+					<span class={SIDECAR_BADGE_CLASS}>
+						{meta.sidecar}
+					</span>
+				{/if}
+
+				<span class="font-medium">{label}</span>
+
+				<span class="-my-1 mx-0.75 w-px self-stretch bg-border"></span>
+
+				<span>{HuggingFaceService.formatFileSize(file.size ?? 0)}</span>
+
+				<span class="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+					{#if entry.isFailed}
+						<RotateCw class="h-3.5 w-3.5 text-destructive" />
+					{:else}
+						<Download
+							class="h-3.5 w-3.5 text-muted-foreground transition-colors duration-150 group-hover:text-foreground"
+						/>
+					{/if}
+				</span>
+			</button>
+		</Tooltip.Trigger>
+
+		<Tooltip.Content>
+			<p>{tooltipText}</p>
+		</Tooltip.Content>
+	</Tooltip.Root>
+{/if}

--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptionsRow.svelte
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/ModelsDiscoverDetailsDownloadOptionsRow.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton from './ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton.svelte';
+	import {
+		BIT_DEPTH_LABEL_SUFFIX,
+		GIGABYTE_LABEL,
+		OTHER_BIT_DEPTH,
+		OTHER_BIT_DEPTH_LABEL
+	} from '$lib/constants';
+	import { ModelSelectableFileKind } from '$lib/enums';
+	import type { ModelDownloadEntryState, ModelSelectableFile } from '$lib/types';
+	import { minMemoryTierGb } from '$lib/utils';
+
+	interface Props {
+		/** Bit depth of the row; `99` renders as "Other". */
+		bitDepth: number;
+		/** Every GGUF of this bit depth, with download state attached. */
+		files: (ModelSelectableFile & { state: ModelDownloadEntryState })[];
+		/** Forwarded to each chip: ask the parent to confirm a cancel. */
+		onRequestCancel?: (repoWithTag: string) => void;
+		/** Forwarded to each chip: ask the parent to confirm a delete. */
+		onRequestDelete?: (repoWithTag: string) => void;
+	}
+
+	let { bitDepth, files, onRequestCancel, onRequestDelete }: Props = $props();
+
+	let mainFile = $derived(files.find((f) => f.kind === ModelSelectableFileKind.MAIN) ?? null);
+	let draftFile = $derived(files.find((f) => f.kind === ModelSelectableFileKind.DRAFT) ?? null);
+
+	let mainMemGb = $derived(mainFile ? minMemoryTierGb(mainFile.size ?? 0) : null);
+	let draftMemGb = $derived(draftFile ? minMemoryTierGb(draftFile.size ?? 0) : null);
+</script>
+
+<div class="grid grid-cols-[5rem_1fr] items-center gap-3 py-3">
+	<div class="pt-1 text-sm tabular-nums text-muted-foreground">
+		{#if bitDepth === OTHER_BIT_DEPTH}
+			{OTHER_BIT_DEPTH_LABEL}
+		{:else}
+			{bitDepth}{BIT_DEPTH_LABEL_SUFFIX}
+		{/if}
+
+		{#if mainMemGb}
+			<span class="block text-[10px] whitespace-nowrap text-muted-foreground/60">
+				needs at least {mainMemGb}{GIGABYTE_LABEL}{draftMemGb
+					? ` + ${draftMemGb}${GIGABYTE_LABEL}`
+					: ''}+ memory
+			</span>
+		{/if}
+	</div>
+
+	<div class="flex flex-wrap justify-end gap-1.5">
+		{#each files as file (file.path)}
+			<ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton
+				entry={file.state}
+				{file}
+				{onRequestCancel}
+				{onRequestDelete}
+			/>
+		{/each}
+	</div>
+</div>

--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/download-options.utils.ts
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/download-options.utils.ts
@@ -1,0 +1,33 @@
+import {
+	DRAFT_FILE_LABEL,
+	isAuxSidecar,
+	isDraftSidecar,
+	MODEL_ID,
+	PATH_SEPARATOR
+} from '$lib/constants';
+import { ModelSelectableFileKind } from '$lib/enums';
+import { HuggingFaceService } from '$lib/services';
+
+/** Kind of a file path: the main weights, a draft sidecar, or an aux sidecar (mmproj). */
+export function classify(path: string): ModelSelectableFileKind {
+	const sidecar = HuggingFaceService.extractQuantMeta(path)?.sidecar;
+
+	if (!sidecar) return ModelSelectableFileKind.MAIN;
+
+	return isAuxSidecar(sidecar) ? ModelSelectableFileKind.AUX : ModelSelectableFileKind.DRAFT;
+}
+
+/** Display label of a file: its quant, else the file name without the extension. */
+export function labelFor(path: string): string {
+	const meta = HuggingFaceService.extractQuantMeta(path);
+
+	if (meta?.quant) return meta.quant;
+
+	// Quantless sidecar files: the chip badge already carries the sidecar type,
+	// so the label only marks draft files; aux sidecars badge alone.
+	if (meta?.sidecar) return isDraftSidecar(meta.sidecar) ? DRAFT_FILE_LABEL : '';
+
+	const basename = path.split(PATH_SEPARATOR).pop() ?? path;
+
+	return basename.replace(MODEL_ID.WEIGHT_EXTENSION_REGEX, '');
+}

--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/index.ts
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/ModelsDiscoverDetailsDownloadOptions/index.ts
@@ -1,0 +1,40 @@
+/**
+ *
+ * MODELS DISCOVER — DETAILS — DOWNLOAD OPTIONS
+ *
+ * The download area of the detail pane: GGUF files grouped by bit depth, each an
+ * independent download action chip, plus the standalone terminal command preview.
+ *
+ */
+
+/**
+ * **ModelsDiscoverDetailsDownloadOptions** - GGUF download options
+ *
+ * Groups GGUF files by bit depth and renders one independent download
+ * action chip per file, plus the standalone terminal command preview.
+ */
+export { default as ModelsDiscoverDetailsDownloadOptions } from './ModelsDiscoverDetailsDownloadOptions.svelte';
+
+/**
+ * **ModelsDiscoverDetailsDownloadOptionsRow** - One bit-depth group of quants
+ *
+ * A single bit-depth row inside ModelsDiscoverDetailsDownloadOptions: the
+ * depth label with its memory hint and the quant chips of that depth.
+ */
+export { default as ModelsDiscoverDetailsDownloadOptionsRow } from './ModelsDiscoverDetailsDownloadOptionsRow.svelte';
+
+/**
+ * **ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton** - One quant chip
+ *
+ * A single GGUF file as an independent action chip: download / retry when
+ * idle, pause / resume / cancel while in flight, delete when downloaded.
+ */
+export { default as ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton } from './ModelsDiscoverDetailsDownloadOptionsQuantDownloadButton.svelte';
+
+/**
+ * **ModelsDiscoverDetailsDownloadOptionsDownloadCommand** - Terminal command
+ *
+ * The `llama serve -hf ...` command box with inline quant selects and a copy
+ * button; owns its picks, nothing two-way binds them to the quant chips.
+ */
+export { default as ModelsDiscoverDetailsDownloadOptionsDownloadCommand } from './ModelsDiscoverDetailsDownloadOptionsDownloadCommand.svelte';

--- a/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/index.ts
+++ b/tools/ui/src/lib/components/app/models/discover/ModelsDiscoverDetails/index.ts
@@ -60,3 +60,5 @@ export { default as ModelsDiscoverDetailsMetadataItem } from './ModelsDiscoverDe
  * Shows the model's chat template in a scrollable dialog with a copy button.
  */
 export { default as ModelsDiscoverChatTemplateDialog } from './ModelsDiscoverChatTemplateDialog.svelte';
+
+export * from './ModelsDiscoverDetailsDownloadOptions';

--- a/tools/ui/src/lib/constants/index.ts
+++ b/tools/ui/src/lib/constants/index.ts
@@ -45,6 +45,7 @@ export * from './path-display.constants';
 export * from './model-id.constants';
 export * from './model-loading.constants';
 export * from './models-discover.constants';
+export * from './models-discover-download.constants';
 export * from './model-compatibility.constants';
 export * from './huggingface.constants';
 export * from './precision.constants';

--- a/tools/ui/src/lib/constants/models-discover-download.constants.ts
+++ b/tools/ui/src/lib/constants/models-discover-download.constants.ts
@@ -1,0 +1,54 @@
+/**
+ * Models Discover — download options constants.
+ *
+ * Shared values backing the download-options area of the details pane: the
+ * serve `--spec-type` mapping, the bit-depth buckets, and the standalone
+ * command builder. Kept here (not component-local) so they sit with the rest
+ * of the discover domain constants.
+ */
+
+import type { ModelSidecar } from '$lib/constants';
+import { ModelAuxSidecar, ModelDraftSidecar } from '$lib/enums';
+
+/**
+ * `--spec-type` value for each draft sidecar; aux sidecars (mmproj, imatrix)
+ * carry none and stay empty.
+ */
+export const SPEC_TYPE: Record<ModelSidecar, string> = {
+	[ModelAuxSidecar.IMATRIX]: '',
+	[ModelAuxSidecar.MMPROJ]: '',
+	[ModelDraftSidecar.DFLASH]: 'draft-dflash',
+	[ModelDraftSidecar.DSPARK]: 'draft-dspark',
+	[ModelDraftSidecar.EAGLE3]: 'eagle3',
+	[ModelDraftSidecar.MTP]: 'draft-mtp'
+};
+
+/** Bit-depth bucket for files that carry no quant token; rendered as "Other". */
+export const OTHER_BIT_DEPTH = 99;
+
+/** Label for the OTHER_BIT_DEPTH bucket. */
+export const OTHER_BIT_DEPTH_LABEL = 'Other';
+
+/** Suffix appended after a bit-depth number to label a row, e.g. `4-bit`. */
+export const BIT_DEPTH_LABEL_SUFFIX = '-bit';
+
+/**
+ * Fixed tokens of the standalone `llama serve` command preview, so the command
+ * builder and its rendered spans share one source of the CLI spelling.
+ */
+export const SERVE_COMMAND = {
+	BIN: 'llama',
+	/** Draft model repo:tag argument (download sidecar / draft weights). */
+	DRAFT_FLAG: '-hfd',
+	/** Main model repo:tag argument. */
+	MODEL_FLAG: '-hf',
+	/** Speculative-decoding type argument for the draft. */
+	SPEC_TYPE_FLAG: '--spec-type',
+	SUBCOMMAND: 'serve'
+} as const;
+
+/** Bit depth preferred for the command's default base quant. */
+export const DEFAULT_BASE_BIT_DEPTH = 4;
+
+/** Label shown for a draft-sidecar chip whose quant is unknown. */
+export const DRAFT_FILE_LABEL = 'draft';


### PR DESCRIPTION
## Overview

Reworks the discover detail pane's download area into per-quant action chips: repo files are grouped into bit-depth rows, the selected quant (plus mmproj and draft sidecars) is queued for download, and a scrollable serve-command preview shows dynamic quant selects wired to the `--spec-type` flags.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - code authored with an AI coding agent (pi, GLM-5.3-Flash) from the contributor's design and reviewed by the contributor; commits carry Assisted-by trailers.
