### PR TITLE
api(llama): expose vocab clean-spaces setting

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -1119,6 +1119,7 @@ extern "C" {
     LLAMA_API bool llama_vocab_get_add_bos(const struct llama_vocab * vocab);
     LLAMA_API bool llama_vocab_get_add_eos(const struct llama_vocab * vocab);
     LLAMA_API bool llama_vocab_get_add_sep(const struct llama_vocab * vocab);
+    LLAMA_API bool llama_vocab_get_clean_spaces(const struct llama_vocab * vocab);
 
     // model-specific suppress tokens (gguf key: tokenizer.ggml.suppress_tokens)
     LLAMA_API const llama_token * llama_vocab_get_suppress_tokens(const struct llama_vocab * vocab, int32_t * n_suppress_tokens);

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -4271,6 +4271,10 @@ bool llama_vocab_get_add_sep(const struct llama_vocab * vocab) {
     return vocab->get_add_sep();
 }
 
+bool llama_vocab_get_clean_spaces(const struct llama_vocab * vocab) {
+    return vocab->get_clean_spaces();
+}
+
 const llama_token * llama_vocab_get_suppress_tokens(const struct llama_vocab * vocab, int32_t * n_suppress_tokens) {
     const std::vector<llama_token> & tokens = vocab->get_suppress_tokens();
     if (n_suppress_tokens) {


### PR DESCRIPTION
## Overview

Add llama_vocab_get_clean_spaces so callers can select the correct detokenization path. Use incremental token_to_piece handling when cleaning is disabled, and fall back to full llama_detokenize when it is enabled so punctuation and English contraction spacing are normalized.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: NO
