### PR TITLE
HIP: fattn-mma: use fp32 accumulation on MFMA devices

### DIFF
--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -1141,7 +1141,7 @@ template<int DV, int ncols> struct mma_tile_sizes {
     using T_C_KQ  = tile<16, 16, float>; // column-major
     using T_A_VKQ = tile<16,  8, half2>; // row-major
     using T_B_VKQ = tile<16,  8, half2>; // column-major
-    using T_C_VKQ = tile<16,  8, half2>; // column-major
+    using T_C_VKQ = tile<16, 16, float>; // column-major
 };
 #else // Volta
 template<int DV, int ncols> struct mma_tile_sizes {
@@ -1227,7 +1227,9 @@ static __device__ __forceinline__ void flash_attn_ext_f16_process_tile(
     T_C_VKQ VKQ_C[cols_per_warp == 8 ? DV/T_C_VKQ::I : DV/(2*T_C_VKQ::J)];
 #elif defined(AMD_WMMA_AVAILABLE) && defined(RDNA3)
     T_C_VKQ VKQ_C[DV % 32 != 0       ? DV/T_C_VKQ::J : DV/(2*T_C_VKQ::J)];
-#elif defined(AMD_WMMA_AVAILABLE) || defined(AMD_MFMA_AVAILABLE)
+#elif defined(AMD_MFMA_AVAILABLE)
+    T_C_VKQ VKQ_C[                                     DV/T_C_VKQ::J];
+#elif defined(AMD_WMMA_AVAILABLE)
     T_C_VKQ VKQ_C[                                     DV/(2*T_C_VKQ::J)];
 #else // Volta
     T_C_VKQ VKQ_C[                                     DV/(2*T_C_VKQ::J)];

--- a/ggml/src/ggml-cuda/fattn-mma-f16.cuh
+++ b/ggml/src/ggml-cuda/fattn-mma-f16.cuh
@@ -181,7 +181,7 @@ static constexpr __host__ __device__ fattn_mma_config ggml_cuda_fattn_mma_get_co
     GGML_CUDA_FATTN_MMA_CONFIG_CASE( 64,  64,  8, 128, 1,  64,  32,  32,  32, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE( 64,  64, 16, 256, 2,  64,  32,  32,  32, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE( 64,  64, 32, 256, 2,  64,  32,  32,  32, 1, true);
-    GGML_CUDA_FATTN_MMA_CONFIG_CASE( 64,  64, 64, 256, 4,  64,  32,  32,  32, 1, true);
+    GGML_CUDA_FATTN_MMA_CONFIG_CASE( 64,  64, 64, 256, 3,  64,  32,  32,  32, 1, true);
 
     GGML_CUDA_FATTN_MMA_CONFIG_CASE( 80,  80,  8, 256, 2,  64,  40,  40,  40, 1, true);
     GGML_CUDA_FATTN_MMA_CONFIG_CASE( 80,  80, 16, 256, 2,  64,  40,  40,  40, 1, true);


### PR DESCRIPTION
## Overview

MFMA dose not support fp16 accumulation, mma.h implements a post V_MFMA downcast path, wich is used for VKQ, but we can gain some performance and also some minor accuracy (still downconverted for smem later) by skipping that.
This increased VGPR pressure and i had to retune the 64,64,64 case, as it saw a big perf drop.
Its possible some of the others could also be retuned for better performance.

<details>
<summary>performance</summary>

gfx908 @ 190 W

| Backend   | GGML op        | Op parameters                                                                                                                                                                                     |   TFLOPS master |   TFLOPS cdnafp32accum |   Speedup |
|:----------|:---------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------:|-----------------------:|----------:|
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            0.53 |                   0.54 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           25.52 |                  30.10 |      1.18 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            0.67 |                   0.69 |      1.03 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           25.67 |                  30.66 |      1.19 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            0.37 |                   0.37 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           24.07 |                  27.61 |      1.15 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            0.76 |                   0.78 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           25.82 |                  31.04 |      1.20 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            0.49 |                   0.49 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[1,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           24.94 |                  28.67 |      1.15 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            2.57 |                   2.63 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           30.84 |                  37.15 |      1.20 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            2.87 |                   2.99 |      1.04 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           30.73 |                  37.47 |      1.22 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            1.49 |                   1.48 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           30.88 |                  36.69 |      1.19 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            3.19 |                   3.25 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           31.26 |                  37.76 |      1.21 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            2.14 |                   2.10 |      0.98 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[4,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           30.69 |                  34.17 |      1.11 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            4.33 |                   4.35 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           31.00 |                  37.35 |      1.21 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            4.89 |                   4.91 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           31.03 |                  38.35 |      1.24 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            2.46 |                   2.46 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           31.43 |                  38.03 |      1.21 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            5.28 |                   5.31 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           31.43 |                  38.49 |      1.22 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            3.55 |                   3.47 |      0.98 |
| ROCm0     | FLASH_ATTN_EXT | hsk=128,hsv=128,nh=8,nr23=[8,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           30.57 |                  37.84 |      1.24 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=10000,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |            1.59 |                   1.63 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=10000,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |            1.07 |                   1.09 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=10000,nb=512,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           29.38 |                  33.84 |      1.15 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=10000,nb=512,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0 |           29.20 |                  32.69 |      1.12 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=1024,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |            0.80 |                   0.80 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=128,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |            0.15 |                   0.14 |      0.98 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=20000,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |            1.74 |                   1.65 |      0.95 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=20000,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |            1.15 |                   1.15 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=20000,nb=512,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           30.47 |                  35.05 |      1.15 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=20000,nb=512,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0 |           30.27 |                  34.41 |      1.14 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=2048,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |            1.07 |                   1.12 |      1.04 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |            1.19 |                   1.19 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=2,nr23=[16,1],kv=512,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |            0.51 |                   0.52 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            0.57 |                   0.59 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           26.33 |                  28.28 |      1.07 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            0.66 |                   0.68 |      1.04 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           26.69 |                  28.71 |      1.08 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            0.39 |                   0.40 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           24.83 |                  26.44 |      1.06 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            0.75 |                   0.76 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           26.94 |                  29.05 |      1.08 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            0.58 |                   0.59 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[1,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           25.48 |                  27.59 |      1.08 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            2.70 |                   2.70 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           29.99 |                  36.45 |      1.22 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            2.94 |                   3.03 |      1.03 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           30.24 |                  36.79 |      1.22 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            1.81 |                   1.81 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           29.97 |                  36.31 |      1.21 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            3.26 |                   3.29 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           30.60 |                  37.32 |      1.22 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            2.42 |                   2.38 |      0.98 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[4,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           29.80 |                  36.41 |      1.22 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            5.24 |                   5.28 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           32.17 |                  35.91 |      1.12 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            5.59 |                   5.65 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           32.44 |                  35.93 |      1.11 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            3.67 |                   3.60 |      0.98 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           33.14 |                  35.57 |      1.07 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            5.83 |                   5.87 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0   |           32.73 |                  36.28 |      1.11 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            4.55 |                   4.67 |      1.03 |
| ROCm0     | FLASH_ATTN_EXT | hsk=256,hsv=256,nh=8,nr23=[8,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0    |           32.21 |                  35.52 |      1.10 |
| ROCm0     | FLASH_ATTN_EXT | hsk=512,hsv=512,nh=1,nr23=[8,1],kv=49152,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |            3.21 |                   3.23 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=512,hsv=512,nh=1,nr23=[8,1],kv=49152,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=2048   |            3.11 |                   3.16 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=1,nr23=[16,1],kv=49152,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0     |            6.13 |                   6.20 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=1,nr23=[16,1],kv=49152,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=2048  |            6.11 |                   6.21 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0      |            2.64 |                   2.80 |      1.06 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0   |           14.29 |                  14.33 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0      |            3.02 |                   3.17 |      1.05 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0   |           14.32 |                  14.35 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0       |            1.99 |                   1.94 |      0.97 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0    |           13.96 |                  14.26 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0      |            3.30 |                   3.30 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0   |           14.23 |                  14.41 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0       |            2.43 |                   2.50 |      1.03 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[4,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0    |           14.27 |                  13.67 |      0.96 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0      |            4.94 |                   5.07 |      1.03 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0   |           14.30 |                  14.35 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0      |            5.18 |                   5.20 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0   |           14.18 |                  14.47 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0       |            4.05 |                   4.04 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0    |           14.39 |                  14.32 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0      |            5.27 |                   5.31 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0   |           14.26 |                  14.44 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0       |            4.62 |                   4.76 |      1.03 |
| ROCm0     | FLASH_ATTN_EXT | hsk=576,hsv=512,nh=8,nr23=[8,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=1,n_kv_max=0    |           14.10 |                  14.37 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            0.37 |                   0.37 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           14.68 |                  21.51 |      1.47 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            0.48 |                   0.49 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           14.81 |                  21.75 |      1.47 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            0.19 |                   0.19 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |           14.21 |                  20.49 |      1.44 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            0.62 |                   0.63 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           14.26 |                  21.81 |      1.53 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            0.22 |                   0.22 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[1,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |           14.53 |                  21.17 |      1.46 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            1.57 |                   1.57 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           29.32 |                  32.56 |      1.11 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            2.17 |                   2.18 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           28.58 |                  31.55 |      1.10 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            0.86 |                   0.88 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |           29.06 |                  33.79 |      1.16 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            2.66 |                   2.53 |      0.95 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           29.42 |                  31.35 |      1.07 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            1.02 |                   1.03 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[4,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |           29.31 |                  34.34 |      1.17 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=16384,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            2.66 |                   2.66 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=16384,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           30.07 |                  34.37 |      1.14 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=32768,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            3.53 |                   3.56 |      1.01 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=32768,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           30.14 |                  33.35 |      1.11 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=4096,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            1.02 |                   1.02 |      0.99 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=4096,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |           30.64 |                  36.46 |      1.19 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=65536,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0        |            4.24 |                   4.25 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=65536,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           30.25 |                  32.99 |      1.09 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=7680,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            1.78 |                   1.83 |      1.03 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=7680,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q4_0,type_V=q4_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            1.15 |                   1.17 |      1.02 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=7680,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0       |            0.80 |                   0.84 |      1.05 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=7680,nb=4,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            8.73 |                   9.34 |      1.07 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=7680,nb=512,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q4_0,type_V=q4_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           25.97 |                  28.47 |      1.10 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=7680,nb=512,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=q8_0,type_V=q8_0,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |           25.62 |                  28.68 |      1.12 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=8192,nb=1,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0         |            1.72 |                   1.72 |      1.00 |
| ROCm0     | FLASH_ATTN_EXT | hsk=64,hsv=64,nh=8,nr23=[8,1],kv=8192,nb=4096,mask=1,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0      |           30.09 |                  35.71 |      1.19 |
| ROCm0     | FLASH_ATTN_EXT | hsk=72,hsv=72,nh=16,nr23=[1,1],kv=5776,nb=5776,mask=0,sinks=0,max_bias=0.000000,logit_softcap=0.000000,prec=f32,type_K=f16,type_V=f16,permute=[0,1,2,3],kv_view=1,v_is_view_of_k=0,n_kv_max=0     |            8.68 |                   8.78 |      1.01 |

| GPU   | Model                 |   Microbatch size | Test         |   t/s master |   t/s cdnafp32accum |   Speedup |
|:------|:----------------------|------------------:|:-------------|-------------:|--------------------:|----------:|
| MI100 | gemma4 26B.A4B Q6_K   |               512 | pp512@d32768 |      1020.86 |             1033.92 |      1.01 |
| MI100 | gemma4 26B.A4B Q6_K   |               512 | tg64@d32768   |        75.02 |               74.71 |      1.00 |
| MI100 | gpt-oss 20B MXFP4 MoE |               512 | pp512@d32768 |      1521.88 |             1535.65 |      1.01 |
| MI100 | gpt-oss 20B MXFP4 MoE |               512 | tg256@d32768 |       113.44 |              114.12 |      1.01 |
| MI100 | lfm2moe 8B.A1B Q8_0   |               512 | pp512@d32768 |      4042.21 |             4099.02 |      1.01 |
| MI100 | lfm2moe 8B.A1B Q8_0   |               512 | tg256@d32768 |       199.40 |              199.56 |      1.00 |
| MI100 | llama 8B Q8_0         |               512 | pp512@d32768 |      1002.87 |             1112.52 |      1.11 |
| MI100 | llama 8B Q8_0         |               512 | tg256@d32768 |        47.37 |               52.05 |      1.10 |
| MI100 | qwen35 27B Q5_K_M     |               512 | pp512@d32768 |       342.72 |              362.81 |      1.06 |
| MI100 | qwen35 27B Q5_K_M     |               512 | tg256@d32768 |        20.82 |               21.74 |      1.04 |

</details>

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: NO
