### PR TITLE
gguf-py : fix sign-loss on wide tensor quantization

### DIFF
--- a/gguf-py/gguf/quants.py
+++ b/gguf-py/gguf/quants.py
@@ -41,11 +41,18 @@ def _apply_over_grouped_rows(func: Callable[[np.ndarray], np.ndarray], arr: np.n
 
 # round away from zero
 # ref: https://stackoverflow.com/a/59143326/22827863
+#
+# The np.sign(...) before the abs is a guard against NumPy 1.x 'temporary
+# elision' on abs(...) on a passed-in temporary at least 256K, rewriting
+# the underlying values for built-ins like abs, which causes a later
+# np.sign(...) to get all-positive numbers. Instead we snapshot the signs,
+# to restore them afterwards.
 def np_roundf(n: np.ndarray) -> np.ndarray:
+    s = np.sign(n)
     a = abs(n)
     floored = np.floor(a)
     b = floored + np.floor(2 * (a - floored))
-    return np.sign(n) * b
+    return s * b
 
 
 class QuantError(Exception): ...

--- a/gguf-py/tests/test_quants.py
+++ b/gguf-py/tests/test_quants.py
@@ -156,6 +156,14 @@ def do_test(libggml_path: Path, quick: bool = False, user_type: GGMLQuantization
     # r[0, 3, 0] = np.inf
     # r[0, 3, 1] = -np.inf
 
+    # Regression test: NumPy 1.x does something called 'temporary elision'
+    # on built-in operations on temporaries that are at least 256K. It makes
+    # the operations 'in-place'. This was causing the sign to be dropped for
+    # quantizations including Q8_0. In order to have a quantization group be
+    # the right size, it has to be >=4096 elements wide at 16 rows. So we use
+    # 16 x 8192 at float32 for 512k to trigger the problem with wide rows.
+    rw = np.random.randn(16, 8192).astype(np.float32, copy=False)
+
     for qtype in ((GGMLQuantizationType.F16, *gguf.quants._type_traits.keys()) if user_type is None else (user_type,)):
         has_dequantize = False
         has_quantize = False
@@ -200,6 +208,21 @@ def do_test(libggml_path: Path, quick: bool = False, user_type: GGMLQuantization
                 logger.error(f"Quantization to {qtype.name} does not match ❌")
             else:
                 logger.info(f"Quantization to {qtype.name} matches exactly ✅")
+
+            rwc = rw.copy()
+
+            logger.debug(f"Quantizing wide rows to {qtype.name} with Python")
+            pyqw = gguf.quants.quantize(rwc, qtype)
+            logger.debug(f"Quantizing wide rows to {qtype.name} with C")
+            ggqw = ggml_quants.quantize(rwc, qtype)
+
+            if qtype == GGMLQuantizationType.F16:
+                pyqw = pyqw.view(np.uint8)
+
+            if not compare_tensors(pyqw, ggqw, qtype):
+                logger.error(f"Quantization of wide rows to {qtype.name} does not match ❌")
+            else:
+                logger.info(f"Quantization of wide rows to {qtype.name} matches exactly ✅")
 
         if has_dequantize:
             if ggq is None and not quick:


### PR DESCRIPTION
Under NumPy 1.x wide tensors 256K and larger passed as a temporary can be modified in-place using 'temporary elision' (their term), which caused the signs to be lost for larger models being quantized on Q8_0, TQ1_0, and TQ2_0. Regression test included. Fixes #28438.

Assisted-by: Claude Code

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
Fixes a quantization bug that triggers on wide tensors (>= 256K) passed as a temporary and loses the sign under NumPy 1.x.
Adds a regression test, as well as warning comments to avoid re-introducing the failure if someone decides to optimize the
code, or inline what appears to be a temporary variable.

## Additional information

Problem described in more detail in #28438.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

Claude Code assisted in debugging the initial problem. The fix and test code was originally written by my agent, with small changes by me. The comments were completely rewritten by me, and their continued loquacity is my fault, although technical accuracy was checked by the agent.

My one caveat to be clear is that I was not aware of NumPy 1.x's temporary elision feature before digging into this. That makes this not a problem I would have recognized on my own. This also informed why I wrote as much in the comments; it's REALLY EASY to see the code in the `np_roundf` function and think, 'Hey, I'll just move that `np.sign(...)` down to the return statement and eliminate an unnecessary variable.' and re-introduce the bug. And if you test on NumPy 2, it'll work, and break NumPy 1.x users.