### PR TITLE
llama : fall back to CPU when a KV/recurrent-state tensor is too large for the assigned device

### DIFF
--- a/src/llama-kv-cache.cpp
+++ b/src/llama-kv-cache.cpp
@@ -18,6 +18,30 @@ static bool ggml_is_power_of_2(int n) {
     return (n & (n - 1)) == 0;
 }
 
+// n_gpu_layers-based device assignment does not know about per-device tensor-size limits (e.g. Vulkan's
+// maxStorageBufferRange), so a KV-cache tensor that is too large for `dev` needs a fallback check here -
+// otherwise the scheduler later aborts the whole process on a pre-allocated tensor it cannot place.
+static bool llama_kv_cache_buft_supported(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft, ggml_type type, uint32_t ne0, uint32_t ne1, uint32_t ne2) {
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead(),
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+
+    ggml_context_ptr ctx { ggml_init(params) };
+    if (!ctx) {
+        return false;
+    }
+
+    ggml_tensor * t = ggml_new_tensor_3d(ctx.get(), type, ne0, ne1, ne2);
+
+    t->buffer = ggml_backend_buft_alloc_buffer(buft, 0);
+    const bool supported = ggml_backend_dev_supports_op(dev, t);
+    ggml_backend_buffer_free(t->buffer);
+
+    return supported;
+}
+
 // orthonormal Walsh-Hadamard rotation matrix
 // note: res^2 == I
 static void ggml_gen_hadamard(ggml_tensor * tensor) {
@@ -209,15 +233,27 @@ llama_kv_cache::llama_kv_cache(
         const uint32_t n_embd_k_gqa =            hparams.n_embd_k_gqa(il);
         const uint32_t n_embd_v_gqa = !v_trans ? hparams.n_embd_v_gqa(il) : hparams.n_embd_v_gqa_max();
 
+        const bool has_k = true;
+        const bool has_v = !is_mla;
+
         const char * dev_name = "CPU";
 
         ggml_backend_buffer_type_t buft = ggml_backend_cpu_buffer_type();
 
         if (offload) {
             auto * dev = model.dev_layer(il);
-            buft = ggml_backend_dev_buffer_type(dev);
+            auto * dev_buft = ggml_backend_dev_buffer_type(dev);
 
-            dev_name = ggml_backend_dev_name(dev);
+            const bool fits = (!has_k || llama_kv_cache_buft_supported(dev, dev_buft, type_k, n_embd_k_gqa, kv_size, n_stream)) &&
+                               (!has_v || llama_kv_cache_buft_supported(dev, dev_buft, type_v, n_embd_v_gqa, kv_size, n_stream));
+
+            if (fits) {
+                buft     = dev_buft;
+                dev_name = ggml_backend_dev_name(dev);
+            } else {
+                LLAMA_LOG_WARN("%s: layer %3d: KV cache tensor too large for %s, falling back to CPU\n",
+                        __func__, il, ggml_backend_dev_name(dev));
+            }
         }
 
         LLAMA_LOG_DEBUG("%s: layer %3d: dev = %s\n", __func__, il, dev_name);
@@ -226,9 +262,6 @@ llama_kv_cache::llama_kv_cache(
         if (!ctx) {
             throw std::runtime_error("failed to create ggml context for kv cache");
         }
-
-        const bool has_k = true;
-        const bool has_v = !is_mla;
 
         ggml_tensor * k = has_k ? ggml_new_tensor_3d(ctx, type_k, n_embd_k_gqa, kv_size, n_stream) : nullptr;
         ggml_tensor * v = has_v ? ggml_new_tensor_3d(ctx, type_v, n_embd_v_gqa, kv_size, n_stream) : nullptr;

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -17,6 +17,30 @@
 // llama_memory_recurrent
 //
 
+// n_gpu_layers-based device assignment does not know about per-device tensor-size limits (e.g. Vulkan's
+// maxStorageBufferRange), so a recurrent-state tensor that is too large for `dev` needs a fallback check
+// here - otherwise the scheduler later aborts the whole process on a pre-allocated tensor it cannot place.
+static bool llama_memory_recurrent_buft_supported(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft, ggml_type type, uint32_t ne0, uint32_t ne1) {
+    ggml_init_params params = {
+        /*.mem_size   =*/ ggml_tensor_overhead(),
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+
+    ggml_context_ptr ctx { ggml_init(params) };
+    if (!ctx) {
+        return false;
+    }
+
+    ggml_tensor * t = ggml_new_tensor_2d(ctx.get(), type, ne0, ne1);
+
+    t->buffer = ggml_backend_buft_alloc_buffer(buft, 0);
+    const bool supported = ggml_backend_dev_supports_op(dev, t);
+    ggml_backend_buffer_free(t->buffer);
+
+    return supported;
+}
+
 llama_memory_recurrent::llama_memory_recurrent(
         const llama_model & model,
                 ggml_type   type_r,
@@ -80,15 +104,26 @@ llama_memory_recurrent::llama_memory_recurrent(
             continue;
         }
 
+        const uint32_t n_rows = mem_size * (1 + n_rs_seq);
+
         const char * dev_name = "CPU";
 
         ggml_backend_buffer_type_t buft = ggml_backend_cpu_buffer_type();
 
         if (offload) {
             auto * dev = model.dev_layer(i);
-            buft = ggml_backend_dev_buffer_type(dev);
+            auto * dev_buft = ggml_backend_dev_buffer_type(dev);
 
-            dev_name = ggml_backend_dev_name(dev);
+            const bool fits = llama_memory_recurrent_buft_supported(dev, dev_buft, type_r, hparams.n_embd_r(), n_rows) &&
+                               llama_memory_recurrent_buft_supported(dev, dev_buft, type_s, hparams.n_embd_s(), n_rows);
+
+            if (fits) {
+                buft     = dev_buft;
+                dev_name = ggml_backend_dev_name(dev);
+            } else {
+                LLAMA_LOG_WARN("%s: layer %3d: recurrent-state tensor too large for %s, falling back to CPU\n",
+                        __func__, i, ggml_backend_dev_name(dev));
+            }
         }
 
         LLAMA_LOG_DEBUG("%s, layer %3d: dev = %s\n", __func__, i, dev_name);
@@ -98,7 +133,6 @@ llama_memory_recurrent::llama_memory_recurrent(
             throw std::runtime_error("failed to create ggml context for rs cache");
         }
 
-        const uint32_t n_rows = mem_size * (1 + n_rs_seq);
         ggml_tensor * r = ggml_new_tensor_2d(ctx, type_r, hparams.n_embd_r(), n_rows);
         ggml_tensor * s = ggml_new_tensor_2d(ctx, type_s, hparams.n_embd_s(), n_rows);
         ggml_format_name(r, "cache_r_l%d", i);


### PR DESCRIPTION
## Overview

Device assignment for KV-cache and recurrent-state tensors based on `n_gpu_layers` did not account for per-device tensor-size constraints, such as Vulkan's `maxStorageBufferRange`. If a cache tensor for a given layer was larger than the limit supported by the selected device, `ggml_backend_sched` would terminate the process rather than placing that tensor on CPU.

This change adds a device capability check before assigning KV/recurrent tensors to a GPU, following the same approach already used by `select_weight_buft` for weight tensors. If the target device cannot accommodate the tensor, allocation now falls back to CPU and emits a warning.

## Additional information

The issue was reproduced on a mobile Adreno GPU with `maxStorageBufferRange = 128 MiB`, using a hybrid attention/gated-deltanet MoE model with a large context size. One full-attention layer required a 256 MiB KV-cache buffer, exceeding the Vulkan storage-buffer limit.

Verified that the previous crash case now completes by placing the affected layers on CPU. The regular full-GPU-offload path remains unchanged for dense models whose tensors stay within device limits.

## Requirements

* I have read and agree to the contributing guidelines
* AI usage disclosure: YES - Claude Code was used to investigate the crash, trace it to the Vulkan buffer-size limitation, and help implement and test the fix
