### PR TITLE
vulkan: enable FA shmem staging on AMD RDNA (scalar path)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -3834,7 +3834,13 @@ static vk_fa_tuning_params get_fa_tuning_params_scalar(const vk_device& device, 
 
     result.d_split = std::min(std::min(result.subgroup_size, 8u), D_lsb / 4);
 
-    result.shmem_staging = (device->vendor_id == VK_VENDOR_ID_NVIDIA && hsk < 256 && hsv < 256) ? 1 : 0;
+    // Staging K/V through shared memory was gated to NVIDIA when introduced (#19625).
+    // On AMD RDNA (scalar FA path, no coopmat) it is a large win as well, including for
+    // head sizes >= 256: measured on gfx1013 (BC-250) with gemma-4-26B-A4B (hsk/hsv 256/512)
+    // pp2048 +12% at d0, +34% at d4096, +50% at d8192, and on an RDNA2 V620 with a 27B dense
+    // model +30% at d8192 / +62% at d16384 (issue #25207). GCN is left untouched (untested).
+    const bool amd_rdna = device->vendor_id == VK_VENDOR_ID_AMD && device->architecture != AMD_GCN;
+    result.shmem_staging = ((device->vendor_id == VK_VENDOR_ID_NVIDIA && hsk < 256 && hsv < 256) || amd_rdna) ? 1 : 0;
 
     if (!reduce_block_rows && !ggml_vk_flash_attn_scalar_shmem_support(device, result, hsk, hsv, f32acc, k_type, v_type)) {
         result.block_rows /= 2;


### PR DESCRIPTION
## Summary

Staging K/V through shared memory in the scalar flash-attention path (`get_fa_tuning_params_scalar`) was gated to NVIDIA when it was introduced in #19625. On AMD RDNA the same staging is a large win, including for head sizes >= 256 which the NVIDIA gate excludes. This PR enables it for AMD non-GCN devices in the scalar path only; GCN and the coopmat1 path are left unchanged.

Ref: #25207

## Measurements

**AMD BC-250 (gfx1013, RDNA2, RADV / Mesa 25.2.6, Debian 13), b10727 stock vs. the same build with this change.**
gemma-4-26B-A4B-it-UD-IQ3_S (MoE; hsk/hsv = 256 on SWA layers, 512 on global layers), FA on, `llama-bench -p 2048`:

| depth | stock pp2048 | patched pp2048 | delta |
|---|---|---|---|
| d0 | baseline | | +12.3 % |
| d4096 | baseline | | +33.7 % |
| d8192 | baseline | | +50.0 % |

Production use since 2026-09-01 on a 5-node RPC cluster (dirigent + 4 workers over 2.5 GbE) with Qwen3.5-122B-A10B IQ3_S: prefill 96 -> 162 t/s (+68 %), generation 19.0 -> 29.5 t/s (+55 %) on a 16k-token prompt; a daily 20k-token batch job went from 803 s to ~440 s. No correctness or stability regressions observed over ~6 days of continuous use across five gfx1013 devices.

**AMD V620 (RDNA2)**, reported by @draetheus in #25207 with the same change: qwen35 27B Q6_K, +29.8 % at d8192, +62.4 % at d16384.

## Notes

- The NVIDIA gate keeps its `hsk < 256 && hsv < 256` condition unchanged. The AMD RDNA gate deliberately has no head-size condition, because the measured gains above are on head sizes 256 and 512.
- Not tested on RDNA3/RDNA4 (coopmat paths); the coopmat1 function is intentionally untouched. Happy to gate narrower (e.g. `!device->coopmat_support`) if maintainers prefer.
- GCN untested, therefore excluded.
