### PR TITLE
CUDA: enable WMMA flash attention for head size 256 on RDNA4

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1826,7 +1826,7 @@ static __global__ void flash_attn_ext_f16(
 #endif // __CUDA_ARCH__ == GGML_CUDA_CC_TURING
 
 #if defined(AMD_WMMA_AVAILABLE)
-    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 128) {
+    if (ncols1*ncols2 < 16 || ncols2 == 1 || DKQ > 256) {
         NO_DEVICE_CODE;
         return;
     }

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -158,7 +158,7 @@ static void ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1(ggml_backend_cuda_con
     }
 
     if (Q->ne[1] <= 32/ncols2 || (GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) == GGML_CUDA_CC_TURING) ||
-            (GGML_CUDA_CC_IS_AMD(cc) && DKQ > 256)) {
+            (GGML_CUDA_CC_IS_AMD(cc) && DKQ >= 256)) {
         ggml_cuda_flash_attn_ext_mma_f16_case<DKQ, DV, 32/ncols2, ncols2>(ctx, dst);
         return;
     }
@@ -645,7 +645,10 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
     }
 
     // AMD WMMA is always faster than the tile kernel if the full tile width of 16 can be utilized.
-    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= 128) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
+    // RDNA4 also runs head size 256, GGML_CUDA_FA_WMMA_256_OFF restores the tile kernel
+    static const bool wmma_256_off = getenv("GGML_CUDA_FA_WMMA_256_OFF") != nullptr;
+    const int wmma_max_dkq = (GGML_CUDA_CC_IS_RDNA4(cc) && !wmma_256_off) ? 256 : 128;
+    if ((amd_wmma_available(cc) && gqa_opt_applies && Q->ne[0] <= wmma_max_dkq) && Q->ne[0] != 40 && Q->ne[0] != 72 && Q->ne[1] * gqa_ratio_eff > 8) {
         return BEST_FATTN_KERNEL_MMA_F16;
     }
 


### PR DESCRIPTION
## Overview

Enable the WMMA flash attention kernel for head size 256 on RDNA4.

The mma-f16 flash attention kernel is compiled out for `DKQ > 128` on AMD WMMA,
so models with 256-wide attention heads (Qwen3.5 / Qwen3-Next) fall back to the
tile kernel on RDNA4 even though the RDNA config table already has entries for
256. The 192/256 instances were compiled as empty stubs (`NO_DEVICE_CODE`), so
lifting only the dispatch gate crashes with "AQL dispatch failed": both the
compile guard and the dispatch need to move. This PR:

- widens the WMMA compile guard in `fattn-mma-f16.cuh` to admit `DKQ <= 256`;
- dispatches the WMMA kernel for head 256 on RDNA4 in
  `ggml_cuda_get_best_fattn_kernel`, and caps the column tile at 32 for
  `DKQ >= 256` on AMD in `ggml_cuda_flash_attn_ext_mma_f16_switch_ncols1`
  (the 64-column instance spills more and was not faster);
- adds `GGML_CUDA_FA_WMMA_256_OFF=1` to restore the previous behaviour for A/B.

RDNA3 is unchanged.

### Measurements

Radeon AI PRO R9700 (gfx1201, ROCm 7.14.1), Qwen3.5-27B Q5_K_M,
`llama-bench -fa 1 -ctk q8_0 -ctv q8_0 -p 2048 -n 0 -d 7600`:

| kernel | pp2048 @ d7600 (tok/s) |
|---|---|
| tile (before) | 828.8, 829.1 |
| WMMA 256 (this PR) | 839.1, 838.1 |

Greedy 160-token completion on a ~700-token prompt is bit-identical.

The gain is modest because the 256-wide instance is register-bound (256 VGPRs,
244 spills). Putting Q in shared memory left 227 spills and was slightly
slower, so the kernel config is unchanged.

### Tests

`test-backend-ops -o FLASH_ATTN_EXT` on ROCm (gfx1201): 2959/2959 passed.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, the assistant identified and implemented the change and ran the builds, tests and benchmarks on my gfx1201 machine; I reviewed the diff and the results..