### PR TITLE
hexagon: fix batch buffer bounds and strided copy dispatch

### DIFF
--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -1691,8 +1691,8 @@ struct ggml_hexagon_opbatch {
         if (it != b_map.end()) { return it->second; }
 
         // Add new buffer to the batch
-        int bi = n_bufs++;
         GGML_ASSERT(n_bufs < HTP_OP_MAX_BUFS);
+        int bi = n_bufs++;
 
         b_map.insert({sbuf->fd(), bi});
 

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -297,7 +297,8 @@ int op_cpy(struct htp_ops_context * octx) {
 
     const bool sametype   = (src0->type == dst->type);
     const bool transposed = (nb00 > nb01) || (nb0 > nb1);
-    const bool sameshape  = !transposed && (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
+    const bool sameshape  = !transposed && nb00 == ct.src0_type_size && nb0 == ct.dst_type_size &&
+                           (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
 
     ct.src0_nrows_per_thread = (nr + n_threads - 1) / n_threads;
 


### PR DESCRIPTION
## Overview

- The batch buffer assertion runs after `n_bufs++`, so adding the valid 16th buffer aborts. Move the check before the increment, keeping `HTP_OP_MAX_BUFS` unchanged.
- Equal shapes do not imply contiguous inner elements. The same-shape copy fast paths ignore dimension-0 strides and can copy incorrect values. Require element-size inner strides on both sides; same-type strided copies use the existing HTP strided path.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md).
- AI usage disclosure: YES. Codex assisted with the fixes.