### PR TITLE
cli: allow --server-base to be set via LLAMA_ARG_SERVER_BASE

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1482,7 +1482,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         [](common_params & params, const std::string & value) {
             params.server_base = value;
         }
-    ).set_examples({LLAMA_EXAMPLE_CLI}));
+    ).set_examples({LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SERVER_BASE"));
     add_opt(common_arg(
         {"--verbose-prompt"},
         string_format("print a verbose prompt before generation (default: %s)", params.verbose_prompt ? "true" : "false"),

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -144,7 +144,7 @@
 
 | Argument | Explanation |
 | -------- | ----------- |
-| `--server-base URL` | connect to this server instead of starting a new one, example: 'http://localhost:8080' (default: none) |
+| `--server-base URL` | connect to this server instead of starting a new one, example: 'http://localhost:8080' (default: none)<br/>(env: LLAMA_ARG_SERVER_BASE) |
 | `--verbose-prompt` | print a verbose prompt before generation (default: false) |
 | `--display-prompt, --no-display-prompt` | whether to print prompt at generation (default: true) |
 | `-co, --color [on\|off\|auto]` | Colorize output to distinguish prompt and user input from generations ('on', 'off', or 'auto', default: 'auto')<br/>'auto' enables colors when output is to a terminal |


### PR DESCRIPTION
## Overview

This PR attaches the `LLAMA_ARG_SERVER_BASE` env var to the `--server-base` CLI flag. This is pretty handy for people who interact with llama-cli mostly through a remote server.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, to find which docs had to be updated.
