### PR TITLE
metal : one backend device per physical GPU, with cross-device copy guard

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal-context.m
+++ b/ggml/src/ggml-metal/ggml-metal-context.m
@@ -142,6 +142,12 @@ ggml_metal_t ggml_metal_init(ggml_metal_device_t dev) {
         res->use_fusion      = getenv("GGML_METAL_FUSION_DISABLE") == nil;
         res->use_concurrency = getenv("GGML_METAL_CONCURRENCY_DISABLE") == nil;
 
+        // concurrent dispatch races on non-Apple GPUs (issue #25866)
+        if (res->use_concurrency && props_dev->gpu_family == 0) {
+            GGML_LOG_WARN("%s: concurrent dispatch disabled for non-Apple GPU %s (issue #25866)\n", __func__, props_dev->name);
+            res->use_concurrency = false;
+        }
+
         {
             const char * val = getenv("GGML_METAL_GRAPH_DEBUG");
             res->debug_graph = val ? atoi(val) : 0;
@@ -414,6 +420,12 @@ void ggml_metal_get_tensor_async(ggml_metal_t ctx, const struct ggml_tensor * te
 }
 
 bool ggml_metal_cpy_tensor_async(ggml_metal_t ctx_src, ggml_metal_t ctx_dst, const struct ggml_tensor * src, struct ggml_tensor * dst) {
+    // a private buffer is only accessible by the device that created it;
+    // cross-device copies fall back to the synchronous host staging path
+    if (ctx_src->dev != ctx_dst->dev) {
+        return false;
+    }
+
     @autoreleasepool {
         struct ggml_metal_buffer_id bid_src = ggml_metal_get_buffer_id(src);
         struct ggml_metal_buffer_id bid_dst = ggml_metal_get_buffer_id(dst);

--- a/ggml/src/ggml-metal/ggml-metal-device.h
+++ b/ggml/src/ggml-metal/ggml-metal-device.h
@@ -303,6 +303,7 @@ void ggml_metal_event_encode_wait  (ggml_metal_event_t ev, ggml_metal_cmd_buf_t 
 
 ggml_metal_device_t ggml_metal_device_init(int device, int n_devices);
 void ggml_metal_device_free(ggml_metal_device_t dev);
+size_t ggml_metal_physical_device_count(void);
 
 ggml_metal_device_t ggml_metal_device_get(int device, int n_devices);
 

--- a/ggml/src/ggml-metal/ggml-metal-device.m
+++ b/ggml/src/ggml-metal/ggml-metal-device.m
@@ -1088,6 +1088,36 @@ const char * ggml_metal_device_id_token(enum ggml_metal_device_id id) {
     return "GGML_METAL_DEVICE_GENERIC";
 }
 
+// physical GPUs sorted by VRAM, largest first
+static NSUInteger ggml_metal_device_vram(id<MTLDevice> mtl_dev) {
+    if (@available(macOS 10.12, iOS 16.0, *)) {
+        return [mtl_dev recommendedMaxWorkingSetSize];
+    }
+    return [mtl_dev maxBufferLength];
+}
+
+// caller must release the result
+static NSArray * ggml_metal_physical_devices(void) {
+    NSArray * devices = [MTLCopyAllDevices() copy];
+    NSArray * sorted = [devices sortedArrayUsingComparator:^NSComparisonResult(id<MTLDevice> a, id<MTLDevice> b) {
+        const NSUInteger size_a = ggml_metal_device_vram(a);
+        const NSUInteger size_b = ggml_metal_device_vram(b);
+        if (size_a == size_b) {
+            return NSOrderedSame;
+        }
+        return size_a > size_b ? NSOrderedAscending : NSOrderedDescending;
+    }];
+    [devices release]; // since it was created by a *Copy* C method
+    return [sorted retain];
+}
+
+size_t ggml_metal_physical_device_count(void) {
+    NSArray * devices = MTLCopyAllDevices();
+    const size_t count = devices.count;
+    [devices release];
+    return count;
+}
+
 ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
     ggml_metal_device_t dev = calloc(1, sizeof(struct ggml_metal_device));
 
@@ -1095,7 +1125,21 @@ ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
 
     @autoreleasepool {
         if (dev->mtl_device == nil) {
-            dev->mtl_device = MTLCreateSystemDefaultDevice();
+            // one backend device per physical GPU, ordered by VRAM (largest first)
+            NSArray * phys_devices = ggml_metal_physical_devices();
+            id<MTLDevice> selected_device = nil;
+            int phys_device = 0;
+            if ((NSUInteger)device < phys_devices.count) {
+                selected_device = phys_devices[device];
+                phys_device = device;
+            }
+            if (selected_device != nil) {
+                dev->mtl_device = [selected_device retain];
+            } else {
+                // index out of range (e.g. GGML_METAL_DEVICES virtual splits): use the default GPU
+                dev->mtl_device = MTLCreateSystemDefaultDevice();
+            }
+            [phys_devices release];
 
             if (dev->mtl_device) {
                 dev->mtl_queue = [dev->mtl_device newCommandQueue];
@@ -1107,9 +1151,9 @@ ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
 
                 dev->props.device = device;
 
-                // the Metal backend uses the system default device as the single physical device;
-                // additional (virtual) devices are emulated on top of it via GGML_METAL_DEVICES
-                dev->props.device_phys = 0;
+                // device index maps to a physical GPU (largest VRAM first);
+                // indices beyond that are virtual devices on the default GPU
+                dev->props.device_phys = phys_device;
                 dev->props.device_virt = device;
 
                 dev->props.has_simdgroup_reduction  = [dev->mtl_device supportsFamily:MTLGPUFamilyApple7];
@@ -2394,6 +2438,12 @@ bool ggml_metal_buffer_cpy_tensor(ggml_metal_buffer_t buf_dst, const struct ggml
     if (buf_dst->is_shared && buf_src->is_shared) {
         memcpy(dst->data, src->data, size);
         return true;
+    }
+
+    // a private buffer is only readable by the device that created it;
+    // for cross-device copies fall back to the host staging path
+    if (buf_src->dev != buf_dst->dev) {
+        return false;
     }
 
     // for private buffers, we need to use Metal blit commands

--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -972,6 +972,12 @@ ggml_backend_reg_t ggml_backend_metal_reg(void) {
         const char * env = getenv("GGML_METAL_DEVICES");
         if (env) {
             g_devices = atoi(env);
+        } else {
+            // one device per physical GPU, ordered by VRAM (largest first)
+            g_devices = (int)ggml_metal_physical_device_count();
+            if (g_devices < 1) {
+                g_devices = 1;
+            }
         }
 
         static std::vector<ggml_backend_device_ptr> devs;


### PR DESCRIPTION
## Overview

This fixes multi-GPU selection in the Metal backend on Macs with more than one physical GPU, for example an Intel Mac with an eGPU.

Previously, all Metal backend devices ended up on the system default GPU, which meant that adding multiple MTL devices didn’t actually allow using multiple physical GPUs.

With this change, backend device indices are mapped to the available physical GPUs, sorted by VRAM (largest first). So MTL0 uses the GPU with the most VRAM, MTL1 the next one, etc.

Existing behavior is kept for GGML_METAL_DEVICES and for device indices that don’t map to a physical GPU. Those continue to use virtual devices on the default GPU.

This also makes it possible to split layers across physical GPUs, for example:

-dev MTL0,MTL1

Tensor copies between different physical GPUs use the host staging path. Metal private buffers can’t be accessed directly from a GPU other than the one that created them.

I also disabled concurrent dispatch on non-Apple GPU families as a workaround for #25866.

Fixes #28565

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

Tested on macOS 26.5.1 on a 2019 Intel MacBook Pro with:

* Radeon Pro 5600M (8 GB)
* RX 6900 XT (16 GB) connected as an eGPU over TB3

The branch has been rebased onto current master.

Benchmarks with Gemma 4 12B UD-Q4_K_XL (pp / tg, t/s):

* RX 6900 XT (MTL0): 62 / 34
* Radeon Pro 5600M (MTL1): 19 / 14
* RX 6900 XT + Radeon Pro 5600M: 45 / 21

There are two limitations I ran into while testing that appear to be unrelated to this change:

* Large prompts on a single eGPU can hit the existing buffer upload issue tracked in #26949.
* Sustained VRAM overcommit on the internal AMD GPU can cause multi-second stalls in the macOS AMD driver. This appears to be an OS/driver issue rather than something specific to llama.cpp.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with die [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — I used AI assistance while working on parts of the implementation and PR description. I reviewed the resulting changes, tested them on the hardware described above, and verified that I understand the code being submitted. 
