### PR TITLE
common : end the URL authority at the first '/', '?' or '#'

### DIFF
--- a/common/http.h
+++ b/common/http.h
@@ -40,10 +40,18 @@ static common_http_url common_http_parse_url(const std::string & url) {
     }
 
     auto rest = url.substr(scheme_end + 3);
-    auto at_pos = rest.find('@');
+
+    // the authority ends at the first '/', '?' or '#', whichever comes first (RFC 3986)
+    auto auth_end = rest.find_first_of("/?#");
+
+    auto authority = rest.substr(0, auth_end);
+    auto path      = auth_end == std::string::npos ? std::string() : rest.substr(auth_end);
+
+    // userinfo, when present, is part of the authority, so '@' only counts before it ends
+    auto at_pos = authority.find('@');
 
     if (at_pos != std::string::npos) {
-        auto auth = rest.substr(0, at_pos);
+        auto auth = authority.substr(0, at_pos);
         auto colon_pos = auth.find(':');
         if (colon_pos != std::string::npos) {
             parts.user = auth.substr(0, colon_pos);
@@ -51,18 +59,14 @@ static common_http_url common_http_parse_url(const std::string & url) {
         } else {
             parts.user = auth;
         }
-        rest = rest.substr(at_pos + 1);
+        authority = authority.substr(at_pos + 1);
     }
 
-    auto slash_pos = rest.find('/');
+    parts.host = authority;
 
-    if (slash_pos != std::string::npos) {
-        parts.host = rest.substr(0, slash_pos);
-        parts.path = rest.substr(slash_pos);
-    } else {
-        parts.host = rest;
-        parts.path = "/";
-    }
+    // an absent path is "/", and a query or fragment that follows the authority directly
+    // hangs off "/" rather than being folded into the host
+    parts.path = (path.empty() || path.front() != '/') ? "/" + path : path;
 
     // split the authority into host and optional port, a bracketed IPv6 literal keeps its inner colons (RFC 3986)
     std::string port_str;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -293,6 +293,10 @@ llama_build_and_test(test-model-resolution.cpp)
 # the test serves its repos from an httplib server, and the library links it privately
 target_link_libraries(test-model-resolution PRIVATE cpp-httplib)
 
+llama_build_and_test(test-http-url.cpp)
+# common/http.h pulls in httplib, which the library links privately
+target_link_libraries(test-http-url PRIVATE cpp-httplib)
+
 if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   # TODO: repair known memory leaks
   llama_build_and_test(test-opt.cpp)

--- a/tests/test-http-url.cpp
+++ b/tests/test-http-url.cpp
@@ -1,0 +1,94 @@
+// tests common_http_parse_url, which splits a URL into the parts the http client is
+// built from. The authority boundary is the interesting part: getting it wrong folds a
+// query string into the hostname, which then fails to resolve.
+
+#include "http.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int g_failures = 0;
+
+static void check(const std::string & url,
+                  const std::string & user,
+                  const std::string & password,
+                  const std::string & host,
+                  int                 port,
+                  const std::string & path) {
+    common_http_url parts;
+
+    try {
+        parts = common_http_parse_url(url);
+    } catch (const std::exception & e) {
+        printf("FAIL %-46s threw: %s\n", url.c_str(), e.what());
+        g_failures++;
+        return;
+    }
+
+    if (parts.user == user && parts.password == password && parts.host == host &&
+        parts.port == port && parts.path == path) {
+        return;
+    }
+
+    printf("FAIL %s\n", url.c_str());
+    printf("     expected user=[%s] password=[%s] host=[%s] port=%d path=[%s]\n",
+           user.c_str(), password.c_str(), host.c_str(), port, path.c_str());
+    printf("     got      user=[%s] password=[%s] host=[%s] port=%d path=[%s]\n",
+           parts.user.c_str(), parts.password.c_str(), parts.host.c_str(), parts.port,
+           parts.path.c_str());
+    g_failures++;
+}
+
+static void check_throws(const std::string & url) {
+    try {
+        common_http_parse_url(url);
+    } catch (const std::exception &) {
+        return;
+    }
+    printf("FAIL %s: expected a throw\n", url.c_str());
+    g_failures++;
+}
+
+int main() {
+    // scheme, host and path
+    check("http://example.com",                 "", "", "example.com",  80, "/");
+    check("https://example.com",                "", "", "example.com", 443, "/");
+    check("https://example.com/",               "", "", "example.com", 443, "/");
+    check("https://example.com/model.gguf",     "", "", "example.com", 443, "/model.gguf");
+    check("https://example.com:8443/a/b",       "", "", "example.com", 8443, "/a/b");
+
+    // a query or fragment ends the authority just as a '/' does, and the path is still
+    // rooted, so neither is absorbed into the host
+    check("https://example.com?download=1",     "", "", "example.com", 443, "/?download=1");
+    check("https://example.com#frag",           "", "", "example.com", 443, "/#frag");
+    check("http://example.com:8080?a=1",        "", "", "example.com", 8080, "/?a=1");
+    check("https://example.com/m.gguf?a=1",     "", "", "example.com", 443, "/m.gguf?a=1");
+
+    // userinfo
+    check("https://user:pass@example.com/x",    "user", "pass", "example.com", 443, "/x");
+    check("https://user@example.com/x",         "user", "",     "example.com", 443, "/x");
+    check("https://user@example.com?a=1",       "user", "",     "example.com", 443, "/?a=1");
+
+    // '@' past the end of the authority belongs to the path or query, not to userinfo
+    check("https://example.com/p?to=a@b.com",   "", "", "example.com", 443, "/p?to=a@b.com");
+    check("https://example.com/a@b",            "", "", "example.com", 443, "/a@b");
+    check("https://example.com?to=a@b.com",     "", "", "example.com", 443, "/?to=a@b.com");
+
+    // IPv6 literals keep their inner colons and lose their brackets
+    check("http://[::1]",                       "", "", "::1", 80, "/");
+    check("http://[::1]:8080/x",                "", "", "::1", 8080, "/x");
+    check("http://[::1]?a=1",                   "", "", "::1", 80, "/?a=1");
+    check("http://u:p@[::1]:8080/x",            "u", "p", "::1", 8080, "/x");
+
+    check_throws("example.com/model.gguf");
+    check_throws("ftp://example.com/model.gguf");
+
+    if (g_failures > 0) {
+        printf("%d failure(s)\n", g_failures);
+        return 1;
+    }
+
+    printf("OK\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #28400.

`common_http_parse_url` split the authority from the path on the first `/` alone. RFC 3986
ends the authority at the first `/`, `?` or `#`, so a URL with a query but no path never
terminated it and the query was folded into the hostname.

### Same function, one line up

`auto at_pos = rest.find('@')` searched the whole remainder of the URL, not just the
authority. Userinfo only exists inside the authority, so an `@` in a path or a query was
read as a userinfo delimiter. This is the more consequential of the two, and it is why the
patch restructures the block rather than only changing the one `find` the issue names.

### Three failure modes, all on master

| URL | host | port | path |
| --- | --- | --- | --- |
| `https://example.com?download=1` | `example.com?download=1` | 443 | `/` |
| `http://example.com:8080?a=1` | `example.com` | 8080 | `/` |
| `https://example.com/p?to=a@b.com` | `b.com` | 443 | `/` |

The first is the reported one and fails loudly, since the host does not resolve. The second
is quieter: `std::stoi("8080?a=1")` stops at the `?`, so the port is right, the connection
succeeds, and the query is simply gone from the request. The third is the worst, because
the request goes to `b.com` with `example.com/p?to=a` passed as the basic-auth username.

### Fix

Find the authority boundary once with `find_first_of("/?#")`, look for userinfo only within
it, and root the remainder at `/` so a query or fragment that follows the authority directly
becomes `/?...` rather than being absorbed into the host. Callers are unaffected:
`common_http_client` already builds the client from scheme, host and port and passes the
path separately.

### Tests

New `tests/test-http-url.cpp`, 22 cases covering the authority boundary, userinfo, explicit
ports, IPv6 literals and the two throwing cases. Against master's `common/http.h` it fails
8 of them, which are exactly the query, fragment and `@` cases above. With this change all
22 pass.

`test-model-resolution`, which drives the real client and `hf_cache` against a local httplib
server, and `test-arg-parser` both still pass.
