### PR TITLE
model : support Kimi-K3 recurrent-state rollback

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1102,6 +1102,7 @@ bool llm_arch_is_diffusion(const llm_arch & arch) {
 
 bool llm_arch_supports_rs_rollback(const llm_arch & arch) {
     switch (arch) {
+        case LLM_ARCH_KIMI_K3:
         case LLM_ARCH_QWEN35:
         case LLM_ARCH_QWEN35MOE:
         case LLM_ARCH_QWEN4EXP:

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <map>
@@ -115,20 +114,13 @@ llama_memory_recurrent::llama_memory_recurrent(
         }
     }
 
-    // nonzero initialization exposes missing snapshot writes in dummy-model tests.
-    const char * LLAMA_RS_DEBUG_FILL = getenv("LLAMA_RS_DEBUG_FILL");
-    const uint8_t rs_debug_fill = LLAMA_RS_DEBUG_FILL ? (uint8_t) strtoul(LLAMA_RS_DEBUG_FILL, nullptr, 0) : 0;
-    if (rs_debug_fill != 0) {
-        LLAMA_LOG_WARN("%s: filling the RS cache with 0x%02x instead of zeros (LLAMA_RS_DEBUG_FILL)\n", __func__, rs_debug_fill);
-    }
-
     // allocate tensors and initialize the buffers to avoid NaNs in the padding
     for (auto & [buft, ctx] : ctx_map) {
         ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
         if (!buf) {
             throw std::runtime_error("failed to allocate buffer for rs cache");
         }
-        ggml_backend_buffer_clear(buf, rs_debug_fill);
+        ggml_backend_buffer_clear(buf, 0);
         LLAMA_LOG_INFO("%s: %10s RS buffer size = %8.2f MiB\n", __func__, ggml_backend_buffer_name(buf), ggml_backend_buffer_get_size(buf)/1024.0/1024.0);
         ctxs_bufs.emplace_back(std::move(ctx), buf);
     }

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <map>
@@ -114,13 +115,23 @@ llama_memory_recurrent::llama_memory_recurrent(
         }
     }
 
+    // the rollback snapshot groups are only ever written by the model graph, so an architecture
+    // that fails to store them leaves the initial fill behind. With a zero fill that is
+    // indistinguishable from a correctly stored near-zero state, which is what the dummy models
+    // used by the tests produce - filling with a non-zero byte instead makes the gap observable.
+    const char * LLAMA_RS_DEBUG_FILL = getenv("LLAMA_RS_DEBUG_FILL");
+    const uint8_t rs_debug_fill = LLAMA_RS_DEBUG_FILL ? (uint8_t) strtoul(LLAMA_RS_DEBUG_FILL, nullptr, 0) : 0;
+    if (rs_debug_fill != 0) {
+        LLAMA_LOG_WARN("%s: filling the RS cache with 0x%02x instead of zeros (LLAMA_RS_DEBUG_FILL)\n", __func__, rs_debug_fill);
+    }
+
     // allocate tensors and initialize the buffers to avoid NaNs in the padding
     for (auto & [buft, ctx] : ctx_map) {
         ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx.get(), buft);
         if (!buf) {
             throw std::runtime_error("failed to allocate buffer for rs cache");
         }
-        ggml_backend_buffer_clear(buf, 0);
+        ggml_backend_buffer_clear(buf, rs_debug_fill);
         LLAMA_LOG_INFO("%s: %10s RS buffer size = %8.2f MiB\n", __func__, ggml_backend_buffer_name(buf), ggml_backend_buffer_get_size(buf)/1024.0/1024.0);
         ctxs_bufs.emplace_back(std::move(ctx), buf);
     }

--- a/src/llama-memory-recurrent.cpp
+++ b/src/llama-memory-recurrent.cpp
@@ -115,10 +115,7 @@ llama_memory_recurrent::llama_memory_recurrent(
         }
     }
 
