### PR TITLE
server : allow model downloads at model limit fix issue #26809

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -976,7 +976,8 @@ void server_models::load(const std::string & name, const load_options & opts) {
     // exceeding models_max. Without this, the window between unload_lru()
     // releasing its lock and this lock_guard acquiring allows multiple
     // threads to each observe capacity and all proceed to load.
-    if (base_params.models_max > 0) {
+    // Download workers do not use models_max slots.
+    if (opts.mode == SERVER_CHILD_MODE_NORMAL && base_params.models_max > 0) {
         size_t count_active = 0;
         for (const auto & m : mapping) {
             if (m.second.meta.is_running()) {

--- a/tools/server/tests/unit/test_router.py
+++ b/tools/server/tests/unit/test_router.py
@@ -540,12 +540,16 @@ def _wait_for_sse_event(collected: list, event_type: str, model: str, timeout: i
 
 
 def test_router_download_model():
-    """Case 1: download a model, verify SSE events and GET /models."""
+    """Case 1: download a model at the model limit, verify SSE events and GET /models."""
     global server
+    server.models_max = 1
     server.start()
 
     # Ensure the model is not present before we start
     server.make_request("DELETE", f"/models?model={MODEL_DOWNLOAD_ID}")
+
+    # A download worker must not consume or evict a model slot
+    _load_model_and_wait(MODEL_B, timeout=120)
 
     sse_events: list = []
     stop = threading.Event()
@@ -580,6 +584,7 @@ def test_router_download_model():
     # Model should now appear in GET /models
     ids = _get_model_ids(is_reload=False)
     assert MODEL_DOWNLOAD_ID in ids, f"{MODEL_DOWNLOAD_ID} not found in /models after download"
+    assert _get_model_status(MODEL_B) == "loaded"
 
 
 def test_router_delete_model():


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
- Bug: When `--models-max` is already at capacity, `POST /models` fails with `"model limit reached, try again later"` (see #26809).
- Root cause: The under-lock capacity recheck in `load()`, intended to prevent concurrent overcommit, also rejects the download child process.
- Fix: Apply the capacity check only for `SERVER_CHILD_MODE_NORMAL`.
- Safety: Download child instances stay in the `DOWNLOADING` state, while `is_running()` only counts `LOADED`, `LOADING`, and `SLEEPING` instances (tools/server/server-models.h). Therefore, downloads do not consume model slots, and the child instance is cleaned up after the download exits.
- Test: Set `models_max=1` and preload `MODEL_B` to occupy the only slot, then start a model download. Verify that the download succeeds and `MODEL_B` remains loaded.
## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->
see #26809
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->YES I used GPT-5.6 Sol to help me with call-stack analysis ,I personally reviewed, understood, and tested the change

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
