### PR TITLE
speculative: fix failed to decode mtmd chunk with DFlash

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1103,6 +1103,12 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
             return true;
         }
 
+        // all rows of an M-RoPE image share one position, so a windowed draft cache never frees cells
+        // skip them - the draft can jump over the gap
+        if (has_embeddings && is_mrope) {
+            return true;
+        }
+
         const int32_t n_tokens = batch_in.n_tokens;
 
         // per-seq inclusive batch range (assumes each seq's tokens are contiguous in the batch)

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1094,18 +1094,11 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
 
         // Target prefill may contain token IDs or multimodal embeddings. Both
         // produce the target-layer features used to seed the draft KV cache, so
-        // skipping the embedding batches leaves a hole in the draft's cache and
-        // the next injection fails to initialize.
+        // embeddings are injected too, except the pinned ones skipped below.
         // TODO: revisit after https://github.com/ggml-org/llama.cpp/pull/24669 is merged
         const bool has_tokens     = batch_in.token != nullptr;
         const bool has_embeddings = batch_in.embd  != nullptr;
         if (has_tokens == has_embeddings) {
-            return true;
-        }
-
-        // all rows of an M-RoPE image share one position, so a windowed draft cache never frees cells
-        // skip them - the draft can jump over the gap
-        if (has_embeddings && is_mrope) {
             return true;
         }
 
@@ -1136,6 +1129,13 @@ struct common_speculative_impl_draft_dflash : public common_speculative_impl {
                 continue;
             }
             const int32_t n_rows = i_batch_end[seq_id] - i_batch_beg[seq_id] + 1;
+
+            // an M-RoPE image pins all its rows to one position, so a windowed draft
+            // cache cannot free cells for it - skip it, the draft can jump over the gap
+            const bool pos_pinned = batch_in.pos[i_batch_beg[seq_id]] == batch_in.pos[i_batch_end[seq_id]];
+            if (has_embeddings && n_rows > 1 && pos_pinned) {
+                continue;
+            }
 
             for (int32_t offset = 0; offset < n_rows; offset += n_ubatch) {
                 const int32_t n_chunk = std::min(n_ubatch, n_rows - offset);


### PR DESCRIPTION
## Overview

When using DFlash w/ vision models, the drafter memory fails to allocate new tokens because images report a fixed offset and errors out (Tested on Qwen3.8 27B Q5_S, RTX 5090 CUDA 13.3):

```
E process: llama_decode(ctx_dft) failed rc=1 (n_tokens=1024, offset=1024)
E post-decode callback failed
E slot operator(): failed to decode mtmd chunk, idx = 8409, res = 1
E slot operator(): failed to process mtmd chunk, res = -1
E srv  send_error: error: failed to process mtmd chunk
```

Stop copying them to allow the drafter to continue.

## Additional information

Repro: `llama-server` with a target + `--mmproj` + a DFlash draft, use an image bigger than whatever -ub is set at.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes
- AI usage disclosure: Yes, used Fable 5.1 to understand the surrounding code and possible solutions.