### PR TITLE
speculative: fix draft model loading target path instead of draft path

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -2542,7 +2542,7 @@ common_speculative_init_result::common_speculative_init_result(
         model_path = params.speculative.draft.mparams.path;
         LOG_INF("%s: loading draft model '%s'\n", __func__, model_path.c_str());
 
-        llama_model * model_dft = llama_model_load_from_file(params.model.path.c_str(), mparams);
+        llama_model * model_dft = llama_model_load_from_file(model_path.c_str(), mparams);
         if (model_dft == NULL) {
             LOG_ERR("%s: failed to load draft model, '%s'\n", __func__, model_path.c_str());
             return;


### PR DESCRIPTION
## Summary

`common_speculative_init_result()` in `common/speculative.cpp` computes `model_path` from `params.speculative.draft.mparams.path` (the `-md`/`--model-draft` path) and even logs it correctly, but then calls `llama_model_load_from_file()` with `params.model.path` (the **target** model path) instead of `model_path`.

```cpp
model_path = params.speculative.draft.mparams.path;
LOG_INF("%s: loading draft model '%s'\n", __func__, model_path.c_str());

llama_model * model_dft = llama_model_load_from_file(params.model.path.c_str(), mparams); // bug: should be model_path
```

## Impact

With a large target model, this silently loads the target a second time as the "draft" instead of the intended (usually much smaller) draft/MTP model. Depending on target size this can:
- waste significant memory and load time,
- OOM setups with tighter memory budgets (e.g. multi-node RPC where the target already consumes most of available RAM on a node).

The log line right above the bug prints the *correct* draft path, which makes the actual model being loaded non-obvious from the logs alone.

## Fix

One-line change: use `model_path` (already computed just above) instead of `params.model.path`.

## Testing

Reproduced and fixed while testing `-md`/`--spec-type draft-mtp` speculative decoding with a Qwen3.8-Flash-Next (qwen4exp) target + a small MTP draft-head sidecar GGUF, split across 2 nodes via `--rpc`. Before the fix, the draft "load" pulled in the full multi-shard target model a second time; after the fix, the correct small draft/MTP file loads and speculative decoding works as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)