### PR TITLE
Github: limit blank issues to maintainers

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Got an idea?
     url: https://github.com/ggml-org/llama.cpp/discussions/categories/ideas


### PR DESCRIPTION
## Overview

As of right now anyone can submit a blank issue to llama.cpp. This is not bad in and of itself but unfortunately the primary way this is being used is to submit language model outputs in clear violation of our guidelines. At least for me personally this is significantly contributing to review fatigue. So I would suggest we disable the option to submit blank issues by default. My understanding is that this change does *not* affect people with write access.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No