### PR TITLE
Fix #28491 linking bug when compiling with BUILD_SHARED_LIBS=OFF

### DIFF
--- a/ggml/src/ggml-rpc/CMakeLists.txt
+++ b/ggml/src/ggml-rpc/CMakeLists.txt
@@ -36,8 +36,10 @@ if (GGML_RPC_RDMA)
     target_compile_definitions(ggml-rpc PRIVATE GGML_RPC_RDMA)
     if (APPLE)
         # librdma.dylib only exists on macOS 26.2 and later. Link it weakly so a build made
-        # where it exists still loads where it does not; checked at runtime before use.
-        target_link_options(ggml-rpc PRIVATE "LINKER:-weak_library,${RDMA_LIB}")
+        # where it exists still loads where it does not; checked at runtime before use
+        # but with BUILD_SHARED_LIBS=OFF ggml-rpc is a static archive and never links
+        # so the librdma symbols used by transport-apple.cpp stay undefined.
+        target_link_options(ggml-rpc PUBLIC "LINKER:-weak_library,${RDMA_LIB}")
         target_compile_definitions(ggml-rpc PRIVATE GGML_RPC_RDMA_APPLE)
         target_sources(ggml-rpc PRIVATE transport-apple.cpp)
     else()


### PR DESCRIPTION
## Overview

When building in MacOS with BUILD_SHARED_LIBS=OFF post commit 2bf04151520843e9ea5694e655e7d4a537973b54, ggml-rpc is a static archive and never links so librdma symbols stay undefined and compilation aborts with a linker error (#28491).

## Additional information

Fix is simple, make target link option public. In ggml/src/ggml-rpc/CMakeLists.txt change `target_link_options(ggml-rpc PRIVATE "LINKER:-weak_library,${RDMA_LIB}")` with `target_link_options(ggml-rpc PUBLIC "LINKER:-weak_library,${RDMA_LIB}")`

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No