### PR TITLE
tests: initialize the L2_NORM batch array

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7229,8 +7229,9 @@ struct test_l2_norm_batch : public test_case {
         if (strided) {
             parent = ggml_new_tensor_4d(ctx, type, ne[0], ne[1] * n_norms, ne[2], ne[3]);  // qkv buffer
         }
+        const int     n = n_norms;
         ggml_tensor * norms[8];
-        for (int t = 0; t < n_norms; ++t) {
+        for (int t = 0; t < n; ++t) {
             ggml_tensor * src;
             if (strided) {
                 src = ggml_view_4d(ctx, parent, ne[0], ne[1], ne[2], ne[3], parent->nb[1], parent->nb[2],
@@ -7240,8 +7241,8 @@ struct test_l2_norm_batch : public test_case {
             }
             norms[t] = ggml_l2_norm(ctx, src, eps);
         }
-        ggml_tensor * out = norms[n_norms - 1];
-        for (int t = n_norms - 2; t >= 0; --t) {
+        ggml_tensor * out = norms[n - 1];
+        for (int t = n - 2; t >= 0; --t) {
             out = ggml_add(ctx, norms[t], out);
         }
         ggml_set_name(out, "out");

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -7229,9 +7229,8 @@ struct test_l2_norm_batch : public test_case {
         if (strided) {
             parent = ggml_new_tensor_4d(ctx, type, ne[0], ne[1] * n_norms, ne[2], ne[3]);  // qkv buffer
         }
-        const int     n = n_norms;
-        ggml_tensor * norms[8];
-        for (int t = 0; t < n; ++t) {
+        ggml_tensor * norms[8] = {};
+        for (int t = 0; t < n_norms; ++t) {
             ggml_tensor * src;
             if (strided) {
                 src = ggml_view_4d(ctx, parent, ne[0], ne[1], ne[2], ne[3], parent->nb[1], parent->nb[2],
@@ -7241,8 +7240,8 @@ struct test_l2_norm_batch : public test_case {
             }
             norms[t] = ggml_l2_norm(ctx, src, eps);
         }
-        ggml_tensor * out = norms[n - 1];
-        for (int t = n - 2; t >= 0; --t) {
+        ggml_tensor * out = norms[n_norms - 1];
+        for (int t = n_norms - 2; t >= 0; --t) {
             out = ggml_add(ctx, norms[t], out);
         }
         ggml_set_name(out, "out");


### PR DESCRIPTION
## Overview

Initialize the array so the read after the fill loop is defined by the language, silencing the GCC maybe-uninitialized warning. No behavior change.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
