### PR TITLE
peg-parser : fail loudly on colliding rule names

### DIFF
--- a/common/peg-parser.cpp
+++ b/common/peg-parser.cpp
@@ -1125,6 +1125,13 @@ common_peg_parser common_peg_parser_builder::schema(const common_peg_parser & p,
 
 common_peg_parser common_peg_parser_builder::rule(const std::string & name, const common_peg_parser & p, bool trigger) {
     auto clean_name = rule_name(name);
+    if (arena_.has_rule(clean_name)) {
+        // rule_name() is lossy (runs of non [a-zA-Z0-9-] characters collapse
+        // to '-'), so distinct rule names can collide after sanitization
+        // (e.g. "my-param" and "my_param"). Registering would silently
+        // replace the existing rule, so fail loudly instead.
+        throw std::runtime_error("rule already exists: " + clean_name);
+    }
     auto rule_id = arena_.add_parser(common_peg_rule_parser{clean_name, p.id(), trigger});
     arena_.add_rule(clean_name, rule_id);
     return ref(clean_name);

--- a/tests/peg-parser/test-basic.cpp
+++ b/tests/peg-parser/test-basic.cpp
@@ -452,6 +452,30 @@ void test_basic(testing & t) {
             t.assert_equal("result_is_fail", true, result.fail());
         });
 
+        // rule_name() collapses runs of characters outside [a-zA-Z0-9-] to a
+        // single '-', so distinct parameter names can sanitize to the same
+        // rule name ("my-param" and "my_param" both become "my-param").
+        // add_rule() is a map assignment, so the second registration
+        // silently replaces the first and refs to the first rule end up
+        // resolving to the second one.
+        t.test("rule_name_collision", [](testing &t) {
+            // "my-param" and "my_param" sanitize to the same rule name; the
+            // second registration must fail loudly instead of silently
+            // replacing the first rule.
+            bool threw = false;
+            try {
+                auto parser = build_peg_parser([](common_peg_parser_builder & p) {
+                    auto arg_a = p.rule("tool-t-arg-my-param", p.literal("A"));
+                    auto arg_b = p.rule("tool-t-arg-my_param", p.literal("B"));
+                    return p.choice({arg_a, arg_b}) + p.end();
+                });
+                (void)parser;
+            } catch (const std::exception &) {
+                threw = true;
+            }
+            t.assert_true("colliding_rule_registration_throws", threw);
+        });
+
         // Test markers
         t.test("marker", [](testing &t) {
             auto bracket_parser = build_peg_parser([](common_peg_parser_builder & p) {


### PR DESCRIPTION
Fixes #28429

## Overview

### The bug

Two tool parameters that sanitize to the same PEG rule name = silent grammar corruption. `rule_name()` collapses runs of non-`[a-zA-Z0-9-]` chars to a single `-`, and registering a rule is a map assignment. Second parameter wins, first parameter is gone from the grammar. Constrained decoding then forces the model to emit one parameter name over and over.

### Why

`add_rule()` is a map assignment, so the second registration of a sanitized name replaces the first, and refs that were meant for the first rule resolve to the second one.

### Fix

- Registering a rule with an already-taken sanitized name now throws → the schema is rejected loudly instead of silently losing parameters
- `rule(name, builder_fn)` keeps its `has_rule()` reuse semantics → recursive refs unaffected

### Tested

Test in `tests/peg-parser/test-basic.cpp`: colliding registration throws. test-peg-parser , test-chat, test-chat-peg-parser, test-grammar-integration, test-json-schema-to-grammar all pass.

## Additional information

Thanks to @ziyuhehe for reporting the non-ASCII case in #28429. This PR follows the "reject loudly" direction discussed there - and  the collision also hits ASCII-only names (`my-param` / `my_param`), so it's not just about non-ASCII parameter names.

Built and tested locally on Windows 11 with MSVC 2022 .

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — I used AI to assist with root-cause analysis, code changes, and test development. I reviewed every line, built and ran the tests locally, and take full responsibility for the change.