### PR TITLE
llama: fix tensor split drift

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -803,18 +803,18 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         int64_t d_rank  = 0;
         int64_t d_count = 1;
         if (tensor_name.substr(0, 4) == "blk.") {
-            const std::string suffix = tensor_name.substr(tensor_name.find('.', 4) + 1);
-            for (uint32_t il2 = 0; il2 < hparams.n_layer_all; il2++) {
-                if (ud->model->get_tensor((std::string("blk.") + std::to_string(il2) + "." + suffix).c_str())) {
-                    d_count++;
-                    if (il2 < tc.il) {
-                        d_rank++;
-                    }
-                }
+            const std::string suffix    = tensor_name.substr(tensor_name.find('.', 4) + 1);
+            const auto        it_layers = ud->model->tensor_split_layers_by_suffix.find(suffix);
+            if (it_layers != ud->model->tensor_split_layers_by_suffix.end()) {
+                const std::vector<uint32_t> & layers = it_layers->second;
+                d_count                              = 1 + (int64_t) layers.size();
+                d_rank = (int64_t) (std::lower_bound(layers.begin(), layers.end(), tc.il) - layers.begin());
             }
         } else if (tensor_name.substr(0, 6) == "cache_") {
+            const bool tc_is_recr = hparams.is_recr(tc.il);
+            const bool tc_is_swa  = hparams.is_swa(tc.il);
             for (uint32_t il2 = 0; il2 < hparams.n_layer_all; il2++) {
-                if (hparams.is_recr(il2) == hparams.is_recr(tc.il) && hparams.is_swa(il2) == hparams.is_swa(tc.il)) {
+                if (hparams.is_recr(il2) == tc_is_recr && hparams.is_swa(il2) == tc_is_swa) {
                     d_count++;
                     if (il2 < tc.il) {
                         d_rank++;
@@ -1713,6 +1713,26 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         for (auto * cur = ggml_get_first_tensor(ctx_ptr.get()); cur != NULL; cur = ggml_get_next_tensor(ctx_ptr.get(), cur)) {
             tensors_by_name.emplace_back(ggml_get_name(cur), cur);
         }
+    }
+
+    // build the per-suffix layer lists used to dither quantized tensor split points across layers (see llama_meta_device_get_split_state)
+    for (const auto & [name, _] : tensors_by_name) {
+        if (name.compare(0, 4, "blk.") != 0) {
+            continue;
+        }
+        const size_t dot = name.find('.', 4);
+        if (dot == std::string::npos || dot == 4) {
+            continue;
+        }
+        const uint32_t il = (uint32_t) std::stoull(name.substr(4, dot));
+        if (il >= hparams.n_layer_all) {
+            continue;
+        }
+        tensor_split_layers_by_suffix[name.substr(dot + 1)].push_back(il);
+    }
+    for (auto & [_, il_layers] : tensor_split_layers_by_suffix) {
+        std::sort(il_layers.begin(), il_layers.end());
+        il_layers.erase(std::unique(il_layers.begin(), il_layers.end()), il_layers.end());
     }
 
     ml.init_mappings(true, use_mlock ? &pimpl->mlock_mmaps : nullptr);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -798,6 +798,30 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
         }
         const std::vector<std::pair<int64_t, uint32_t>> segments = get_split_segments(split_state.axis, tc.il);
         const std::vector<int64_t> granularity = get_split_granularity(blck_size, tc.il, segments);
+        // dither the choice of quantized split point across the layers sharing this tensor so the per-layer rounding errors
+        // cancel out class-wide; a one-sided floor to the block granularity would bias every tensor down by up to a full quantum
+        int64_t d_rank  = 0;
+        int64_t d_count = 1;
+        if (tensor_name.substr(0, 4) == "blk.") {
+            const std::string suffix = tensor_name.substr(tensor_name.find('.', 4) + 1);
+            for (uint32_t il2 = 0; il2 < hparams.n_layer_all; il2++) {
+                if (ud->model->get_tensor((std::string("blk.") + std::to_string(il2) + "." + suffix).c_str())) {
+                    d_count++;
+                    if (il2 < tc.il) {
+                        d_rank++;
+                    }
+                }
+            }
+        } else if (tensor_name.substr(0, 6) == "cache_") {
+            for (uint32_t il2 = 0; il2 < hparams.n_layer_all; il2++) {
+                if (hparams.is_recr(il2) == hparams.is_recr(tc.il) && hparams.is_swa(il2) == hparams.is_swa(tc.il)) {
+                    d_count++;
+                    if (il2 < tc.il) {
+                        d_rank++;
+                    }
+                }
+            }
+        }
         for (size_t is = 0; is < segments.size(); is++) {
             const int64_t  ne_s = segments[is].first;
             const uint32_t nr_s = segments[is].second;
@@ -805,10 +829,14 @@ struct ggml_backend_meta_split_state llama_meta_device_get_split_state(const str
             int64_t low = 0;
             size_t j = 0;
             for (; j < ud->n_devices - 1; j++) {
-                int64_t high = tensor_split_scan.back() == 0.0f ?
-                    ne_s * (j+1)/ud->n_devices : ne_s * tensor_split_scan[j]/tensor_split_scan.back();
-                if (high % g_s != 0) {
-                    high -= high % g_s;
+                const double  b    = tensor_split_scan.back() == 0.0f ?
+                                         (double) ne_s * (j + 1) / ud->n_devices :
+                                         (double) ne_s * tensor_split_scan[j] / tensor_split_scan.back();
+                const int64_t k0   = (int64_t) (b / g_s);
+                const int64_t cnt  = (int64_t) llround((b - k0 * g_s) * (double) d_count / g_s);
+                int64_t       high = (k0 + (d_rank < cnt ? 1 : 0)) * g_s;
+                if (high > ne_s) {
+                    high = ne_s;
                 }
                 split_state.ne[is*ud->n_devices + (j + tc.rotation) % ud->n_devices] = high - low;
                 low = high;

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -703,6 +703,9 @@ struct llama_model {
     // for quantize-stats only
     std::vector<std::pair<std::string, struct ggml_tensor *>> tensors_by_name;
 
+    // for quantized tensor split dither: the layers owning each blk. tensor, keyed by the part of the name after "blk.<il>."
+    std::map<std::string, std::vector<uint32_t>> tensor_split_layers_by_suffix;
+
     // for keeping track of associated LoRA adapters
     std::unordered_set<llama_adapter_lora *> loras;
 

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -10,6 +10,7 @@
 // TODO: replace with #include "llama-ext.h" in the future
 #include "../src/llama-arch.h"
 #include "../src/llama-model-saver.h"
+#include "../src/llama-model.h"
 
 #include <cinttypes>
 #include <cstddef>
@@ -454,6 +455,72 @@ static std::vector<float> get_logits(
     return ret;
 }
 
+// llama GGUF from get_gguf_ctx: n_embd 256, n_head 2, n_head_kv 2, n_layer 2
+// attn_k.weight has split axis 1 of size 256 and a granularity of 128 (half the axis),
+// so the one-sided floor to the granularity biases the class-wide split maximally
+static int test_tensor_split_dither() {
+    const float splits[3][2] = {
+        { 0.48f, 0.52f },
+        { 0.72f, 0.28f },
+        { 0.5f,  0.5f  }
+    };
+    const int64_t axis_ne = 256;
+
+    gguf_context_ptr gguf_ctx = get_gguf_ctx(LLM_ARCH_LLAMA, false);
+    if (!gguf_ctx) {
+        return 1;
+    }
+
+    auto class_ne = [&](const float tensor_split[2]) -> std::vector<int64_t> {
+        llama_model_params model_params = llama_model_default_params();
+        model_params.progress_callback  = silent_model_load_progress;
+        std::vector<ggml_backend_dev_t> devs{ nullptr };
+        model_params.devices      = devs.data();
+        model_params.tensor_split = tensor_split;
+
+        size_t          tmp = 0;
+        llama_model_ptr model(llama_model_init_from_user(gguf_ctx.get(), set_tensor_data, &tmp, model_params));
+        if (!model) {
+            throw std::runtime_error("failed to create llama model");
+        }
+
+        llama_meta_device_get_split_state_userdata ud;
+        ud.n_devices = 2;
+        ud.model     = model.get();
+
+        std::vector<int64_t> ret(2, 0);
+        for (uint32_t il = 0; il < model->hparams.n_layer(); il++) {
+            ggml_tensor t;
+            memset(&t, 0, sizeof(t));
+            t.type = GGML_TYPE_F16;
+            ggml_format_name(&t, "blk.%u.attn_k.weight", il);
+            t.ne[0] = axis_ne;
+            t.ne[1] = axis_ne;
+
+            const ggml_backend_meta_split_state state = llama_meta_device_get_split_state(&t, &ud);
+            GGML_ASSERT(state.n_segments == 1);
+            for (size_t d = 0; d < 2; d++) {
+                ret[d] += state.ne[d];
+            }
+        }
+        return ret;
+    };
+
+    bool ok = true;
+    for (int i = 0; i < 3; i++) {
+        const std::vector<int64_t> ret    = class_ne(splits[i]);
+        const double               ratio0 = double(ret[0]) / double(ret[0] + ret[1]);
+        printf("tensor split dither: -ts %0.2f,%0.2f -> %0.2f/%0.2f\n", splits[i][0], splits[i][1], ratio0,
+               1.0 - ratio0);
+        const double err = ratio0 - double(splits[i][0]);
+        if (err < -0.05 || err > 0.05) {
+            printf("tensor split dither: class-wide split deviates by %0.2f from the requested ratio\n", err);
+            ok = false;
+        }
+    }
+    return ok ? 0 : 1;
+}
+
 static bool moe_mandatory(const llm_arch arch) {
     switch (arch) {
         case LLM_ARCH_LLAMA4:
@@ -869,7 +936,11 @@ int main(int argc, char ** argv) {
         if (!out.empty()) {
             return save_models(arch, seed, verbosity, out);
         }
-        return test_backends(arch, seed, verbosity);
+        const int ret = test_backends(arch, seed, verbosity);
+        if (ret != 0) {
+            return ret;
+        }
+        return test_tensor_split_dither();
     } catch (const std::exception & err) {
         fprintf(stderr, "encountered runtime error: %s\n", err.what());
         return -1;


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Currently each tensor's split point is floored to a fixed granularity, and therefore biases the whole model towards one device. The resulting device split drifts largely from the requested ratio, even with a tiny change to it. This PR dithers the rounding so that the bias cancels out over the full model, allowing finer-grained control over the precious VRAM.

## Additional information

Issue: https://github.com/ggml-org/llama.cpp/issues/28506

The second commit speeds up the split calculation by precomputing the per-suffix layer lists.

The test is in tests/test-llama-archs.cpp for the bug fix regression test mentioned in the CONTRIBUTING requirement.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. A local model (Qwen3.8 27B based) is used to investigate the issue and draft the fix. I reviewed the changes and steered.
