### PR TITLE
server : pass id_slot through the Anthropic /v1/messages conversion

### DIFF
--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -575,8 +575,10 @@ json server_chat_convert_anthropic_to_oai(const json & body) {
         oai_body["max_tokens"] = 4096;
     }
 
-    // Pass through common params
-    for (const auto & key : {"temperature", "top_p", "top_k", "stream", "chat_template_kwargs"}) {
+    // Pass through common params. id_slot: explicit slot pin, honoured by the
+    // completion handler on every other endpoint; a proxy pinning a session
+    // to the slot holding its KV cache needs it to survive the conversion.
+    for (const auto & key : {"temperature", "top_p", "top_k", "stream", "chat_template_kwargs", "id_slot"}) {
         if (body.contains(key)) {
             oai_body[key] = body.at(key);
         }

--- a/tools/server/tests/unit/test_compat_anthropic.py
+++ b/tools/server/tests/unit/test_compat_anthropic.py
@@ -701,6 +701,35 @@ def test_anthropic_top_k():
     assert res.body["type"] == "message"
 
 
+def test_anthropic_id_slot():
+    """Test that id_slot (llama.cpp specific) is honoured by the Anthropic endpoint"""
+    server.n_slots = 2
+    server.server_slots = True
+    server.start()
+
+    # on an idle server automatic selection picks the LAST slot (the LRU scan
+    # compares with <= and every slot starts with the same t_last_used), so
+    # pinning slot 0 is what shows whether id_slot survived the conversion
+    res = server.make_request("POST", "/v1/messages", data={
+        "model": "test",
+        "max_tokens": 8,
+        "id_slot": 0,
+        "messages": [
+            {"role": "user", "content": "Hello"}
+        ]
+    })
+
+    assert res.status_code == 200
+    assert res.body["type"] == "message"
+
+    slots_res = server.make_request("GET", "/slots")
+    assert slots_res.status_code == 200
+    slot_0 = next(slot for slot in slots_res.body if slot["id"] == 0)
+    slot_1 = next(slot for slot in slots_res.body if slot["id"] == 1)
+    assert slot_0["n_prompt_tokens"] > 0, "request should have been served by slot 0"
+    assert slot_1.get("n_prompt_tokens", 0) == 0, "slot 1 should not have served the request"
+
+
 # Error handling tests
 
 def test_anthropic_missing_messages():


### PR DESCRIPTION
## Overview

`server_chat_convert_anthropic_to_oai` copies a fixed list of request keys
(`temperature`, `top_p`, `top_k`, `stream`, `chat_template_kwargs`) into the
OAI body. `id_slot` is not in that list, so a slot pin that works on
`/completion` and `/v1/chat/completions` is silently ignored on
`/v1/messages`: the request falls back to automatic slot selection and no
error is returned.

This adds `id_slot` to the pass-through list so the Anthropic route behaves
like the other two.

Why it matters: I found this during development on
[my own project](https://github.com/pcvelz/llama-swap-macos-extended), a
llama-swap fork that keeps each client session on the slot already holding
its KV cache by sending `id_slot`. With a hybrid/recurrent model
(Qwen3-Next class) a wrong slot is not a partial cache hit but a full
re-prefill; on a 99k-token session that is ~16 minutes at ~100 t/s for a
single tool call. Running Claude Code against llama-server through the
Anthropic endpoint, the proxy pinned the slot, the child still logged
`selected slot by LCP similarity`, and `/slots` showed the request on the
other slot. With the patch the child logs `selected slot by id (N)` and
follow-ups append to the existing cache.

Test: `test_anthropic_id_slot` in
`tools/server/tests/unit/test_compat_anthropic.py`. With `n_slots = 2` on
an idle server automatic selection picks the last slot, so requesting slot 0
and asserting slot 0 served the request fails without the change.

## Additional information

Same fix as #26758 by @lobo235, unreviewed since August and flagged for the
PR template; this one follows the template. Fine with either being merged.

Not in this PR: the Anthropic response serializers (`to_json_anthropic`,
`to_json_anthropic_stream`) never emit `id_slot`, unlike the OAI path, so a
proxy cannot learn the slot from the response and has to assign it up
front. Emitting it in the non-streaming message and the `message_start`
event would close that gap; I can follow up separately if wanted.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the root cause was located and the patch and
  test were drafted with AI assistance (Claude); the change was built, run
  and verified by me on a real workload, and this description is mine.