-    // the rollback snapshot groups are only ever written by the model graph, so an architecture
-    // that fails to store them leaves the initial fill behind. With a zero fill that is
-    // indistinguishable from a correctly stored near-zero state, which is what the dummy models
-    // used by the tests produce - filling with a non-zero byte instead makes the gap observable.
+    // nonzero initialization exposes missing snapshot writes in dummy-model tests.
     const char * LLAMA_RS_DEBUG_FILL = getenv("LLAMA_RS_DEBUG_FILL");
     const uint8_t rs_debug_fill = LLAMA_RS_DEBUG_FILL ? (uint8_t) strtoul(LLAMA_RS_DEBUG_FILL, nullptr, 0) : 0;
     if (rs_debug_fill != 0) {

--- a/src/models/kimi-k3.cpp
+++ b/src/models/kimi-k3.cpp
@@ -1,4 +1,6 @@
 #include "models.h"
+
+#include <algorithm>
 #include "llama-memory-recurrent.h"
 
 //
@@ -357,7 +359,8 @@ static ggml_tensor * kimi_k3_conv1d(ggml_cgraph * gf, ggml_context * ctx0,
                                     ggml_tensor * conv_states_all, ggml_tensor * conv_state_all,
                                     int64_t qkv, ggml_tensor * x, ggml_tensor * proj_w, ggml_tensor * conv_w,
                                     int64_t d_conv, int64_t head_dim, int64_t n_head,
-                                    int64_t n_seq_tokens, int64_t n_seqs, int64_t n_tokens, int64_t kv_head) {
+                                    int64_t n_seq_tokens, int64_t n_seqs, int64_t n_tokens, int64_t kv_head,
+                                    int64_t mem_size, int64_t K_rs) {
     const int64_t d_inner         = head_dim * n_head;
     const int64_t conv_state_size = (d_conv - 1) * d_inner;
     const int64_t n_embd_r_total  = 3 * conv_state_size;
@@ -371,14 +374,22 @@ static ggml_tensor * kimi_k3_conv1d(ggml_cgraph * gf, ggml_context * ctx0,
     ggml_tensor * x_3d   = ggml_reshape_3d(ctx0, x_proj, d_inner, n_seq_tokens, n_seqs);
     ggml_tensor * conv_x = ggml_concat(ctx0, conv_state_x, ggml_transpose(ctx0, x_3d), 0);
 
-    ggml_tensor * last_conv_x = ggml_view_3d(ctx0, conv_x, d_conv - 1, d_inner, n_seqs,
-        conv_x->nb[1], conv_x->nb[2], n_seq_tokens * conv_x->nb[0]);
-    ggml_build_forward_expand(gf,
-        ggml_cpy(ctx0, last_conv_x,
-            ggml_view_3d(ctx0, conv_states_all, d_conv - 1, d_inner, n_seqs,
-                (d_conv - 1)   * ggml_element_size(conv_states_all),
-                n_embd_r_total * ggml_element_size(conv_states_all),
-                (kv_head * n_embd_r_total + qkv * conv_state_size) * ggml_element_size(conv_states_all))));
+    // store the conv window into the recurrent cache. With bounded rollback (cparams.n_rs_seq > 0,
+    // K_rs = n_rs_seq + 1) the cache rows are widened to K_rs groups and group s must hold the window
+    // as of s tokens back - same scheme as llm_build_delta_net_base::build_conv_state, applied per
+    // Q/K/V third. K_rs == 1 is the original single store of the final window.
+    // [TAG_RECURRENT_ROLLBACK_SPLITS] relies on the last K_rs tokens of a seq sharing one ubatch.
+    for (int64_t s = 0; s < K_rs; ++s) {
+        const int64_t s_idx = std::max<int64_t>(0, n_seq_tokens - s);
+        ggml_tensor * conv_x_s = ggml_view_3d(ctx0, conv_x, d_conv - 1, d_inner, n_seqs,
+            conv_x->nb[1], conv_x->nb[2], s_idx * conv_x->nb[0]);
+        ggml_build_forward_expand(gf,
+            ggml_cpy(ctx0, conv_x_s,
+                ggml_view_3d(ctx0, conv_states_all, d_conv - 1, d_inner, n_seqs,
+                    (d_conv - 1)   * ggml_element_size(conv_states_all),
+                    n_embd_r_total * ggml_element_size(conv_states_all),
+                    ((s * mem_size + kv_head) * n_embd_r_total + qkv * conv_state_size) * ggml_element_size(conv_states_all))));
+    }
 
     ggml_tensor * conv_weight = ggml_reshape_2d(ctx0, conv_w, d_conv, d_inner);
     ggml_tensor * Xcur = ggml_ssm_conv(ctx0, conv_x, conv_weight);
@@ -399,9 +410,13 @@ ggml_tensor * llama_model_kimi_k3::graph::build_kda_layer(
     ggml_tensor * conv_states_all = mctx_cur->get_r_l(il);
     ggml_tensor * conv_state_all  = build_rs(inp_rs, conv_states_all, hparams.n_embd_r(), n_seqs);
 
-    ggml_tensor * Qcur = kimi_k3_conv1d(gf, ctx0, conv_states_all, conv_state_all, 0, cur, layer.wq, layer.ssm_q_conv, d_conv, head_dim, n_head_kda, n_seq_tokens, n_seqs, n_tokens, kv_head);
-    ggml_tensor * Kcur = kimi_k3_conv1d(gf, ctx0, conv_states_all, conv_state_all, 1, cur, layer.wk, layer.ssm_k_conv, d_conv, head_dim, n_head_kda, n_seq_tokens, n_seqs, n_tokens, kv_head);
-    ggml_tensor * Vcur = kimi_k3_conv1d(gf, ctx0, conv_states_all, conv_state_all, 2, cur, layer.wv, layer.ssm_v_conv, d_conv, head_dim, n_head_kda, n_seq_tokens, n_seqs, n_tokens, kv_head);
+    // bounded recurrent-state rollback (speculative decoding): K_rs snapshot groups per cache row
+    const int64_t mem_size = mctx_cur->get_size();
+    const int64_t K_rs     = (int64_t) cparams.n_rs_seq + 1;
+
+    ggml_tensor * Qcur = kimi_k3_conv1d(gf, ctx0, conv_states_all, conv_state_all, 0, cur, layer.wq, layer.ssm_q_conv, d_conv, head_dim, n_head_kda, n_seq_tokens, n_seqs, n_tokens, kv_head, mem_size, K_rs);
+    ggml_tensor * Kcur = kimi_k3_conv1d(gf, ctx0, conv_states_all, conv_state_all, 1, cur, layer.wk, layer.ssm_k_conv, d_conv, head_dim, n_head_kda, n_seq_tokens, n_seqs, n_tokens, kv_head, mem_size, K_rs);
+    ggml_tensor * Vcur = kimi_k3_conv1d(gf, ctx0, conv_states_all, conv_state_all, 2, cur, layer.wv, layer.ssm_v_conv, d_conv, head_dim, n_head_kda, n_seq_tokens, n_seqs, n_tokens, kv_head, mem_size, K_rs);
     cb(Qcur, "kda_q_conv", il);
     cb(Kcur, "kda_k_conv", il);
     cb(Vcur, "kda_v_conv", il);
@@ -445,16 +460,13 @@ ggml_tensor * llama_model_kimi_k3::graph::build_kda_layer(
     Qcur = ggml_l2_norm(ctx0, Qcur, eps);
     Kcur = ggml_l2_norm(ctx0, Kcur, eps);
 
-    auto attn_out = build_delta_net(Qcur, Kcur, Vcur, g1, beta, state, il);
-
-    ggml_tensor * output    = ggml_cont(ctx0, attn_out.first);
+    // build_recurrent_attn stores the new KDA state itself: at slot 0 when cparams.n_rs_seq == 0
+    // (identical to the previous explicit copy), or the last K_rs per-token snapshots via the fused
+    // ggml_gated_delta_net(..., K) when bounded rollback is enabled (g1 is the [S_v, H_v, ...] KDA gate
+    // shape the op documents).
+    ggml_tensor * output = build_recurrent_attn(inp_rs, ssm_states_all, Qcur, Kcur, Vcur, g1, beta, state, il);
+    output = ggml_cont(ctx0, output);
     cb(output, "kda_scan_out", il);
-    ggml_tensor * new_state = attn_out.second;
-
-    ggml_build_forward_expand(gf,
-        ggml_cpy(ctx0, new_state,
-            ggml_view_1d(ctx0, ssm_states_all, hparams.n_embd_s() * n_seqs,
-                         kv_head * hparams.n_embd_s() * ggml_element_size(ssm_states_all))));
 
     // K3: single full-rank gate (kimi-linear factors this as g_b(g_a(x)))
     ggml_tensor * cur_2d = ggml_reshape_2d(ctx0, cur_3d, cur_3d->ne[0], n_seq_tokens * n_seqs);

--- a/src/models/kimi-k3.cpp
+++ b/src/models/kimi-k3.cpp
@@ -374,11 +374,8 @@ static ggml_tensor * kimi_k3_conv1d(ggml_cgraph * gf, ggml_context * ctx0,
     ggml_tensor * x_3d   = ggml_reshape_3d(ctx0, x_proj, d_inner, n_seq_tokens, n_seqs);
     ggml_tensor * conv_x = ggml_concat(ctx0, conv_state_x, ggml_transpose(ctx0, x_3d), 0);
 
-    // store the conv window into the recurrent cache. With bounded rollback (cparams.n_rs_seq > 0,
-    // K_rs = n_rs_seq + 1) the cache rows are widened to K_rs groups and group s must hold the window
-    // as of s tokens back - same scheme as llm_build_delta_net_base::build_conv_state, applied per
-    // Q/K/V third. K_rs == 1 is the original single store of the final window.
-    // [TAG_RECURRENT_ROLLBACK_SPLITS] relies on the last K_rs tokens of a seq sharing one ubatch.
+    // group s holds the conv window s tokens back.
+    // [TAG_RECURRENT_ROLLBACK_SPLITS]: the last K_rs tokens must share one ubatch.
     for (int64_t s = 0; s < K_rs; ++s) {
         const int64_t s_idx = std::max<int64_t>(0, n_seq_tokens - s);
         ggml_tensor * conv_x_s = ggml_view_3d(ctx0, conv_x, d_conv - 1, d_inner, n_seqs,
@@ -410,7 +407,6 @@ ggml_tensor * llama_model_kimi_k3::graph::build_kda_layer(
     ggml_tensor * conv_states_all = mctx_cur->get_r_l(il);
     ggml_tensor * conv_state_all  = build_rs(inp_rs, conv_states_all, hparams.n_embd_r(), n_seqs);
 
-    // bounded recurrent-state rollback (speculative decoding): K_rs snapshot groups per cache row
     const int64_t mem_size = mctx_cur->get_size();
     const int64_t K_rs     = (int64_t) cparams.n_rs_seq + 1;
 
@@ -460,10 +456,6 @@ ggml_tensor * llama_model_kimi_k3::graph::build_kda_layer(
     Qcur = ggml_l2_norm(ctx0, Qcur, eps);
     Kcur = ggml_l2_norm(ctx0, Kcur, eps);
 
-    // build_recurrent_attn stores the new KDA state itself: at slot 0 when cparams.n_rs_seq == 0
-    // (identical to the previous explicit copy), or the last K_rs per-token snapshots via the fused
-    // ggml_gated_delta_net(..., K) when bounded rollback is enabled (g1 is the [S_v, H_v, ...] KDA gate
-    // shape the op documents).
     ggml_tensor * output = build_recurrent_attn(inp_rs, ssm_states_all, Qcur, Kcur, Vcur, g1, beta, state, il);
     output = ggml_cont(ctx0, output);
     cb(output, "kda_scan_out", il);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -248,18 +248,6 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
         FIXTURES_REQUIRED generate-models
     )
 
-    # nonzero cache fill exposes unwritten rollback snapshots.
-    llama_test(
-        test-recurrent-state-rollback
-        NAME test-recurrent-state-rollback-kimi-k3-fill
-        LABEL main
-        ARGS -m "${MODEL_DIR}/kimi-k3-moe.gguf"
-    )
-    set_tests_properties(test-recurrent-state-rollback-kimi-k3-fill PROPERTIES
-        FIXTURES_REQUIRED generate-models
-        ENVIRONMENT "LLAMA_RS_DEBUG_FILL=0x3e"
-    )
-
     # Test state save/load functionality across all architectures, using the generated dummy models
     llama_test(
         test-save-load-state

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -238,6 +238,29 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
     set_tests_properties(test-recurrent-state-rollback-dsv4 PROPERTIES
         FIXTURES_REQUIRED generate-models
     )
+    llama_test(
+        test-recurrent-state-rollback
+        NAME test-recurrent-state-rollback-kimi-k3
+        LABEL main
+        ARGS -m "${MODEL_DIR}/kimi-k3-moe.gguf"
+    )
+    set_tests_properties(test-recurrent-state-rollback-kimi-k3 PROPERTIES
+        FIXTURES_REQUIRED generate-models
+    )
+
+    # Same coverage, but with the recurrent cache pre-filled with a non-zero byte. A rollback
+    # snapshot group that the graph never stores then reads back as garbage rather than as
+    # zeros, which on these dummy models is otherwise within the comparison tolerance.
+    llama_test(
+        test-recurrent-state-rollback
+        NAME test-recurrent-state-rollback-kimi-k3-fill
+        LABEL main
+        ARGS -m "${MODEL_DIR}/kimi-k3-moe.gguf"
+    )
+    set_tests_properties(test-recurrent-state-rollback-kimi-k3-fill PROPERTIES
+        FIXTURES_REQUIRED generate-models
+        ENVIRONMENT "LLAMA_RS_DEBUG_FILL=0x3e"
+    )
 
     # Test state save/load functionality across all architectures, using the generated dummy models
     llama_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -248,9 +248,7 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
         FIXTURES_REQUIRED generate-models
     )
 
-    # Same coverage, but with the recurrent cache pre-filled with a non-zero byte. A rollback
-    # snapshot group that the graph never stores then reads back as garbage rather than as
-    # zeros, which on these dummy models is otherwise within the comparison tolerance.
+    # nonzero cache fill exposes unwritten rollback snapshots.
     llama_test(
         test-recurrent-state-rollback
         NAME test-recurrent-state-rollback-kimi-k3-fill

--- a/tests/test-recurrent-state-rollback.cpp
+++ b/tests/test-recurrent-state-rollback.cpp
@@ -56,8 +56,9 @@ static llama_context * init_ctx(llama_model * model, llama_context_params cparam
         return ctx;
     }
 
-    // Populate a sequence so state_write visits the cache buffers.
-    if (!decode_one(ctx, 0, 0)) {
+    // Use a full ubatch so buffer discovery preserves prefill allocation sizes.
+    const uint32_t n_tokens = llama_n_ubatch(ctx);
+    if (!decode_tokens(ctx, std::vector<llama_token>(n_tokens, 0), n_tokens)) {
         llama_free(ctx);
         return nullptr;
     }

--- a/tests/test-recurrent-state-rollback.cpp
+++ b/tests/test-recurrent-state-rollback.cpp
@@ -207,33 +207,7 @@ static bool test_multi_seq_split_replay(const common_params & params, llama_mode
     return true;
 }
 
-int main(int argc, char ** argv) {
-    std::setlocale(LC_NUMERIC, "C");
-
-    common_params params;
-    params.sampling.seed = 1234;
-    params.n_predict = 1;
-
-    common_init();
-
-    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_COMMON)) {
-        return 1;
-    }
-
-    ggml_backend_load_all();
-
-    common_init_result_ptr llama_init = common_init_from_params(params);
-    llama_model * model = llama_init->model();
-    if (model == nullptr) {
-        fprintf(stderr, "%s : failed to init model\n", __func__);
-        return 1;
-    }
-
-    if (!llama_model_is_recurrent(model) && !llama_model_is_hybrid(model)) {
-        fprintf(stderr, "%s : skipping for non-recurrent model\n", __func__);
-        return 0;
-    }
-
+static int test_rollback(const common_params & params, llama_model * model) {
     const llama_vocab * vocab   = llama_model_get_vocab(model);
     const int           n_vocab = llama_vocab_n_tokens(vocab);
 
@@ -395,6 +369,44 @@ int main(int argc, char ** argv) {
 
     if (!test_multi_seq_split_replay(params, model, n_vocab)) {
         return 1;
+    }
+
+    return 0;
+}
+
+int main(int argc, char ** argv) {
+    std::setlocale(LC_NUMERIC, "C");
+
+    common_params params;
+    params.sampling.seed = 1234;
+    params.n_predict = 1;
+
+    common_init();
+
+    if (!common_params_parse(argc, argv, params, LLAMA_EXAMPLE_COMMON)) {
+        return 1;
+    }
+
+    ggml_backend_load_all();
+
+    common_init_result_ptr llama_init = common_init_from_params(params);
+    llama_model * model = llama_init->model();
+    if (model == nullptr) {
+        fprintf(stderr, "%s : failed to init model\n", __func__);
+        return 1;
+    }
+
+    if (!llama_model_is_recurrent(model) && !llama_model_is_hybrid(model)) {
+        fprintf(stderr, "%s : skipping for non-recurrent model\n", __func__);
+        return 0;
+    }
+
+    for (const char * fill : { "0", "0x3e" }) {
+        common_set_env("LLAMA_RS_DEBUG_FILL", fill);
+        fprintf(stderr, "%s : testing with LLAMA_RS_DEBUG_FILL=%s\n", __func__, fill);
+        if (test_rollback(params, model) != 0) {
+            return 1;
+        }
     }
 
     return 0;

--- a/tests/test-recurrent-state-rollback.cpp
+++ b/tests/test-recurrent-state-rollback.cpp
@@ -1,21 +1,18 @@
 #include "arg.h"
 #include "common.h"
+#include "ggml-backend.h"
 #include "llama.h"
+
+#include "../src/llama-io.h"
+#include "../src/llama-memory.h"
 
 #include <algorithm>
 #include <clocale>
 #include <cmath>
 #include <cstdio>
+#include <limits>
+#include <set>
 #include <vector>
-
-static llama_context * make_ctx(const common_params & params, llama_model * model) {
-    auto cparams = common_context_params_to_llama(params);
-    cparams.n_seq_max = 1;
-    cparams.n_rs_seq  = 8;
-    cparams.n_batch   = std::max(cparams.n_batch,  (uint32_t) (cparams.n_rs_seq + 1));
-    cparams.n_ubatch  = std::max(cparams.n_ubatch, (uint32_t) (cparams.n_rs_seq + 1));
-    return llama_init_from_model(model, cparams);
-}
 
 static bool decode_tokens(llama_context * ctx, const std::vector<llama_token> & tokens, uint32_t count) {
     llama_batch batch = llama_batch_init(count, 0, 1);
@@ -35,12 +32,69 @@ static bool decode_one(llama_context * ctx, llama_token tok, llama_pos pos) {
     return ok;
 }
 
+struct cache_buffer_collector : llama_io_write_i {
+    std::set<ggml_backend_buffer_t> buffers;
+    size_t size = 0;
+
+    void write(const void *, size_t n) override {
+        size += n;
+    }
+
+    void write_tensor(ggml_tensor * tensor, size_t, size_t n) override {
+        buffers.insert(tensor->buffer);
+        size += n;
+    }
+
+    size_t n_bytes() override {
+        return size;
+    }
+};
+
+static llama_context * init_ctx(llama_model * model, llama_context_params cparams, uint8_t fill) {
+    llama_context * ctx = llama_init_from_model(model, cparams);
+    if (ctx == nullptr || fill == 0) {
+        return ctx;
+    }
+
+    // Populate a sequence so state_write visits the cache buffers.
+    if (!decode_one(ctx, 0, 0)) {
+        llama_free(ctx);
+        return nullptr;
+    }
+    llama_synchronize(ctx);
+    cache_buffer_collector collector;
+    llama_get_memory(ctx)->state_write(collector);
+    llama_memory_clear(llama_get_memory(ctx), true);
+    if (collector.buffers.empty()) {
+        fprintf(stderr, "%s : no cache buffers found\n", __func__);
+        llama_free(ctx);
+        return nullptr;
+    }
+    for (auto * buffer : collector.buffers) {
+        ggml_backend_buffer_clear(buffer, fill);
+    }
+    return ctx;
+}
+
+static llama_context * make_ctx(const common_params & params, llama_model * model, uint8_t fill) {
+    auto cparams = common_context_params_to_llama(params);
+    cparams.n_seq_max = 1;
+    cparams.n_rs_seq  = 8;
+    cparams.n_batch   = std::max(cparams.n_batch,  (uint32_t) (cparams.n_rs_seq + 1));
+    cparams.n_ubatch  = std::max(cparams.n_ubatch, (uint32_t) (cparams.n_rs_seq + 1));
+    return init_ctx(model, cparams, fill);
+}
+
+static float logit_diff(float a, float b) {
+    return std::isfinite(a) && std::isfinite(b) ? std::fabs(a - b) : std::numeric_limits<float>::infinity();
+}
+
 // Roll back multiple sequences, then replay them in a single batch whose
 // per-seq token count exceeds n_ubatch: each seq's replay spans several
 // ubatches while its rollback restore is still pending. Compared against a
 // reference context that never advanced past the rollback point and decodes
 // the identical replay batch.
-static bool test_multi_seq_split_replay(const common_params & params, llama_model * model, const int n_vocab) {
+static bool test_multi_seq_split_replay(const common_params & params, llama_model * model, const int n_vocab, uint8_t fill) {
     constexpr uint32_t  n_seqs     = 2;
     constexpr uint32_t  n_ubatch   = 16;
     constexpr uint32_t  n_prompt   = 19;
@@ -56,7 +110,7 @@ static bool test_multi_seq_split_replay(const common_params & params, llama_mode
         cparams.n_batch    = 256;
         cparams.n_ubatch   = n_ubatch;
         cparams.kv_unified = false;
-        return llama_init_from_model(model, cparams);
+        return init_ctx(model, cparams, fill);
     };
 
     llama_context * ctx_roll = make_ctx_multi();
@@ -143,7 +197,7 @@ static bool test_multi_seq_split_replay(const common_params & params, llama_mode
             return false;
         }
         for (int t = 0; t < n_vocab; ++t) {
-            const float diff = std::fabs(l_roll[t] - l_ref[t]);
+            const float diff = logit_diff(l_roll[t], l_ref[t]);
             if (diff > eps && pos_first < 0) {
                 seq_first = i/n_replay;
                 pos_first = p0 + (int32_t) (i%n_replay);
@@ -191,7 +245,7 @@ static bool test_multi_seq_split_replay(const common_params & params, llama_mode
         const float * l_ref  = llama_get_logits_ith(ctx_ref,  0);
         ok = l_roll != nullptr && l_ref != nullptr;
         for (int t = 0; ok && t < n_vocab; ++t) {
-            diff_tail = std::max(diff_tail, std::fabs(l_roll[t] - l_ref[t]));
+            diff_tail = std::max(diff_tail, logit_diff(l_roll[t], l_ref[t]));
         }
     }
 
@@ -207,12 +261,12 @@ static bool test_multi_seq_split_replay(const common_params & params, llama_mode
     return true;
 }
 
-static int test_rollback(const common_params & params, llama_model * model) {
+static int test_rollback(const common_params & params, llama_model * model, uint8_t fill) {
     const llama_vocab * vocab   = llama_model_get_vocab(model);
     const int           n_vocab = llama_vocab_n_tokens(vocab);
 
-    llama_context * ctx_src = make_ctx(params, model);
-    llama_context * ctx_dst = make_ctx(params, model);
+    llama_context * ctx_src = make_ctx(params, model, fill);
+    llama_context * ctx_dst = make_ctx(params, model, fill);
     if (ctx_src == nullptr || ctx_dst == nullptr) {
         fprintf(stderr, "%s : failed to init contexts\n", __func__);
         return 1;
@@ -285,7 +339,7 @@ static int test_rollback(const common_params & params, llama_model * model) {
 
             logits_src_replay[i].assign(logits_src, logits_src + n_vocab);
             for (int token = 0; token < n_vocab; ++token) {
-                if (std::fabs(logits_src[token] - logits_dst[token]) > eps) {
+                if (logit_diff(logits_src[token], logits_dst[token]) > eps) {
                     fprintf(stderr, "%s : %s logits mismatch at position %d, token %d (%g != %g)\n",
                             __func__, mode, pos, token, (double) logits_src[token], (double) logits_dst[token]);
                     return false;
@@ -316,7 +370,7 @@ static int test_rollback(const common_params & params, llama_model * model) {
     // Repeat the load into a context that already has its own rollback state:
     // groups 1..n_rs_seq hold a different prompt's history, and rs_idx[0] is
     // non-zero at load time. The restore must wipe that state and still match.
-    llama_context * ctx_dirty = make_ctx(params, model);
+    llama_context * ctx_dirty = make_ctx(params, model, fill);
     if (ctx_dirty == nullptr) {
         fprintf(stderr, "%s : failed to init dirty ctx\n", __func__);
         return 1;
@@ -354,7 +408,7 @@ static int test_rollback(const common_params & params, llama_model * model) {
         }
 
         for (int token = 0; token < n_vocab; ++token) {
-            if (std::fabs(logits_src_replay[i][token] - logits_dirty[token]) > eps) {
+            if (logit_diff(logits_src_replay[i][token], logits_dirty[token]) > eps) {
                 fprintf(stderr, "%s : dirty-ctx logits mismatch at position %d, token %d (%g != %g)\n",
                         __func__, pos, token, (double) logits_src_replay[i][token], (double) logits_dirty[token]);
                 return 1;
@@ -367,7 +421,7 @@ static int test_rollback(const common_params & params, llama_model * model) {
     llama_free(ctx_dst);
     llama_free(ctx_dirty);
 
-    if (!test_multi_seq_split_replay(params, model, n_vocab)) {
+    if (!test_multi_seq_split_replay(params, model, n_vocab, fill)) {
         return 1;
     }
 
@@ -401,10 +455,9 @@ int main(int argc, char ** argv) {
         return 0;
     }
 
-    for (const char * fill : { "0", "0x3e" }) {
-        common_set_env("LLAMA_RS_DEBUG_FILL", fill);
-        fprintf(stderr, "%s : testing with LLAMA_RS_DEBUG_FILL=%s\n", __func__, fill);
-        if (test_rollback(params, model) != 0) {
+    for (uint8_t fill : { 0, 0x3e }) {
+        fprintf(stderr, "%s : testing with cache fill 0x%02x\n", __func__, fill);
+        if (test_rollback(params, model, fill) != 0) {
             return 1;
         }
     }


### PR DESCRIPTION
## Overview

Enable bounded recurrent-state rollback for Kimi-K3 during speculative decoding. Kimi-K3 currently has rollback disabled and stores only the final KDA state and Q/K/V convolution windows. Enabling rollback without changing those stores would restore unwritten snapshot groups after rejecting draft tokens.

Save the convolution windows for each rollback position, use the existing `build_recurrent_attn` helper to save KDA state snapshots, and add Kimi-K3 to `llm_arch_supports_rs_rollback`.

Closes #28461.

Related: [#28019](https://github.com/ggml-org/llama.cpp/issues/28019) reports multi-sequence rollback corruption for qwen4exp. The connection to Kimi-K3's missing snapshots is an inference, not a maintainer-confirmed diagnosis. This change is limited to Kimi-K3 and does not resolve that issue.

## Additional information

Validation:

- `tests/CMakeLists.txt` registers the generated Kimi-K3 model with the existing rollback test. Each registered model runs both zero-filled and `0x3e`-filled cache passes in the test executable.
- CPU Release build on macOS with Apple clang passed. `GGML_SCHED_DEBUG_REALLOC=1 ctest --test-dir build-cpu -R 'recurrent-state-rollback' --output-on-failure`: 5/5 passed, including model generation and the four rollback tests.
- NVIDIA Vulkan Debug build on RTX PRO 6000 Blackwell passed the same 5/5 checks with `GGML_SCHED_NO_REALLOC=ON` and fatal warnings enabled.
- Both passes passed checkpoint restoration, multi-sequence split replay, and sequence-isolation checks for Qwen3.5, Nemotron-H, DeepSeek-V4, and Kimi-K3. Logit comparisons reject NaN and infinity; sequence-isolation checks matched exactly.

The nonzero pass uses the existing state-writing interface to collect and fill cache buffers entirely within the test. Buffer discovery decodes a full micro-batch to preserve Vulkan's prefill allocation sizes. Production cache initialization uses zeros; the `LLAMA_RS_DEBUG_FILL` hook has been removed. With only the Kimi-K3 allowlist change, the zero pass succeeded but the nonzero pass failed split replay (max logit difference `2.35e-6`, tolerance `1e-7`). Both passes succeed with the snapshot writes.

CI for `1ffc6ac3c`: 22 checks passed and four failed. The Kimi-K3 rollback test passes in all four failed jobs; the earlier Vulkan allocation abort is resolved.

| Failed job | Failure |
| --- | --- |
| [ROCm](https://github.com/ggml-org/llama.cpp/actions/runs/34106973977/job/101702142062) | Qwen3.5 split-replay mismatch in the zero-fill pass; also [seen on master](https://github.com/ggml-org/llama.cpp/actions/runs/34089517818/job/101639999492). |
| [Vulkan Apple](https://github.com/ggml-org/llama.cpp/actions/runs/34106973977/job/101702142174) | `test-thread-safety` bus error; also [seen on master](https://github.com/ggml-org/llama.cpp/actions/runs/34089517818/job/101639999950). |
| [Vulkan NVIDIA CM](https://github.com/ggml-org/llama.cpp/actions/runs/34106973977/job/101702141787) | `test-backend-ops` timed out after 1505 seconds on Tesla T4. |
| [Vulkan Intel Linux](https://github.com/ggml-org/llama.cpp/actions/runs/34106973977/job/101702142322) | `test-backend-ops` failed one `TOPK_MOE` numerical comparison. |

This PR does not change `test-backend-ops` or the GGML backends. The causes of the timeout and TOPK mismatch have not been confirmed.

Real-model measurements on September 5 used Kimi-K3 UD-IQ2_XXS on 8x RTX PRO 6000 Blackwell GPUs, with four server slots and seven draft tokens. The RadixArk DSpark draft shared GPU 7 with the target's output weights. These runs used a RelWithDebInfo build based on `4d91760`; DSpark also required a separate `t_layer_inp` registration patch, outside this PR. Throughput is in tok/s:

| Workload | No speculation | DSpark + host checkpoints | DSpark + rollback |
| --- | ---: | ---: | ---: |
| Rewrite | 12.88 | 17.7-19.6 | 22.19 |
| Knowledge | 12.81 | 11.9-12.4 | 15.75 |
| Code | 12.62 | 10.2-10.9 | 15.65 |
| Benchmark, concurrency 1 (1024 input / 256 output tokens) | 10.14 | Unavailable | 13.98 |
| Benchmark, concurrency 4 | 18.30 | Unavailable | 14.92 |

The rollback configuration was 13-25% faster on rewrite, 27-32% on knowledge, and 44-53% on code than the recorded host-checkpoint ranges. However, fit margins and model placement differed: the target's host model buffer was 5419.75 MiB with host checkpoints and 11010.12 MiB with rollback. These gains are not from a placement-controlled A/B.

Host-checkpoint results are unavailable for the concurrency benchmarks, so those rows cannot isolate rollback's contribution. Compared with no speculation, the combined DSpark and rollback configuration reduced TPOT from 77.7 to 49.2 ms at concurrency 1, but increased it from 134.5 to 220.6 ms at concurrency 4. These runs used random token inputs, disabled prompt caching, and four requests per concurrency slot.

Greedy outputs matched between DSpark with host checkpoints and DSpark with rollback on the three probe prompts. The rewrite output differed from the no-speculation run; knowledge and code outputs matched all three configurations. This does not establish output equivalence between DSpark and no speculation.

Snapshot storage multiplies recurrent-state memory by `1 + n_rs_seq`: the recorded four-slot cache grew from 1772.44 to 14179.50 MiB with seven rollback positions.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assisted with implementation, investigation, and validation. Codex drafted the commit message and this description from the patch and recorded results.
