### PR TITLE
ggml-cuda: pipeline NVFP4 MMQ tile loads with cp.async and TMA on Blackwell (+14% pp)

### DIFF
--- a/ggml/src/ggml-cuda/cp-async.cuh
+++ b/ggml/src/ggml-cuda/cp-async.cuh
@@ -1,3 +1,5 @@
+#pragma once
+
 // Simplified API for asynchronous data loading.
 
 #include "common.cuh"
@@ -41,6 +43,37 @@ static __device__ __forceinline__ void cp_async_cg_16(const unsigned int dst, co
 #else
     GGML_UNUSED(dst);
     GGML_UNUSED(src);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_AVAILABLE
+}
+
+// 4 byte copy through L1 (ca == cache all) for sources that are only 4 byte aligned, e.g. the 36 byte NVFP4 blocks.
+static __device__ __forceinline__ void cp_async_ca_4(const unsigned int dst, const void * src) {
+#ifdef CP_ASYNC_AVAILABLE
+    asm volatile("cp.async.ca.shared.global [%0], [%1], 4;" : : "r"(dst), "l"(src));
+#else
+    GGML_UNUSED(dst);
+    GGML_UNUSED(src);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_AVAILABLE
+}
+
+// Groups the copies issued so far by this thread, see cp_async_wait_group.
+static __device__ __forceinline__ void cp_async_commit_group() {
+#ifdef CP_ASYNC_AVAILABLE
+    asm volatile("cp.async.commit_group;");
+#else
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_AVAILABLE
+}
+
+// Waits until at most N of this thread's copy groups are still pending. Like cp_async_wait_all this
+// does not synchronize between threads.
+template <int N>
+static __device__ __forceinline__ void cp_async_wait_group() {
+#ifdef CP_ASYNC_AVAILABLE
+    asm volatile("cp.async.wait_group %0;" : : "n"(N));
+#else
     NO_DEVICE_CODE;
 #endif // CP_ASYNC_AVAILABLE
 }

--- a/ggml/src/ggml-cuda/cp-async.cuh
+++ b/ggml/src/ggml-cuda/cp-async.cuh
@@ -78,6 +78,103 @@ static __device__ __forceinline__ void cp_async_wait_group() {
 #endif // CP_ASYNC_AVAILABLE
 }
 
+// Bulk asynchronous copies (sm_90+): one instruction moves a contiguous, 16 byte aligned range whose size is a
+// multiple of 16 bytes and signals completion on an mbarrier in shared memory, without any per thread copy
+// instructions or a block wide barrier. The waiting side spins on the barrier phase.
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+#define CP_ASYNC_BULK_AVAILABLE
+#endif // defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900 && !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+
+// initialize an mbarrier that completes a phase after `arrivals` arrivals (and all expected transaction bytes)
+static __device__ __forceinline__ void mbarrier_init(uint64_t * bar, const uint32_t arrivals) {
+#ifdef CP_ASYNC_BULK_AVAILABLE
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" : : "r"(ggml_cuda_cvta_generic_to_shared(bar)), "r"(arrivals) : "memory");
+#else
+    GGML_UNUSED(bar);
+    GGML_UNUSED(arrivals);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_BULK_AVAILABLE
+}
+
+// makes the initialized barriers visible to the async proxy, call once after all inits and before use
+static __device__ __forceinline__ void mbarrier_fence_init() {
+#ifdef CP_ASYNC_BULK_AVAILABLE
+    asm volatile("fence.mbarrier_init.release.cluster;" : : : "memory");
+#else
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_BULK_AVAILABLE
+}
+
+static __device__ __forceinline__ void mbarrier_arrive(uint64_t * bar) {
+#ifdef CP_ASYNC_BULK_AVAILABLE
+    asm volatile("mbarrier.arrive.shared::cta.b64 _, [%0];" : : "r"(ggml_cuda_cvta_generic_to_shared(bar)) : "memory");
+#else
+    GGML_UNUSED(bar);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_BULK_AVAILABLE
+}
+
+// arrive and register `bytes` of bulk copy transactions that must complete before the phase flips
+static __device__ __forceinline__ void mbarrier_arrive_expect_tx(uint64_t * bar, const uint32_t bytes) {
+#ifdef CP_ASYNC_BULK_AVAILABLE
+    asm volatile("mbarrier.arrive.expect_tx.shared::cta.b64 _, [%0], %1;" : : "r"(ggml_cuda_cvta_generic_to_shared(bar)), "r"(bytes) : "memory");
+#else
+    GGML_UNUSED(bar);
+    GGML_UNUSED(bytes);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_BULK_AVAILABLE
+}
+
+// wait until the phase with the given parity (0 or 1) has completed
+static __device__ __forceinline__ void mbarrier_wait_parity(uint64_t * bar, const uint32_t parity) {
+#ifdef CP_ASYNC_BULK_AVAILABLE
+    asm volatile(
+        "{\n"
+        ".reg .pred done;\n"
+        "wait_loop_%=:\n"
+        "mbarrier.try_wait.parity.shared::cta.b64 done, [%0], %1;\n"
+        "@!done bra wait_loop_%=;\n"
+        "}\n"
+        : : "r"(ggml_cuda_cvta_generic_to_shared(bar)), "r"(parity) : "memory");
+#else
+    GGML_UNUSED(bar);
+    GGML_UNUSED(parity);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_BULK_AVAILABLE
+}
+
+// copy `bytes` (multiple of 16) from 16 byte aligned global memory to 16 byte aligned shared memory,
+// completion is counted on the mbarrier
+static __device__ __forceinline__ void cp_async_bulk_g2s(void * dst, const void * src, const uint32_t bytes, uint64_t * bar) {
+#ifdef CP_ASYNC_BULK_AVAILABLE
+    asm volatile("cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
+        : : "r"(ggml_cuda_cvta_generic_to_shared(dst)), "l"(src), "r"(bytes), "r"(ggml_cuda_cvta_generic_to_shared(bar)) : "memory");
+#else
+    GGML_UNUSED(dst);
+    GGML_UNUSED(src);
+    GGML_UNUSED(bytes);
+    GGML_UNUSED(bar);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_BULK_AVAILABLE
+}
+
+// 2D tensor copy (TMA) of one box described by the tensor map at coordinates (c0 in elements of the inner
+// dimension, c1 rows) into 128 byte aligned shared memory, completion counted on the mbarrier. tmap must be a
+// __grid_constant__ kernel parameter or live in global/constant memory.
+static __device__ __forceinline__ void cp_async_bulk_tensor_2d_g2s(void * dst, const void * tmap, const int c0, const int c1, uint64_t * bar) {
+#ifdef CP_ASYNC_BULK_AVAILABLE
+    asm volatile("cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [%0], [%1, {%2, %3}], [%4];"
+        : : "r"(ggml_cuda_cvta_generic_to_shared(dst)), "l"(tmap), "r"(c0), "r"(c1), "r"(ggml_cuda_cvta_generic_to_shared(bar)) : "memory");
+#else
+    GGML_UNUSED(dst);
+    GGML_UNUSED(tmap);
+    GGML_UNUSED(c0);
+    GGML_UNUSED(c1);
+    GGML_UNUSED(bar);
+    NO_DEVICE_CODE;
+#endif // CP_ASYNC_BULK_AVAILABLE
+}
+
 // Makes each thread wait until its asynchronous data copies are done.
 // This does NOT provide any additional synchronization.
 // In particular, when copying data with multiple warps a call to __syncthreads will be needed.

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -1173,8 +1173,10 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 // Both quantizations encode values as e2m1 (FP4) and produce one uint32 scale per
 // m16n8k64 MMA call; only the PTX kind (scale_vec::2X ue8m0 vs scale_vec::4X ue4m3)
 // and the per-type stride constant differ.
