### PR TITLE
vulkan: disable large matmul tile on Samsung GPUs with 32KB shared memory

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -183,6 +183,7 @@ static bool is_pow2(uint32_t x) { return x > 1 && (x & (x-1)) == 0; }
 #define VK_VENDOR_ID_INTEL 0x8086
 #define VK_VENDOR_ID_NVIDIA 0x10de
 #define VK_VENDOR_ID_QUALCOMM 0x5143
+#define VK_VENDOR_ID_SAMSUNG 0x144d
 
 #define VK_DEVICE_DESCRIPTOR_POOL_SIZE 256
 
@@ -7108,6 +7109,20 @@ static vk_device ggml_vk_get_device(size_t idx) {
                 device->mul_mat_id_m[i] = true;
                 device->mul_mat_id_s[i] = true;
                 break;
+            case VK_VENDOR_ID_SAMSUNG: {
+                // Samsung Xclipse: the large tile gives each thread 128 accumulators instead of 32, so they spill to scratch.
+                // With 32KB of shared memory it also cuts occupancy from 3 workgroups per CU to 1, so nothing hides the spill.
+                // Parts with 64KB keep 3 workgroups, so leave the large tile on there.
+                const bool large_tile = device->properties.limits.maxComputeSharedMemorySize >= 65536; // 32KB: Xclipse 530, 540, 550, 920, 930A, 940, 950. 64KB: Xclipse 960.
+                device->mul_mat_l[i] = large_tile;
+                device->mul_mat_m[i] = true;
+                device->mul_mat_s[i] = true;
+                // mul_mat_id is not tested here, so follow AMD and keep it off the large tile.
+                device->mul_mat_id_l[i] = false;
+                device->mul_mat_id_m[i] = true;
+                device->mul_mat_id_s[i] = true;
+                break;
+            }
 #endif
             default:
                 device->mul_mat_l[i] = true;


### PR DESCRIPTION

## Overview

On my mobile device, prefill speed is unexpectedly low when I select "n_ubatch" option for 128 or more.

This problem may be caused by the following sequence of events:

1. Large n_ubatch (>= 128) triggers large tile mat_mul.
2. Large tile mat_mul makes the number of accumulators per thread quadrupled.
3. Quadrupled the number of accumulators need larger register space per thread.
4. Event 3 makes register spill.
5. Event 2 makes concurrent workgroups per CU fewer. 
(ldsSizePerLocalWorkGroup: 32768, medium_tile: 8704 -> 3, large_tile:  17408 -> 1)
6. With 4,5 events, gpu stops calculating while reading memory.

So, I disable large mat_mul tile if shared memory is not enough.


### Scope of this PR.
- I cover it only for Samsung GPUs and tested it on my mobile phone only.
- By the [vulkan gpu information of Samsung Xclipse 960](https://vulkan.gpuinfo.org/displayreport.php?id=48979#properties), it has enough shared memory to make enough workgroups. 
As I'm not sure how my changes will affect it, I prevented the behavior from changing.

## Additional information

My device info : 
- SoC : Samsung Exynos 2400

```zsh
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Samsung Xclipse 940 (Samsung Proprietary driver) | uma: 1 | fp16: 1 | bf16: 0 | fp4: 0 | warp size: 64 | shared memory: 32768 | int dot: 0 | matrix cores: none
```

Build command :
```zsh
export ANDROID_NDK=$HOME/Library/Android/sdk/ndk/28.2.13676358

cmake -S . -B build-android -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK/build/cmake/android.toolchain.cmake" \
  -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-28 \
  -DGGML_NATIVE=OFF -DGGML_OPENMP=OFF -DGGML_LLAMAFILE=OFF -DLLAMA_OPENSSL=OFF \
  -DGGML_VULKAN=ON \
  -DVulkan_GLSLC_EXECUTABLE="$ANDROID_NDK/shader-tools/darwin-x86_64/glslc" \
  -DSPIRV-Headers_DIR=/opt/homebrew/share/cmake/SPIRV-Headers \
  -DCMAKE_CXX_FLAGS="-isystem /opt/homebrew/opt/spirv-headers/include"

cmake --build build-android --config Release --parallel \
  --target llama-perplexity test-backend-ops llama-bench
```
## Before

### Performance
 
Test command :
- Q4_K-Medium

```zsh
./llama-bench -m /data/local/tmp/Llama-3.2-1B-Instruct-Q4_K_M.gguf -p 512 -n 0 -ngl 99 -t 4 -ub 64,128,256,512 -r 3
```

| model                          |       size |     params | backend    | ngl | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | --------------: | -------------------: |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |       64 |           pp512 |        435.85 ± 5.72 |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      128 |           pp512 |         10.16 ± 0.02 |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      256 |           pp512 |          9.44 ± 0.03 |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      512 |           pp512 |          9.65 ± 0.02 |

build: 3ad1ba733 (10828)

- Q4_0
```zsh
./llama-bench -m /data/local/tmp/Llama-3.2-1B-Instruct-Q4_0.gguf -p 512 -n 0 -ngl 99 -t 4 -ub 64,128,256,512 -r 3
```

| model                          |       size |     params | backend    | ngl | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | --------------: | -------------------: |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |       64 |           pp512 |        519.53 ± 8.52 |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |      128 |           pp512 |          9.34 ± 0.03 |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |      256 |           pp512 |          8.39 ± 0.03 |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |      512 |           pp512 |          8.46 ± 0.01 |

build: 3ad1ba733 (10828)


### Spill Evidence:

For ub 64, 

```zsh
GGML_VK_PIPELINE_STATS=matmul_q4_k llama-bench -m /data/local/tmp/Llama-3.2-1B-Instruct-Q4_K_M.gguf -p 512 -n 0 -ngl 99 -t 4 -ub 64 -r 1
```
| model                          |       size |     params | backend    | ngl | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | --------------: | -------------------: |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |       64 |           pp512 |        443.28 ± 0.00 |
```
ggml_vulkan: pipeline stats for matmul_q4_k_f32_f16acc_aligned_m:
ggml_vulkan:   numUsedVgprs: 72
ggml_vulkan:   numUsedSgprs: 40
ggml_vulkan:   ldsSizePerLocalWorkGroup: 32768
ggml_vulkan:   ldsUsageSizeInBytes: 8704
ggml_vulkan:   scratchMemUsageInBytes: 0

build: 3ad1ba733 (10828)
```

For ub 128,

```zsh
GGML_VK_PIPELINE_STATS=matmul_q4_k llama-bench -m  /data/local/tmp/Llama-3.2-1B-Instruct-Q4_K_M.gguf -p 512 -n 0 -ngl 99 -t 4 -ub 128 -r 1
```

| model                          |       size |     params | backend    | ngl | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | --------------: | -------------------: |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      128 |           pp512 |         10.15 ± 0.00 |
```
ggml_vulkan: pipeline stats for matmul_q4_k_f32_f16acc_aligned_l:
ggml_vulkan:   numUsedVgprs: 132
ggml_vulkan:   numUsedSgprs: 69
ggml_vulkan:   ldsSizePerLocalWorkGroup: 32768
ggml_vulkan:   ldsUsageSizeInBytes: 17408
ggml_vulkan:   scratchMemUsageInBytes: 576

build: 3ad1ba733 (10828)
```

### Test backend ops (3ad1ba733)
```zsh
LD_LIBRARY_PATH=. ./test-backend-ops test -b Vulkan0 

...

ggml_vulkan: Compute pipeline creation failed for rope_norm_f16
ggml_vulkan: vk::Device::createComputePipeline: ErrorUnknown
0: 0x7719e9cd08 
1: 0x7719e9cc14 ggml_print_backtrace
2: 0x7719eb3154 
3: 0x7719f2d7bc 
4: 0x7719f47da0 __cxa_get_exception_ptr
5: 0x7719f47d7c 
6: 0x77266b5ff4 
7: 0x772667de60 
8: 0x77266fccf0 
9: 0x77266e74bc 
10: 0x77266cd18c 
11: 0x7719ebe524 ggml_backend_compare_graph_backend
12: 0x6551768190 
13: 0x6551755eb0 
14: 0x65516c3260 
15: 0x77242bb45c __libc_init
libc++abi: terminating due to uncaught exception of type vk::SystemError: vk::Device::createComputePipeline: ErrorUnknown
Aborted 

```


## After

### Performance
Test command :
- Q4_K-Medium

```zsh
./llama-bench -m /data/local/tmp/Llama-3.2-1B-Instruct-Q4_K_M.gguf -p 512 -n 0 -ngl 99 -t 4 -ub 64,128,256,512 -r 3
```

| model                          |       size |     params | backend    | ngl | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | --------------: | -------------------: |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |       64 |           pp512 |        445.63 ± 5.29 |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      128 |           pp512 |        456.41 ± 3.41 |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      256 |           pp512 |        444.77 ± 1.82 |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      512 |           pp512 |        434.01 ± 0.92 |

build: ebd79edbf (10829)

- Q4_0
```zsh
./llama-bench -m /data/local/tmp/Llama-3.2-1B-Instruct-Q4_0.gguf -p 512 -n 0 -ngl 99 -t 4 -ub 64,128,256,512 -r 3
```


| model                          |       size |     params | backend    | ngl | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | --------------: | -------------------: |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |       64 |           pp512 |        509.89 ± 6.26 |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |      128 |           pp512 |        540.79 ± 4.86 |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |      256 |           pp512 |       589.12 ± 19.76 |
| llama 1B Q4_0                  | 729.75 MiB |     1.24 B | Vulkan     |  99 |       4 |      512 |           pp512 |        539.68 ± 0.67 |

build: ebd79edbf (10829)

### Spill Evidence:
```zsh
GGML_VK_PIPELINE_STATS=matmul_q4_k ./llama-bench \
  -m /data/local/tmp/Llama-3.2-1B-Instruct-Q4_K_M.gguf \
  -p 512 -n 0 -ngl 99 -t 4 -ub 128 -r 1
```
| model                          |       size |     params | backend    | ngl | threads | n_ubatch |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | -------: | --------------: | -------------------: |
| llama 1B Q4_K - Medium         | 762.81 MiB |     1.24 B | Vulkan     |  99 |       4 |      128 |           pp512 |        459.33 ± 0.00 |
```
ggml_vulkan: pipeline stats for matmul_q4_k_f32_f16acc_aligned_m:
ggml_vulkan:   numUsedVgprs: 72
ggml_vulkan:   numUsedSgprs: 40
ggml_vulkan:   ldsSizePerLocalWorkGroup: 32768
ggml_vulkan:   ldsUsageSizeInBytes: 8704
ggml_vulkan:   scratchMemUsageInBytes: 0

build: ebd79edbf (10829)
```


### Test backend ops (ebd79edbf)

```zsh
LD_LIBRARY_PATH=. ./test-backend-ops test -b Vulkan0 

...
ggml_vulkan: Compute pipeline creation failed for rope_norm_f16
ggml_vulkan: vk::Device::createComputePipeline: ErrorUnknown
0: 0x7f598eed18 
1: 0x7f598eec24 ggml_print_backtrace
2: 0x7f59905164 
3: 0x7f5997f7cc 
4: 0x7f59999db0 __cxa_get_exception_ptr
5: 0x7f59999d8c 
6: 0x7f5bed5038 
7: 0x7f5be9cea4 
8: 0x7f5bf1bd34 
9: 0x7f5bf06500 
10: 0x7f5beec1d0 
11: 0x7f59910534 ggml_backend_compare_graph_backend
12: 0x55c8b901a0 
13: 0x55c8b7dec0 
14: 0x55c8aeb270 
15: 0x7f56a8c45c __libc_init
libc++abi: terminating due to uncaught exception of type vk::SystemError: vk::Device::createComputePipeline: ErrorUnknown
Aborted 
```
My changes didn't change this failure. 


```zsh
LD_LIBRARY_PATH=. ./test-backend-ops test -b Vulkan0 -o MUL_MAT

...
  1106/1106 tests passed
  Backend Vulkan0: OK
```

```zsh
LD_LIBRARY_PATH=. ./test-backend-ops test -b Vulkan0 -o MUL_MAT_ID

...
  883/883 tests passed
  Backend Vulkan0: OK
```


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  Yes, I use it for coding and analyzing the test output <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
