### PR TITLE
webui: exclude server liveness endpoints from service worker cache (#28444)

### DIFF
--- a/tools/ui/src/lib/constants/pwa.constants.ts
+++ b/tools/ui/src/lib/constants/pwa.constants.ts
@@ -275,9 +275,13 @@ export const RUNTIME_CACHING = {
 	HANDLER: 'NetworkFirst'
 } as const;
 
-// Workbox runtime caching patterns
+// Workbox runtime caching patterns.
+// Liveness/status endpoints (/health, /props) are intentionally NOT cached:
+// serving a stale "server is up" response from the service worker makes the
+// web UI look connected to a running server when llama.cpp is stopped
+// (issue #28444). Server availability must always come from a live request.
 export const API_CACHING_PATTERNS = {
-	STATIC_API: /^\/(health|props|models|tools|slots|cors-proxy).*/,
+	STATIC_API: /^\/(models|tools|slots|cors-proxy).*/,
 	V1_API: /^\/v1\/.*/
 } as const;
 

--- a/tools/ui/tests/unit/pwa-liveness-cache.test.ts
+++ b/tools/ui/tests/unit/pwa-liveness-cache.test.ts
@@ -1,0 +1,38 @@
+import { API_CACHING_PATTERNS } from '$lib/constants';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression test for issue #28444 ("Llama.cpp localhost shows the ui even
+ * when llama.cpp isnt running").
+ *
+ * The service worker uses NetworkFirst runtime caching, which falls back to a
+ * cached response when the network request fails. If the server liveness /
+ * status endpoints (/health, /props) are cache-eligible, a stopped llama.cpp
+ * server still yields a cached "server is up" response, so the web UI appears
+ * connected to a running server. These endpoints must therefore always be
+ * resolved from a live request and never matched by a caching route.
+ */
+describe('PWA runtime caching does not mask a stopped server', () => {
+	const LIVENESS_ENDPOINTS = ['/health', '/props'];
+	const CACHEABLE_DATA_ENDPOINTS = ['/models', '/slots', '/tools', '/cors-proxy'];
+	const patterns = Object.values(API_CACHING_PATTERNS);
+	const isCacheEligible = (path: string) => patterns.some((pattern) => pattern.test(path));
+
+	it('never caches server liveness/status endpoints (/health, /props)', () => {
+		for (const endpoint of LIVENESS_ENDPOINTS) {
+			const eligible = isCacheEligible(endpoint);
+
+			console.info(`[#28444] ${endpoint} cache-eligible: ${eligible} (expected false)`);
+			expect(eligible, `${endpoint} must always hit the network, never a cache`).toBe(false);
+		}
+	});
+
+	it('still caches non-liveness data endpoints', () => {
+		for (const endpoint of CACHEABLE_DATA_ENDPOINTS) {
+			const eligible = isCacheEligible(endpoint);
+
+			console.info(`[#28444] ${endpoint} cache-eligible: ${eligible} (expected true)`);
+			expect(eligible, `${endpoint} should remain cache-eligible`).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
 **Overview**

Reproduced on a build of master with the PWA service worker installed:

1. Start llama-server, open the web UI, let it load once.
2. Stop the server.
3. Reload the page.

The UI still renders as connected, and it stays that way across a browser restart and a manual cache clear — which matches what the reporter describes in #28444.

The cause is in the service worker's runtime caching. /health and /props are matched by API_CACHING_PATTERNS.STATIC_API and handled with NetworkFirst, cached in api-cache for API_CACHE_MAX_AGE_SECONDS (24h). NetworkFirst falls back to the cache when the request fails, so once those two responses have been cached, a stopped server no longer produces a failed liveness check: the service worker answers from cache and the UI concludes the server is up. Clearing the browser cache does not help because the entry lives in the service worker's own Cache Storage.

The patch removes health and props from that pattern, so server availability is always resolved from a live request. /models, /tools, /slots, /cors-proxy and /v1 keep the caching they had.

One consequence worth your call: offline PWA use will now show the server as down rather than showing a stale but populated UI. That looks right for a liveness check, but if you would rather keep /props cached and exclude only /health, it is a one-word change.

**Additional information**

Fixes #28444.

The added unit test asserts that /health and /props match none of the caching patterns while the four data endpoints still do. It fails if the constant is reverted.

**Requirements**

- I have read and agree with the contributing guidelines (...)
- AI usage disclosure: YES — the code change and the test were written with AI assistance, and the first version of this PR was opened by an automated pipeline of mine with a generated description : AGENTS.md asks autonomous agents not to submit here, and that description was the AI-written kind your guidelines prohibit. 

I have excluded this repository from that pipeline. I understand the change and can explain or drop it if you would rather not take it.

the fix is real and tested 