-// x tile rows of sram_stride ints: the quantized values followed by the packed block scales at x_sc_offset
-template <ggml_type type, int J, bool fallback, int sram_stride, int x_sc_offset>
+// x tile rows of sram_stride ints. x_raw == false: the quantized values followed by the packed block scales
+// at x_sc_offset (ldmatrix friendly). x_raw == true: the rows are the NVFP4 blocks as stored in memory, 9 words
+// per block (the scale word, then 8 value words), so the fragments are gathered with plain loads.
+template <ggml_type type, int J, bool fallback, int sram_stride, int x_sc_offset, bool x_raw = false>
 static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_fp4_fp4_mma_impl(
         const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
 
@@ -1185,6 +1187,8 @@ static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_fp4_fp4_mma_impl(
     constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
     constexpr int ntx           = rows_per_warp / tile_C::I;
     constexpr int nfrags        = MMQ_TILE_NE_K / tile_A::J;
+    constexpr int wpb           = sizeof(block_nvfp4) / sizeof(int); // words per raw block
+    static_assert(!x_raw || type == GGML_TYPE_NVFP4, "raw x rows are only defined for NVFP4");
 
     y += (threadIdx.y % ntx) * (tile_C::J * MMQ_TILE_Y_K);
 
@@ -1207,12 +1211,27 @@ static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_fp4_fp4_mma_impl(
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
-        const uint4 sa = *(const uint4 *) (x_sc + (i0 + n * tile_A::I + tidx_A) * sram_stride + k00 / tile_A::J);
-        scaleA[n][0] = sa.x; scaleA[n][1] = sa.y; scaleA[n][2] = sa.z; scaleA[n][3] = sa.w;
+        if constexpr (x_raw) {
+            const int * row_sc = x_qs + (i0 + n * tile_A::I + tidx_A) * sram_stride + (k00 / tile_A::J) * wpb;
 #pragma unroll
-        for (int frag = 0; frag < nfrags; ++frag) {
-            const int k0 = k00 + frag * tile_A::J;
-            load_ldmatrix(A[n][frag], x_qs + (i0 + n * tile_A::I) * sram_stride + k0, sram_stride);
+            for (int frag = 0; frag < nfrags; ++frag) {
+                scaleA[n][frag] = row_sc[frag * wpb];
+                // value word w of block frag is raw word frag*wpb + 1 + w of the row. The registers follow the
+                // ldmatrix.x4 order used by load_ldmatrix: rows g and g+8 at word tig, then at word tig + 4.
+                const int * blk = x_qs + (i0 + n * tile_A::I + threadIdx.x / 4) * sram_stride + (k00 / tile_A::J + frag) * wpb + 1 + threadIdx.x % 4;
+                A[n][frag].x[0] = blk[0];
+                A[n][frag].x[1] = blk[8 * sram_stride];
+                A[n][frag].x[2] = blk[4];
+                A[n][frag].x[3] = blk[8 * sram_stride + 4];
+            }
+        } else {
+            const uint4 sa = *(const uint4 *) (x_sc + (i0 + n * tile_A::I + tidx_A) * sram_stride + k00 / tile_A::J);
+            scaleA[n][0] = sa.x; scaleA[n][1] = sa.y; scaleA[n][2] = sa.z; scaleA[n][3] = sa.w;
+#pragma unroll
+            for (int frag = 0; frag < nfrags; ++frag) {
+                const int k0 = k00 + frag * tile_A::J;
+                load_ldmatrix(A[n][frag], x_qs + (i0 + n * tile_A::I) * sram_stride + k0, sram_stride);
+            }
         }
     }
 

--- a/ggml/src/ggml-cuda/mmq-vec-dot.cuh
+++ b/ggml/src/ggml-cuda/mmq-vec-dot.cuh
@@ -1173,14 +1173,15 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 // Both quantizations encode values as e2m1 (FP4) and produce one uint32 scale per
 // m16n8k64 MMA call; only the PTX kind (scale_vec::2X ue8m0 vs scale_vec::4X ue4m3)
 // and the per-type stride constant differ.
-template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_fp4_fp4_mma(
+// x tile rows of sram_stride ints: the quantized values followed by the packed block scales at x_sc_offset
+template <ggml_type type, int J, bool fallback, int sram_stride, int x_sc_offset>
+static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_fp4_fp4_mma_impl(
         const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
 
     typedef tile<16, 8, int>   tile_A;
     typedef tile<8,  8, int>   tile_B;
     typedef tile<16, 8, float> tile_C;
 
-    constexpr int sram_stride   = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
     constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
     constexpr int ntx           = rows_per_warp / tile_C::I;
     constexpr int nfrags        = MMQ_TILE_NE_K / tile_A::J;
@@ -1188,7 +1189,7 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
     y += (threadIdx.y % ntx) * (tile_C::J * MMQ_TILE_Y_K);
 
     const int *      x_qs = (const int *) x;
-    const uint32_t * x_sc = (const uint32_t *) (x_qs + 2 * MMQ_TILE_NE_K);
+    const uint32_t * x_sc = (const uint32_t *) (x_qs + x_sc_offset);
     const int *      y_qs = (const int *) y + 4;
     const uint32_t * y_sc = (const uint32_t *) y;
 
@@ -1198,16 +1199,20 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
     const int tidx_B = threadIdx.x / 4;
     const int i0     = (threadIdx.y / ntx) * rows_per_warp;
 
+    // the scale words of the nfrags fragments of a row are adjacent and 16 byte aligned, one vector load each
+    static_assert(nfrags == 4 && (sram_stride*4) % 16 == 0 && (MMQ_TILE_Y_K*4) % 16 == 0, "scale vector loads need 16 byte aligned rows");
+
     tile_A   A[ntx][nfrags];
     uint32_t scaleA[ntx][nfrags];
 
 #pragma unroll
     for (int n = 0; n < ntx; ++n) {
+        const uint4 sa = *(const uint4 *) (x_sc + (i0 + n * tile_A::I + tidx_A) * sram_stride + k00 / tile_A::J);
+        scaleA[n][0] = sa.x; scaleA[n][1] = sa.y; scaleA[n][2] = sa.z; scaleA[n][3] = sa.w;
 #pragma unroll
         for (int frag = 0; frag < nfrags; ++frag) {
             const int k0 = k00 + frag * tile_A::J;
             load_ldmatrix(A[n][frag], x_qs + (i0 + n * tile_A::I) * sram_stride + k0, sram_stride);
-            scaleA[n][frag] = x_sc[(i0 + n * tile_A::I + tidx_A) * sram_stride + k0 / tile_A::J];
         }
     }
 
@@ -1216,25 +1221,28 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
         tile_B   B[nfrags];
         uint32_t scaleB[nfrags];
 
+        const uint4 sb = *(const uint4 *) (y_sc + (j0 + tidx_B) * MMQ_TILE_Y_K);
+        scaleB[0] = sb.x; scaleB[1] = sb.y; scaleB[2] = sb.z; scaleB[3] = sb.w;
 #pragma unroll
         for (int frag = 0; frag < nfrags; ++frag) {
             const int k0 = frag * tile_B::J;
             load_generic(B[frag], y_qs + j0 * MMQ_TILE_Y_K + k0, MMQ_TILE_Y_K);
-            scaleB[frag] = y_sc[(j0 + tidx_B) * MMQ_TILE_Y_K + frag];
         }
 
 #pragma unroll
         for (int n = 0; n < ntx; ++n) {
+            // accumulate in place, the sum layout matches tile_C
+            tile_C & C = *reinterpret_cast<tile_C *>(sum + (j0 / tile_C::J + n) * tile_C::ne);
 #pragma unroll
             for (int frag = 0; frag < nfrags; ++frag) {
-                tile_C C = {};
                 mma_block_scaled_fp4<type>(C, A[n][frag], B[frag], scaleA[n][frag], scaleB[frag]);
-#pragma unroll
-                for (int l = 0; l < tile_C::ne; ++l) {
-                    sum[(j0 / tile_C::J + n) * tile_C::ne + l] += C.x[l];
-                }
             }
         }
     }
 }
 
+template <ggml_type type, int J, bool fallback> static __device__ __forceinline__ void ggml_cuda_mmq_vec_dot_fp4_fp4_mma(
+        const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00) {
+    constexpr int sram_stride = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+    ggml_cuda_mmq_vec_dot_fp4_fp4_mma_impl<type, J, fallback, sram_stride, 2*MMQ_TILE_NE_K>(x, y, sum, k00);
+}

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -82,6 +82,63 @@ static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, con
     }
 }
 
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 12050
+typedef CUresult (*ggml_cuda_tmap_encode_t)(CUtensorMap *, CUtensorMapDataType, cuuint32_t, void *, const cuuint64_t *,
+    const cuuint64_t *, const cuuint32_t *, const cuuint32_t *, CUtensorMapInterleave, CUtensorMapSwizzle,
+    CUtensorMapL2promotion, CUtensorMapFloatOOBfill);
+
+// cuTensorMapEncodeTiled through the runtime, so that no driver library needs to be linked
+static ggml_cuda_tmap_encode_t ggml_cuda_get_tmap_encode() {
+    static ggml_cuda_tmap_encode_t fn = nullptr;
+    static bool tried = false;
+    if (!tried) {
+        tried = true;
+        void * ptr = nullptr;
+        cudaDriverEntryPointQueryResult status;
+        if (cudaGetDriverEntryPointByVersion("cuTensorMapEncodeTiled", &ptr, 12000, cudaEnableDefault, &status) == cudaSuccess &&
+                status == cudaDriverEntryPointSuccess) {
+            fn = (ggml_cuda_tmap_encode_t) ptr;
+        } else {
+            (void) cudaGetLastError();
+        }
+    }
+    return fn;
+}
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 12050
+
+bool ggml_cuda_mmq_encode_tmap_nvfp4(const ggml_tensor * src0, const int cc, ggml_cuda_tmap & tmap) {
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 12050
+    if (src0->type != GGML_TYPE_NVFP4 || !blackwell_mma_available(cc)) {
+        return false;
+    }
+    // 144 byte boxes need 16 byte aligned row spans: K % 256 == 0; rows of all channels and samples are one
+    // strided 2D array, so the tensor has to be contiguous
+    const int64_t row_bytes = ggml_row_size(src0->type, src0->ne[0]);
+    const int64_t nrows     = src0->ne[1]*src0->ne[2]*src0->ne[3];
+    if (src0->ne[0] % 256 != 0 || (size_t) row_bytes != src0->nb[1] || !ggml_is_contiguous(src0) ||
+            reinterpret_cast<uintptr_t>(src0->data) % 16 != 0 || nrows > INT32_MAX) {
+        return false;
+    }
+    const ggml_cuda_tmap_encode_t encode = ggml_cuda_get_tmap_encode();
+    if (!encode) {
+        return false;
+    }
+    const cuuint64_t global_dim[2]     = { (cuuint64_t) row_bytes, (cuuint64_t) nrows };
+    const cuuint64_t global_stride[1]  = { (cuuint64_t) row_bytes };
+    const cuuint32_t box_dim[2]        = { MMQ_FP4_TMA_BOX_BYTES, (cuuint32_t) ggml_cuda_mmq_get_I(GGML_TYPE_NVFP4, 8, false, cc) };
+    const cuuint32_t element_stride[2] = { 1, 1 };
+    const CUresult res = encode(&tmap, CU_TENSOR_MAP_DATA_TYPE_UINT8, 2, src0->data, global_dim, global_stride, box_dim,
+        element_stride, CU_TENSOR_MAP_INTERLEAVE_NONE, CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+        CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    return res == CUDA_SUCCESS;
+#else
+    GGML_UNUSED(src0);
+    GGML_UNUSED(cc);
+    GGML_UNUSED(tmap);
+    return false;
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 12050
+}
+
 void ggml_cuda_mul_mat_q(
         ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst) {
     GGML_ASSERT(        src1->type == GGML_TYPE_F32);
@@ -165,9 +222,13 @@ void ggml_cuda_mul_mat_q(
                                 ne11 * ne10_padded * sizeof(block_q8_1) / (QK8_1 * sizeof(int));
         const int64_t s13 = ne12*s12;
 
+        ggml_cuda_tmap tmap_x;
+        const bool use_tmap = ggml_cuda_mmq_encode_tmap_nvfp4(src0, cc, tmap_x);
+
         const mmq_args args = {
             src0_d, src0->type, (const int *) src1_q8_1.ptr, nullptr, nullptr, dst_d,
             src0->type == GGML_TYPE_NVFP4 && use_native_fp4 ? src1_scale.ptr : nullptr,
+            use_tmap ? &tmap_x : nullptr,
             ne00, ne01, ne1, s01, ne11, s1,
             ne02, ne12, s02, s12, s2,
             ne03, ne13, s03, s13, s3,
@@ -245,9 +306,13 @@ void ggml_cuda_mul_mat_q(
     const int64_t s13 = ne12*s12;
 
     // Note that ne02 is used instead of ne12 because the number of y channels determines the z dimension of the CUDA grid.
+    ggml_cuda_tmap tmap_x;
+    const bool use_tmap = ggml_cuda_mmq_encode_tmap_nvfp4(src0, cc, tmap_x);
+
     const mmq_args args = {
         src0_d, src0->type, (const int *) src1_q8_1.get(), ids_dst.get(), expert_bounds.get(), dst_d,
         src1_scale.ptr,
+        use_tmap ? &tmap_x : nullptr,
         ne00, ne01, ne_get_rows, s01, ne_get_rows, s1,
         ne02, ne02, s02, s12, s2,
         ne03, ne13, s03, s13, s3,

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common.cuh"
+#include "cp-async.cuh"
 
 #include <climits>
 #include <cstdint>
@@ -9,6 +10,11 @@
 #define MMQ_ITER_K             256
 #define MMQ_ITER_K_FP4         512
 #define MMQ_NWARPS               8
+
+// NVFP4 on Blackwell processes its tile with a cp.async pipeline of MMQ_FP4_PIPE_STAGES stages of 256 values in K,
+// see mul_mat_q_process_tile_fp4_pipe. Each x stage row holds 32 words of values and 4 words of block scales.
+#define MMQ_FP4_PIPE_STAGES 2
+#define MMQ_FP4_PIPE_XS     36
 
 typedef void (*ggml_cuda_mmq_load_tiles_t)(const char * __restrict__ x, int * x_tile, const int kbx0, const int i_max, const int stride);
 typedef void (*ggml_cuda_mmq_vec_dot_t)(const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00);
@@ -865,6 +871,106 @@ static constexpr __device__ ggml_cuda_mmq_write_back_t ggml_cuda_mmq_get_write_b
 
 // ---------------------------------------------------------------------------------------------
 
+#if defined(BLACKWELL_MMA_AVAILABLE)
+// NVFP4 tile processing with a two stage cp.async pipeline: while the tensor cores work on one stage of
+// 256 values in K, the copies for the next stage are in flight. NVFP4 blocks are 36 bytes (4 scale bytes,
+// then 32 bytes of values), so the x tile is copied word by word into rows of MMQ_FP4_PIPE_XS ints:
+// the 32 words of values, then the 4 scale words. The y tile is the contiguous block_fp4_mmq layout.
+template <ggml_type type, int J, bool fallback, bool fixup>
+static __device__ __forceinline__ void mul_mat_q_process_tile_fp4_pipe(
+        const char * __restrict__ x, const int offset_x, const int * __restrict__ y,
+        const int * __restrict__ ids_dst, float * __restrict__ dst, float * __restrict__ tmp_fixup,
+        const float * __restrict__ y_scale,
+        const int stride_row_x, const int ncols_y, const int stride_col_dst,
+        const int tile_x_max_i, const int tile_y_max_j, const int kb0_start, const int kb0_stop) {
+    static_assert(type == GGML_TYPE_NVFP4, "pipelined tile processing is only implemented for NVFP4");
+
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads  = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps    = nthreads / warp_size;
+    constexpr int I         = ggml_cuda_mmq_get_I(type, J, fallback);
+    constexpr int XS        = MMQ_FP4_PIPE_XS;
+    constexpr int KB_STAGE  = 8*MMQ_TILE_NE_K / QK_NVFP4;       // blocks of 64 values per stage
+    constexpr int WPB       = sizeof(block_nvfp4) / sizeof(int); // words per block
+    constexpr int X_STAGE   = I*XS;                              // ints per x stage buffer
+    constexpr int Y_STAGE   = J*MMQ_TILE_Y_K;                    // ints per y stage buffer
+    constexpr int sz        = sizeof(block_q8_1_mmq) / sizeof(int);
+    static_assert(XS == MMQ_TILE_NE_K + KB_STAGE && XS % 8 == 4, "x stage rows: values, scales, ldmatrix friendly stride");
+    static_assert(sizeof(block_nvfp4) % sizeof(int) == 0, "NVFP4 blocks must be word aligned");
+    constexpr ggml_cuda_mmq_write_back_t write_back = ggml_cuda_mmq_get_write_back<type, J, fallback>();
+
+    extern __shared__ int data_mul_mat_q[];
+    int * stages = data_mul_mat_q + J; // [MMQ_FP4_PIPE_STAGES][X_STAGE + Y_STAGE], after the ids
+
+    const int tid = threadIdx.y*warp_size + threadIdx.x;
+
+    // x copy: the stage data of a row is KB_STAGE*WPB consecutive words, lane l copies word l and, for the words
+    // beyond the warp, word warp_size + l. Word q of a row lands in the scale area (word 0 of a block) or the
+    // value area (words 1..8 of a block); these per lane destinations are loop invariant.
+    constexpr int ROW_WORDS = KB_STAGE*WPB;
+    static_assert(ROW_WORDS > warp_size && ROW_WORDS <= 2*warp_size && I % nwarps == 0, "bad x row copy split");
+    auto x_dst_word = [](const int q) {
+        const int b = q / WPB;
+        const int w = q % WPB;
+        return w == 0 ? MMQ_TILE_NE_K + b : 8*b + (w - 1);
+    };
+    const int lane = threadIdx.x;
+    const int q1   = warp_size + lane;
+    const int d0   = x_dst_word(lane);
+    const int d1   = x_dst_word(q1 < ROW_WORDS ? q1 : 0);
+
+    // copy the stage starting at block kb0 into stage buffer s
+    auto issue = [&](const int kb0, const int s) {
+        int * xs = stages + s*(X_STAGE + Y_STAGE);
+        int * ys = xs + X_STAGE;
+#pragma unroll
+        for (int r = 0; r < I/nwarps; ++r) {
+            const int i     = threadIdx.y*(I/nwarps) + r;
+            const int i_src = fallback ? min(i, tile_x_max_i) : i;
+            const int * row = (const int *) ((const block_nvfp4 *) x + offset_x + i_src*stride_row_x + kb0);
+            cp_async_ca_4(ggml_cuda_cvta_generic_to_shared(xs + i*XS + d0), row + lane);
+            if (q1 < ROW_WORDS) {
+                cp_async_ca_4(ggml_cuda_cvta_generic_to_shared(xs + i*XS + d1), row + q1);
+            }
+        }
+        const int * by0 = y + ncols_y * (kb0*QK_NVFP4/QK_FP4_MMQ) * sz;
+        for (int l = 4*tid; l < Y_STAGE; l += 4*nthreads) {
+            cp_async_cg_16<0>(ggml_cuda_cvta_generic_to_shared(ys + l), by0 + l);
+        }
+        cp_async_commit_group();
+    };
+
+    float sum[J*I / (nwarps*warp_size)] = {0.0f};
+
+    // a partial last stage reads x past kb0_stop (finite values, padding or the next row) against zero padded y
+    const int n_stages = (kb0_stop - kb0_start + KB_STAGE - 1) / KB_STAGE;
+    if (n_stages > 0) {
+        issue(kb0_start, 0);
+    }
+    for (int s = 0; s < n_stages; ++s) {
+        // the buffer of stage s+1 was last read in iteration s-1, which ended with a barrier
+        if (s + 1 < n_stages) {
+            issue(kb0_start + (s + 1)*KB_STAGE, (s + 1) % MMQ_FP4_PIPE_STAGES);
+            cp_async_wait_group<1>();
+        } else {
+            cp_async_wait_group<0>();
+        }
+        __syncthreads();
+
+        const int * xs = stages + (s % MMQ_FP4_PIPE_STAGES)*(X_STAGE + Y_STAGE);
+        ggml_cuda_mmq_vec_dot_fp4_fp4_mma_impl<type, J, fallback, XS, MMQ_TILE_NE_K>(xs, xs + X_STAGE, sum, 0);
+
+        __syncthreads();
+    }
+
+    if (fixup) {
+        write_back(sum, ids_dst, tmp_fixup + blockIdx.x*(J*I), y_scale, I, I, J);
+    } else {
+        write_back(sum, ids_dst, dst, y_scale, stride_col_dst, tile_x_max_i, tile_y_max_j);
+    }
+}
+#endif // defined(BLACKWELL_MMA_AVAILABLE)
+
 template <ggml_type type, int J, bool fallback, bool fixup>
 static __device__ __forceinline__ void mul_mat_q_process_tile(
         const char * __restrict__ x, const int offset_x, const int * __restrict__ y,
@@ -872,6 +978,14 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
         const float * __restrict__ y_scale,
         const int stride_row_x, const int ncols_y, const int stride_col_dst,
         const int tile_x_max_i, const int tile_y_max_j, const int kb0_start, const int kb0_stop) {
+#if defined(BLACKWELL_MMA_AVAILABLE)
+    if constexpr (type == GGML_TYPE_NVFP4) {
+        mul_mat_q_process_tile_fp4_pipe<type, J, fallback, fixup>(
+            x, offset_x, y, ids_dst, dst, tmp_fixup, y_scale, stride_row_x, ncols_y, stride_col_dst,
+            tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
+        return;
+    }
+#endif // defined(BLACKWELL_MMA_AVAILABLE)
 
     constexpr int              warp_size  = ggml_cuda_get_physical_warp_size();
     constexpr int              nwarps     = ggml_cuda_mmq_get_nthreads(type, J, fallback) / warp_size;
@@ -1380,6 +1494,9 @@ struct mmq_args {
 
 static size_t mmq_get_nbytes_shared(const ggml_cuda_mmq_config & config, const int cc) {
     const size_t nbs_ids = config.J*sizeof(int);
+    if (blackwell_mma_available(cc) && config.type == GGML_TYPE_NVFP4) {
+        return nbs_ids + MMQ_FP4_PIPE_STAGES*(config.I*MMQ_FP4_PIPE_XS + config.J*MMQ_TILE_Y_K)*sizeof(int);
+    }
     const size_t nbs_x = ggml_cuda_mmq_get_nbytes_shared_x(config, cc);
     const size_t nbs_y = config.J * (sizeof(block_q8_1_mmq));
     return nbs_ids + nbs_x + GGML_PAD(nbs_y, config.nthreads*sizeof(int));

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -6,6 +6,16 @@
 #include <climits>
 #include <cstdint>
 
+// TMA tensor map for the NVFP4 weight tile (see mul_mat_q_process_tile_fp4_bulk), an opaque 128 byte descriptor
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+#include <cuda.h>
+typedef CUtensorMap ggml_cuda_tmap;
+#define GGML_CUDA_GRID_CONSTANT __grid_constant__
+#else
+struct alignas(64) ggml_cuda_tmap { char opaque[128]; };
+#define GGML_CUDA_GRID_CONSTANT
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+
 #define MMQ_DP4A_MAX_BATCH_SIZE 64 // Max. batch size to use for dp4a MMQ kernels when FP16 tensor cores are available.
 #define MMQ_ITER_K             256
 #define MMQ_ITER_K_FP4         512
@@ -15,6 +25,8 @@
 // see mul_mat_q_process_tile_fp4_pipe. Each x stage row holds 32 words of values and 4 words of block scales.
 #define MMQ_FP4_PIPE_STAGES 2
 #define MMQ_FP4_PIPE_XS     36
+#define MMQ_FP4_PIPE_NBAR   (2*MMQ_FP4_PIPE_STAGES) // full and empty mbarrier per stage (bulk copy variant)
+#define MMQ_FP4_TMA_BOX_BYTES 144                    // inner box of the weight tensor map: 4 NVFP4 blocks
 
 typedef void (*ggml_cuda_mmq_load_tiles_t)(const char * __restrict__ x, int * x_tile, const int kbx0, const int i_max, const int stride);
 typedef void (*ggml_cuda_mmq_vec_dot_t)(const int * __restrict__ x, const int * __restrict__ y, float * __restrict__ sum, const int k00);
@@ -969,22 +981,132 @@ static __device__ __forceinline__ void mul_mat_q_process_tile_fp4_pipe(
         write_back(sum, ids_dst, dst, y_scale, stride_col_dst, tile_x_max_i, tile_y_max_j);
     }
 }
+
+// Same pipeline with hardware copies: the whole x stage (I rows x 144 bytes, one box of the tensor map, rows
+// past the matrix are zero filled) and the whole y stage are each moved by a single asynchronous copy that
+// completes on the stage's full barrier, so no thread spends instructions on copying. The x rows stay in their
+// raw block layout (see x_raw in the vec dot). Consumers release a stage buffer through its empty barrier,
+// there is no block wide synchronization in the loop. Requires K % 256 == 0 (16 byte aligned 144 byte spans).
+template <ggml_type type, int J, bool fallback, bool fixup>
+static __device__ __forceinline__ void mul_mat_q_process_tile_fp4_bulk(
+        const ggml_cuda_tmap * __restrict__ tmap_x, const int offset_x, const int * __restrict__ y,
+        const int * __restrict__ ids_dst, float * __restrict__ dst, float * __restrict__ tmp_fixup,
+        const float * __restrict__ y_scale,
+        const int stride_row_x, const int ncols_y, const int stride_col_dst,
+        const int tile_x_max_i, const int tile_y_max_j, const int kb0_start, const int kb0_stop) {
+    static_assert(type == GGML_TYPE_NVFP4, "bulk tile processing is only implemented for NVFP4");
+
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int nthreads  = ggml_cuda_mmq_get_nthreads(type, J, fallback);
+    constexpr int nwarps    = nthreads / warp_size;
+    constexpr int I         = ggml_cuda_mmq_get_I(type, J, fallback);
+    constexpr int KB_STAGE  = 8*MMQ_TILE_NE_K / QK_NVFP4;        // blocks of 64 values per stage
+    constexpr int WPB       = sizeof(block_nvfp4) / sizeof(int);  // words per block
+    constexpr int XS        = KB_STAGE*WPB;                       // raw row stride in ints (36)
+    constexpr int X_STAGE   = I*XS;
+    constexpr int Y_STAGE   = J*MMQ_TILE_Y_K;
+    constexpr int STAGES    = MMQ_FP4_PIPE_STAGES;
+    constexpr int sz        = sizeof(block_q8_1_mmq) / sizeof(int);
+    constexpr uint32_t X_BYTES = X_STAGE*sizeof(int);
+    constexpr uint32_t Y_BYTES = Y_STAGE*sizeof(int);
+    static_assert(XS == MMQ_FP4_PIPE_XS && XS*sizeof(int) == MMQ_FP4_TMA_BOX_BYTES, "the stage row is one tensor map box row");
+    static_assert(X_BYTES % 128 == 0 && Y_BYTES % 16 == 0, "copy destinations must stay aligned");
+    constexpr ggml_cuda_mmq_write_back_t write_back = ggml_cuda_mmq_get_write_back<type, J, fallback>();
+
+    extern __shared__ int data_mul_mat_q[];
+    // stage buffers start 128 byte aligned (tensor copies), the barriers follow them
+    int      * stages = (int *) (((uintptr_t) (data_mul_mat_q + J) + 127) & ~(uintptr_t) 127); // [STAGES][X_STAGE + Y_STAGE]
+    uint64_t * full   = (uint64_t *) (stages + STAGES*(X_STAGE + Y_STAGE));
+    uint64_t * empty  = full + STAGES;
+
+    const int  lane   = threadIdx.x;
+    const bool leader = threadIdx.y == 0 && lane == 0;
+
+    // the leader issues both copies of a stage and arrives once on the full barrier, each warp releases a
+    // buffer with one arrival on the empty barrier
+    // a block processes several tiles in a row, a warp may still be releasing the last stage of the previous tile
+    __syncthreads();
+    if (leader) {
+#pragma unroll
+        for (int s = 0; s < STAGES; ++s) {
+            mbarrier_init(full  + s, 1);
+            mbarrier_init(empty + s, nwarps);
+        }
+        mbarrier_fence_init();
+    }
+    __syncthreads();
+
+    // the tensor map addresses x as bytes per row and rows over all channels and samples
+    const int row0 = offset_x / stride_row_x;
+
+    auto issue = [&](const int kb0, const int s) {
+        int * xs = stages + s*(X_STAGE + Y_STAGE);
+        int * ys = xs + X_STAGE;
+        mbarrier_arrive_expect_tx(full + s, X_BYTES + Y_BYTES);
+        cp_async_bulk_tensor_2d_g2s(xs, tmap_x, kb0*(int) sizeof(block_nvfp4), row0, full + s);
+        cp_async_bulk_g2s(ys, y + ncols_y * (kb0*QK_NVFP4/QK_FP4_MMQ) * sz, Y_BYTES, full + s);
+    };
+
+    float sum[J*I / (nwarps*warp_size)] = {0.0f};
+
+    const int n_stages = (kb0_stop - kb0_start) / KB_STAGE; // exact, K is a multiple of the stage
+    if (leader && n_stages > 0) {
+        issue(kb0_start, 0);
+    }
+    for (int s = 0; s < n_stages; ++s) {
+        const int      buf   = s % STAGES;
+        const uint32_t round = s / STAGES;
+        if (leader && s + 1 < n_stages) {
+            const int      buf1   = (s + 1) % STAGES;
+            const uint32_t round1 = (s + 1) / STAGES;
+            // the buffer of stage s+1 was released by every warp after stage s+1-STAGES; the first round passes
+            mbarrier_wait_parity(empty + buf1, (round1 & 1) ^ 1);
+            issue(kb0_start + (s + 1)*KB_STAGE, buf1);
+        }
+        mbarrier_wait_parity(full + buf, round & 1);
+
+        const int * xs = stages + buf*(X_STAGE + Y_STAGE);
+        ggml_cuda_mmq_vec_dot_fp4_fp4_mma_impl<type, J, fallback, XS, 0, true>(xs, xs + X_STAGE, sum, 0);
+
+        __syncwarp();
+        if (lane == 0) {
+            mbarrier_arrive(empty + buf);
+        }
+    }
+
+    GGML_UNUSED(tile_x_max_i); // rows past the matrix are zero filled by the tensor copy
+
+    if (fixup) {
+        write_back(sum, ids_dst, tmp_fixup + blockIdx.x*(J*I), y_scale, I, I, J);
+    } else {
+        write_back(sum, ids_dst, dst, y_scale, stride_col_dst, tile_x_max_i, tile_y_max_j);
+    }
+}
 #endif // defined(BLACKWELL_MMA_AVAILABLE)
 
 template <ggml_type type, int J, bool fallback, bool fixup>
 static __device__ __forceinline__ void mul_mat_q_process_tile(
-        const char * __restrict__ x, const int offset_x, const int * __restrict__ y,
+        const char * __restrict__ x, const ggml_cuda_tmap * __restrict__ tmap_x, const int offset_x, const int * __restrict__ y,
         const int * __restrict__ ids_dst, float * __restrict__ dst, float * __restrict__ tmp_fixup,
         const float * __restrict__ y_scale,
         const int stride_row_x, const int ncols_y, const int stride_col_dst,
         const int tile_x_max_i, const int tile_y_max_j, const int kb0_start, const int kb0_stop) {
 #if defined(BLACKWELL_MMA_AVAILABLE)
     if constexpr (type == GGML_TYPE_NVFP4) {
-        mul_mat_q_process_tile_fp4_pipe<type, J, fallback, fixup>(
-            x, offset_x, y, ids_dst, dst, tmp_fixup, y_scale, stride_row_x, ncols_y, stride_col_dst,
-            tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
+        // the host provides a tensor map when the TMA path applies (K % 256 == 0, contiguous rows)
+        if (tmap_x != nullptr) {
+            mul_mat_q_process_tile_fp4_bulk<type, J, fallback, fixup>(
+                tmap_x, offset_x, y, ids_dst, dst, tmp_fixup, y_scale, stride_row_x, ncols_y, stride_col_dst,
+                tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
+        } else {
+            mul_mat_q_process_tile_fp4_pipe<type, J, fallback, fixup>(
+                x, offset_x, y, ids_dst, dst, tmp_fixup, y_scale, stride_row_x, ncols_y, stride_col_dst,
+                tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
+        }
         return;
     }
+#else
+    GGML_UNUSED(tmap_x);
 #endif // defined(BLACKWELL_MMA_AVAILABLE)
 
     constexpr int              warp_size  = ggml_cuda_get_physical_warp_size();
@@ -1061,7 +1183,8 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 template <ggml_type type, int J, bool fallback>
 __launch_bounds__(ggml_cuda_mmq_get_nthreads(type, J, fallback), ggml_cuda_mmq_get_occupancy(type, J, fallback))
 static __global__ void mul_mat_q(
-        const char * __restrict__ x, const int * __restrict__ y, const int32_t * __restrict__ ids_dst,
+        const char * __restrict__ x, const GGML_CUDA_GRID_CONSTANT ggml_cuda_tmap tmap_x, const int use_tmap_x,
+        const int * __restrict__ y, const int32_t * __restrict__ ids_dst,
         const int32_t * __restrict__ expert_bounds, float * __restrict__ dst, float * __restrict__ tmp_fixup,
         const float * __restrict__ y_scale,
         const uint3 blocks_per_ne00, const int nrows_x, const int ncols_dst, const int stride_row_x, const int ncols_y, const int stride_col_dst,
@@ -1162,7 +1285,7 @@ static __global__ void mul_mat_q(
 
         constexpr bool fixup = false;
         mul_mat_q_process_tile<type, J, fallback, fixup>
-            (x, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, y_scale_tile,
+            (x, use_tmap_x ? &tmap_x : nullptr, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, y_scale_tile,
              stride_row_x, ncols_y, stride_col_dst,
              tile_x_max_i, tile_y_max_j, 0, blocks_per_ne00.z);
         return;
@@ -1256,7 +1379,7 @@ static __global__ void mul_mat_q(
 
         constexpr bool fixup = false; // All but (potentially) the last iterations write their data to dst rather than the fixup buffer.
         mul_mat_q_process_tile<type, J, fallback, fixup>
-            (x, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, y_scale_tile,
+            (x, use_tmap_x ? &tmap_x : nullptr, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, y_scale_tile,
              stride_row_x, ncols_y, stride_col_dst,
              tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
 
@@ -1340,7 +1463,7 @@ static __global__ void mul_mat_q(
 
     constexpr bool fixup = true; // Last index writes its data to fixup buffer to avoid data races with other blocks.
     mul_mat_q_process_tile<type, J, fallback, fixup>
-        (x, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, y_scale_tile,
+        (x, use_tmap_x ? &tmap_x : nullptr, offset_x, y + offset_y, ids_dst_shared, dst + offset_dst, tmp_fixup, y_scale_tile,
          stride_row_x, ncols_y, stride_col_dst,
          tile_x_max_i, tile_y_max_j, kb0_start, kb0_stop);
 }
@@ -1486,6 +1609,7 @@ static __global__ void mul_mat_q_stream_k_fixup(
 struct mmq_args {
     const char * x; ggml_type type_x; const int * y; const int32_t * ids_dst; const int32_t * expert_bounds; float * dst;
     const float * y_scale;
+    const ggml_cuda_tmap * tmap_x; // tensor map of x for the TMA tile path (NVFP4 on Blackwell), or nullptr
     int64_t ncols_x; int64_t nrows_x; int64_t ncols_dst; int64_t stride_row_x; int64_t ncols_y; int64_t nrows_dst;
     int64_t nchannels_x; int64_t nchannels_y; int64_t stride_channel_x; int64_t stride_channel_y; int64_t stride_channel_dst;
     int64_t nsamples_x; int64_t nsamples_y; int64_t stride_sample_x; int64_t stride_sample_y; int64_t stride_sample_dst;
@@ -1495,7 +1619,8 @@ struct mmq_args {
 static size_t mmq_get_nbytes_shared(const ggml_cuda_mmq_config & config, const int cc) {
     const size_t nbs_ids = config.J*sizeof(int);
     if (blackwell_mma_available(cc) && config.type == GGML_TYPE_NVFP4) {
-        return nbs_ids + MMQ_FP4_PIPE_STAGES*(config.I*MMQ_FP4_PIPE_XS + config.J*MMQ_TILE_Y_K)*sizeof(int);
+        // stage buffers aligned to 128 bytes for the tensor copies, then the barriers
+        return nbs_ids + 128 + MMQ_FP4_PIPE_STAGES*(config.I*MMQ_FP4_PIPE_XS + config.J*MMQ_TILE_Y_K)*sizeof(int) + MMQ_FP4_PIPE_NBAR*sizeof(uint64_t);
     }
     const size_t nbs_x = ggml_cuda_mmq_get_nbytes_shared_x(config, cc);
     const size_t nbs_y = config.J * (sizeof(block_q8_1_mmq));
@@ -1536,9 +1661,13 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     const uint3 channel_ratio_fd   = init_fastdiv_values(channel_ratio);
     const uint3 sample_ratio_fd    = init_fastdiv_values(sample_ratio);
 
+    // the tensor map is passed by value as a kernel parameter, a zeroed one when unused
+    const ggml_cuda_tmap tmap_x = args.tmap_x ? *args.tmap_x : ggml_cuda_tmap{};
+    const int use_tmap_x = args.tmap_x != nullptr;
+
     if (!ggml_cuda_mmq_get_stream_k(type, J, fallback, cc)) {
         mul_mat_q<type, J, fallback><<<block_nums_xy_tiling, block_dims, nbytes_shared, stream>>>
-            (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, nullptr, args.y_scale,
+            (args.x, tmap_x, use_tmap_x, args.y, args.ids_dst, args.expert_bounds, args.dst, nullptr, args.y_scale,
              blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
              channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
              sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
@@ -1567,7 +1696,7 @@ static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & a
     const dim3 block_dims_fixup(block_dims.x, block_dims.y/2, block_dims.z);
 
     mul_mat_q<type, J, fallback><<<block_nums_stream_k, block_dims, nbytes_shared, stream>>>
-        (args.x, args.y, args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr, args.y_scale,
+        (args.x, tmap_x, use_tmap_x, args.y, args.ids_dst, args.expert_bounds, args.dst, tmp_fixup.ptr, args.y_scale,
          blocks_per_ne00_fd, args.nrows_x, args.ncols_dst, args.stride_row_x, args.ncols_y, args.nrows_dst,
          channel_ratio_fd, nchannels_y_fd, args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst,
          sample_ratio_fd, nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst,
@@ -1711,5 +1840,8 @@ extern DECL_MMQ_CASE(GGML_TYPE_NVFP4);
 
 void ggml_cuda_mul_mat_q(
         ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst);
+
+// encodes the tensor map of an NVFP4 weight tensor for the TMA tile path when it applies, returns false otherwise
+bool ggml_cuda_mmq_encode_tmap_nvfp4(const ggml_tensor * src0, int cc, ggml_cuda_tmap & tmap);
 
 bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t n_experts);


### PR DESCRIPTION
## Overview

NVFP4 prefill was starving the tensor cores: every thread copied its piece of each tile and the block waited at a barrier. Overlap the loads with the MMAs, hand them to the TMA engine, and stop spilling registers in the accumulate step.

Two commits, both only apply to NVFP4 on Blackwell (checks for `blackwell_mma_available`):

- **Overlap loads with math, fix the register spills.** 
- **Hand the loads to the TMA engine.**

**Performance.** RTX 5090 at 600 W, CUDA 13.3, Qwen3.8-27B NVFP4, `llama-bench -ub 1024 -p 16384 -n 0 -r 3`:

| build | pp16384 t/s |
|---|---:|
| master (dbeb37548) | 6146.5 ± 9.8 |
| this PR | 7009.7 ± 9.1 (+14.0%) |

**Verification**
- Perplexity, wikitext-2 test, `-c 512 -b 2048 -ub 1024`: master 7.1927 ± 0.0469, this PR 7.1957 ± 0.0469.
- `test-backend-ops -b CUDA0`: MUL_MAT 1288/1288, MUL_MAT_ID 880/880.
- No change for other models: Q5_K_S on the same card, pp4096 3199.5 → 3199.9 t/s, tg64 71.1 → 70.8 t/s.

## Additional information

This PR came as a result of me trying to figure out the prefill gap between [NInfer](https://github.com/Neroued/ninfer) and llama.cpp which is my daily driver. Additional profiling is in #28514. The remaining kernels from that discussion (Qwen3.5 gated delta net prefill, GLU->MMQ fusion) will be a separate PR after this one, roughly a ~25% extra uplift.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes.
- AI usage disclosure: Yes, this PR was co-developed with Fable 5.1. I am a software developer but **CUDA is not my area of expertise**, however I fully understand what the code is intended to do.
