### PR TITLE
model : re-enable -sm tensor for qwen4exp

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -1149,7 +1149,6 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
         case LLM_ARCH_BAILINGMOE3:
         case LLM_ARCH_KIMI_K3:
         case LLM_ARCH_QWEN3TTS:
-        case LLM_ARCH_QWEN4EXP:   // TODO: fix test-llama-archs
             return false;
         default:
             return true;

--- a/src/models/qwen4exp.cpp
+++ b/src/models/qwen4exp.cpp
@@ -373,6 +373,8 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
             ggml_reshape_3d(ctx0, inpL, n_embd, 1, n_tokens),
             n_embd, hc, n_tokens, 1);
     cb(res_hc, "hc_init", -1);
+    // make sure hc_init is in the same graph split as the first layer (-sm tensor)
+    ggml_build_forward_expand(gf, res_hc);
 
     for (int il = 0; il < n_layer; ++il) {
         res->t_layer_inp[il] = res_hc;


### PR DESCRIPTION
## Overview

Re-enables `-sm tensor` for qwen4exp. #27941 disabled it because `test-llama-archs -a qwen4exp` asserted on the Meta device once the fixture carried a PLE layer, and removed the test's earlier Meta skip for the arch.

The abort is a scheduler placement, not QSA. `test-llama-archs` builds the model with the embeddings host-resident, so the PLE embedding gather (`ggml_get_rows` on `per_layer_token_embd`) is a CPU node. In the qwen4exp graph `hc_init` (the `ggml_repeat_4d` that fans the embedding out to the hc streams) is first materialised inside layer 0's PLE path, after that gather. `ggml_backend_sched_split_graph` pass 2 expands a device assignment upwards only until it meets a CPU-assigned node, so the REPEAT is never reached from the first Meta node and "expand rest" leaves it on the CPU. The later `ggml_reshape_3d(hc_init)` inside the PLE query norm is then a view of a host-resident node inside the meta split, which `ggml_backend_meta_graph_compute` only tolerates for `view_src->op == GGML_OP_NONE`: `GGML_ASSERT(ggml_backend_buffer_is_meta(tensor->buffer))` at ggml-backend-meta.cpp:476. deepseek4 builds the same hc init but its REPEAT is followed directly by a weight matmul, so the expansion reaches it.

Fix: `ggml_build_forward_expand(gf, res_hc)` right after `hc_init` is built. The REPEAT then directly precedes the first device node and pass 2 assigns it there; the embedding reshape stays in the CPU split and is copied in as a split input, the same shape deepseek4's graph has.

`test-llama-archs` on this branch (master dbeb37548 + the change; RelWithDebInfo, RADV gfx1151, Mesa 25.2.8):

| arch | Vulkan | Meta (-sm tensor) |
|---|---|---|
| qwen4exp | OK (8.67e-08) | OK (8.67e-08), was GGML_ASSERT |
| deepseek4 | OK (8.86e-08) | OK (8.86e-08) |
| qwen35 | OK (8.80e-08) | OK (8.80e-08) |

Real model: Qwen3.8-Flash-Next UD-Q4_K_XL, `-sm tensor` over two RPC devices (#26610 tree with this change, one Vulkan `ggml-rpc-server` per Strix Halo box, ctx 65536) vs a single device, greedy: byte-identical on a short prompt and on a 1.8k-token prompt (1752 generated tokens), and identical to master's single-device output.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI-assisted analysis of the scheduler passes and test runs; the change and the tests were reviewed and run by me.