### PR TITLE
ggml-cuda : fix MMVQ max batch limit for virtual CUDA archs

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -249,10 +249,11 @@ static constexpr __host__ __device__ int get_mmvq_mmid_max_batch_rdna4(ggml_type
 int get_mmvq_mmid_max_batch(ggml_type type, int cc) {
     // NVIDIA: Volta, Ada Lovelace, and Blackwell always use MMVQ for MUL_MAT_ID.
     if (GGML_CUDA_CC_IS_NVIDIA(cc)) {
-        if (cc == GGML_CUDA_CC_VOLTA || cc >= GGML_CUDA_CC_ADA_LOVELACE) {
+        const int carch = ggml_cuda_highest_compiled_arch(cc);
+        if (carch == GGML_CUDA_CC_VOLTA || carch >= GGML_CUDA_CC_ADA_LOVELACE) {
             return MMVQ_MAX_BATCH_SIZE;
         }
-        if (cc >= GGML_CUDA_CC_TURING) {
+        if (carch >= GGML_CUDA_CC_TURING) {
             return get_mmvq_mmid_max_batch_turing_plus(type);
         }
         return get_mmvq_mmid_max_batch_pascal_older(type);


### PR DESCRIPTION
## Overview

Fixes an issue where get_mmvq_mmid_max_batch checked the physical GPU architecture (cc) instead of the highest compiled target architecture (carch).

When compiling with virtual multi-architecture targets (e.g., -DCMAKE_CUDA_ARCHITECTURES='61-virtual;80-virtual'), this mismatch causes CUDA invalid argument errors during MUL_MAT_ID operations on GPUs like the GTX 1660 Ti.

Using ggml_cuda_highest_compiled_arch(cc) ensures the batch size matches the active code target, aligning with the pattern used across ggml-cuda. Verified via test-backend-ops test -o MUL_MAT_ID -b CUDA0 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:   NO 

