### PR TITLE
server: prioritise throughput over latency

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1718,6 +1718,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_CACHE_RAM").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
+        {"--slot-linger-ms"}, "N",
+        "maximum wait time after a slot is freed before a pre-existing queued request is assigned. "
+        "If a new request arrives inside this window, immediately assign it. Default 0 (disabled)",
+        [](common_params & params, int value) {
+            params.slot_linger_ms = value;
+        }
+    ).set_env("LLAMA_ARG_SLOT_LINGER_MS").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-kvu", "--kv-unified"},
         {"-no-kvu", "--no-kv-unified"},
         "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",

--- a/common/common.h
+++ b/common/common.h
@@ -626,6 +626,7 @@ struct common_params {
     int32_t n_cache_reuse       = 0;     // min chunk size to reuse from the cache via KV shifting
     bool    cache_prompt        = true;  // whether to enable prompt caching
     bool    cache_idle_slots    = true;  // save and clear idle slots upon starting a new task
+    int32_t slot_linger_ms      = 0;     // linger on slot release to serve new arrivals (0 = disabled)
     int32_t n_ctx_checkpoints   = 32;    // max number of context checkpoints per slot
     int32_t kv_unified_per_slot = 0;     // max context per parallel slot; 0 = unset
     int32_t checkpoint_min_step = 8192;  // minimum spacing between context checkpoints

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1300,7 +1300,14 @@ private:
             SLT_TRC(slot, "new slot, n_ctx = %d\n", slot.n_ctx);
 
             slot.callback_on_release = [this](int id_slot) {
-                queue_tasks.pop_deferred_task(id_slot);
+                // holding a slot only pays off if its cache is worth reusing
+                const int min_prompt_tokens = 10;
+
+                const server_slot * slot_ptr = get_slot_by_id(id_slot);
+                const bool has_significant_prompt = slot_ptr && slot_ptr->prompt.n_tokens() >= min_prompt_tokens;
+                const bool should_linger = has_significant_prompt && params_base.slot_linger_ms > 0;
+
+                queue_tasks.pop_deferred_with_linger(id_slot, params_base.slot_linger_ms, should_linger);
             };
 
             slot.callback_on_reset = [this](const server_slot & slot) {
@@ -1705,6 +1712,9 @@ private:
     }
 
     bool launch_slot_with_task(server_slot & slot, server_task && task) {
+        // Cancel linger if this slot was waiting for an in-window arrival
+        queue_tasks.cancel_linger_if_active(slot.id);
+
         // process per-request lora adapters
         if (!task.params.lora.empty()) {
             auto task_loras = construct_lora_list(task.params.lora);

--- a/tools/server/server-queue.cpp
+++ b/tools/server/server-queue.cpp
@@ -112,6 +112,71 @@ void server_queue::pop_deferred_task(int id_slot) {
     condition_tasks.notify_one();
 }
 
+void server_queue::pop_deferred_with_linger(int id_slot, int32_t linger_ms, bool should_linger) {
+    std::unique_lock<std::mutex> lock(mutex_tasks);
+
+    // a task already bound to this slot is the best use of it, waiting only adds latency
+    const bool has_bound_task = std::any_of(queue_tasks_deferred.begin(), queue_tasks_deferred.end(),
+                                            [id_slot](const server_task & task) {
+                                                return task.id_slot == id_slot;
+                                            });
+
+    // Check if we should linger: deferred queue must be non-empty, linger_ms > 0, and should_linger must be true
+    const bool can_linger = !queue_tasks_deferred.empty() && linger_ms > 0 && should_linger && !has_bound_task;
+
+    if (!can_linger) {
+        // No lingering: immediately pop
+        lock.unlock();
+        pop_deferred_task(id_slot);
+        return;
+    }
+
+    // Start lingering: record deadline but don't promote from deferred queue yet
+    // If a fresh arrival finds the idle slot during this window, that's the hit
+    const int64_t now      = ggml_time_ms();
+    const int64_t deadline = now + linger_ms;
+
+    linger_slots[id_slot] = deadline;
+
+    QUE_DBG("slot %d lingering for %d ms (until %" PRId64 ")\n",
+            id_slot, linger_ms, deadline);
+
+    time_last_task = now;
+    condition_tasks.notify_one();
+}
+
+bool server_queue::cancel_linger_if_active(int id_slot) {
+    std::unique_lock<std::mutex> lock(mutex_tasks);
+    if (linger_slots.erase(id_slot) > 0) {
+        QUE_DBG("slot %d linger cancelled (hit)\n", id_slot);
+        return true;
+    }
+    return false;
+}
+
+int64_t server_queue::linger_deadline_min() const {
+    int64_t res = -1;
+    for (const auto & kv : linger_slots) {
+        if (res < 0 || kv.second < res) {
+            res = kv.second;
+        }
+    }
+    return res;
+}
+
+std::vector<int> server_queue::linger_take_expired(int64_t now) {
+    std::vector<int> res;
+    for (auto it = linger_slots.begin(); it != linger_slots.end(); ) {
+        if (now >= it->second) {
+            res.push_back(it->first);
+            it = linger_slots.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    return res;
+}
+
 void server_queue::wait_until_no_sleep() {
     std::unique_lock<std::mutex> lock(mutex_tasks);
     if (!sleeping) {
@@ -319,6 +384,26 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
         QUE_DBG("%s", "waiting for new tasks\n");
         while (true) {
             std::unique_lock<std::mutex> lock(mutex_tasks);
+
+            // Handle lingering expiry: every slot whose deadline passed is still idle, so promote
+            // one deferred task for each. A slot taken during its window was already removed by
+            // cancel_linger_if_active()
+            if (!linger_slots.empty()) {
+                const std::vector<int> expired = linger_take_expired(ggml_time_ms());
+                if (!expired.empty()) {
+                    lock.unlock();
+                    for (const int id_slot : expired) {
+                        QUE_DBG("slot %d linger expired, falling back to FIFO\n", id_slot);
+                        pop_deferred_task(id_slot);
+                    }
+                    lock.lock();
+                    // After popping, we may have a new task to process
+                    if (!queue_tasks.empty()) {
+                        break; // go back to process new tasks
+                    }
+                }
+            }
+
             if (!running || !queue_tasks.empty()) {
                 break; // go back to process new tasks or terminate
             }
@@ -350,14 +435,22 @@ void server_queue::start_loop(int64_t idle_sleep_ms) {
                 condition_tasks.notify_all(); // notify wait_until_no_sleep()
                 break; // process new tasks
             } else {
-                // wait for new tasks or timeout for checking sleeping condition
-                bool res = condition_tasks.wait_for(lock, max_wait_time, [&]{
+                // Determine wait timeout: if lingering, wake for the earliest deadline
+                std::chrono::milliseconds wait_time = max_wait_time;
+                const int64_t deadline = linger_deadline_min();
+                if (deadline >= 0) {
+                    const int64_t remaining = std::max<int64_t>(0, deadline - ggml_time_ms());
+                    wait_time = std::chrono::milliseconds(remaining);
+                }
+
+                // wait for new tasks or timeout for checking sleeping condition / linger expiry
+                bool res = condition_tasks.wait_for(lock, wait_time, [&]{
                     return (!queue_tasks.empty() || !running);
                 });
                 if (res) {
                     break; // new task arrived or terminate
                 }
-                // otherwise, loop again to check sleeping condition
+                // otherwise, loop again to check linger expiry / sleeping condition
             }
         }
     }

--- a/tools/server/server-queue.h
+++ b/tools/server/server-queue.h
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <deque>
 #include <exception>
+#include <map>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -19,6 +20,10 @@ private:
     bool sleeping = false;
     bool req_stop_sleeping = false;
     int64_t time_last_task = 0;
+
+    // slot lingering state: deadline per slot that released while tasks were deferred
+    // one entry per slot, so releases from different slots do not displace each other
+    std::map<int, int64_t> linger_slots;
 
     // queues
     std::deque<server_task> queue_tasks;
@@ -64,6 +69,14 @@ public:
     // Call when the state of one slot is changed, it will move one task from deferred to main queue
     // prioritize tasks that use the specified slot (otherwise, pop the first deferred task)
     void pop_deferred_task(int id_slot);
+
+    // Start lingering on a slot release: wait linger_ms before popping from deferred queue
+    // Only lingers if deferred queue is non-empty and should_linger is true
+    void pop_deferred_with_linger(int id_slot, int32_t linger_ms, bool should_linger);
+
+    // Check if a slot is currently lingering, and if so, cancel the linger (hit occurred)
+    // Thread-safe. Returns true if linger was cancelled.
+    bool cancel_linger_if_active(int id_slot);
 
     // if sleeping, request exiting sleep state and wait until it is done
     // returns immediately if not sleeping
@@ -138,6 +151,14 @@ public:
 
 private:
     void cleanup_pending_task(int id_target);
+
+    // earliest deadline among the lingering slots, or -1 if none is lingering
+    // mutex_tasks must be held
+    int64_t linger_deadline_min() const;
+
+    // remove every slot whose linger deadline passed and return their ids
+    // mutex_tasks must be held
+    std::vector<int> linger_take_expired(int64_t now);
 
     // process all pending tasks in the queue
     // returns true if the queue is terminated, false if there is no more task to process

--- a/tools/server/tests/unit/test_slot_linger.py
+++ b/tools/server/tests/unit/test_slot_linger.py
@@ -1,0 +1,314 @@
+import os
+import re
+import tempfile
+import time
+
+import pytest
+from utils import *
+
+server = ServerPreset.tinyllama2()
+
+
+@pytest.fixture(autouse=True)
+def create_server():
+    global server
+    server = ServerPreset.tinyllama2()
+    server.n_slots = 1
+    server.n_ctx = 1024
+    server.n_predict = 4
+    server.temperature = 0.0
+    server.cache_ram = 1  # MiB: default, overridden per test
+    server.kv_unified = True
+    server.debug = True
+    fd, server.log_path = tempfile.mkstemp(suffix=".log")
+    os.close(fd)
+    yield
+
+
+def test_linger_disabled_with_empty_deferred_queue():
+    """No linger when deferred queue is empty: throughput unaffected."""
+    server.slot_linger_ms = 2000  # Large value to make any linger visible
+    server.n_predict = 8
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()  # Clear initial logs
+
+    prompt_a = make_prompt(1, "chapterA")
+
+    # Send requests one at a time (no deferred queue)
+    start = time.monotonic()
+    for _ in range(3):
+        res = server.make_request(
+            "POST",
+            "/completion",
+            data={
+                "prompt": prompt_a,
+                "cache_prompt": True,
+            },
+        )
+        assert res.status_code == 200
+    elapsed = time.monotonic() - start
+
+    drained = log.drain()
+    # Neither linger marker should appear since deferred queue was always empty
+    assert "linger cancelled (hit)" not in drained
+    assert "linger expired, falling back to FIFO" not in drained
+
+    # Throughput check: with no deferred queue, linger should not trigger
+    # Even with a 2000ms linger setting, total time should be much less than 6s (3 * 2000ms)
+    assert elapsed < 3.0, f"Expected fast sequential processing, got {elapsed:.2f}s"
+
+
+def test_linger_hit_serves_in_window_arrival_first():
+    """In-window arrival is served ahead of older queued request."""
+    server.slot_linger_ms = 2000  # Long window to ensure test isn't racing
+    server.n_predict = 12  # Long enough to queue multiple requests
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    prompt_a = make_prompt(1, "chapterA")
+    prompt_b = make_prompt(2, "chapterB")
+    prompt_c = make_prompt(3, "chapterC")
+
+    import threading
+
+    blocking_result = None
+    old_result = None
+    new_result = None
+    old_ts = None
+    new_ts = None
+    blocking_done = threading.Event()
+
+    def blocking_request():
+        nonlocal blocking_result
+        blocking_result = server.make_request(
+            "POST", "/completion", data={"prompt": prompt_a, "cache_prompt": True}
+        )
+        blocking_done.set()
+
+    def old_request():
+        nonlocal old_result, old_ts
+        old_result = server.make_request(
+            "POST", "/completion", data={"prompt": prompt_b, "cache_prompt": True}
+        )
+        old_ts = time.monotonic()
+
+    def new_request():
+        nonlocal new_result, new_ts
+        # Wait for blocking to complete, then send during linger window
+        blocking_done.wait()
+        new_result = server.make_request(
+            "POST", "/completion", data={"prompt": prompt_c, "cache_prompt": True}
+        )
+        new_ts = time.monotonic()
+
+    # Occupy the slot with a blocking request
+    blocking_thread = threading.Thread(target=blocking_request)
+    blocking_thread.start()
+    time.sleep(0.05)  # Let it start
+
+    # Queue an old request while slot is busy
+    old_thread = threading.Thread(target=old_request)
+    old_thread.start()
+    time.sleep(0.01)  # Ensure it's queued
+
+    # Start new request thread (it will wait for blocking to complete)
+    new_thread = threading.Thread(target=new_request)
+    new_thread.start()
+
+    # Wait for all to complete
+    blocking_thread.join()
+    old_thread.join()
+    new_thread.join()
+
+    assert blocking_result.status_code == 200
+    assert old_result.status_code == 200
+    assert new_result.status_code == 200
+
+    drained = log.drain()
+    assert "linger cancelled (hit)" in drained, (
+        "Expected linger hit marker when new request arrives in window"
+    )
+
+    # The new request (arriving in-window) should complete before the old one
+    margin = old_ts - new_ts
+    print(
+        f"\nCompletion timestamps: new={new_ts:.6f}s, old={old_ts:.6f}s, margin={margin:.6f}s"
+    )
+    assert new_ts < old_ts, (
+        f"Expected in-window arrival to complete first, but new={new_ts:.6f}s old={old_ts:.6f}s"
+    )
+
+
+def test_linger_expired_uses_fifo():
+    """Post-expiry arrival is NOT preferred: FIFO is honored."""
+    server.slot_linger_ms = 100  # Short window that will expire
+    server.n_predict = 12
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    prompt_a = make_prompt(1, "chapterA")
+    prompt_b = make_prompt(2, "chapterB")
+    prompt_c = make_prompt(3, "chapterC")
+
+    import threading
+
+    blocking_result = None
+    old_result = None
+    late_result = None
+    old_ts = None
+    late_ts = None
+    blocking_done = threading.Event()
+
+    def blocking_request():
+        nonlocal blocking_result
+        blocking_result = server.make_request(
+            "POST", "/completion", data={"prompt": prompt_a, "cache_prompt": True}
+        )
+        blocking_done.set()
+
+    def old_request():
+        nonlocal old_result, old_ts
+        old_result = server.make_request(
+            "POST", "/completion", data={"prompt": prompt_b, "cache_prompt": True}
+        )
+        old_ts = time.monotonic()
+
+    def late_request():
+        nonlocal late_result, late_ts
+        # Wait for blocking to complete, then wait for linger to expire
+        blocking_done.wait()
+        time.sleep(0.15)  # Wait longer than linger window (100ms)
+        late_result = server.make_request(
+            "POST", "/completion", data={"prompt": prompt_c, "cache_prompt": True}
+        )
+        late_ts = time.monotonic()
+
+    # Occupy the slot
+    blocking_thread = threading.Thread(target=blocking_request)
+    blocking_thread.start()
+    time.sleep(0.05)
+
+    # Queue an old request while slot is busy
+    old_thread = threading.Thread(target=old_request)
+    old_thread.start()
+    time.sleep(0.01)
+
+    # Start late request thread (it will wait for linger to expire)
+    late_thread = threading.Thread(target=late_request)
+    late_thread.start()
+
+    blocking_thread.join()
+    old_thread.join()
+    late_thread.join()
+
+    assert blocking_result.status_code == 200
+    assert old_result.status_code == 200
+    assert late_result.status_code == 200
+
+    drained = log.drain()
+    assert "linger expired, falling back to FIFO" in drained, (
+        "Expected linger expired marker when window times out"
+    )
+
+    # FIFO: old request must complete before late request
+    assert old_ts < late_ts, (
+        f"Expected FIFO order (old first), but old={old_ts:.6f}s late={late_ts:.6f}s"
+    )
+
+
+def test_linger_does_not_drop_concurrent_slot_releases():
+    """Two slots have independent linger windows.
+
+    If four tasks are queued with a 1.5s linger window, total time will
+    be greater than 1.5s and much less than 3s.
+    """
+    server.n_slots = 2
+    server.n_ctx = 2048  # 1024 per slot; prompts are ~840 tokens
+    server.slot_linger_ms = 1500
+    server.n_predict = 8
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    prompts = [make_prompt(i, f"chapter{i}") for i in range(4)]
+
+    # slots 0 and 1 take the first two, the other two are deferred. Both slots then release
+    # inside the same linger window
+    start = time.monotonic()
+    results = parallel_function_calls(
+        [
+            (
+                server.make_request,
+                ("POST", "/completion", {"prompt": p, "cache_prompt": True}),
+            )
+            for p in prompts
+        ]
+    )
+    elapsed = time.monotonic() - start
+
+    assert all(r.status_code == 200 for r in results)
+
+    drained = log.drain()
+    expired_slots = set(re.findall(r"slot (\d+) linger expired", drained))
+    assert len(expired_slots) == 2, (
+        f"Expected both slots to expire their own linger, got {expired_slots}"
+    )
+
+    # one 1500 ms window, not two
+    assert elapsed < 2.6, (
+        f"Expected the deferred backlog to drain in a single linger window, took {elapsed:.2f}s"
+    )
+
+
+def test_no_linger_when_a_deferred_task_is_bound_to_the_slot():
+    """A deferred task already pinned to the releasing slot must not wait out the window.
+
+    Lingering exists to catch a new arrival that could reuse the slot cache. A task bound to
+    this slot by id_slot is already the best use of it, so holding the slot only adds latency.
+    """
+    server.slot_linger_ms = 3000
+    server.n_predict = 16
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    prompt_a = make_prompt(1, "chapterA")
+    prompt_b = make_prompt(2, "chapterB")
+
+    import threading
+
+    results = {}
+
+    def occupier():
+        results["a"] = server.make_request(
+            "POST", "/completion", data={"prompt": prompt_a, "cache_prompt": True}
+        )
+
+    start = time.monotonic()
+    occupier_thread = threading.Thread(target=occupier)
+    occupier_thread.start()
+    time.sleep(0.1)  # wait for slot 0 to be occupied
+
+    # arrives while slot 0 is busy, so it is deferred while pinned to slot 0
+    results["b"] = server.make_request(
+        "POST",
+        "/completion",
+        data={"prompt": prompt_b, "id_slot": 0, "cache_prompt": True},
+    )
+    occupier_thread.join()
+    elapsed = time.monotonic() - start
+
+    assert results["a"].status_code == 200
+    assert results["b"].status_code == 200
+    assert results["b"].body["id_slot"] == 0
+
+    drained = log.drain()
+    assert "linger expired, falling back to FIFO" not in drained, (
+        "Expected no linger window for a slot that already has a task bound to it"
+    )
+    assert elapsed < 2.0, (
+        f"Expected the bound task to run without waiting out the 3000 ms window, took {elapsed:.2f}s"
+    )

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -7,6 +7,7 @@ import subprocess
 import os
 
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmp")
+import random
 import re
 import json
 from json import JSONDecodeError
@@ -113,6 +114,7 @@ class ServerProcess:
     media_path: str | None = None
     sleep_idle_seconds: int | None = None
     cache_ram: int | None = None
+    slot_linger_ms: int | None = None
     no_cache_idle_slots: bool = False
     log_path: str | None = None
     ui_mcp_proxy: bool = False
@@ -278,6 +280,8 @@ class ServerProcess:
             server_args.extend(["--sleep-idle-seconds", self.sleep_idle_seconds])
         if self.cache_ram is not None:
             server_args.extend(["--cache-ram", self.cache_ram])
+        if self.slot_linger_ms is not None:
+            server_args.extend(["--slot-linger-ms", str(self.slot_linger_ms)])
         if self.no_cache_idle_slots:
             server_args.append("--no-cache-idle-slots")
         if self.ui_mcp_proxy:
@@ -724,3 +728,50 @@ def download_file(url: str, output_file_path: str | None = None) -> str:
 
 def is_slow_test_allowed():
     return os.environ.get("SLOW_TESTS") == "1" or os.environ.get("SLOW_TESTS") == "ON"
+
+
+class LogReader:
+    """Read a server log incrementally, returning only what was appended since the last call."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.pos = 0
+
+    def drain(self) -> str:
+        with open(self.path) as f:
+            f.seek(self.pos)
+            content = f.read()
+            self.pos = f.tell()
+        return content
+
+
+# word pool for building long prompts that share a prefix but differ past it
+COMMON_WORDS = [
+    "the", "be", "to", "of", "and", "a", "in", "that", "have", "I",
+    "it", "for", "not", "on", "with", "he", "as", "you", "do", "at",
+    "this", "but", "his", "by", "from", "they", "we", "say", "her", "she",
+    "or", "an", "will", "my", "one", "all", "would", "there", "their", "what",
+    "so", "up", "out", "if", "about", "who", "get", "which", "go", "me",
+    "when", "make", "can", "like", "time", "no", "just", "him", "know", "take",
+    "people", "into", "year", "your", "good", "some", "could", "them", "see", "other",
+    "than", "then", "now", "look", "only", "come", "its", "over", "think", "also",
+    "back", "after", "use", "two", "how", "our", "work", "first", "well", "way",
+    "even", "new", "want", "because", "any", "these", "give", "day", "most", "us",
+    "is", "was", "are", "been", "has", "had", "were", "said", "did", "having",
+    "may", "should", "could", "would", "might", "must", "shall", "can", "will", "am",
+    "find", "give", "tell", "become", "leave", "put", "mean", "keep", "let", "begin",
+    "seem", "help", "talk", "turn", "start", "show", "hear", "play", "run", "move",
+    "live", "believe", "hold", "bring", "happen", "write", "provide", "sit", "stand", "lose",
+    "pay", "meet", "include", "continue", "set", "learn", "change", "lead", "understand", "watch",
+    "follow", "stop", "create", "speak", "read", "allow", "add", "spend", "grow", "open",
+    "walk", "win", "offer", "remember", "love", "consider", "appear", "buy", "wait", "serve",
+    "die", "send", "expect", "build", "stay", "fall", "cut", "reach", "kill", "remain"
+]
+
+
+def make_prompt(seed: int, prefix: str) -> str:
+    """Deterministic 320-word prompt, unique in its first word and seeded past it.
+    Tokenizes to roughly 840 tokens with the stories260K vocab."""
+    rng = random.Random(seed)
+    words = [prefix] + rng.choices(COMMON_WORDS, k=319)
+    return " ".join(words)


### PR DESCRIPTION
## Overview

Prioritise existing sessions over queued sessions, reducing the time wasted swapping from cache (or preloading from scratch)

## Additional information

When there is high contention over slots, a lot of time can be wasted swapping between KV contexts. In some situations, a large proportion of turns end with a tool call which runs in a few milliseconds (e.g. write, edit, sed, grep), and overall throughput can be significantly increased by allowing the loaded context to be resumed.

By setting --slot-linger-ms to a positive value, whenever a slot becomes available, it prioritises a new request over existing requests for a short period of time, allowing sessions to quickly be resumed, avoiding the session switching overheads.

The overhead of enabling this feature is very low: if only a single client is using a single-slotted llama, it is just as fast; it's only when there's already an enqueued request that there is some delay.

The benefits of this will be greatest when the cost of swapping sessions is higher, such as higher average context size. If a server is processing just a few thousand tokens at a time, and most requests are unrelated to earlier ones, there will be negligible gain. But if a coding harness is being used which makes many fast tool calls, the time savings can be significant.

Using a simple script (https://gist.github.com/nicois/34a8b26215e75e793da652a6ad55862e) I simulated a couple of concurrent sessions on my Arc b70 (with qwen3.8 27B). 

This session had `--slot-linger-ms 500`:
```
$ ~/.local/bin/slot-linger-harness.py --base http://192.168.0.23:8080 --model "Qwen3.8-27B Q4" --sessions 2 --turns 10 --seed-base 2000 --max-tokens 16384 --tool-wait-max 0.6 --fast 0.8 --tag fast
=== fast  base=http://192.168.0.23:8080  sessions=2 turns=10 requests=20 seed_base=2000 ===
wall time     : 270.4 s   throughput = 0.07 req/s
latency  all  : count=20   mean=19.908    p50=12.953    p90=17.226    p99=122.455   max=146.098   s
prompt   all  : count=20   mean=1420.050  p50=1099.209  p90=1444.418  p99=4305.679  max=4308.158  ms
cache reuse all : t0=0/2 (0%)  t1=2/2 (100%)  t2=2/2 (100%)  t3=2/2 (100%)  t4=2/2 (100%)  t5=2/2 (100%)  t6=2/2 (100%)  t7=2/2 (100%)  t8=2/2 (100%)  t9=2/2 (100%)

t0 cold  : latency count=2    mean=81.415    p50=81.415    p90=133.161   p99=144.804   max=146.098   s | prompt count=2    mean=4301.635  p50=4301.635  p90=4306.853  p99=4308.028  max=4308.158  ms | cache-reuse 0/2 (0%)
t1 follow: latency count=2    mean=18.400    p50=18.400    p90=21.011    p99=21.598    max=21.663    s | prompt count=2    mean=1104.935  p50=1104.935  p90=1105.814  p99=1106.012  max=1106.034  ms | cache-reuse 2/2 (100%)
t2 follow: latency count=2    mean=15.472    p50=15.472    p90=15.971    p99=16.083    max=16.095    s | prompt count=2    mean=1125.607  p50=1125.607  p90=1127.261  p99=1127.633  max=1127.674  ms | cache-reuse 2/2 (100%)
t3 follow: latency count=2    mean=12.135    p50=12.135    p90=13.337    p99=13.607    max=13.637    s | prompt count=2    mean=1093.586  p50=1093.586  p90=1094.610  p99=1094.840  max=1094.866  ms | cache-reuse 2/2 (100%)
t4 follow: latency count=2    mean=11.439    p50=11.439    p90=11.771    p99=11.846    max=11.854    s | prompt count=2    mean=1097.895  p50=1097.895  p90=1104.517  p99=1106.007  max=1106.173  ms | cache-reuse 2/2 (100%)
t5 follow: latency count=2    mean=12.652    p50=12.652    p90=12.879    p99=12.930    max=12.936    s | prompt count=2    mean=1094.349  p50=1094.349  p90=1099.630  p99=1100.818  max=1100.950  ms | cache-reuse 2/2 (100%)
t6 follow: latency count=2    mean=12.033    p50=12.033    p90=12.782    p99=12.950    max=12.969    s | prompt count=2    mean=1091.164  p50=1091.164  p90=1097.607  p99=1099.057  max=1099.218  ms | cache-reuse 2/2 (100%)
t7 follow: latency count=2    mean=13.861    p50=13.861    p90=14.024    p99=14.061    max=14.065    s | prompt count=2    mean=1094.722  p50=1094.722  p90=1095.185  p99=1095.289  max=1095.301  ms | cache-reuse 2/2 (100%)
t8 follow: latency count=2    mean=10.330    p50=10.330    p90=10.413    p99=10.432    max=10.434    s | prompt count=2    mean=1101.905  p50=1101.905  p90=1114.471  p99=1117.298  max=1117.612  ms | cache-reuse 2/2 (100%)
t9 follow: latency count=2    mean=11.342    p50=11.342    p90=11.472    p99=11.502    max=11.505    s | prompt count=2    mean=1094.697  p50=1094.697  p90=1098.300  p99=1099.110  max=1099.200  ms | cache-reuse 2/2 (100%)
```

while this one had the default `0` linger time:
```
$ ~/.local/bin/slot-linger-harness.py --base http://192.168.0.23:8080 --model "Qwen3.8-27B Q4" --sessions 2 --turns 10 --seed-base 3000 --max-tokens 16384 --tool-wait-max 0.6 --fast 0.8 --tag baseline
=== baseline  base=http://192.168.0.23:8080  sessions=2 turns=10 requests=20 seed_base=3000 ===
wall time     : 508.6 s   throughput = 0.04 req/s
latency  all  : count=20   mean=47.980    p50=39.755    p90=71.698    p99=108.458   max=109.841   s
prompt   all  : count=20   mean=1521.973  p50=1092.966  p90=1740.400  p99=5249.971  max=5477.663  ms
cache reuse all : t0=0/2 (0%)  t1=2/2 (100%)  t2=2/2 (100%)  t3=2/2 (100%)  t4=2/2 (100%)  t5=2/2 (100%)  t6=2/2 (100%)  t7=2/2 (100%)  t8=2/2 (100%)  t9=2/2 (100%)

t0 cold  : latency count=2    mean=26.097    p50=26.097    p90=31.112    p99=32.240    max=32.366    s | prompt count=2    mean=4878.472  p50=4878.472  p90=5357.825  p99=5465.679  max=5477.663  ms | cache-reuse 0/2 (0%)
t1 follow: latency count=2    mean=30.129    p50=30.129    p90=30.465    p99=30.541    max=30.549    s | prompt count=2    mean=1255.044  p50=1255.044  p90=1395.666  p99=1427.305  max=1430.821  ms | cache-reuse 2/2 (100%)
t2 follow: latency count=2    mean=34.898    p50=34.898    p90=35.537    p99=35.681    max=35.697    s | prompt count=2    mean=1276.820  p50=1276.820  p90=1422.006  p99=1454.672  max=1458.302  ms | cache-reuse 2/2 (100%)
t3 follow: latency count=2    mean=55.761    p50=55.761    p90=55.773    p99=55.776    max=55.776    s | prompt count=2    mean=1094.638  p50=1094.638  p90=1099.732  p99=1100.878  max=1101.005  ms | cache-reuse 2/2 (100%)
t4 follow: latency count=2    mean=70.263    p50=70.263    p90=101.926   p99=109.050   max=109.841   s | prompt count=2    mean=1089.540  p50=1089.540  p90=1091.913  p99=1092.447  max=1092.506  ms | cache-reuse 2/2 (100%)
t5 follow: latency count=2    mean=74.964    p50=74.964    p90=97.041    p99=102.008   max=102.560   s | prompt count=2    mean=1090.700  p50=1090.700  p90=1093.877  p99=1094.592  max=1094.671  ms | cache-reuse 2/2 (100%)
t6 follow: latency count=2    mean=35.983    p50=35.983    p90=44.893    p99=46.898    max=47.120    s | prompt count=2    mean=1091.620  p50=1091.620  p90=1093.066  p99=1093.391  max=1093.427  ms | cache-reuse 2/2 (100%)
t7 follow: latency count=2    mean=52.077    p50=52.077    p90=62.106    p99=64.362    max=64.613    s | prompt count=2    mean=1090.215  p50=1090.215  p90=1092.034  p99=1092.444  max=1092.489  ms | cache-reuse 2/2 (100%)
t8 follow: latency count=2    mean=50.783    p50=50.783    p90=59.434    p99=61.381    max=61.597    s | prompt count=2    mean=1254.668  p50=1254.668  p90=1390.535  p99=1421.105  max=1424.502  ms | cache-reuse 2/2 (100%)
t9 follow: latency count=2    mean=48.846    p50=48.846    p90=64.384    p99=67.880    max=68.269    s | prompt count=2    mean=1098.014  p50=1098.014  p90=1108.787  p99=1111.212  max=1111.481  ms | cache-reuse 2/2 (100%)
```

This shows how the average time before the first turn is much higher when linger is enabled, but subsequent turns are fast (as long as tool calls are under 500ms), meaning that (in this synthetic case) throughput is doubled. In a more realistic environment I would expect throughput improvements of 5-10%, but it will vary immensely based on workload. 

Note that I'm not very happy with the python tests, as there are assumptions about how quickly each request will be processed, as this will vary based on the CI/dev environment. For example, I could try performing a single LLM call during test setup, and using the timings from that to scale the tests' expectations.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  yes, it assisted with the code and test writing.
