### PR TITLE
rpc : query the remote backend's supports_op instead of assuming every op is supported

### DIFF
--- a/ggml/include/ggml-rpc.h
+++ b/ggml/include/ggml-rpc.h
@@ -8,7 +8,8 @@ extern "C" {
 
 #define RPC_PROTO_MAJOR_VERSION    6
 #define RPC_PROTO_MINOR_VERSION    0
-#define RPC_PROTO_PATCH_VERSION    0
+// 6.0.1: RPC_CMD_GET_DEVICE_SUPPORTS_OP (optional; servers below 6.0.1 are assumed to support every op)
+#define RPC_PROTO_PATCH_VERSION    1
 
 #ifdef  __cplusplus
 static_assert(GGML_OP_COUNT == 101, "GGML_OP_COUNT has changed - update RPC_PROTO_PATCH_VERSION");

--- a/ggml/src/ggml-rpc/ggml-rpc.cpp
+++ b/ggml/src/ggml-rpc/ggml-rpc.cpp
@@ -78,6 +78,7 @@ enum rpc_cmd {
     RPC_CMD_GRAPH_RECOMPUTE,
     RPC_CMD_MEMSET_TENSOR,
     RPC_CMD_NONE,
+    RPC_CMD_GET_DEVICE_SUPPORTS_OP, // 6.0.1; sent only to servers advertising patch >= 1
     RPC_CMD_COUNT,
 };
 
@@ -204,6 +205,16 @@ struct rpc_msg_graph_recompute_req {
     uint32_t device;
 };
 
+struct rpc_msg_get_device_supports_op_req {
+    uint32_t   device;
+    rpc_tensor op;
+    rpc_tensor srcs[GGML_MAX_SRC];
+};
+
+struct rpc_msg_get_device_supports_op_rsp {
+    uint8_t supported;
+};
+
 #pragma pack(pop)
 
 // RPC data structures
@@ -213,12 +224,18 @@ static ggml_guid_t ggml_backend_rpc_guid() {
     return &guid;
 }
 
+class rpc_dispatcher;
+
 struct ggml_backend_rpc_device_context {
     std::string endpoint;
     uint32_t    device;
     std::string name;
     std::string description;
     uint64_t    last_graph_uid;
+    bool        supports_op_query;
+    std::shared_ptr<rpc_dispatcher> dispatcher;         // keeps the connection open between supports_op queries
+    std::mutex                      supports_op_mutex;
+    std::unordered_map<std::string, bool> supports_op_cache; // keyed by op signature (op, op_params, dst/src types+shapes)
 };
 
 struct ggml_backend_rpc_buffer_type_context {
@@ -304,6 +321,41 @@ static bool parse_endpoint(const std::string & endpoint, std::string & host, int
     return true;
 }
 
+struct rpc_server_version {
+    uint8_t major;
+    uint8_t minor;
+    uint8_t patch;
+};
+
+static std::mutex & rpc_endpoint_versions_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+static std::unordered_map<std::string, rpc_server_version> & rpc_endpoint_versions() {
+    static std::unordered_map<std::string, rpc_server_version> versions;
+    return versions;
+}
+
+static void rpc_endpoint_set_version(const std::string & endpoint, const rpc_msg_hello_rsp & response) {
+    std::lock_guard<std::mutex> lock(rpc_endpoint_versions_mutex());
+    rpc_endpoint_versions()[endpoint] = rpc_server_version {
+        response.major,
+        response.minor,
+        response.patch,
+    };
+}
+
+static bool rpc_endpoint_has_op_support_query(const std::string & endpoint) {
+    std::lock_guard<std::mutex> lock(rpc_endpoint_versions_mutex());
+    auto & versions = rpc_endpoint_versions();
+    auto it = versions.find(endpoint);
+    return it != versions.end() &&
+        it->second.major == RPC_PROTO_MAJOR_VERSION &&
+        it->second.minor == RPC_PROTO_MINOR_VERSION &&
+        it->second.patch >= 1;
+}
+
 // RPC request : | rpc_cmd (1 byte) | request_size (8 bytes) | request_data (request_size bytes) |
 // No response
 static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, size_t input_size) {
@@ -344,7 +396,7 @@ static bool send_rpc_cmd(socket_ptr sock, enum rpc_cmd cmd, const void * input, 
 // Performs HELLO handshake with transport auto-negotiation.
 // Advertises local capabilities via conn_caps; if the server responds with
 // matching capabilities, the socket is upgraded transparently.
-static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
+static bool negotiate_hello(const std::string & endpoint, const std::shared_ptr<socket_t> & sock) {
     rpc_msg_hello_req request = {};
     rpc_msg_hello_rsp response = {};
 
@@ -359,6 +411,7 @@ static bool negotiate_hello(const std::shared_ptr<socket_t> & sock) {
         return false;
     }
 
+    rpc_endpoint_set_version(endpoint, response);
     sock->update_caps(response.conn_caps);
     return true;
 }
@@ -546,7 +599,7 @@ void rpc_dispatcher::start(const std::string & endpoint) {
     if (sock == nullptr) {
         GGML_ABORT("Failed to connect to %s\n", endpoint.c_str());
     }
-    if (!negotiate_hello(sock)) {
+    if (!negotiate_hello(endpoint, sock)) {
         GGML_ABORT("RPC handshake failed for %s\n", endpoint.c_str());
     }
     LOG_DBG("[%s] connected to %s\n", __func__, endpoint.c_str());
@@ -1152,6 +1205,7 @@ public:
     bool init_tensor(const rpc_msg_init_tensor_req & request);
     bool get_alloc_size(const rpc_msg_get_alloc_size_req & request, rpc_msg_get_alloc_size_rsp & response);
     bool get_device_memory(const rpc_msg_get_device_memory_req & request, rpc_msg_get_device_memory_rsp & response);
+    bool get_device_supports_op(const rpc_msg_get_device_supports_op_req & request, rpc_msg_get_device_supports_op_rsp & response);
 
     struct stored_graph {
         std::vector<uint8_t>   buffer;
@@ -1781,6 +1835,42 @@ bool rpc_server::get_device_memory(const rpc_msg_get_device_memory_req & request
     return true;
 }
 
+bool rpc_server::get_device_supports_op(const rpc_msg_get_device_supports_op_req & request, rpc_msg_get_device_supports_op_rsp & response) {
+    uint32_t dev_id = request.device;
+    if (dev_id >= backends.size()) {
+        return false;
+    }
+
+    struct ggml_init_params params {
+        /*.mem_size   =*/ ggml_tensor_overhead()*(1 + GGML_MAX_SRC),
+        /*.mem_buffer =*/ NULL,
+        /*.no_alloc   =*/ true,
+    };
+
+    ggml_context_ptr ctx_ptr { ggml_init(params) };
+    GGML_ASSERT(ctx_ptr != nullptr);
+    ggml_context * ctx = ctx_ptr.get();
+
+    ggml_tensor * op = deserialize_tensor(ctx, &request.op);
+    if (op == nullptr) {
+        GGML_LOG_ERROR("Null tensor pointer passed to server supports_op function.\n");
+        return false;
+    }
+
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        if (request.srcs[i].id != 0) {
+            op->src[i] = deserialize_tensor(ctx, &request.srcs[i]);
+            if (op->src[i] == nullptr) {
+                GGML_LOG_ERROR("Null source tensor pointer passed to server supports_op function.\n");
+                return false;
+            }
+        }
+    }
+
+    response.supported = ggml_backend_supports_op(backends[dev_id], op) ? 1 : 0;
+    return true;
+}
+
 rpc_server::~rpc_server() {
     for (auto buffer : buffers) {
         ggml_backend_buffer_free(buffer);
@@ -2047,6 +2137,20 @@ static void rpc_serve_client(const std::vector<ggml_backend_t> & backends, const
                 }
                 break;
             }
+            case RPC_CMD_GET_DEVICE_SUPPORTS_OP: {
+                rpc_msg_get_device_supports_op_req request;
+                if (!recv_msg(sock, &request, sizeof(request))) {
+                    return;
+                }
+                rpc_msg_get_device_supports_op_rsp response;
+                if (!server.get_device_supports_op(request, response)) {
+                    return;
+                }
+                if (!send_msg(sock, &response, sizeof(response))) {
+                    return;
+                }
+                break;
+            }
             default: {
                 GGML_LOG_ERROR("Unknown command: %d\n", cmd);
                 return;
@@ -2184,10 +2288,60 @@ static ggml_backend_buffer_type_t ggml_backend_rpc_device_get_buffer_type(ggml_b
 }
 
 static bool ggml_backend_rpc_device_supports_op(ggml_backend_dev_t dev, const struct ggml_tensor * op) {
-    GGML_UNUSED(dev);
-    GGML_UNUSED(op);
-    //TODO: call the remote backend and cache the results
-    return true;
+    ggml_backend_rpc_device_context * ctx = (ggml_backend_rpc_device_context *) dev->context;
+    if (!ctx->supports_op_query) {
+        LOG_DBG("[%s] server %s does not support remote op support queries; assuming supported for compatibility\n",
+                __func__, ctx->endpoint.c_str());
+        return true;
+    }
+
+    std::string key;
+    key.reserve(256);
+    auto add_tensor = [&key](const ggml_tensor * t) {
+        if (t == nullptr) { key.push_back('-'); return; }
+        key.append(std::to_string((int) t->type)); key.push_back(':');
+        for (int d = 0; d < GGML_MAX_DIMS; d++) { key.append(std::to_string(t->ne[d])); key.push_back(','); }
+        key.push_back(ggml_is_contiguous(t) ? 'c' : 'n'); key.push_back(';');
+    };
+    key.append(std::to_string((int) op->op)); key.push_back('/');
+    key.append((const char *) op->op_params, sizeof(op->op_params));
+    key.push_back('/');
+    add_tensor(op);
+    for (int i = 0; i < GGML_MAX_SRC; i++) {
+        add_tensor(op->src[i]);
+    }
+    {
+        std::lock_guard<std::mutex> lock(ctx->supports_op_mutex);
+        auto it = ctx->supports_op_cache.find(key);
+        if (it != ctx->supports_op_cache.end()) {
+            return it->second;
+        }
+    }
+
+    auto request = std::make_shared<rpc_msg_get_device_supports_op_req>();
+    request->device = ctx->device;
+    request->op = serialize_tensor(op);
+    for (uint32_t i = 0; i < GGML_MAX_SRC; i++) {
+        request->srcs[i] = serialize_tensor(op->src[i]);
+    }
+
+    rpc_msg_get_device_supports_op_rsp response = {};
+    std::shared_ptr<rpc_dispatcher> dispatcher;
+    {
+        std::lock_guard<std::mutex> lock(ctx->supports_op_mutex);
+        if (!ctx->dispatcher) {
+            ctx->dispatcher = get_dispatcher(ctx->endpoint);
+        }
+        dispatcher = ctx->dispatcher;
+    }
+    dispatcher->send(RPC_CMD_GET_DEVICE_SUPPORTS_OP, request, sizeof(*request), &response, sizeof(response));
+
+    const bool supported = response.supported != 0;
+    {
+        std::lock_guard<std::mutex> lock(ctx->supports_op_mutex);
+        ctx->supports_op_cache.emplace(key, supported);
+    }
+    return supported;
 }
 
 static bool ggml_backend_rpc_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
@@ -2317,6 +2471,7 @@ ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
     if (dev_count == 0) {
         return nullptr;
     }
+    const bool supports_op_query = rpc_endpoint_has_op_support_query(endpoint);
     ggml_backend_rpc_reg_context * ctx = new ggml_backend_rpc_reg_context;
     ctx->name = "RPC[" + std::string(endpoint) + "]";
     for (uint32_t ind = 0; ind < dev_count; ind++) {
@@ -2328,6 +2483,10 @@ ggml_backend_reg_t ggml_backend_rpc_add_server(const char * endpoint) {
             /* .name        = */    dev_name,
             /* .description = */    dev_desc,
             /* .last_graph_uid = */ 0,
+            /* .supports_op_query = */ supports_op_query,
+            /* .dispatcher  = */    nullptr,
+            /* .supports_op_mutex = */ {},
+            /* .supports_op_cache = */ {},
         };
 
         ggml_backend_dev_t dev = new ggml_backend_device {


### PR DESCRIPTION
## Overview

Rebase of #24325 by @zihaomu (closed under the one-open-PR limit; he invited reuse) onto the proto-6 RPC client, with two changes on top of the original:

1. The dispatcher is held on the RPC device context. `get_dispatcher()` caches by `weak_ptr`, so a `supports_op` query issued before any backend or buffer holds the dispatcher (llama's tensor-placement probes at model load) opened a TCP connection per call: 1,180 connections and a 30-minute load for Qwen3.8-Flash-Next Q4_K_XL at 262k before the change, 6 connections and 132 s after.
2. Answers are memoised per op signature (op, op_params, dst/src types, shapes, contiguity), the TODO in the original.

Protocol 6.0.1; servers below 6.0.1 are assumed to support every op, as before.

What it fixes, measured on two Strix Halo boxes (Vulkan/RADV both ends, one `ggml-rpc-server` per box, USB4 link):

- Qwen3.8-Flash-Next (qwen4exp) two-box at 524k and 1M context loads at `-ub 2048`. On master the RPC worker requests the indexer's `[n_kv, n_ubatch]` F32 tensor as one allocation (4 GiB + 4 B at 524k x 2048), over RADV's maxBufferSize; single-box the Vulkan `supports_op` declines it and the graph falls back, over RPC the device says yes to everything. Loads: 524k 128 s, 1M 156 s; pp16k 284 t/s at -ub 2048 vs 215 at the `-ub 512` workaround.
- DeepSeek-V4-Flash Q4_K_XL two-box on a tree without the Vulkan fused HC ops: the ops resolve to the RPC device ("assigned to device RPC0 (usually due to missing support)") and the worker dies with `vk::Queue::submit: ErrorDeviceLost` on the first graph. With the query they resolve to "not supported, set to disabled" and the model runs (Q4_K_XL at 262k: 106 / 7.7 t/s pp/tg; IQ4_XS at 1M loads at -ub 2048). Same mechanism as #24177 (HIP TOP_K asserting on the remote).
- Output identity: Qwen3.8-Flash-Next 1,752-token greedy completion byte-identical to single-box.
- Decode overhead of the query: none measurable, 20.27 to 20.41 t/s across the five compatibility arms vs 20.47 on the same two-box shape without it.

Full `test-backend-ops` on Vulkan: 18371/18371.

## Additional information

Compatibility matrix (Flash-Next Q4_K_XL two-box, 50/50 layer split):

| client / server | context | load | worker connections | prompt A | note |
|---|---|---|---|---|---|
| new / new | 262k | 156 s | 4 | identical, tg 20.41 | |
| new / new | 1M, -ub 2048 | 188 s | 4 | short tg 19.35; pp16k 297.8 | the shape master cannot load |
| new / old 6.0.0 | 262k | 133 s | 8 | identical, tg 20.33 | silent fallback to "assume supported" |
| new / old 6.0.0 | 1M, -ub 2048 | fails at 121 s | 8 | | `graph_reserve: failed to allocate compute buffers`, as master |
| old 6.0.0 / new | 262k | 133 s | 8 | identical, tg 20.27 | |

Ref #24325, #24177.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used to port the original change onto the current client, to collect and reduce the test and benchmark data, and to organize this description; I reviewed the changes and ran the tests, and I am responsible for them.