### PR TITLE
cuda : warn when flash attention falls back to the CPU backend due to unsupported KV cache types

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -5,6 +5,8 @@
 #include "fattn-vec.cuh"
 #include "fattn.cuh"
 
+#include <unordered_set>
+
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 __launch_bounds__(256, 1)
 static __global__ void flash_attn_mask_to_sparse_indices(
@@ -574,11 +576,25 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
 
 #ifndef GGML_CUDA_FA_ALL_QUANTS
     if (K->type != V->type) {
+        static std::unordered_set<int> warned_kvtypes;
+        if (warned_kvtypes.insert((int(K->type) << 8) | int(V->type)).second) {
+            GGML_LOG_WARN("%s: mixed K (%s) and V (%s) cache types are not supported by the compiled FlashAttention kernels; "
+                "the op will run on the CPU backend with a large performance penalty. "
+                "Rebuild with -DGGML_CUDA_FA_ALL_QUANTS=ON or use matching K/V types from the compiled set (f16, q4_0, q8_0, bf16).\n",
+                __func__, ggml_type_name(K->type), ggml_type_name(V->type));
+        }
         return BEST_FATTN_KERNEL_NONE;
     }
 #endif // GGML_CUDA_FA_ALL_QUANTS
 
     if (!ggml_cuda_fattn_kv_type_supported(K->type) || !ggml_cuda_fattn_kv_type_supported(V->type)) {
+        static std::unordered_set<int> warned_kvtypes;
+        if (warned_kvtypes.insert((int(K->type) << 8) | int(V->type)).second) {
+            GGML_LOG_WARN("%s: %s K cache / %s V cache is not supported by the compiled FlashAttention kernels; "
+                "the op will run on the CPU backend with a large performance penalty (e.g. ~8x slower prompt processing). "
+                "Rebuild with -DGGML_CUDA_FA_ALL_QUANTS=ON or use f16/q4_0/q8_0/bf16 cache types.\n",
+                __func__, ggml_type_name(K->type), ggml_type_name(V->type));
+        }
         return BEST_FATTN_KERNEL_NONE;
     }
 


### PR DESCRIPTION
## Overview

The default CUDA build only compiles FlashAttention kernels for f16, q4_0, q8_0, bf16 KV cache types. Using -fa on with q5_0/q5_1/q4_1 (or mixed K/V) silently runs the whole attention op on the CPU backend — prefill drops about 8x and nothing is logged. This PR prints a LOG_WARN on the two paths in `ggml_cuda_get_best_fattn_kernel()` that currently return NONE without telling anyone.

## Additional information

Reproduced on RTX 4080 32G, 27B model: pp512 goes from 1511 t/s (q8_0) to 197 t/s (q5_1) with default build. After rebuilding with -DGGML_CUDA_FA_ALL_QUANTS=ON the same q5_1 setup reaches 1510 t/s, so the kernels exist and work — the problem is purely that the fallback is silent.

Verified: q5_1/q5_1 and q8_0/q5_1 (mixed) now warn; q8_0/q8_0 stays silent. Fixes #28455, also explains the q4_1 case in #27109 and the request in #24485.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI (GLM5.3 Flash Max) assisted with debugging and drafting the patch; this description, review and testing are my own.