### PR TITLE
server : allow logprobs with tools + stream

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1381,9 +1381,8 @@ json oaicompat_chat_params_parse(
     // Handle "logprobs" field
     // TODO: The response format of this option is not yet OAI-compatible, but seems like no one really using it; We may need to fix it in the future
     if (json_value(body, "logprobs", false)) {
-        if (has_tools && stream) {
-            throw std::invalid_argument("logprobs is not supported with tools + stream");
-        }
+        // n_probs is allowed with tools + stream, so logprobs (which maps to the
+        // same parameter) is allowed as well
         llama_params["n_probs"] = json_value(body, "top_logprobs", 20);
     } else if (body.contains("top_logprobs") && !body.at("top_logprobs").is_null()) {
         throw std::invalid_argument("top_logprobs requires logprobs to be set to true");

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -125,6 +125,43 @@ def do_test_completion_with_required_tool_tiny(server: ServerProcess, tool: dict
             actual_arguments = json.loads(actual_arguments)
         assert argument_key in actual_arguments, f"tool arguments: {actual_arguments}, expected: {argument_key}"
 
+
+def test_logprobs_with_tools_stream():
+    # Regression: `logprobs` used to be rejected with tools + stream, while the
+    # equivalent `n_probs` parameter was allowed. Both must behave the same.
+    # https://github.com/ggml-org/llama.cpp/issues/28478
+    global server
+    server.jinja = True
+    server.start()
+    res = server.make_any_request("POST", "/v1/chat/completions", data={
+        "max_tokens": 8,
+        "messages": [
+            {"role": "user", "content": "Write an example"},
+        ],
+        "tools": [TEST_TOOL],
+        "stream": True,
+        "logprobs": True,
+        "top_logprobs": 2,
+    })
+    assert res["choices"][0]["message"]["role"] == "assistant", f"Unexpected response: {res}"
+
+
+def test_logprobs_with_tools_no_stream():
+    global server
+    server.jinja = True
+    server.start()
+    res = server.make_any_request("POST", "/v1/chat/completions", data={
+        "max_tokens": 8,
+        "messages": [
+            {"role": "user", "content": "Write an example"},
+        ],
+        "tools": [TEST_TOOL],
+        "stream": False,
+        "logprobs": True,
+        "top_logprobs": 2,
+    })
+    assert res["choices"][0]["message"]["role"] == "assistant", f"Unexpected response: {res}"
+
 # PR #22654: commented out since we're now allowing content before tool calls in tool_call: required, so we can't force this
 # in the tiny model just by using the grammar
 #


### PR DESCRIPTION
Fixes #28478

## Problem

`logprobs` is rejected with HTTP 400 on streaming requests that carry tools, while passing the equivalent `n_probs` parameter directly succeeds and streams tool calls with `top_logprobs`. Both parameters end up setting the same internal value, so the two ways of requesting probabilities behave differently for no functional reason.

## Change

Remove the `has_tools && stream` rejection in `oaicompat_chat_params_parse`. `logprobs` still maps to `n_probs` exactly as before (defaulting `top_logprobs` to 20), it just no longer refuses requests that the identical `n_probs` path accepts. The `top_logprobs requires logprobs` validation is untouched.

## Tests

Added `test_logprobs_with_tools_stream` and `test_logprobs_with_tools_no_stream` to `tools/server/tests/unit/test_tool_call.py`, asserting a streaming and a non streaming tools request with `logprobs` and `top_logprobs` return a well formed response. The streaming test fails against master with `400 Bad Request` and passes with this patch.

## Manual verification

Built `llama-server` from source for CPU and ran the exact request from the issue against `Qwen/Qwen2.5-0.5B-Instruct-GGUF` (Q4_K_M, local file):

Before (master):

```
{"error":{"code":400,"message":"logprobs is not supported with tools + stream","type":"invalid_request_error"}}
```

After (this patch), streaming request with `tools`, `stream: true`, `logprobs: true`, `top_logprobs: 2`:

```
data: {"choices":[{"delta":{"role":"assistant"},"logprobs":{"content":[{"token":"<tool_call>","logprob":-0.0077,"top_logprobs":[{"token":"<tool_call>",...},{"token":"Sure",...}]}]}}...
...
finish_reason: "tool_calls"
```

37 streamed chunks, each carrying `top_logprobs`, ending with `finish_reason: "tool_calls"`. The non streaming variant returns 200 with `logprobs.content` populated as before.
