### PR TITLE
ngram : draft from the selected continuation

### DIFF
--- a/common/ngram-map.cpp
+++ b/common/ngram-map.cpp
@@ -503,7 +503,7 @@ void common_ngram_map_draft(common_ngram_map & map,
     int n_draft_tokens = std::min((int) m, (int) curr_key.values[slot_max].n_accepted);
 
     for (int i = 0; i < n_draft_tokens; ++i) {
-        draft.push_back(inp[match_pos + n + i]);
+        draft.push_back(inp[curr_key.values[slot_max].value_idx + i]);
     }
 
     LOG_DBG("%s: key_offset = %zu, slot_max = %d, key_num = %d, draft.size = %zu\n", __func__,

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -2,6 +2,7 @@
 #include "common.h"
 #include "download.h"
 #include "llama.h"
+#include "ngram-map.h"
 #include "speculative.h"
 
 #include <cmath>
@@ -99,6 +100,17 @@ static void test(void) {
         const auto draft = common_base_params_to_speculative(base);
         assert(draft.n_outputs_max == 4);
         assert(draft.n_outputs_max_per_seq == 1);
+    }
+
+    // The most frequent continuation differs from the latest match in both histories.
+    for (const llama_tokens & tokens : std::vector<llama_tokens>{
+            {0, 1, 10, 11, 1, 10, 11, 1, 10, 11, 1, 20, 21, 99, 99},
+            {0, 1, 20, 21, 1, 10, 11, 1, 10, 11, 1, 10, 11, 1, 10, 11, 1, 20, 21, 99, 99}}) {
+        common_ngram_map map(1, 2, false, 1);
+        common_ngram_map_begin(map, tokens);
+        llama_tokens draft;
+        common_ngram_map_draft(map, tokens, 1, draft);
+        assert(draft == llama_tokens({10, 11}));
     }
 
     printf("test-arg-parser: make sure there is no duplicated arguments in any examples\n\n");


### PR DESCRIPTION
## Overview

Fix ngram-map-k4v copying draft tokens from the latest match instead of the selected most frequent continuation. Add regression coverage for different candidate slots.

## Testing

- Regression fails before the fix and passes after.
- Full test-arg-parser passes.
- Eight additional ASan/UBSan cases pass.

## Requirements

- AI usage disclosure: NO.
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)