### PR TITLE
vulkan: raise the hoisted row-id limit for mul_mat_id from 256 to 512 experts

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -10217,7 +10217,8 @@ static void ggml_vk_mul_mat_id_q_f16(ggml_backend_vk_context * ctx, vk_context& 
     // n_as counts, n_as offsets, one total, then one packed row id per (expert, token).
     // Hoisting requires 16-bit indices for the packing and a table that fits one binding.
     const uint64_t hoisted_row_id_words = 2 * n_as + 1 + nei0 * nei1;
-    const bool hoist_row_ids = n_as <= 256 && nei0 <= 0xffff && nei1 <= 0xffff &&
+    // 512 matches MAX_EXPERTS in count_experts.comp (models such as Qwen3.8-Flash-Next have 512 experts)
+    const bool hoist_row_ids = n_as <= 512 && nei0 <= 0xffff && nei1 <= 0xffff &&
                                 hoisted_row_id_words * sizeof(uint32_t) <=
                                     ctx->device->properties.limits.maxStorageBufferRange;
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/count_experts.comp
@@ -30,9 +30,14 @@ layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 layout (binding = 0) readonly buffer A {uint data_a[];};
 layout (binding = 1) writeonly buffer D {uint data_d[];};
 
-shared uint vals[BLOCK_SIZE];
-shared uint offsets[BLOCK_SIZE];
-shared uint cursors[BLOCK_SIZE];
+// Upper bound on n_experts for the hoisted row-id path. Must match the limit in
+// ggml_vk_mul_mat_id_q_f16 (hoist_row_ids). The non-hoisted reduction below only
+// needs BLOCK_SIZE entries.
+#define MAX_EXPERTS 512
+
+shared uint vals[MAX_EXPERTS];
+shared uint offsets[MAX_EXPERTS];
+shared uint cursors[MAX_EXPERTS];
 
 // data_d layout when p.hoist_row_ids is set:
 //   [0,              n_experts)   per-expert row count
@@ -46,8 +51,8 @@ void main() {
     const uint tid = gl_LocalInvocationID.x;
 
     if (p.hoist_row_ids != 0) {
-        if (tid < p.n_experts) {
-            vals[tid] = 0;
+        for (uint e = tid; e < p.n_experts; e += BLOCK_SIZE) {
+            vals[e] = 0;
         }
         barrier();
 

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -9813,6 +9813,11 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
 
     // gpt-oss issue with Vulkan mmq_id
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_MXFP4, GGML_TYPE_F32, 32, 2, false, 2880, 32, 2880));
+    // more than 256 experts (hoisted row-id path, e.g. Qwen3.8-Flash-Next with 512 experts)
+    for (int n : {1, 5, 64, 300}) {
+        test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_IQ3_S,  GGML_TYPE_F32, 512, 10, false, 128, n, 512));
+        test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q4_0,   GGML_TYPE_F32, 512, 10, false, 256, n, 128));
+    }
     test_cases.emplace_back(new test_mul_mat_id(GGML_TYPE_Q4_0, GGML_TYPE_F32, 32, 2, false, 2880, 32, 2880));
 
     for (ggml_type type_a : all_types) {


### PR DESCRIPTION
## Overview

I was working on trying different optimizations for this stack together with Fable 5.1 in CC. We stumbled across this finding that `count_experts.comp` sizes its shared arrays with `BLOCK_SIZE` (256), so `ggml_vk_mul_mat_id_q_f16` turns row-id hoisting (#26686) off when a model has more than 256 experts. Every mul_mat_id workgroup then rescans the whole ids tensor. Qwen3.8-Flash-Next has 512 experts.

This fix seems to work:
The patch sizes the shared arrays with a separate `MAX_EXPERTS` (512), clears them in a loop instead of one entry per thread, and raises the host limit to match.

Measured on Strix Halo (Radeon 8060S, RADV, Mesa 26.0.3), 512 experts, 10 used, batch 2048, µs per op:

| shape | before | after |
|---|---:|---:|
| iq3_s 640×2560 | 12 537 | 9 483 |
| iq4_nl 2560×640 | 14 033 | 7 508 |
| q8_0 2560×640 | 13 904 | 7 902 |

End to end this makes prompt processing faster. On Qwen3.8-Flash-Next Q5_K, prefill throughput (tokens per second, higher is better) goes from 426 to 507 t/s for an 8k prompt (+19 %) and from 333 to 387 t/s for a 32k prompt (+16 %). Token generation speed is unchanged, since it does not use this code path, and greedy output is identical before and after.

## Additional information

Sidenote:

`test-backend-ops -o MUL_MAT_ID` passes on master plus this patch (891/891), including the new 512-expert cases (n = 1, 5, 64, 300; iq3_s and q4_0). Found while profiling prefill on this box, see the discussion in #27950.

This is one piece of a larger Strix Halo stack for Qwen3.8-Flash-Next. For the decode side, mainly MTP speculation with a vocabulary-trimmed draft head (FR-Spec), see my write-up in #27950, the comment on #25187, the branch https://github.com/drluoto/llama.cpp/tree/frspec-qwen4exp-strix and the draft heads at https://huggingface.co/drluoto/Qwen3.8-Flash-Next-MTP-GGUF.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the profiling that found the limit and the patch were done with Claude Fable 5.1 (Claude Code). I reviewed the change, built and tested it on master, and I wrote this description myself.
