### PR TITLE
spec: enforce respect of per sequence draft limits in MTP

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1691,7 +1691,8 @@ struct common_speculative_impl_draft_mtp : public common_speculative_impl {
 
                 result.push_back(id);
 
-                if (params.n_max <= (int) result.size()) {
+                if (params.n_max <= (int) result.size() ||
+                    (dp.n_max > 0 && dp.n_max <= (int) result.size())) {
                     drafting[seq_id] = false;
                     n_drafting--;
                     continue;

--- a/tools/server/tests/README.md
+++ b/tools/server/tests/README.md
@@ -65,6 +65,16 @@ cmake --build build -j --target llama-server && ./tools/server/tests/tests.sh
 
 To see all available arguments, please refer to [pytest documentation](https://docs.pytest.org/en/stable/how-to/usage.html)
 
+### MTP draft-limit regression
+
+Provide a GGUF containing embedded MTP weights to run the output-budget test:
+
+```shell
+LLAMACPP_TEST_MODELFILE=/path/to/model-with-mtp.gguf ./tests.sh unit/test_speculative.py -k mtp_output_budget -v
+```
+
+The test is skipped when no model path is provided. It checks that short output budgets do not cause excess drafts to be generated and then truncated, with one and two server slots.
+
 ### Debugging external llama-server
 It can sometimes be useful to run the server in a debugger when invesigating test
 failures. To do this, the environment variable `DEBUG_EXTERNAL=1` can be set

--- a/tools/server/tests/unit/test_speculative.py
+++ b/tools/server/tests/unit/test_speculative.py
@@ -203,3 +203,40 @@ def test_multi_requests_parallel(n_slots: int, n_requests: int):
     for res in results:
         assert res.status_code == 200
         assert match_regex("(wise|kind|owl|answer)+", res.body["content"])
+
+
+@pytest.mark.skipif(not os.environ.get("LLAMACPP_TEST_MODELFILE"), reason="requires a GGUF with embedded MTP weights")
+@pytest.mark.parametrize("n_slots", [1, 2])
+def test_mtp_output_budget(n_slots, tmp_path, monkeypatch):
+    global server
+    server = ServerProcess()
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    server.model_file = os.environ["LLAMACPP_TEST_MODELFILE"]
+    server.n_ctx = 256 * n_slots
+    server.n_slots = n_slots
+    server.n_threads = 2
+    server.n_batch = 32
+    server.n_ubatch = 32
+    server.spec_type = "draft-mtp"
+    server.spec_draft_n_min = 1
+    server.spec_draft_n_max = 8
+    server.debug = True
+    server.log_path = str(tmp_path / "mtp.log")
+    monkeypatch.setenv("LLAMA_ARG_SPEC_DRAFT_P_MIN", "0")
+    server.start()
+    tasks = [(server.make_request, ("POST", "/completion", {
+        "prompt": "Hello",
+        "n_predict": budget,
+        "temperature": 0.0,
+        "ignore_eos": True,
+        "cache_prompt": False,
+    })) for budget in [3, 10]]
+    responses = parallel_function_calls(tasks)
+    assert all(res.status_code == 200 for res in responses)
+    assert sorted(res.body["tokens_predicted"] for res in responses) == [3, 10]
+    server.stop()
+    with open(server.log_path) as log:
+        text = log.read()
+    assert "draft candidate" in text
+    assert "truncating draft to" not in text


### PR DESCRIPTION
## Overview

description: right now MTP drafts up to the global limit be4 wrapper truncates result to per sequence limit. stop drafting when either limit is reached.

with a draft lim. of 8 and `n_predict=3`, this reduces draft decodes from 8 to 1 while preserving the tested output tokens.

this adds regression test for one and two slots, test also requires an MTP model via `LLAMACPP_TEST_MODELFILE`.

Validation:

- Regression fails before the fix and passes afterward.
- 10 speculative server tests pass.
- 53 main CPU tests pass.

ai assisted,  used codex

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - ai assisted,  used codex
