### PR TITLE
hexagon: support for multi-device model split (aka row-split)

### DIFF
--- a/docs/backend/snapdragon/README.md
+++ b/docs/backend/snapdragon/README.md
@@ -188,7 +188,7 @@ llama_memory_breakdown_print: |   - Host               |                  439 = 
 Op test for MUL_MAT:
 
 ```
-~/src/llama.cpp$ ./scripts/snapdragon/run.py --target adb --hex-hostbuf 0 --devices HTP0:0 -- test-backend-ops -b HTP0:0 -o MUL_MAT
+~/src/llama.cpp$ ./scripts/snapdragon/run.py --target adb --devices HTP0:0 -- test-backend-ops -b HTP0:0 -o MUL_MAT
 ...
 Backend 2/3: HTP0:0
 Device description: Hexagon
@@ -213,14 +213,109 @@ ggml-hex: new session: HTP0 : session-id 0 domain-id 3 uri file:///libggml-htp-v
 | llama 1B Q4_0  | 729.75 MiB | 1.24 B | HTP        |  99 |       4 |     128 |    0 |  tg64 |  51.54 ± 1.13 |
 ```
 
+## Multi-Device Execution Modes
+
+The Hexagon backend supports multiple execution and partitioning modes to accommodate different model sizes, memory
+constraints, and single- or multi-NPU hardware topologies:
+
+### 1. Single-Device Mode with Dynamic Buffer Mapping
+
+Runs the model on a single NPU session (e.g. `HTP0` or `HTP0:0`).
+
+A single NPU session provides ~3.5GB of available virtual address space. For models larger than 3.5GB, the backend
+automatically maps and unmaps weight buffers during graph execution. This allows large models to run on a single NPU
+without manual configuration:
+
+```bash
+./scripts/snapdragon/run.py --target adb --devices HTP0:0 -- \
+    llama-cli -m models/Llama-3.2-3B-Instruct-Q4_0.gguf -ngl 99 -p "Hello"
+```
+
+### 2. Layer-Split Mode across Virtual Sessions (`HTP0,HTP1,...` or `HTP0:0,HTP0:1,...`)
+
+Partitions model layers at load time across multiple virtual sessions hosted on a single physical NPU.
+
+Each virtual session acts as an independent backend device from llama.cpp's perspective (similar to multiple GPUs).
+Because layers are permanently distributed across sessions, each session's allocated weights remain within its private 3.5GB
+address space window, eliminating runtime buffer re-mapping overhead.
+
+Here is an example of running the GPT-OSS-20B model on a Snapdragon device using 4 virtual sessions on a single NPU:
+
+```bash
+./scripts/snapdragon/run.py --target adb \
+    --devices HTP0:0,HTP0:1,HTP0:2,HTP0:3 -- \
+    llama-cli --load-mode none -m /data/local/tmp/gguf/gpt-oss-20b-Q4_0.gguf -t 4 \
+    --ctx-size 8192 --batch-size 128 -ctk q8_0 -ctv q8_0 -fa on -ngl 99 -no-cnv -f surfing.txt
+```
+
+Log output snippet:
+
+```
+...
+llama_model_loader: - type  f32:  289 tensors
+llama_model_loader: - type q4_0:   96 tensors
+llama_model_loader: - type q8_0:    2 tensors
+llama_model_loader: - type mxfp4:  72 tensors
+...
+load_tensors: offloaded 25/25 layers to GPU
+load_tensors:          CPU model buffer size =  1182.09 MiB
+load_tensors:       HTP0:1 model buffer size =  2512.58 MiB
+load_tensors:       HTP0:3 model buffer size =  2093.83 MiB
+load_tensors:       HTP0:0 model buffer size =  2931.34 MiB
+load_tensors:       HTP0:2 model buffer size =  2512.58 MiB
+...
+llama_perf_context_print: prompt eval time =    3843.67 ms /   197 tokens ( 19.51 ms per token, 51.25 tokens per second)
+llama_perf_context_print:        eval time =    1686.13 ms /    31 runs   ( 54.39 ms per token, 18.39 tokens per second)
+llama_perf_context_print:       total time =    6266.30 ms /   228 tokens
+llama_memory_breakdown_print: | memory breakdown [MiB] | total   free    self   model   context   compute    unaccounted |
+llama_memory_breakdown_print: |   - HTP0:0 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
+llama_memory_breakdown_print: |   - HTP0:1 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
+llama_memory_breakdown_print: |   - HTP0:2 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
+llama_memory_breakdown_print: |   - HTP0:3 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
+llama_memory_breakdown_print: |   - Host               |                 1476 =  1208 +     105 +     162                |
+```
+
+### 3. Tensor-Split Mode across Physical Devices (`HTP0:0,HTP1:0,...`)
+
+Distributes model tensors across distinct physical NPU hardware cores using llama.cpp's tensor parallelism
+(`--split-mode tensor`).
+
+Tensors are partitioned across physical NPUs for parallel execution (proportions are distributed equally by default without
+needing an explicit `--tensor-split` option):
+
+```bash
+./scripts/snapdragon/run.py --target adb \
+    --devices HTP0:0,HTP1:0 -- \
+    llama-cli -m models/Llama-3.2-3B-Instruct-Q4_0.gguf --split-mode tensor -ngl 99 -p "Hello"
+```
+
+### 4. Row-Split Multi-Device Mode via Device Grouping (`HTP0[0-1]`)
+
+Groups multiple physical NPU cores into a single logical device using bracket notation (`HTP0[0-1]` or `HTP0[0,1]`).
+
+Unlike host-level tensor-splitting, row-splitting is executed entirely inside the Hexagon backend:
+
+```bash
+./scripts/snapdragon/run.py --target adb \
+    --devices HTP0[0-1] -- \
+    llama-cli -m models/Llama-3.2-3B-Instruct-Q4_0.gguf -ngl 99 -p "Hello"
+```
+
+You can also combine row-splitting with layer-splitting across multiple grouped devices (e.g. `--devices HTP0[0-1],HTP1[2-3]`
+on 4 physical NPUs, or `--devices HTP0[0-1:0],HTP1[0-1:1]` on 2 physical NPUs using virtual sessions 0 and 1).
+
 ## Environment variables
 
 - `GGML_HEXAGON_DEVICES` (default: not set, defaults to HTP0 session)
-  Controls which NPU devices and sessions to allocate. Can be configured as:
-  - A single integer `N`: Allocates `N` sessions named `HTP0`, `HTP1`, ..., `HTP<N-1>` (behaves identically to `GGML_HEXAGON_NDEV=N`).
-  - A comma-separated list of device names in `HTP<physical_idx>:<virtual_idx>` format (or legacy `HTP<idx>` format). For example, `HTP0:0,HTP0:1` creates two virtual
-    sessions on the first physical NPU (useful for memory limits). `HTP0:0,HTP1:0` allocates one session on each of the two physical NPUs
-    on a dual-NPU device.
+  Controls which NPU devices and sessions to allocate. Configurable via `--devices` in `run.py`:
+  - `N` (single integer): Allocates `N` virtual sessions named `HTP0`, `HTP1`, ..., `HTP<N-1>` on physical NPU 0.
+  - `HTP<phys>:<virt>,...`: Comma-separated list of individual devices specifying physical and virtual index:
+    - `HTP0:0,HTP0:1`: Two virtual sessions on physical NPU 0 (layer-split on single NPU).
+    - `HTP0:0,HTP1:0`: One session on physical NPU 0 and one on physical NPU 1 (tensor-split across physical cores).
+  - `HTP<name>[<phys_spec>]`: Device grouping syntax for row-split multi-device execution:
+    - `HTP0[0-1]`: A single logical device `HTP0` that groups physical cores 0 and 1.
+    - `HTP0[0-1],HTP1[2-3]`: Two layer-split devices across 4 physical NPUs (cores 0-1 and 2-3).
+    - `HTP0[0-1:0],HTP1[0-1:1]`: Two layer-split devices across 2 physical NPUs using virtual sessions 0 and 1.
 
 - `GGML_HEXAGON_NDEV` (deprecated)
   Replaced by `GGML_HEXAGON_DEVICES`. Controls the number of virtual sessions to allocate on physical NPU `0`.
@@ -229,9 +324,8 @@ ggml-hex: new session: HTP0 : session-id 0 domain-id 3 uri file:///libggml-htp-v
 - `GGML_HEXAGON_NHVX=0`
   Controls the number of HVX hardware threads to use. The default is all (actual number varies depending on the hardware version).
 
-- `GGML_HEXAGON_HOSTBUF=1`
-  Controls whether the Hexagon backend allocates host buffers. By default, all buffers except for REPACK are host buffers.
-  This option is required for testing Ops that require REPACK buffers (MUL_MAT and MUL_MAT_ID).
+- `GGML_HEXAGON_HOSTBUF=1` (default: 0, disabled)
+  Enables allocating host buffers for debugging. By default, host buffers are disabled.
 
 - `GGML_HEXAGON_VERBOSE=1`
   Enables verbose logging of Ops from the backend. Example output:
@@ -246,23 +340,27 @@ ggml-hex: new session: HTP0 : session-id 0 domain-id 3 uri file:///libggml-htp-v
   ```
 
 - `GGML_HEXAGON_PROFILE=1`
-  Enables Op profiling:
+  Enables Op profiling (configurable via `--hex-profile` in `run.py`):
 
-  - `1` Basic profile with per-op `usecs` and `cycles` counters
-  - `2` Extended profile with per-op `usecs`, `cycles` and default PMU counter data
-  - `0x1,...,0x8` Extended profile with per-op `usecs`, `cycles` and custom PMU counter data
+  - `1`: Basic profile with per-op `usecs` and `cycles` counters
+  - `2`: Extended profile with per-op `usecs`, `cycles` and default PMU counter data
+  - `0x1,...,0x8`: Extended profile with per-op `usecs`, `cycles` and custom PMU counter data
 
-  The logging output can be either saved into a file for post-processing or it can be piped directly into the post-processing tool
-  to generate the report.
-  Examples:
+  The logging output can be saved to a file or piped directly into the post-processing script:
 
-      `GGML_HEXAGON_PROFILE=1 ./scripts/snapdragon/run.py --target adb -- llama-cli ... |& ./scripts/snapdragon/ggml-hexagon-profile.py -`
+  ```bash
+  ./scripts/snapdragon/run.py --target adb --hex-profile 1 -- llama-cli ... |& \
+      ./scripts/snapdragon/ggml-hexagon-profile.py -
+  ```
 
 - `GGML_HEXAGON_OPFILTER=regex`
-  Allows filtering (disabling) Ops that match the regex pattern:
+  Filters (disables) Ops matching the regex pattern (configurable via `--hex-opfilter` in `run.py`):
 
-  Examples:
+  ```bash
+  # Disable Flash Attention on Hexagon (falls back to CPU or GPU)
+  ./scripts/snapdragon/run.py --target adb --hex-opfilter "FLASH_ATTN_EXT" -- llama-cli ...
 
-      `GGML_HEXAGON_OPFILTER="FLASH_ATTN_EXT" ./scripts/snapdragon/run.py --target adb -- llama-cli ...` - Disable Flash Attention on Hexagon (falls back to CPU or GPU)
-      `GGML_HEXAGON_OPFILTER="ADD\|SUB" ./scripts/snapdragon/run.py --target adb -- llama-cli ...` - Disable ADD and SUB on Hexagon (fall back to CPU or GPU)
+  # Disable ADD and SUB on Hexagon (fall back to CPU or GPU)
+  ./scripts/snapdragon/run.py --target adb --hex-opfilter "ADD|SUB" -- llama-cli ...
+  ```
 

--- a/docs/backend/snapdragon/README.md
+++ b/docs/backend/snapdragon/README.md
@@ -297,12 +297,12 @@ Unlike host-level tensor-splitting, row-splitting is executed entirely inside th
 
 ```bash
 ./scripts/snapdragon/run.py --target adb \
-    --devices HTP0[0-1] -- \
+    --devices 'HTP0[0-1]' -- \
     llama-cli -m models/Llama-3.2-3B-Instruct-Q4_0.gguf -ngl 99 -p "Hello"
 ```
 
-You can also combine row-splitting with layer-splitting across multiple grouped devices (e.g. `--devices HTP0[0-1],HTP1[2-3]`
-on 4 physical NPUs, or `--devices HTP0[0-1:0],HTP1[0-1:1]` on 2 physical NPUs using virtual sessions 0 and 1).
+You can also combine row-splitting with layer-splitting across multiple grouped devices (e.g. `--devices 'HTP0[0-1],HTP1[2-3]'`
+on 4 physical NPUs, or `--devices 'HTP0[0-1:0],HTP1[0-1:1]'` on 2 physical NPUs using virtual sessions 0 and 1).
 
 ## Environment variables
 
@@ -363,4 +363,3 @@ on 4 physical NPUs, or `--devices HTP0[0-1:0],HTP1[0-1:1]` on 2 physical NPUs us
   # Disable ADD and SUB on Hexagon (fall back to CPU or GPU)
   ./scripts/snapdragon/run.py --target adb --hex-opfilter "ADD|SUB" -- llama-cli ...
   ```
-

--- a/docs/backend/snapdragon/developer.md
+++ b/docs/backend/snapdragon/developer.md
@@ -120,6 +120,15 @@ Writing high-performance operators for Hexagon requires following specific guide
 
 - Keep worker functions independent and re-entrant. Worker threads should only operate on their designated chunk of rows or elements.
 
+### Avoid Redundant Defensive NULL Checks
+
+- Do not add defensive NULL checks or assertions for internal framework pointers (`ctx`, `octx`, local context structs
+  like `*ctx`, `kparams`, or `data` in worker callbacks).
+- These pointers are architectural invariants and are guaranteed non-NULL during kernel execution. Checks like
+  `if (!octx || !octx->ctx)` clutter the code and obscure intent.
+- **Distinction**: `octx->src[N]` pointers *can* be NULL by design for optional inputs (such as attention masks, optional
+  bias/weights in fused kernels, or frequency factors) and must be checked when optional.
+
 ### Multiline Macro Formatting
 
 - Keep trailing backslashes in multiline `#define` macros cleanly aligned to a consistent column.

--- a/docs/backend/snapdragon/developer.md
+++ b/docs/backend/snapdragon/developer.md
@@ -2,16 +2,16 @@
 
 ## Backend libraries
 
-The Hexagon backend consist of two parts:
+The Hexagon backend consists of two parts:
 
   - `libggml-hexagon`
-    This is the regular CPU-side GGML backend library, either shared or statically linked
+    This is the regular CPU-side GGML backend library, either shared or statically linked.
 
   - `libggml-htp-vNN`
     This is the NPU-side (HTP stands for Hexagon Tensor Processor) shared library that contains the Op dispatcher and kernels.
     The correct library is selected automatically at runtime based on the HW version.
 
-Here is an example of the build artifacts
+Here is an example of the build artifacts:
 
 ```
 ~/src/llama.cpp$ ls -l pkg-adb/llama.cpp/lib/libggml*
@@ -26,75 +26,296 @@ pkg-adb/llama.cpp/lib/libggml-htp-v81.so
 
 ## Memory buffers
 
-Hexagon NPU backend takes advantage of the Snapdragon's unified memory model where all buffers are fully accessible by the CPU and GPU.
-The NPU does have a dedicated tightly-coupled memory called VTCM but that memory is used only for intermediate data (e.g. dynamically
-quantized tensors) or temporary data (chunks of the weight tensors fetched via DMA).
-
-Please note that currently the Hexagon backend does not implement SET/GET_ROWS Ops because there is no advantage in offloading those
-to the NPU at this point.
-
-The backend does allocates non-host buffers for the tensors with datatypes that require repacking: Q4_0, Q8_0, MXFP4.
-From the MMU perspective these buffers are still regular buffers (normal access by the CPU) they are marked as non-host simply to force
-the repacking.
+The Hexagon NPU backend takes advantage of Snapdragon unified memory where all DDR buffers are accessible by CPU, GPU, and NPU.
+The NPU has dedicated tightly-coupled memory called VTCM (Vector Tightly-Coupled Memory). VTCM is used for intermediate data (such as
+dynamically quantized activations) and streaming buffers (chunks of weight and activation tensors fetched via DMA).
 
 ## Large model handling
 
-Hexagon NPU sessions (aka Process Domains (PD) in the Hexagon SDK) are limited to a maximum memory mapping window of around 3.5GB.
+Hexagon NPU sessions have a 32-bit virtual address space window of around 3.5GB.
 In llama.cpp/GGML, each Hexagon session is mapped to a single GGML backend device (e.g., `HTP0:0`, `HTP0:1`, etc. when using
 `GGML_HEXAGON_DEVICES`, or `HTP0`, `HTP1` in legacy mode).
 
-To support running models larger than 3.5GB on a single device, the Hexagon backend dynamically maps and unmaps execution buffers
-during the graph execution cycle to stay within the Process Domain window. This enables large models to run successfully on a single
-NPU device.
+To support running models larger than 3.5GB on a single device, the Hexagon backend dynamically maps and unmaps buffers:
+- Buffers are allocated in shared DDR (RPCMEM) via file descriptors (`fastrpc_mmap` using `FASTRPC_MAP_FD_DELAYED`).
+- Pinned buffers (such as KV cache and active compute buffers) remain mapped throughout execution.
+- Inactive weight buffers are dynamically mapped into the NPU session via `HAP_mmap()` during batch buffer preparation
+  (`prep_op_bufs()` in `htp/main.c`) and unmapped via `htp_iface_munmap()` when no longer needed by the active batch.
+- This dynamic sliding window allows a single NPU session to execute models that exceed the 3.5GB window.
 
-Alternatively, users can choose to use standard llama.cpp/GGML layer-splitting mode to partition and split the model across
-multiple Hexagon devices or virtual sessions (which behave like multiple GPUs from the offload and splitting perspective).
+Alternatively, users can partition and split the model across multiple virtual sessions or physical NPUs using layer-splitting,
+tensor-splitting, or row-splitting modes. For user-facing execution modes and examples, see the
+[Snapdragon user guide](README.md#multi-device-execution-modes).
 
-Here is an example of running GPT-OSS-20B model on a Snapdragon device using 4 virtual sessions on a single NPU (physical index 0).
+## Op and Kernel Development Guidelines
+
+Writing high-performance operators for Hexagon requires following specific guidelines.
+
+### DDR -> DMA -> VTCM Execution Pipeline
+
+- Strongly prefer the `DDR -> DMA -> VTCM -> compute (HVX/HMX) -> VTCM -> DMA -> DDR` data flow.
+- Direct HVX reads/writes from/to DDR are less efficient and should only be used as a fallback.
+- The DMA queue is a strict FIFO where operations must be pushed and popped in strict order.
+- Follow the pipelined multi-buffering sequence properly (typically 2x to 16x buffering) so every push has a corresponding pop:
+
+  1. In the prologue, push initial DDR -> VTCM transfers to prime the pipeline.
+  2. In the loop body, wait for buffer N via DMA pop, launch HVX/HMX compute on buffer N, push VTCM -> DDR writeback of result N,
+     and push DDR -> VTCM prefetch of buffer N+2.
+  3. In the epilogue, pop all remaining in-flight transfers to drain the pipeline.
+
+- Because every push must be matched by a pop, `dma_queue_flush()` is not required when the pipeline sequence is followed
+  properly. Flushing is only used in rare exceptions where a batch of operations is pushed without individual pops.
+- Use the DMA queue interface from [`dma-queue.h`](../../../ggml/src/ggml-hexagon/htp/dma-queue.h)
+  (`dma_queue_push_ddr_to_vtcm`, `dma_queue_pop`, `dma_queue_push_vtcm_to_ddr`).
+  See [`cumsum-ops.c`](../../../ggml/src/ggml-hexagon/htp/cumsum-ops.c) and
+  [`act-ops.c`](../../../ggml/src/ggml-hexagon/htp/act-ops.c) for reference implementations.
+
+### Avoid Scalar Reads and Writes to VTCM
+
+- Access VTCM data using DMA transfers or HVX/HMX vector instructions rather than scalar reads and writes.
+
+### Avoid Scalar Division in Inner Loops
+
+- Hexagon cores do not have hardware division instructions.
+- For recurring divisions across iterations or threads, use `fastdiv` from
+  [`hex-fastdiv.h`](../../../ggml/src/ggml-hexagon/htp/hex-fastdiv.h) with precomputed divisors (such as
+  `octx->ctx->mdev.count_div` or `octx->n_threads_div`).
+- Do not call `init_fastdiv_values()` for single-use divisions; use standard compiler division (`/`) instead.
+
+### Host-Side Precomputation via `kernel_params`
+
+- Precompute tensor shapes, strides, scale conversions, tiling layouts, and validation checks on the host CPU during graph
+  preparation in [`ggml-hexagon.cpp`](../../../ggml/src/ggml-hexagon/ggml-hexagon.cpp).
+- Pack precomputed parameters into the operator's fixed `kernel_params` structure in `htp_op_node` (such as
+  `htp_mm_kernel_params`, `htp_unary_kernel_params`, `htp_fa_kernel_params`, `htp_get_rows_kernel_params`).
+- The NPU executes directly using `octx->kernel_params` without redundant runtime metadata extraction or validation.
+- **Strict Host-Kernel Alignment**:
+  - Verify that parameters calculated by the host CPU are strictly honored by the NPU kernel.
+  - Ensure the kernel does not ignore host-computed fields (for example, falling back to `octx->n_threads` instead of
+    using `kparams->n_threads`, or ignoring precomputed `tasks_per_thread` and chunk counts).
+  - Both human developers and coding agents must audit both sides of the interface: ensure fields populated in `kernel_params`
+    in [`ggml-hexagon.cpp`](../../../ggml/src/ggml-hexagon/ggml-hexagon.cpp) are actively and consistently utilized by the
+    corresponding operator entry point and worker threads in `htp/*-ops.c`.
+
+### Tracing Instrumentation
+
+- All kernels must include trace events for performance profiling and timeline visualization in Perfetto
+  ([`hex-profile.h`](../../../ggml/src/ggml-hexagon/htp/hex-profile.h)).
+- Surround compute sections with `htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) info)` and
+  `htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) info)`.
+- Use specific event types for major phases:
+  - `HTP_TRACE_EVT_HVX_COMP`: Vector compute execution.
+  - `HTP_TRACE_EVT_DMA`: DMA transfer wait or poll cycles.
+  - `HTP_TRACE_EVT_FENCE`: Multi-device fence barrier synchronization.
+  - `HTP_TRACE_EVT_L2FLUSH`: L2 cache cleaning operations.
+- Pass meaningful progress metrics (such as row index, chunk index, or token index) in the 16-bit `info` parameter.
+
+### Work Queue and Threading
+
+- Distribute parallel work across NPU worker threads using the thread pool work queue:
+
+  ```c
+  work_queue_run(ctx->work_queue, worker_func, &op_ctx, n_threads);
+  ```
+
+- Keep worker functions independent and re-entrant. Worker threads should only operate on their designated chunk of rows or elements.
+
+### Multiline Macro Formatting
+
+- Keep trailing backslashes in multiline `#define` macros cleanly aligned to a consistent column.
+- Avoid trailing whitespace after macro backslashes.
+- Use [`scripts/snapdragon/ggml-hexagon-align-macros.py`](../../../scripts/snapdragon/ggml-hexagon-align-macros.py) to inspect, diff,
+  or automatically align macro definitions across Hexagon kernel sources:
+
+  ```bash
+  # Check for misaligned macros
+  python3 scripts/snapdragon/ggml-hexagon-align-macros.py ggml/src/ggml-hexagon/htp/
+
+  # Fix misaligned macros in-place
+  python3 scripts/snapdragon/ggml-hexagon-align-macros.py --fix ggml/src/ggml-hexagon/htp/
+  ```
+
+## Multi-Device Partitioning (mdev)
+
+Multi-device (mdev) mode enables row-level tensor parallel execution across multiple physical NPU cores or virtual NPU
+sessions.
+
+### 128-Byte Cache Line Alignment
+
+- Shared tensor buffers reside in DDR (RPCMEM) with a 128-byte cache line granularity
+  (`HEX_L2_LINE_SIZE` = 128 bytes, `HTP_TENSOR_MDEV_LINE_SIZE`).
+- **Rule**: Multi-device work partitions must align destination write regions to 128-byte cache line boundaries so distinct
+  devices never share or overwrite the same cache line.
+
+### Partitioning Helpers in `htp-tensor.h`
+
+Common partitioning logic is factored into reusable inline helpers in
+[`htp-tensor.h`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h):
+
+1. [`htp_tensor_mdev_rows_per_chunk`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h#L67):
+   Determines the minimum number of rows per chunk so that the chunk byte size is a multiple of 128 bytes:
+
+   ```
+   rows_per_chunk = 128 / hex_gcd_u32(row_size, 128)
+   ```
+
+   If row stride `nb[1]` is already a multiple of 128 bytes, `rows_per_chunk = 1`.
+   Returns `false` if the tensor cannot be safely row-partitioned (such as unaligned base pointer, permuted layout,
+   or non-128-byte aligned outer strides).
+
+2. [`htp_tensor_mdev_partition`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h#L94):
+   Calculates the per-device work range `struct htp_tensor_mdev_range { uint32_t start; uint32_t count; }` given
+   `total_units`, `units_per_chunk`, `mdev_idx`, `mdev_count`, and the precomputed `mdev_count_div`.
+   Handles chunk distribution across devices, assigns remainder units to the last device, and automatically triggers
+   single-device fallback when partitioning is unsafe.
+
+### Row-Partitioned Operators
+
+For row-wise operators
+(such as activations in [`act-ops.c`](../../../ggml/src/ggml-hexagon/htp/act-ops.c),
+binary ops in [`binary-ops.c`](../../../ggml/src/ggml-hexagon/htp/binary-ops.c),
+unary ops in [`unary-ops.c`](../../../ggml/src/ggml-hexagon/htp/unary-ops.c), and
+sameshape copies in [`cpy-ops.c`](../../../ggml/src/ggml-hexagon/htp/cpy-ops.c)):
+
+```c
+const uint32_t total_rows   = ne01 * ne02 * ne03;
+const size_t   dst_row_size = dst->ne[0] * elem_size;
+
+uint32_t row_start = 0;
+uint32_t nrows     = total_rows;
+
+if (octx->ctx->mdev.count > 1) {
+    uint32_t rows_per_chunk = 0;
+    htp_tensor_mdev_rows_per_chunk(dst, elem_size, (uint32_t) dst_row_size, &rows_per_chunk);
+    const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(
+        total_rows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+    row_start = range.start;
+    nrows     = range.count;
+}
+
+if (nrows == 0) {
+    return HTP_STATUS_OK;
+}
+```
+
+### Element-Partitioned Operators
+
+For flat element-wise operations (such as reshape copies in
+[`cpy-ops.c`](../../../ggml/src/ggml-hexagon/htp/cpy-ops.c)):
+- Partition total linear elements N = ne0 * ne1 * ne2 * ne3 in 128-byte cache line chunks (`elems_per_line = (elem_size == 4) ? 32 : 64`).
+- Requires strict 1D contiguity:
+  [`htp_tensor_is_contiguous(dst, elem_size)`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h#L28)
+  and 128-byte aligned destination pointer
+  [`htp_tensor_mdev_data_aligned(dst)`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h#L47).
+- If contiguous and aligned, pass `elems_per_line` to
+  [`htp_tensor_mdev_partition`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h#L94);
+  otherwise pass 0 to trigger Device 0 fallback.
+
+### Single-Device Fallback (Device 0)
+
+- Fallback to Device 0 (`mdev.idx == 0`) when partitioning would cause cache line tearing or when work cannot be evenly distributed.
+- Triggers:
+  1. Destination tensor cannot be safely partitioned (`rows_per_chunk == 0` or non-contiguous/unaligned buffer).
+  2. Total aligned chunks < `mdev_count`.
+- Device 0 processes the entire tensor `[0, total_units)`.
+- Devices 1 ... N-1 receive `count = 0` and return `HTP_STATUS_OK` immediately.
+
+### Flatten Outer Dimensions Globally
+
+- **Never partition solely on `ne01` (dimension 1).**
+- Partitioning only on `ne01` repeats the device boundary across every 2D slice (`ne02`, `ne03`). If each 2D slice is small,
+  false sharing occurs repeatedly throughout the tensor.
+- Always flatten outer dimensions globally: `total_rows = ne01 * ne02 * ne03` and partition once across the combined row space.
+
+### Stateless Starting Coordinates
+
+- Do not use incremental state variables across slices that assume the thread or device starts at index 0.
+- Precompute starting multidimensional coordinates at `r = row_start` (or `e = elem_start`) once using `fastdiv`.
+- In inner loops, step base pointers directly (`ptr += stride`) or reset/wrap coordinates explicitly (`if (++i01 == ne01) { ... }`).
+
+### Clean Range Encapsulation
+
+- Initialize single-device default ranges at declaration:
+
+  ```c
+  uint32_t row_start = 0;
+  uint32_t nrows     = total_rows;
+  ```
+
+- Encapsulate all multi-device logic inside `if (octx->ctx->mdev.count > 1)`. If the block is omitted or compiled out,
+  the operator runs standard single-device execution untouched.
+- Do not propagate `mdev_` prefixes to worker functions or context structs. Worker threads are device-agnostic and
+  should only receive standard range parameters (`ctx.row_start`, `ctx.nrows`).
+- In worker threads, calculate row intervals using standard arithmetic:
+
+  ```c
+  const uint32_t ir0 = ctx->row_start + dr * ith;
+  const uint32_t ir1 = MIN(ir0 + dr, ctx->row_start + ctx->nrows);
+  ```
+
+  In single-device mode (`row_start == 0`), this naturally simplifies to `dr * ith` and `MIN(ir0 + dr, ctx->nrows)` with zero overhead.
+
+## Multi-Device Synchronization
+
+Multi-device execution synchronizes worker sessions across devices using explicit barriers and tensor cache flushing.
+
+### Synchronization Fence Protocol
+
+Multi-device execution synchronizes worker sessions through atomic fence slots and barriers defined in
+[`htp-fence.h`](../../../ggml/src/ggml-hexagon/htp/htp-fence.h):
 
 ```
-~/src/llama.cpp$ ./scripts/snapdragon/run.py --target adb --devices HTP0:0,HTP0:1,HTP0:2,HTP0:3 -- llama-cli --load-mode none -m /data/local/tmp/gguf/gpt-oss-20b-Q4_0.gguf -t 4 --ctx-size 8192 --batch-size 128 -ctk q8_0 -ctv q8_0 -fa on -ngl 99 -no-cnv -f surfing.txt
-...
-llama_model_loader: - type  f32:  289 tensors
-llama_model_loader: - type q4_0:   96 tensors
-llama_model_loader: - type q8_0:    2 tensors
-llama_model_loader: - type mxfp4:  72 tensors
-...
-load_tensors: offloaded 25/25 layers to GPU
-load_tensors:          CPU model buffer size =  1182.09 MiB
-load_tensors:       HTP0:1 model buffer size =  2512.58 MiB
-load_tensors:       HTP0:3 model buffer size =  2093.83 MiB
-load_tensors:       HTP0:0 model buffer size =  2931.34 MiB
-load_tensors:       HTP0:2 model buffer size =  2512.58 MiB
-...
-llama_context: n_ctx_per_seq (8192) < n_ctx_train (131072) -- the full capacity of the model will not be utilized
-llama_context:        CPU  output buffer size =     0.77 MiB
-llama_kv_cache_iswa: creating non-SWA KV cache, size = 8192 cells
-llama_kv_cache:     HTP0:1 KV buffer size =    25.50 MiB
-llama_kv_cache:     HTP0:3 KV buffer size =    25.50 MiB
-llama_kv_cache:     HTP0:0 KV buffer size =    25.50 MiB
-llama_kv_cache:     HTP0:2 KV buffer size =    25.50 MiB
-llama_kv_cache: size =  102.00 MiB (  8192 cells,  12 layers,  1/1 seqs), K (q8_0):   51.00 MiB, V (q8_0):   51.00 MiB
-llama_kv_cache_iswa: creating     SWA KV cache, size = 256 cells
-llama_kv_cache:     HTP0:1 KV buffer size =     0.80 MiB
-llama_kv_cache:     HTP0:3 KV buffer size =     0.53 MiB
-llama_kv_cache:     HTP0:0 KV buffer size =     1.06 MiB
-llama_kv_cache:     HTP0:2 KV buffer size =     0.80 MiB
-llama_kv_cache: size =    3.19 MiB (   256 cells,  12 layers,  1/1 seqs), K (q8_0):    1.59 MiB, V (q8_0):    1.59 MiB
-llama_context:     HTP0:0 compute buffer size =    16.06 MiB
-llama_context:     HTP0:1 compute buffer size =    16.06 MiB
-llama_context:     HTP0:2 compute buffer size =    16.06 MiB
-llama_context:     HTP0:3 compute buffer size =    16.06 MiB
-llama_context:        CPU compute buffer size =    98.19 MiB
-...
-llama_perf_context_print: prompt eval time =    3843.67 ms /   197 tokens ( 19.51 ms per token, 51.25 tokens per second)
-llama_perf_context_print:        eval time =    1686.13 ms /    31 runs   ( 54.39 ms per token, 18.39 tokens per second)
-llama_perf_context_print:       total time =    6266.30 ms /   228 tokens
-llama_perf_context_print:    graphs reused =         30
-llama_memory_breakdown_print: | memory breakdown [MiB] | total   free    self   model   context   compute    unaccounted |
-llama_memory_breakdown_print: |   - HTP0:0 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
-llama_memory_breakdown_print: |   - HTP0:1 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
-llama_memory_breakdown_print: |   - HTP0:2 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
-llama_memory_breakdown_print: |   - HTP0:3 (Hexagon)   |  2048 = 2048 + (   0 =     0 +       0 +       0) +           0 |
-llama_memory_breakdown_print: |   - Host               |                 1476 =  1208 +     105 +     162                |
+[NPU Session 0]                              [NPU Session 1]
+       |                                            |
+  (Input Prep)                                 (Input Prep)
+       |                                            |
+  Pre-Op Barrier ----------------------------- Pre-Op Barrier
+  (mdev_sync_fence)                            (mdev_sync_fence)
+       |                                            |
+  Kernel Execution                             Kernel Execution
+  (Output Slice 0)                             (Output Slice 1)
+       |                                            |
+  Tensor Cache Flush                           Tensor Cache Flush
+  (htp_tensor_flush_all)                       (htp_tensor_flush_all)
+       |                                            |
+  Post-Op/Batch Barrier ---------------------- Post-Op/Batch Barrier
+  (htp_mdev_group_barrier)                     (htp_mdev_group_barrier)
+       |                                            |
+  Return Response to Host                      Return Response to Host
 ```
+
+### Atomic Fence Slots and Cache Invalidation
+
+- Fence synchronization operates on dedicated RPCMEM shared memory mapped across all participating sessions (`ctx->mdev.fence_base`).
+- Each device owns a dedicated 128-byte cache-line aligned fence slot:
+
+  ```c
+  atomic_uint * my_fence = htp_mdev_fence_slot(fence_base, mdev_idx);
+  ```
+
+- **Writing to fence ([`htp_fence_write`](../../../ggml/src/ggml-hexagon/htp/htp-fence.h#L18))**:
+  Stores `seq` and `status`, issues a `syncht` thread synchronization barrier, and flushes/invalidates the line
+  using `Q6_dccleaninva_A(fence)`.
+- **Reading from peer fence ([`htp_fence_read`](../../../ggml/src/ggml-hexagon/htp/htp-fence.h#L26))**:
+  Executes `Q6_dccleaninva_A(fence)` and `syncht` before reading atomic values to ensure fresh data from DDR.
+
+### Deterministic Monotonic Sequence Numbers
+
+- Barrier fences use monotonically increasing sequence numbers:
+
+  ```c
+  const uint32_t seq = ++ctx->mdev.fence_seq;
+  ```
+
+- Comparing sequence numbers with signed arithmetic `(int32_t)(peer_seq - seq) >= 0` prevents race conditions or
+  misaligned barrier arrivals across iterations.
+- If any peer reports an error status (`peer_status > HTP_STATUS_OK`), the barrier propagates the error and unblocks immediately.
+
+### Tensor Cache Flush and Pipeline Completion
+
+- In the kernel, ensure all pushed DMA operations have been popped in strict FIFO order to drain the queue.
+- Use [`htp_tensor_flush_all()`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h) to flush specific dirty tensors back to DDR:
+  - [`htp_tensor_flush_all()`](../../../ggml/src/ggml-hexagon/htp/htp-tensor.h) flushes only modified tensor address ranges,
+    ensuring peer devices and the host CPU observe consistent data in DDR.
+- Never signal completion before all DMA transfers are drained and dirty tensor flushes have completed.
+

--- a/docs/backend/snapdragon/developer.md
+++ b/docs/backend/snapdragon/developer.md
@@ -122,12 +122,14 @@ Writing high-performance operators for Hexagon requires following specific guide
 
 ### Avoid Redundant Defensive NULL Checks
 
-- Do not add defensive NULL checks or assertions for internal framework pointers (`ctx`, `octx`, local context structs
-  like `*ctx`, `kparams`, or `data` in worker callbacks).
-- These pointers are architectural invariants and are guaranteed non-NULL during kernel execution. Checks like
-  `if (!octx || !octx->ctx)` clutter the code and obscure intent.
-- **Distinction**: `octx->src[N]` pointers *can* be NULL by design for optional inputs (such as attention masks, optional
-  bias/weights in fused kernels, or frequency factors) and must be checked when optional.
+- Do not add defensive NULL checks or assertions for internal framework pointers or required graph operands and outputs.
+  Internal pointers include `ctx`, `octx`, local context structs like `*ctx`, `kparams`, and worker callback `data`.
+- These pointers are architectural invariants during kernel execution and host-side graph preparation.
+  Graph compute receives allocated nodes with valid required `node->src[N]` and `node->data` pointers.
+- Do not turn an invariant violation into an unsupported operation or missed fusion.
+  Checks such as `if (!octx || !octx->ctx)` clutter the code, obscure intent, and hide upstream errors.
+- **Distinction**: `octx->src[N]` pointers *can* be NULL by design and must be checked when optional.
+  Examples include attention masks, optional bias or weights in fused kernels, and frequency factors.
 
 ### Multiline Macro Formatting
 

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -5124,6 +5124,14 @@ static bool ggml_hexagon_supported_pad(const struct ggml_hexagon_session * sess,
         return false;
     }
 
+    const int32_t lp0 = ((const int32_t *) op->op_params)[0];
+    const int32_t rp0 = ((const int32_t *) op->op_params)[1];
+    const int32_t circular = ((const int32_t *) op->op_params)[8];
+
+    if (circular && (lp0 > src0->ne[0] || rp0 > src0->ne[0])) {
+        return false;
+    }
+
     return true;
 
     GGML_UNUSED(sess);

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -614,25 +614,27 @@ struct ggml_hexagon_shared_buffer {
 };
 
 struct ggml_hexagon_fence_buffer : public ggml_hexagon_shared_buffer {
-    size_t              fence_size = 0;
+    uint32_t            slot_count = 0;
+    uint32_t            slot_start = 0;
     uint32_t            slot_head  = 0;
     ggml_backend_buffer backend_buffer{};
 
-    ggml_hexagon_fence_buffer(ggml_hexagon_session * sess, ggml_backend_buffer_type_t buft, size_t size)
-        : ggml_hexagon_shared_buffer(sess, size, false /* pinned */), fence_size(size) {
+    ggml_hexagon_fence_buffer(ggml_hexagon_session * sess, ggml_backend_buffer_type_t buft, size_t size, uint32_t reserved_slots = 0)
+        : ggml_hexagon_shared_buffer(sess, size, false /* pinned */),
+          slot_count(size / GGML_HEXAGON_FENCE_SLOT_SIZE),
+          slot_start(reserved_slots),
+          slot_head(reserved_slots) {
         backend_buffer.buft    = buft;
         backend_buffer.context = static_cast<ggml_hexagon_shared_buffer *>(this);
         backend_buffer.size    = size;
-        if (base()) {
-            memset(base(), 0, size);
-        }
+        memset(base(), 0, size);
     }
 
     uint8_t * alloc_slot(uint32_t n_slots = 1) {
-        int max_slots = fence_size / GGML_HEXAGON_FENCE_SLOT_SIZE;
-        uint32_t slot = slot_head % max_slots;
-        if (slot + n_slots > (uint32_t) max_slots) {
-            slot = 0;
+        if (slot_start + n_slots > slot_count) return nullptr;
+        uint32_t slot = slot_head;
+        if (slot + n_slots > slot_count) {
+            slot = slot_start;
         }
         slot_head = slot + n_slots;
         return base() + (size_t) slot * GGML_HEXAGON_FENCE_SLOT_SIZE;
@@ -640,7 +642,7 @@ struct ggml_hexagon_fence_buffer : public ggml_hexagon_shared_buffer {
 };
 
 inline uint8_t * ggml_hexagon_session::alloc_fence(uint32_t n_slots) {
-    return fence_buf ? fence_buf->alloc_slot(n_slots) : nullptr;
+    return fence_buf->alloc_slot(n_slots);
 }
 
 static ggml_hexagon_session * ggml_backend_hexagon_buffer_get_sess(ggml_backend_buffer_t buffer) {
@@ -2927,7 +2929,7 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
 void ggml_hexagon_session::enqueue_mdev_setup() {
     htp_opnode setup_node(HTP_OP_MDEV_SETUP);
 
-    uint8_t * fence_ptr = this->alloc_fence(this->mdev_count);
+    uint8_t * fence_ptr = this->fence_buf->base();
 
     static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
     ggml_tensor dummy_t {};
@@ -3413,8 +3415,9 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
 
     // Allocate buffers and state for op batching
     this->op_queue = new ggml_hexagon_opqueue(this, opt_opbatch, opt_opqueue);
-    ggml_backend_buffer_type_t fence_buft = dev_ctx ? &dev_ctx->fence_buffer_type : nullptr;
-    this->fence_buf = new ggml_hexagon_fence_buffer(this, fence_buft, 64 * 1024);
+
+    const uint32_t reserved_slots = this->mdev_count > 1 ? this->mdev_count : 0;
+    this->fence_buf = new ggml_hexagon_fence_buffer(this, &dev_ctx->fence_buffer_type, 64 * 1024, reserved_slots);
 
     if (!opt_vmem) {
         opt_vmem = ggml_hexagon_measure_max_vmem(this);
@@ -3495,7 +3498,7 @@ void ggml_hexagon_session::release() noexcept(true) {
 
 ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t mdev_idx, uint32_t mdev_count) noexcept(false) {
     this->dev        = dev;
-    this->dev_ctx    = dev ? static_cast<ggml_backend_hexagon_device_context *>(dev->context) : nullptr;
+    this->dev_ctx    = static_cast<ggml_backend_hexagon_device_context *>(dev->context);
     this->mdev_idx   = mdev_idx;
     this->mdev_count = mdev_count > 0 ? mdev_count : (uint32_t) (1 + config.mdev_group.size());
     op_batch         = nullptr;
@@ -3509,7 +3512,6 @@ ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & co
             for (size_t i = 0; i < config.mdev_group.size(); i++) {
                 mdev_sessions.push_back(std::make_unique<ggml_hexagon_session>(
                     config.mdev_group[i], this->dev, (uint32_t) (i + 1), this->mdev_count));
-                mdev_sessions.back()->clone_buffer(this->fence_buf);
             }
         }
     } catch (const std::exception & exc) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -365,6 +365,12 @@ struct ggml_hexagon_fence_buffer;
 struct ggml_hexagon_session;
 struct ggml_backend_hexagon_device_context;
 
+struct ggml_hexagon_mdev_group {
+    uint32_t idx   = 0;
+    uint32_t count = 1;
+    std::vector<std::unique_ptr<ggml_hexagon_session>> sessions;
+};
+
 struct ggml_backend_hexagon_comm_context {
     std::vector<ggml_backend_t> backends;
     size_t                      n_backends = 0;
@@ -411,9 +417,7 @@ struct ggml_hexagon_session {
 
     mutable std::unordered_set<const ggml_tensor *> needs_repack;
 
-    uint32_t mdev_idx    = 0;
-    uint32_t mdev_count  = 1;
-    std::vector<std::unique_ptr<ggml_hexagon_session>> mdev_sessions;
+    ggml_hexagon_mdev_group                mdev;
     ggml_backend_dev_t                     dev       = nullptr;
     ggml_backend_hexagon_device_context *  dev_ctx   = nullptr;
     ggml_hexagon_fence_buffer *            fence_buf = nullptr;
@@ -428,7 +432,7 @@ struct ggml_hexagon_session {
 
     uint8_t * alloc_fence(uint32_t n_slots = 1);
 
-    void enqueue_mdev_setup();
+    void enqueue_mdev_group();
     void enqueue_op(const htp_opnode & node);
     void enqueue_cpy(const ggml_tensor * src, ggml_tensor * dst, const ggml_tensor * sync_tensor = nullptr, uint32_t fence_seq = 0);
     void enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq = 0);
@@ -2764,7 +2768,7 @@ void ggml_hexagon_session::flush_peers() {
         peer->flush_async();
     }
 
-    for (auto & sub : mdev_sessions) {
+    for (auto & sub : this->mdev.sessions) {
         sub->flush_peers();
     }
 }
@@ -2775,7 +2779,7 @@ void ggml_hexagon_session::flush_async() {
 }
 
 void ggml_hexagon_session::flush_pending(bool all) {
-    for (auto & sub : mdev_sessions) {
+    for (auto & sub : this->mdev.sessions) {
         sub->flush_pending(all);
     }
 
@@ -2822,6 +2826,15 @@ void ggml_hexagon_session::flush_sync(bool all) {
     flush_pending(all);
 }
 
+static void update_mdev_idx(dspqueue_buffer & dbuf, const htp_opbatch_req & req, const ggml_hexagon_opbatch * op_batch, uint32_t mdev_idx) {
+    if (op_batch->n_ops > 0 && op_batch->h_ops[0].opcode == HTP_OP_MDEV_GROUP) {
+        const size_t b_size = sizeof(htp_buf_desc) * req.n_bufs;
+        const size_t t_size = sizeof(htp_tensor)   * req.n_tensors;
+        htp_op_desc * o_ptr = (htp_op_desc *) ((uint8_t *) dbuf.ptr + b_size + t_size);
+        o_ptr[0].params[0] = (int32_t) mdev_idx;
+    }
+}
+
 void ggml_hexagon_session::flush_batch(size_t min_ops) {
     if (op_batch->n_ops < min_ops) { return; }
 
@@ -2835,18 +2848,9 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
         op_queue->push(req, dbuf, op_batch);
     }
 
-    req.mdev_idx   = (uint16_t) this->mdev_idx;
-    req.mdev_count = (uint16_t) this->mdev_count;
+    update_mdev_idx(dbuf, req, op_batch, this->mdev.idx);
 
-    if (op_batch->n_ops > 0 && op_batch->h_ops[0].opcode == HTP_OP_MDEV_SETUP) {
-        const size_t b_size = sizeof(htp_buf_desc) * req.n_bufs;
-        const size_t t_size = sizeof(htp_tensor)   * req.n_tensors;
-        htp_op_desc * o_ptr = (htp_op_desc *) ((uint8_t *) dbuf.ptr + b_size + t_size);
-        o_ptr[0].params[0] = (int32_t) this->mdev_idx;
-        o_ptr[0].params[1] = (int32_t) this->mdev_count;
-    }
-
-    for (auto & sub : mdev_sessions) {
+    for (auto & sub : this->mdev.sessions) {
         htp_opbatch_req sub_req {};
         dspqueue_buffer sub_dbuf{};
 
@@ -2855,22 +2859,13 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
             sub->op_queue->push(sub_req, sub_dbuf, op_batch);
         }
 
-        sub_req.seq        = req.seq;
-        sub_req.mdev_idx   = (uint16_t) sub->mdev_idx;
-        sub_req.mdev_count = (uint16_t) sub->mdev_count;
+        sub_req.seq = req.seq;
 
-        if (op_batch->n_ops > 0 && op_batch->h_ops[0].opcode == HTP_OP_MDEV_SETUP) {
-            const size_t b_size = sizeof(htp_buf_desc) * sub_req.n_bufs;
-            const size_t t_size = sizeof(htp_tensor)   * sub_req.n_tensors;
-            htp_op_desc * o_ptr = (htp_op_desc *) ((uint8_t *) sub_dbuf.ptr + b_size + t_size);
-            o_ptr[0].params[0] = (int32_t) sub->mdev_idx;
-            o_ptr[0].params[1] = (int32_t) sub->mdev_count;
-        }
+        update_mdev_idx(sub_dbuf, sub_req, op_batch, sub->mdev.idx);
 
         sub->op_pending++;
 
-        HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u mdev-idx %u mdev-count %u\n",
-                    sub->c_name(), sub_dbuf.ptr, sub_dbuf.size, sub_req.mdev_idx, sub_req.mdev_count);
+        HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u\n", sub->c_name(), sub_dbuf.ptr, sub_dbuf.size);
 
         int err = dspqueue_write(sub->queue, 0, 1, &sub_dbuf, sizeof(sub_req), (const uint8_t*) &sub_req, DSPQUEUE_TIMEOUT);
         if (err != 0) {
@@ -2881,7 +2876,7 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
     // Bump pending flag (cleared in the session::flush once we get the response)
     this->op_pending++;  // atomic inc
 
-    HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u mdev-idx %u mdev-count %u\n", this->c_name(), dbuf.ptr, dbuf.size, req.mdev_idx, req.mdev_count);
+    HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u\n", this->c_name(), dbuf.ptr, dbuf.size);
 
     int err = dspqueue_write(this->queue, 0, 1, &dbuf, sizeof(req), (const uint8_t*) &req, DSPQUEUE_TIMEOUT);
     if (err != 0) {
@@ -2898,7 +2893,7 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
             if (ggml_backend_hexagon_buffer_get_sess(t->buffer) != this) {
                 this->clone_buffer(sbuf);
             }
-            for (auto & sub : mdev_sessions) {
+            for (auto & sub : this->mdev.sessions) {
                 sub->clone_buffer(sbuf);
             }
         }
@@ -2919,15 +2914,15 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
         flush_async();
     }
 
-    if (this->mdev_count > 1 && op_batch->n_ops == 0) {
-        enqueue_mdev_setup();
+    if (this->mdev.count > 1 && op_batch->n_ops == 0) {
+        enqueue_mdev_group();
     }
 
     op_batch->add_op(node);
 }
 
-void ggml_hexagon_session::enqueue_mdev_setup() {
-    htp_opnode setup_node(HTP_OP_MDEV_SETUP);
+void ggml_hexagon_session::enqueue_mdev_group() {
+    htp_opnode group_node(HTP_OP_MDEV_GROUP);
 
     uint8_t * fence_ptr = this->fence_buf->base();
 
@@ -2936,48 +2931,48 @@ void ggml_hexagon_session::enqueue_mdev_setup() {
     dummy_t.buffer = &this->fence_buf->backend_buffer;
     dummy_t.extra  = &fence_extra;
     dummy_t.data   = (void *) fence_ptr;
-    dummy_t.type   = GGML_TYPE_I32;
-    dummy_t.ne[0]  = (this->mdev_count * HTP_FENCE_SLOT_SIZE) / sizeof(int32_t);
-    dummy_t.ne[1]  = 1;
+    dummy_t.type   = GGML_TYPE_I8;
+    dummy_t.ne[0]  = HTP_FENCE_SLOT_SIZE;
+    dummy_t.ne[1]  = (int64_t) this->mdev.count;
     dummy_t.ne[2]  = 1;
     dummy_t.ne[3]  = 1;
-    dummy_t.nb[0]  = sizeof(int32_t);
-    dummy_t.nb[1]  = dummy_t.ne[0] * sizeof(int32_t);
-    dummy_t.nb[2]  = dummy_t.nb[1];
+    dummy_t.nb[0]  = 1;
+    dummy_t.nb[1]  = HTP_FENCE_SLOT_SIZE;
+    dummy_t.nb[2]  = dummy_t.nb[1] * dummy_t.ne[1];
     dummy_t.nb[3]  = dummy_t.nb[2];
     dummy_t.op     = GGML_OP_NONE;
-    dummy_t.op_params[0] = (int32_t) this->mdev_idx;
-    dummy_t.op_params[1] = (int32_t) this->mdev_count;
+    dummy_t.op_params[0] = (int32_t) this->mdev.idx;
 
-    ggml_tensor * node = setup_node.add_dummy(dummy_t);
+    ggml_tensor * node = group_node.add_dummy(dummy_t);
     node->src[0] = node;
-    setup_node.init(node);
-    setup_node.outputs.clear();
-    setup_node.name = "MDEV_SETUP";
+    group_node.init(node);
+    group_node.outputs.clear();
+    group_node.name = "MDEV_GROUP";
 
     if (this->fence_buf->sess != this) {
         this->clone_buffer(this->fence_buf);
     }
-    for (auto & sub : mdev_sessions) {
+    for (auto & sub : this->mdev.sessions) {
         sub->clone_buffer(this->fence_buf);
     }
 
-    op_batch->add_op(setup_node);
+    op_batch->add_op(group_node);
 }
 
 void ggml_hexagon_session::enqueue_cpy(const ggml_tensor * src, ggml_tensor * dst, const ggml_tensor * sync_tensor, uint32_t fence_seq) {
-    htp_opnode cpy_node(HTP_OP_CPY);
+    const bool with_fence = sync_tensor != nullptr;
+    htp_opnode cpy_node(with_fence ? HTP_OP_CPY_FENCE : HTP_OP_CPY);
 
     ggml_tensor* node = cpy_node.add_dummy(*dst);
     node->op     = GGML_OP_CPY;
     node->src[0] = const_cast<ggml_tensor *>(src);
-    node->src[1] = sync_tensor ? cpy_node.add_dummy(*sync_tensor) : nullptr;
-    if (sync_tensor) {
+    node->src[1] = with_fence ? cpy_node.add_dummy(*sync_tensor) : nullptr;
+    if (with_fence) {
         node->op_params[0] = (int32_t) fence_seq;
     }
 
     cpy_node.init(node);
-    if (sync_tensor) {
+    if (with_fence) {
         cpy_node.name = "CPY+FENCE";
     }
     this->enqueue_op(cpy_node);
@@ -3203,7 +3198,7 @@ void ggml_hexagon_session::unclone_buffer(int fd) {
         it->second->unmap();
         this->cloned_buffers.erase(it);
     }
-    for (auto & sub : mdev_sessions) {
+    for (auto & sub : this->mdev.sessions) {
         sub->unclone_buffer(fd);
     }
 }
@@ -3416,7 +3411,7 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
     // Allocate buffers and state for op batching
     this->op_queue = new ggml_hexagon_opqueue(this, opt_opbatch, opt_opqueue);
 
-    const uint32_t reserved_slots = this->mdev_count > 1 ? this->mdev_count : 0;
+    const uint32_t reserved_slots = this->mdev.count > 1 ? this->mdev.count : 0;
     this->fence_buf = new ggml_hexagon_fence_buffer(this, &dev_ctx->fence_buffer_type, 64 * 1024, reserved_slots);
 
     if (!opt_vmem) {
@@ -3450,7 +3445,7 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
 void ggml_hexagon_session::release() noexcept(true) {
     GGML_LOG_INFO("ggml-hex: releasing session: %s\n", this->name.c_str());
 
-    mdev_sessions.clear();
+    this->mdev.sessions.clear();
 
     int err;
 
@@ -3499,8 +3494,8 @@ void ggml_hexagon_session::release() noexcept(true) {
 ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t mdev_idx, uint32_t mdev_count) noexcept(false) {
     this->dev        = dev;
     this->dev_ctx    = static_cast<ggml_backend_hexagon_device_context *>(dev->context);
-    this->mdev_idx   = mdev_idx;
-    this->mdev_count = mdev_count > 0 ? mdev_count : (uint32_t) (1 + config.mdev_group.size());
+    this->mdev.idx   = mdev_idx;
+    this->mdev.count = mdev_count > 0 ? mdev_count : (uint32_t) (1 + config.mdev_group.size());
     op_batch         = nullptr;
     op_queue         = nullptr;
     fence_buf        = nullptr;
@@ -3508,10 +3503,10 @@ ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & co
 
     try {
         allocate(config);
-        if (mdev_idx == 0 && !config.mdev_group.empty()) {
+        if (this->mdev.idx == 0 && !config.mdev_group.empty()) {
             for (size_t i = 0; i < config.mdev_group.size(); i++) {
-                mdev_sessions.push_back(std::make_unique<ggml_hexagon_session>(
-                    config.mdev_group[i], this->dev, (uint32_t) (i + 1), this->mdev_count));
+                this->mdev.sessions.push_back(std::make_unique<ggml_hexagon_session>(
+                    config.mdev_group[i], this->dev, (uint32_t) (i + 1), this->mdev.count));
             }
         }
     } catch (const std::exception & exc) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -400,14 +400,18 @@ struct ggml_hexagon_session {
     uint64_t vtcm_size   = 0;
     size_t   max_vmem    = 0;
     size_t   max_bufsize = 0;
-    uint32_t fence_seq;
+    uint32_t fence_seq   = 0;
 
     uint64_t                cached_uid = 0;
     std::vector<htp_opnode> cached_nodes;
 
     mutable std::unordered_set<const ggml_tensor *> needs_repack;
 
-    ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev = nullptr) noexcept(false);
+    uint32_t idev        = 0;
+    uint32_t ndev        = 1;
+    std::vector<std::unique_ptr<ggml_hexagon_session>> subsessions;
+
+    ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev = nullptr, uint32_t idev = 0, uint32_t ndev = 1) noexcept(false);
     ~ggml_hexagon_session() noexcept(true);
 
     const char* c_name() const { return name.c_str(); }
@@ -434,12 +438,15 @@ struct ggml_hexagon_session {
     }
 
     void flush_sync_peers() {
-        if (sync_peers.empty()) return;
-
-        for (auto * peer : sync_peers) {
-            peer->flush_batch();
+        if (!sync_peers.empty()) {
+            for (auto * peer : sync_peers) {
+                peer->flush_batch();
+            }
+            sync_peers.clear();
         }
-        sync_peers.clear();
+        for (auto & sub : subsessions) {
+            if (sub) sub->flush_sync_peers();
+        }
     }
 };
 
@@ -450,9 +457,11 @@ struct ggml_backend_hexagon_device_context {
     ggml_hexagon_device_config config;
     ggml_backend_dev_t         dev = nullptr;
     size_t                     max_bufsize = 0;
+    bool                       enable_row_split = false;
 
-    ggml_backend_buffer_type buffer_type      = {};
-    ggml_backend_buffer_type host_buffer_type = {};
+    ggml_backend_buffer_type buffer_type       = {};
+    ggml_backend_buffer_type host_buffer_type  = {};
+    ggml_backend_buffer_type split_buffer_type = {};
 
     std::unique_ptr<ggml_hexagon_session> sess;
 
@@ -463,7 +472,8 @@ struct ggml_backend_hexagon_device_context {
 
     ggml_hexagon_session * session() {
         if (!sess) {
-            sess = std::make_unique<ggml_hexagon_session>(config, dev);
+            uint32_t ndev = (enable_row_split && opt_ndev > 1) ? (uint32_t) opt_ndev : 1;
+            sess = std::make_unique<ggml_hexagon_session>(config, dev, dev_id, ndev);
         }
         return sess.get();
     }
@@ -1610,7 +1620,7 @@ static ggml_backend_buffer_type_i ggml_backend_hexagon_host_buffer_type_interfac
 };
 
 ggml_backend_hexagon_device_context::ggml_backend_hexagon_device_context(int dev_id, const ggml_hexagon_device_config & config, ggml_backend_dev_t dev)
-    : dev_id(dev_id), config(config), dev(dev), max_bufsize(opt_mbuf) {
+    : dev_id(dev_id), config(config), dev(dev), max_bufsize(opt_mbuf), enable_row_split(false) {
     buffer_type.device  = dev;
     buffer_type.iface   = ggml_backend_hexagon_buffer_type_interface;
     buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name, this);
@@ -1618,11 +1628,16 @@ ggml_backend_hexagon_device_context::ggml_backend_hexagon_device_context(int dev
     host_buffer_type.device  = dev;
     host_buffer_type.iface   = ggml_backend_hexagon_host_buffer_type_interface;
     host_buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name + "-HOST", this);
+
+    split_buffer_type.device  = dev;
+    split_buffer_type.iface   = ggml_backend_hexagon_buffer_type_interface;
+    split_buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name + "-SPLIT", this);
 }
 
 ggml_backend_hexagon_device_context::~ggml_backend_hexagon_device_context() {
     delete static_cast<ggml_backend_hexagon_buffer_type_context *>(buffer_type.context);
     delete static_cast<ggml_backend_hexagon_buffer_type_context *>(host_buffer_type.context);
+    delete static_cast<ggml_backend_hexagon_buffer_type_context *>(split_buffer_type.context);
 }
 
 static bool ggml_backend_buffer_is_hexagon(const struct ggml_backend_buffer * b) {
@@ -2721,6 +2736,12 @@ struct ggml_hexagon_opqueue {
 
 // Flush HTP response queue i.e wait for all outstanding requests to complete
 void ggml_hexagon_session::flush_pending(bool all) {
+    for (auto & sub : subsessions) {
+        if (sub) {
+            sub->flush_pending(all);
+        }
+    }
+
     while (this->op_pending) {
         struct htp_opbatch_rsp rsp;
         uint32_t               rsp_size;
@@ -2760,6 +2781,12 @@ void ggml_hexagon_session::flush_pending(bool all) {
 }
 
 void ggml_hexagon_session::flush_batch(size_t min_ops) {
+    for (auto & sub : subsessions) {
+        if (sub) {
+            sub->flush_batch(min_ops);
+        }
+    }
+
     if (op_batch->n_ops < min_ops) { return; }
 
     htp_opbatch_req req {};
@@ -2770,10 +2797,13 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
         op_queue->push(req, dbuf, op_batch);
     }
 
+    req.idev = (uint16_t) this->idev;
+    req.ndev = (uint16_t) this->ndev;
+
     // Bump pending flag (cleared in the session::flush once we get the response)
     this->op_pending++;  // atomic inc
 
-    HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u\n", this->c_name(), dbuf.ptr, dbuf.size);
+    HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u idev %u ndev %u\n", this->c_name(), dbuf.ptr, dbuf.size, req.idev, req.ndev);
 
     int err = dspqueue_write(this->queue, 0, 1, &dbuf, sizeof(req), (const uint8_t*) &req, DSPQUEUE_TIMEOUT);
     if (err != 0) {
@@ -2800,6 +2830,12 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
             if (ggml_backend_hexagon_buffer_get_sess(t->buffer) != this) {
                 this->clone_buffer(static_cast<const ggml_hexagon_shared_buffer *>(t->buffer->context));
             }
+        }
+    }
+
+    for (auto & sub : subsessions) {
+        if (sub) {
+            sub->enqueue_op(node);
         }
     }
 
@@ -3283,6 +3319,8 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
 void ggml_hexagon_session::release() noexcept(true) {
     GGML_LOG_INFO("ggml-hex: releasing session: %s\n", this->name.c_str());
 
+    subsessions.clear();
+
     int err;
 
     if (this->valid_iface) {
@@ -3325,13 +3363,40 @@ void ggml_hexagon_session::release() noexcept(true) {
     this->cloned_buffers.clear();
 }
 
-ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev) noexcept(false) {
+ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t idev, uint32_t ndev) noexcept(false) {
+    this->idev = idev;
+    this->ndev = ndev;
     op_batch = nullptr;
     op_queue = nullptr;
     fence_seq = ((uintptr_t)this) & 0xFFFF;
 
     try {
         allocate(config);
+        if (idev == 0 && ndev > 1) {
+            std::unordered_set<int> phys_set;
+            phys_set.insert(config.physical_idx);
+
+            std::vector<const ggml_hexagon_device_config *> sub_configs;
+            for (size_t i = 1; i < ndev; i++) {
+                if (i < opt_ndev) {
+                    const auto & cfg = opt_device_configs[i];
+                    if (phys_set.count(cfg.physical_idx) == 0) {
+                        phys_set.insert(cfg.physical_idx);
+                        sub_configs.push_back(&cfg);
+                    } else {
+                        GGML_LOG_WARN("ggml-hex: %s skipping device %s with duplicate physical index %d for row-split\n",
+                                      this->c_name(), cfg.name.c_str(), cfg.physical_idx);
+                    }
+                }
+            }
+
+            const uint32_t actual_ndev = (uint32_t) (1 + sub_configs.size());
+            this->ndev = actual_ndev;
+
+            for (size_t i = 0; i < sub_configs.size(); i++) {
+                subsessions.push_back(std::make_unique<ggml_hexagon_session>(*sub_configs[i], nullptr, (uint32_t) (i + 1), actual_ndev));
+            }
+        }
     } catch (const std::exception & exc) {
         release();
         throw;
@@ -6083,13 +6148,7 @@ static bool ggml_backend_hexagon_device_supports_op(ggml_backend_dev_t dev, cons
 static bool ggml_backend_hexagon_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
     auto dev_ctx = static_cast<ggml_backend_hexagon_device_context *>(dev->context);
 
-    // Technically we can clone hexagon buffers from any session but for some reason the output is garbled with layer-split,
-    // tensor-split works correctly, so it needs mode debugging and investigation. For now accept only our own buffers.
-#if 0
-    bool supp = (buft->iface.get_alignment == ggml_backend_hexagon_buffer_type_get_alignment);
-#else
-    bool supp = (buft == &dev_ctx->host_buffer_type) || (buft == &dev_ctx->buffer_type);
-#endif
+    bool supp = (buft == &dev_ctx->host_buffer_type) || (buft == &dev_ctx->buffer_type) || (buft == &dev_ctx->split_buffer_type);
 
     HEX_VERBOSE("ggml-hex: %s device-supports-buft %s %s\n", dev_ctx->c_name(), ggml_backend_buft_name(buft), supp ? "yes" : "no");
     return supp;
@@ -6270,8 +6329,24 @@ static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct
     return true;
 }
 
+static ggml_backend_buffer_type_t ggml_backend_hexagon_split_buffer_type(int main_device, const float * tensor_split) {
+    GGML_UNUSED(tensor_split);
+    auto reg = ggml_backend_hexagon_reg();
+    auto dev = ggml_backend_reg_dev_get(reg, main_device);
+    if (!dev) {
+        dev = ggml_backend_reg_dev_get(reg, 0);
+    }
+    if (!dev) return nullptr;
+    auto dev_ctx = static_cast<ggml_backend_hexagon_device_context *>(dev->context);
+    dev_ctx->enable_row_split = true;
+    return &dev_ctx->split_buffer_type;
+}
+
 static void * ggml_backend_hexagon_get_proc_address(ggml_backend_reg_t reg, const char * name) {
     GGML_UNUSED(reg);
+    if (strcmp(name, "ggml_backend_split_buffer_type") == 0) {
+        return (void *) ggml_backend_hexagon_split_buffer_type;
+    }
     if (strcmp(name, "ggml_backend_comm_init") == 0) {
         return (void *) ggml_backend_hexagon_comm_init;
     }

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -450,7 +450,7 @@ struct ggml_hexagon_session {
     void     wait_event(uint64_t seq);
 
     bool clone_buffer(const ggml_hexagon_shared_buffer*);
-    void unclone_buffer(int fd);
+    void unclone_buffer(const ggml_hexagon_shared_buffer*);
 
     void add_peer(ggml_hexagon_session * peer) {
         if (this->phys_idx == peer->phys_idx) {
@@ -609,9 +609,6 @@ struct ggml_hexagon_shared_buffer {
     }
 
     ~ggml_hexagon_shared_buffer() {
-        if (sess && mem) {
-            sess->unclone_buffer(fd());
-        }
         free();
         for (auto * extra : tensor_extra) {
             delete extra;
@@ -658,6 +655,7 @@ static ggml_hexagon_session * ggml_backend_hexagon_buffer_get_sess(ggml_backend_
 
 static void ggml_backend_hexagon_buffer_free_buffer(ggml_backend_buffer_t buffer) {
     auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(buffer->context);
+    sbuf->sess->unclone_buffer(sbuf);
     delete sbuf;
 }
 
@@ -3188,16 +3186,18 @@ bool ggml_hexagon_session::clone_buffer(const ggml_hexagon_shared_buffer *sbuf)
     return true;
 }
 
-void ggml_hexagon_session::unclone_buffer(int fd) {
+void ggml_hexagon_session::unclone_buffer(const ggml_hexagon_shared_buffer * sbuf) {
+    if (!sbuf) return;
+    int fd = sbuf->fd();
     if (fd < 0) return;
 
     auto it = this->cloned_buffers.find(fd);
     if (it != this->cloned_buffers.end()) {
-        it->second->unmap();
+        auto clone = std::move(it->second);
         this->cloned_buffers.erase(it);
     }
     for (auto & sub : this->mdev.sessions) {
-        sub->unclone_buffer(fd);
+        sub->unclone_buffer(sbuf);
     }
 }
 
@@ -3459,8 +3459,11 @@ void ggml_hexagon_session::release() noexcept(true) {
 
     delete this->op_batch;
     delete this->op_queue;
-    delete this->fence_buf;
-    this->fence_buf = nullptr;
+    if (this->fence_buf) {
+        unclone_buffer(this->fence_buf);
+        delete this->fence_buf;
+        this->fence_buf = nullptr;
+    }
 
     if (opt_etm) {
         err = htp_iface_etm(this->handle, 0);

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -6445,15 +6445,21 @@ static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct
         }
     }
 
-    auto sess_0 = static_cast<ggml_hexagon_session *>(comm_ctx->backends[0]->context);
-    if (++sess_0->fence_seq == 0) sess_0->fence_seq = 1;
-    uint32_t fence_seq_entry = sess_0->fence_seq;
-    if (++sess_0->fence_seq == 0) sess_0->fence_seq = 1;
-    uint32_t fence_seq_exit  = sess_0->fence_seq;
-
+    uint32_t max_seq = static_cast<ggml_hexagon_session *>(comm_ctx->backends[0]->context)->fence_seq;
     for (size_t i = 1; i < n_backends; i++) {
         auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
-        sess_i->fence_seq = sess_0->fence_seq;
+        if ((int32_t)(sess_i->fence_seq - max_seq) > 0) {
+            max_seq = sess_i->fence_seq;
+        }
+    }
+    if (++max_seq == 0) max_seq = 1;
+    uint32_t fence_seq_entry = max_seq;
+    if (++max_seq == 0) max_seq = 1;
+    uint32_t fence_seq_exit  = max_seq;
+
+    for (size_t i = 0; i < n_backends; i++) {
+        auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
+        sess_i->fence_seq = max_seq;
     }
 
     volatile uint32_t * fences[GGML_HEXAGON_MAX_SESSIONS];

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -445,7 +445,7 @@ struct ggml_hexagon_session {
             sync_peers.clear();
         }
         for (auto & sub : subsessions) {
-            if (sub) sub->flush_sync_peers();
+            sub->flush_sync_peers();
         }
     }
 };
@@ -2602,7 +2602,7 @@ struct ggml_hexagon_opqueue {
     size_t shm_size() const { return shm_buf ? shm_buf->size() : 0; }
 
     // push new batch
-    bool push(htp_opbatch_req& req, dspqueue_buffer& dbuf, ggml_hexagon_opbatch* op_batch) {
+    bool push(htp_opbatch_req& req, dspqueue_buffer& dbuf, const ggml_hexagon_opbatch* op_batch) {
         static_assert(sizeof(htp_opbatch_req) % 8 == 0, "sizeof(htp_opbatch_req) must be multiple of 8");
         static_assert(sizeof(htp_opbatch_rsp) % 8 == 0, "sizeof(htp_opbatch_rsp) must be multiple of 8");
         static_assert(sizeof(htp_buf_desc)    % 8 == 0, "sizeof(htp_buf_desc) must be multiple of 8");
@@ -2618,7 +2618,7 @@ struct ggml_hexagon_opqueue {
         req.n_ops     = op_batch->n_ops;
         req.seq       = ++req_seq;
 
-        op_cache[req.id]   = std::move(op_batch->ops);
+        op_cache[req.id]   = op_batch->ops;
         start_usec[req.id] = ggml_time_us();
 
         const size_t b_size = sizeof(htp_buf_desc)  * req.n_bufs;
@@ -2647,8 +2647,6 @@ struct ggml_hexagon_opqueue {
         uint8_t * t_ptr = m_ptr; m_ptr += t_size;
         uint8_t * o_ptr = m_ptr;
 
-        op_batch->sort_buffers();
-
         memcpy(b_ptr, (void *) op_batch->h_bufs.data(), b_size);
         memcpy(t_ptr, (void *) op_batch->h_tens.data(), t_size);
         memcpy(o_ptr, (void *) op_batch->h_ops.data(),  o_size);
@@ -2656,8 +2654,6 @@ struct ggml_hexagon_opqueue {
         HEX_VERBOSE("ggml-hex: %s opqueue-push batch #%u : n-bufs %u n-tensors %u n-ops %u vmem %zu : b-size %zu t-size %zu o-size %zu m-size %zu\n",
                 shm_buf->sess->c_name(), req.id, req.n_bufs, req.n_tensors, req.n_ops, op_batch->b_vmem,
                 b_size, t_size, o_size, (size_t) dbuf.size);
-
-        op_batch->reset();
 
         if (opt_verbose > 1) {
             htp_buf_desc *b = (htp_buf_desc*) b_ptr;
@@ -2737,9 +2733,7 @@ struct ggml_hexagon_opqueue {
 // Flush HTP response queue i.e wait for all outstanding requests to complete
 void ggml_hexagon_session::flush_pending(bool all) {
     for (auto & sub : subsessions) {
-        if (sub) {
-            sub->flush_pending(all);
-        }
+        sub->flush_pending(all);
     }
 
     while (this->op_pending) {
@@ -2781,13 +2775,32 @@ void ggml_hexagon_session::flush_pending(bool all) {
 }
 
 void ggml_hexagon_session::flush_batch(size_t min_ops) {
+    if (op_batch->n_ops < min_ops) { return; }
+
+    op_batch->sort_buffers();
+
     for (auto & sub : subsessions) {
-        if (sub) {
-            sub->flush_batch(min_ops);
+        htp_opbatch_req sub_req {};
+        dspqueue_buffer sub_dbuf{};
+
+        if (!sub->op_queue->push(sub_req, sub_dbuf, op_batch)) {
+            sub->flush_pending(false);
+            sub->op_queue->push(sub_req, sub_dbuf, op_batch);
+        }
+
+        sub_req.idev = (uint16_t) sub->idev;
+        sub_req.ndev = (uint16_t) sub->ndev;
+
+        sub->op_pending++;
+
+        HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u idev %u ndev %u\n",
+                    sub->c_name(), sub_dbuf.ptr, sub_dbuf.size, sub_req.idev, sub_req.ndev);
+
+        int err = dspqueue_write(sub->queue, 0, 1, &sub_dbuf, sizeof(sub_req), (const uint8_t*) &sub_req, DSPQUEUE_TIMEOUT);
+        if (err != 0) {
+            GGML_ABORT("ggml-hex: %s dspqueue_write failed: 0x%08x\n", sub->c_name(), (unsigned) err);
         }
     }
-
-    if (op_batch->n_ops < min_ops) { return; }
 
     htp_opbatch_req req {};
     dspqueue_buffer dbuf{};
@@ -2809,6 +2822,8 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
     if (err != 0) {
         GGML_ABORT("ggml-hex: %s dspqueue_write failed: 0x%08x\n", this->c_name(), (unsigned) err);
     }
+
+    op_batch->reset();
 }
 
 void ggml_hexagon_session::flush(bool all) {
@@ -2818,25 +2833,23 @@ void ggml_hexagon_session::flush(bool all) {
 }
 
 void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
-    for (auto t : node.get_inputs()) {
+    auto clone_tensor_buffer = [this](const ggml_tensor * t) {
         if (t && t->buffer && ggml_backend_buffer_is_hexagon(t->buffer)) {
+            auto sbuf = static_cast<const ggml_hexagon_shared_buffer *>(t->buffer->context);
             if (ggml_backend_hexagon_buffer_get_sess(t->buffer) != this) {
-                this->clone_buffer(static_cast<const ggml_hexagon_shared_buffer *>(t->buffer->context));
+                this->clone_buffer(sbuf);
+            }
+            for (auto & sub : subsessions) {
+                sub->clone_buffer(sbuf);
             }
         }
+    };
+
+    for (auto t : node.get_inputs()) {
+        clone_tensor_buffer(t);
     }
     for (auto t : node.get_outputs()) {
-        if (t && t->buffer && ggml_backend_buffer_is_hexagon(t->buffer)) {
-            if (ggml_backend_hexagon_buffer_get_sess(t->buffer) != this) {
-                this->clone_buffer(static_cast<const ggml_hexagon_shared_buffer *>(t->buffer->context));
-            }
-        }
-    }
-
-    for (auto & sub : subsessions) {
-        if (sub) {
-            sub->enqueue_op(node);
-        }
+        clone_tensor_buffer(t);
     }
 
     if (opt_opfusion && op_batch->try_fuse(node)) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -434,6 +434,7 @@ struct ggml_hexagon_session {
     void     wait_event(uint64_t seq);
 
     bool clone_buffer(const ggml_hexagon_shared_buffer*);
+    void unclone_buffer(int fd);
 
     void add_sync_peer(ggml_hexagon_session * peer) {
         sync_peers.insert(peer);
@@ -619,6 +620,9 @@ struct ggml_hexagon_shared_buffer {
     }
 
     ~ggml_hexagon_shared_buffer() {
+        if (sess && mem) {
+            sess->unclone_buffer(fd());
+        }
         free();
         for (auto * extra : tensor_extra) {
             delete extra;
@@ -3088,6 +3092,19 @@ bool ggml_hexagon_session::clone_buffer(const ggml_hexagon_shared_buffer *sbuf)
 
     this->cloned_buffers[sbuf->fd()] = std::move(clone);
     return true;
+}
+
+void ggml_hexagon_session::unclone_buffer(int fd) {
+    if (fd < 0) return;
+
+    auto it = this->cloned_buffers.find(fd);
+    if (it != this->cloned_buffers.end()) {
+        it->second->unmap();
+        this->cloned_buffers.erase(it);
+    }
+    for (auto & sub : mdev_sessions) {
+        sub->unclone_buffer(fd);
+    }
 }
 
 static size_t ggml_hexagon_measure_max_vmem(ggml_hexagon_session *sess) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -407,11 +407,11 @@ struct ggml_hexagon_session {
 
     mutable std::unordered_set<const ggml_tensor *> needs_repack;
 
-    uint32_t idev        = 0;
-    uint32_t ndev        = 1;
-    std::vector<std::unique_ptr<ggml_hexagon_session>> subsessions;
+    uint32_t mdev_idx    = 0;
+    uint32_t mdev_count  = 1;
+    std::vector<std::unique_ptr<ggml_hexagon_session>> mdev_sessions;
 
-    ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev = nullptr, uint32_t idev = 0, uint32_t ndev = 1) noexcept(false);
+    ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev = nullptr, uint32_t mdev_idx = 0, uint32_t mdev_count = 1) noexcept(false);
     ~ggml_hexagon_session() noexcept(true);
 
     const char* c_name() const { return name.c_str(); }
@@ -444,7 +444,7 @@ struct ggml_hexagon_session {
             }
             sync_peers.clear();
         }
-        for (auto & sub : subsessions) {
+        for (auto & sub : mdev_sessions) {
             sub->flush_sync_peers();
         }
     }
@@ -472,8 +472,8 @@ struct ggml_backend_hexagon_device_context {
 
     ggml_hexagon_session * session() {
         if (!sess) {
-            uint32_t ndev = (enable_row_split && opt_ndev > 1) ? (uint32_t) opt_ndev : 1;
-            sess = std::make_unique<ggml_hexagon_session>(config, dev, dev_id, ndev);
+            uint32_t mdev_count = (enable_row_split && opt_ndev > 1) ? (uint32_t) opt_ndev : 1;
+            sess = std::make_unique<ggml_hexagon_session>(config, dev, dev_id, mdev_count);
         }
         return sess.get();
     }
@@ -2732,7 +2732,7 @@ struct ggml_hexagon_opqueue {
 
 // Flush HTP response queue i.e wait for all outstanding requests to complete
 void ggml_hexagon_session::flush_pending(bool all) {
-    for (auto & sub : subsessions) {
+    for (auto & sub : mdev_sessions) {
         sub->flush_pending(all);
     }
 
@@ -2779,7 +2779,7 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
 
     op_batch->sort_buffers();
 
-    for (auto & sub : subsessions) {
+    for (auto & sub : mdev_sessions) {
         htp_opbatch_req sub_req {};
         dspqueue_buffer sub_dbuf{};
 
@@ -2788,13 +2788,13 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
             sub->op_queue->push(sub_req, sub_dbuf, op_batch);
         }
 
-        sub_req.idev = (uint16_t) sub->idev;
-        sub_req.ndev = (uint16_t) sub->ndev;
+        sub_req.mdev_idx   = (uint16_t) sub->mdev_idx;
+        sub_req.mdev_count = (uint16_t) sub->mdev_count;
 
         sub->op_pending++;
 
-        HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u idev %u ndev %u\n",
-                    sub->c_name(), sub_dbuf.ptr, sub_dbuf.size, sub_req.idev, sub_req.ndev);
+        HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u mdev-idx %u mdev-count %u\n",
+                    sub->c_name(), sub_dbuf.ptr, sub_dbuf.size, sub_req.mdev_idx, sub_req.mdev_count);
 
         int err = dspqueue_write(sub->queue, 0, 1, &sub_dbuf, sizeof(sub_req), (const uint8_t*) &sub_req, DSPQUEUE_TIMEOUT);
         if (err != 0) {
@@ -2810,13 +2810,13 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
         op_queue->push(req, dbuf, op_batch);
     }
 
-    req.idev = (uint16_t) this->idev;
-    req.ndev = (uint16_t) this->ndev;
+    req.mdev_idx   = (uint16_t) this->mdev_idx;
+    req.mdev_count = (uint16_t) this->mdev_count;
 
     // Bump pending flag (cleared in the session::flush once we get the response)
     this->op_pending++;  // atomic inc
 
-    HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u idev %u ndev %u\n", this->c_name(), dbuf.ptr, dbuf.size, req.idev, req.ndev);
+    HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u mdev-idx %u mdev-count %u\n", this->c_name(), dbuf.ptr, dbuf.size, req.mdev_idx, req.mdev_count);
 
     int err = dspqueue_write(this->queue, 0, 1, &dbuf, sizeof(req), (const uint8_t*) &req, DSPQUEUE_TIMEOUT);
     if (err != 0) {
@@ -2839,7 +2839,7 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
             if (ggml_backend_hexagon_buffer_get_sess(t->buffer) != this) {
                 this->clone_buffer(sbuf);
             }
-            for (auto & sub : subsessions) {
+            for (auto & sub : mdev_sessions) {
                 sub->clone_buffer(sbuf);
             }
         }
@@ -3332,7 +3332,7 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
 void ggml_hexagon_session::release() noexcept(true) {
     GGML_LOG_INFO("ggml-hex: releasing session: %s\n", this->name.c_str());
 
-    subsessions.clear();
+    mdev_sessions.clear();
 
     int err;
 
@@ -3376,21 +3376,21 @@ void ggml_hexagon_session::release() noexcept(true) {
     this->cloned_buffers.clear();
 }
 
-ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t idev, uint32_t ndev) noexcept(false) {
-    this->idev = idev;
-    this->ndev = ndev;
+ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t mdev_idx, uint32_t mdev_count) noexcept(false) {
+    this->mdev_idx   = mdev_idx;
+    this->mdev_count = mdev_count;
     op_batch = nullptr;
     op_queue = nullptr;
     fence_seq = ((uintptr_t)this) & 0xFFFF;
 
     try {
         allocate(config);
-        if (idev == 0 && ndev > 1) {
+        if (mdev_idx == 0 && mdev_count > 1) {
             std::unordered_set<int> phys_set;
             phys_set.insert(config.physical_idx);
 
             std::vector<const ggml_hexagon_device_config *> sub_configs;
-            for (size_t i = 1; i < ndev; i++) {
+            for (size_t i = 1; i < mdev_count; i++) {
                 if (i < opt_ndev) {
                     const auto & cfg = opt_device_configs[i];
                     if (phys_set.count(cfg.physical_idx) == 0) {
@@ -3403,11 +3403,11 @@ ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & co
                 }
             }
 
-            const uint32_t actual_ndev = (uint32_t) (1 + sub_configs.size());
-            this->ndev = actual_ndev;
+            const uint32_t actual_mdev_count = (uint32_t) (1 + sub_configs.size());
+            this->mdev_count = actual_mdev_count;
 
             for (size_t i = 0; i < sub_configs.size(); i++) {
-                subsessions.push_back(std::make_unique<ggml_hexagon_session>(*sub_configs[i], nullptr, (uint32_t) (i + 1), actual_ndev));
+                mdev_sessions.push_back(std::make_unique<ggml_hexagon_session>(*sub_configs[i], nullptr, (uint32_t) (i + 1), actual_mdev_count));
             }
         }
     } catch (const std::exception & exc) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -411,6 +411,8 @@ struct ggml_hexagon_session {
     size_t   max_vmem    = 0;
     size_t   max_bufsize = 0;
     uint32_t fence_seq   = 0;
+    uint64_t req_seq     = 0;
+    uint64_t rsp_seq     = 0;
 
     uint64_t                cached_uid = 0;
     std::vector<htp_opnode> cached_nodes;
@@ -1942,6 +1944,12 @@ struct ggml_hexagon_opbatch {
         }
     }
 
+    void update_mdev_group(uint32_t mdev_idx) {
+        if (n_ops > 0 && h_ops[0].opcode == HTP_OP_MDEV_GROUP) {
+            h_ops[0].params[0] = (int32_t) mdev_idx;
+        }
+    }
+
     bool try_fuse_allreduce_add(const htp_opnode & node) {
         if (n_ops == 0 || opt_ar_select != 2) return false;
         if (node.opcode != HTP_OP_ADD) return false;
@@ -2581,9 +2589,6 @@ struct ggml_hexagon_opqueue {
     ggml_hexagon_shared_buffer *shm_buf;
     size_t                      shm_blk_size;
 
-    uint64_t req_seq = 0;
-    uint64_t rsp_seq = 0;
-
     using opvec = std::vector<htp_opnode>;
 
     std::queue<unsigned int>    done;           // completed batch ids
@@ -2627,7 +2632,7 @@ struct ggml_hexagon_opqueue {
     size_t shm_size() const { return shm_buf ? shm_buf->size() : 0; }
 
     // push new batch
-    bool push(htp_opbatch_req& req, dspqueue_buffer& dbuf, const ggml_hexagon_opbatch* op_batch) {
+    bool push(htp_opbatch_req& req, dspqueue_buffer& dbuf, const ggml_hexagon_opbatch* op_batch, uint64_t seq) {
         static_assert(sizeof(htp_opbatch_req) % 8 == 0, "sizeof(htp_opbatch_req) must be multiple of 8");
         static_assert(sizeof(htp_opbatch_rsp) % 8 == 0, "sizeof(htp_opbatch_rsp) must be multiple of 8");
         static_assert(sizeof(htp_buf_desc)    % 8 == 0, "sizeof(htp_buf_desc) must be multiple of 8");
@@ -2641,7 +2646,7 @@ struct ggml_hexagon_opqueue {
         req.n_bufs    = op_batch->n_bufs;
         req.n_tensors = op_batch->n_tens;
         req.n_ops     = op_batch->n_ops;
-        req.seq       = ++req_seq;
+        req.seq       = seq;
 
         op_cache[req.id]   = op_batch->ops;
         start_usec[req.id] = ggml_time_us();
@@ -2748,10 +2753,6 @@ struct ggml_hexagon_opqueue {
                 ggml_hexagon_dump_trace_events(shm_buf->sess->name, rsp, trace_events, n_traces);
             }
         }
-
-        if (rsp.seq > rsp_seq) {
-            rsp_seq = rsp.seq;
-        }
     }
 };
 
@@ -2815,6 +2816,10 @@ void ggml_hexagon_session::flush_pending(bool all) {
 
         op_queue->pop(rsp, dbuf);
 
+        if (rsp.seq > this->rsp_seq) {
+            this->rsp_seq = rsp.seq;
+        }
+
         this->op_pending--;  // atomic dec
 
         if (!all) break;
@@ -2826,15 +2831,6 @@ void ggml_hexagon_session::flush_sync(bool all) {
     flush_pending(all);
 }
 
-static void update_mdev_idx(dspqueue_buffer & dbuf, const htp_opbatch_req & req, const ggml_hexagon_opbatch * op_batch, uint32_t mdev_idx) {
-    if (op_batch->n_ops > 0 && op_batch->h_ops[0].opcode == HTP_OP_MDEV_GROUP) {
-        const size_t b_size = sizeof(htp_buf_desc) * req.n_bufs;
-        const size_t t_size = sizeof(htp_tensor)   * req.n_tensors;
-        htp_op_desc * o_ptr = (htp_op_desc *) ((uint8_t *) dbuf.ptr + b_size + t_size);
-        o_ptr[0].params[0] = (int32_t) mdev_idx;
-    }
-}
-
 void ggml_hexagon_session::flush_batch(size_t min_ops) {
     if (op_batch->n_ops < min_ops) { return; }
 
@@ -2843,25 +2839,26 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
     htp_opbatch_req req {};
     dspqueue_buffer dbuf{};
 
-    if (!op_queue->push(req, dbuf, op_batch)) {
-        flush_pending(false);
-        op_queue->push(req, dbuf, op_batch);
-    }
+    const uint64_t seq = ++this->req_seq;
 
-    update_mdev_idx(dbuf, req, op_batch, this->mdev.idx);
+    op_batch->update_mdev_group(this->mdev.idx);
+
+    if (!op_queue->push(req, dbuf, op_batch, seq)) {
+        flush_pending(false);
+        op_queue->push(req, dbuf, op_batch, seq);
+    }
 
     for (auto & sub : this->mdev.sessions) {
         htp_opbatch_req sub_req {};
         dspqueue_buffer sub_dbuf{};
 
-        if (!sub->op_queue->push(sub_req, sub_dbuf, op_batch)) {
+        sub->req_seq = seq;
+        op_batch->update_mdev_group(sub->mdev.idx);
+
+        if (!sub->op_queue->push(sub_req, sub_dbuf, op_batch, seq)) {
             sub->flush_pending(false);
-            sub->op_queue->push(sub_req, sub_dbuf, op_batch);
+            sub->op_queue->push(sub_req, sub_dbuf, op_batch, seq);
         }
-
-        sub_req.seq = req.seq;
-
-        update_mdev_idx(sub_dbuf, sub_req, op_batch, sub->mdev.idx);
 
         sub->op_pending++;
 
@@ -3158,17 +3155,17 @@ void ggml_hexagon_session::enqueue_allreduce(
 
 void ggml_hexagon_session::wait_event(uint64_t seq) {
     HEX_VERBOSE("ggml-hex: %s opqueue-wait start: seq %llu, current rsp-seq %llu, pending %d\n",
-                this->name.c_str(), (unsigned long long)seq, (unsigned long long)op_queue->rsp_seq, (int)this->op_pending);
-    while (op_queue->rsp_seq < seq && this->op_pending > 0) {
+                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->rsp_seq, (int)this->op_pending);
+    while (this->rsp_seq < seq && this->op_pending > 0) {
         flush_sync(false);
     }
     HEX_VERBOSE("ggml-hex: %s opqueue-wait end: seq %llu, current rsp-seq %llu, pending %d\n",
-                this->name.c_str(), (unsigned long long)seq, (unsigned long long)op_queue->rsp_seq, (int)this->op_pending);
+                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->rsp_seq, (int)this->op_pending);
 }
 
 uint64_t ggml_hexagon_session::record_event() {
     flush_async();
-    return op_queue->req_seq;
+    return this->req_seq;
 }
 
 bool ggml_hexagon_session::clone_buffer(const ggml_hexagon_shared_buffer *sbuf)

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -438,7 +438,9 @@ struct ggml_hexagon_session {
     void enqueue_op(const htp_opnode & node);
     void enqueue_cpy(const ggml_tensor * src, ggml_tensor * dst, const ggml_tensor * sync_tensor = nullptr, uint32_t fence_seq = 0);
     void enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq = 0);
-    void enqueue_allreduce(const ggml_tensor * dst, const std::vector<const ggml_tensor *> & src_tensors, const std::vector<const ggml_tensor *> & sync_tensors, uint32_t rank, uint32_t n_ranks, uint32_t fence_seq_entry = 0, uint32_t fence_seq_exit = 0);
+    void enqueue_allreduce(const ggml_tensor * dst, const std::vector<const ggml_tensor *> & src_tensors,
+                           const std::vector<const ggml_tensor *> & sync_tensors, uint32_t rank, uint32_t n_ranks,
+                           uint32_t fence_seq_entry = 0, uint32_t fence_seq_exit = 0);
 
     void flush_sync(bool all = true);
     void flush_async();

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -66,7 +66,6 @@ using u32vec  = std::vector<uint32_t>;
 
 #define GGML_HEXAGON_MAX_SESSIONS          16
 
-#define GGML_HEXAGON_FENCE_BUFFER_SIZE     8192
 #define GGML_HEXAGON_FENCE_SLOT_SIZE       128
 
 struct ggml_hexagon_device_config {
@@ -362,7 +361,9 @@ struct htp_opnode;
 struct ggml_hexagon_opbatch;
 struct ggml_hexagon_opqueue;
 struct ggml_hexagon_shared_buffer;
+struct ggml_hexagon_fence_buffer;
 struct ggml_hexagon_session;
+struct ggml_backend_hexagon_device_context;
 
 struct ggml_backend_hexagon_comm_context {
     std::vector<ggml_backend_t> backends;
@@ -413,6 +414,9 @@ struct ggml_hexagon_session {
     uint32_t mdev_idx    = 0;
     uint32_t mdev_count  = 1;
     std::vector<std::unique_ptr<ggml_hexagon_session>> mdev_sessions;
+    ggml_backend_dev_t                     dev       = nullptr;
+    ggml_backend_hexagon_device_context *  dev_ctx   = nullptr;
+    ggml_hexagon_fence_buffer *            fence_buf = nullptr;
 
     ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev = nullptr, uint32_t mdev_idx = 0, uint32_t mdev_count = 0) noexcept(false);
     ~ggml_hexagon_session() noexcept(true);
@@ -422,6 +426,9 @@ struct ggml_hexagon_session {
     void allocate(const ggml_hexagon_device_config & config) noexcept(false);
     void release() noexcept(true);
 
+    uint8_t * alloc_fence(uint32_t n_slots = 1);
+
+    void enqueue_mdev_setup();
     void enqueue_op(const htp_opnode & node);
     void enqueue_cpy(const ggml_tensor * src, ggml_tensor * dst, const ggml_tensor * sync_tensor = nullptr, uint32_t fence_seq = 0);
     void enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq = 0);
@@ -458,6 +465,7 @@ struct ggml_backend_hexagon_device_context {
 
     ggml_backend_buffer_type buffer_type       = {};
     ggml_backend_buffer_type host_buffer_type  = {};
+    ggml_backend_buffer_type fence_buffer_type = {};
 
     std::unique_ptr<ggml_hexagon_session> sess;
 
@@ -513,8 +521,6 @@ struct ggml_hexagon_shared_buffer {
     ggml_hexagon_session *                     sess;
     std::shared_ptr<ggml_hexagon_rpcmem_block> mem;
     std::vector<ggml_hexagon_tensor_extra *>   tensor_extra;
-    uint32_t fence_head = 0;
-    size_t   fences_size = 0;
     bool     mapped;
     bool     pinned;
 
@@ -522,16 +528,6 @@ struct ggml_hexagon_shared_buffer {
     uint8_t *    base()   const { return mem ? mem->base : nullptr; }
     size_t       size()   const { return mem ? mem->size : 0;  }
     int          fd()     const { return mem ? mem->fd   : -1; }
-
-    uint8_t * alloc_fence() {
-        if (fences_size == 0) return nullptr;
-        int max_slots = fences_size / GGML_HEXAGON_FENCE_SLOT_SIZE;
-        uint32_t slot = (fence_head++) % max_slots;
-
-        size_t guard_offset = size() - fences_size;
-        uint8_t * fence_ptr = base() + guard_offset + (size_t)slot * GGML_HEXAGON_FENCE_SLOT_SIZE;
-        return fence_ptr;
-    }
 
     void mmap() {
         if (!this->mem) return;
@@ -572,9 +568,6 @@ struct ggml_hexagon_shared_buffer {
         if (this->mem) return;
 
         this->mem = std::make_shared<ggml_hexagon_rpcmem_block>(size);
-        if (fences_size > 0 && this->size() >= fences_size) {
-            memset(base() + (this->size() - fences_size), 0, fences_size);
-        }
 
         HEX_VERBOSE("ggml-hex: %s allocated buffer: base %p size %zu fd %d pinned %d\n", sess->c_name(),
                     (void *) base(), this->size(), fd(), (int) pinned);
@@ -589,29 +582,24 @@ struct ggml_hexagon_shared_buffer {
         this->mem  = nullptr;
     }
 
-    ggml_hexagon_shared_buffer(ggml_hexagon_session * sess, size_t size, bool pinned = false, size_t fence_size = 0) {
-        this->sess        = sess;
-        this->mapped      = false;
-        this->pinned      = pinned;
-        this->fences_size = fence_size;
+    ggml_hexagon_shared_buffer(ggml_hexagon_session * sess, size_t size, bool pinned = false) {
+        this->sess   = sess;
+        this->mapped = false;
+        this->pinned = pinned;
 
-        // Size adjustment inside the buffer class
+        // Size adjustment inside the buffer class: 4K aligned data size + 4K guard page
         size_t guard_offset = (size + 4095) & ~4095;
-        size_t total_size = guard_offset;
-        if (fence_size > 0) {
-            total_size += 4096 + fence_size;
-        }
+        size_t total_size   = guard_offset + 4096;
 
         alloc(total_size);
     }
 
     // Clone constructor for cross-session mapping
     ggml_hexagon_shared_buffer(ggml_hexagon_session * sess, const ggml_hexagon_shared_buffer & other) {
-        this->sess        = sess;
-        this->mem         = other.mem;
-        this->mapped      = false;
-        this->pinned      = other.pinned;
-        this->fences_size = other.fences_size;
+        this->sess   = sess;
+        this->mem    = other.mem;
+        this->mapped = false;
+        this->pinned = other.pinned;
     }
 
     ~ggml_hexagon_shared_buffer() {
@@ -624,6 +612,36 @@ struct ggml_hexagon_shared_buffer {
         }
     }
 };
+
+struct ggml_hexagon_fence_buffer : public ggml_hexagon_shared_buffer {
+    size_t              fence_size = 0;
+    uint32_t            slot_head  = 0;
+    ggml_backend_buffer backend_buffer{};
+
+    ggml_hexagon_fence_buffer(ggml_hexagon_session * sess, ggml_backend_buffer_type_t buft, size_t size)
+        : ggml_hexagon_shared_buffer(sess, size, false /* pinned */), fence_size(size) {
+        backend_buffer.buft    = buft;
+        backend_buffer.context = static_cast<ggml_hexagon_shared_buffer *>(this);
+        backend_buffer.size    = size;
+        if (base()) {
+            memset(base(), 0, size);
+        }
+    }
+
+    uint8_t * alloc_slot(uint32_t n_slots = 1) {
+        int max_slots = fence_size / GGML_HEXAGON_FENCE_SLOT_SIZE;
+        uint32_t slot = slot_head % max_slots;
+        if (slot + n_slots > (uint32_t) max_slots) {
+            slot = 0;
+        }
+        slot_head = slot + n_slots;
+        return base() + (size_t) slot * GGML_HEXAGON_FENCE_SLOT_SIZE;
+    }
+};
+
+inline uint8_t * ggml_hexagon_session::alloc_fence(uint32_t n_slots) {
+    return fence_buf ? fence_buf->alloc_slot(n_slots) : nullptr;
+}
 
 static ggml_hexagon_session * ggml_backend_hexagon_buffer_get_sess(ggml_backend_buffer_t buffer) {
     auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(buffer->context);
@@ -1548,7 +1566,7 @@ static ggml_backend_buffer_t ggml_backend_hexagon_buffer_type_alloc_buffer(
     auto dev_ctx = static_cast<ggml_backend_hexagon_buffer_type_context *>(buffer_type->context)->dev_ctx;
     auto sess    = dev_ctx->session();
     try {
-        ggml_hexagon_shared_buffer * sbuf = new ggml_hexagon_shared_buffer(sess, size, false, GGML_HEXAGON_FENCE_BUFFER_SIZE);
+        ggml_hexagon_shared_buffer * sbuf = new ggml_hexagon_shared_buffer(sess, size, false);
         return ggml_backend_buffer_init(buffer_type, ggml_backend_hexagon_buffer_interface, sbuf, size);
     } catch (const std::exception & exc) {
         GGML_LOG_ERROR("ggml-hex: %s failed to allocate device buffer context: %s\n", dev_ctx->c_name(), exc.what());
@@ -1561,7 +1579,7 @@ static ggml_backend_buffer_t ggml_backend_hexagon_host_buffer_type_alloc_buffer(
     auto dev_ctx = static_cast<ggml_backend_hexagon_buffer_type_context *>(buffer_type->context)->dev_ctx;
     auto sess    = dev_ctx->session();
     try {
-        ggml_hexagon_shared_buffer * sbuf = new ggml_hexagon_shared_buffer(sess, size, false, GGML_HEXAGON_FENCE_BUFFER_SIZE);
+        ggml_hexagon_shared_buffer * sbuf = new ggml_hexagon_shared_buffer(sess, size, false);
         return ggml_backend_buffer_init(buffer_type, ggml_backend_hexagon_host_buffer_interface, sbuf, size);
     } catch (const std::exception & exc) {
         GGML_LOG_ERROR("ggml-hex: %s failed to allocate host buffer context: %s\n", dev_ctx->c_name(), exc.what());
@@ -1629,11 +1647,16 @@ ggml_backend_hexagon_device_context::ggml_backend_hexagon_device_context(int dev
     host_buffer_type.device  = dev;
     host_buffer_type.iface   = ggml_backend_hexagon_host_buffer_type_interface;
     host_buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name + "-HOST", this);
+
+    fence_buffer_type.device  = dev;
+    fence_buffer_type.iface   = ggml_backend_hexagon_buffer_type_interface;
+    fence_buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name + "-FENCE", this);
 }
 
 ggml_backend_hexagon_device_context::~ggml_backend_hexagon_device_context() {
     delete static_cast<ggml_backend_hexagon_buffer_type_context *>(buffer_type.context);
     delete static_cast<ggml_backend_hexagon_buffer_type_context *>(host_buffer_type.context);
+    delete static_cast<ggml_backend_hexagon_buffer_type_context *>(fence_buffer_type.context);
 }
 
 static bool ggml_backend_buffer_is_hexagon(const struct ggml_backend_buffer * b) {
@@ -2813,6 +2836,14 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
     req.mdev_idx   = (uint16_t) this->mdev_idx;
     req.mdev_count = (uint16_t) this->mdev_count;
 
+    if (op_batch->n_ops > 0 && op_batch->h_ops[0].opcode == HTP_OP_MDEV_SETUP) {
+        const size_t b_size = sizeof(htp_buf_desc) * req.n_bufs;
+        const size_t t_size = sizeof(htp_tensor)   * req.n_tensors;
+        htp_op_desc * o_ptr = (htp_op_desc *) ((uint8_t *) dbuf.ptr + b_size + t_size);
+        o_ptr[0].params[0] = (int32_t) this->mdev_idx;
+        o_ptr[0].params[1] = (int32_t) this->mdev_count;
+    }
+
     for (auto & sub : mdev_sessions) {
         htp_opbatch_req sub_req {};
         dspqueue_buffer sub_dbuf{};
@@ -2825,6 +2856,14 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
         sub_req.seq        = req.seq;
         sub_req.mdev_idx   = (uint16_t) sub->mdev_idx;
         sub_req.mdev_count = (uint16_t) sub->mdev_count;
+
+        if (op_batch->n_ops > 0 && op_batch->h_ops[0].opcode == HTP_OP_MDEV_SETUP) {
+            const size_t b_size = sizeof(htp_buf_desc) * sub_req.n_bufs;
+            const size_t t_size = sizeof(htp_tensor)   * sub_req.n_tensors;
+            htp_op_desc * o_ptr = (htp_op_desc *) ((uint8_t *) sub_dbuf.ptr + b_size + t_size);
+            o_ptr[0].params[0] = (int32_t) sub->mdev_idx;
+            o_ptr[0].params[1] = (int32_t) sub->mdev_count;
+        }
 
         sub->op_pending++;
 
@@ -2877,7 +2916,51 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
     if (!op_batch->fit_op(node)) {
         flush_async();
     }
+
+    if (this->mdev_count > 1 && op_batch->n_ops == 0) {
+        enqueue_mdev_setup();
+    }
+
     op_batch->add_op(node);
+}
+
+void ggml_hexagon_session::enqueue_mdev_setup() {
+    htp_opnode setup_node(HTP_OP_MDEV_SETUP);
+
+    uint8_t * fence_ptr = this->alloc_fence(this->mdev_count);
+
+    static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
+    ggml_tensor dummy_t {};
+    dummy_t.buffer = &this->fence_buf->backend_buffer;
+    dummy_t.extra  = &fence_extra;
+    dummy_t.data   = (void *) fence_ptr;
+    dummy_t.type   = GGML_TYPE_I32;
+    dummy_t.ne[0]  = (this->mdev_count * HTP_FENCE_SLOT_SIZE) / sizeof(int32_t);
+    dummy_t.ne[1]  = 1;
+    dummy_t.ne[2]  = 1;
+    dummy_t.ne[3]  = 1;
+    dummy_t.nb[0]  = sizeof(int32_t);
+    dummy_t.nb[1]  = dummy_t.ne[0] * sizeof(int32_t);
+    dummy_t.nb[2]  = dummy_t.nb[1];
+    dummy_t.nb[3]  = dummy_t.nb[2];
+    dummy_t.op     = GGML_OP_NONE;
+    dummy_t.op_params[0] = (int32_t) this->mdev_idx;
+    dummy_t.op_params[1] = (int32_t) this->mdev_count;
+
+    ggml_tensor * node = setup_node.add_dummy(dummy_t);
+    node->src[0] = node;
+    setup_node.init(node);
+    setup_node.outputs.clear();
+    setup_node.name = "MDEV_SETUP";
+
+    if (this->fence_buf->sess != this) {
+        this->clone_buffer(this->fence_buf);
+    }
+    for (auto & sub : mdev_sessions) {
+        sub->clone_buffer(this->fence_buf);
+    }
+
+    op_batch->add_op(setup_node);
 }
 
 void ggml_hexagon_session::enqueue_cpy(const ggml_tensor * src, ggml_tensor * dst, const ggml_tensor * sync_tensor, uint32_t fence_seq) {
@@ -3330,6 +3413,8 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
 
     // Allocate buffers and state for op batching
     this->op_queue = new ggml_hexagon_opqueue(this, opt_opbatch, opt_opqueue);
+    ggml_backend_buffer_type_t fence_buft = dev_ctx ? &dev_ctx->fence_buffer_type : nullptr;
+    this->fence_buf = new ggml_hexagon_fence_buffer(this, fence_buft, 64 * 1024);
 
     if (!opt_vmem) {
         opt_vmem = ggml_hexagon_measure_max_vmem(this);
@@ -3376,6 +3461,8 @@ void ggml_hexagon_session::release() noexcept(true) {
 
     delete this->op_batch;
     delete this->op_queue;
+    delete this->fence_buf;
+    this->fence_buf = nullptr;
 
     if (opt_etm) {
         err = htp_iface_etm(this->handle, 0);
@@ -3407,26 +3494,28 @@ void ggml_hexagon_session::release() noexcept(true) {
 }
 
 ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t mdev_idx, uint32_t mdev_count) noexcept(false) {
+    this->dev        = dev;
+    this->dev_ctx    = dev ? static_cast<ggml_backend_hexagon_device_context *>(dev->context) : nullptr;
     this->mdev_idx   = mdev_idx;
     this->mdev_count = mdev_count > 0 ? mdev_count : (uint32_t) (1 + config.mdev_group.size());
-    op_batch = nullptr;
-    op_queue = nullptr;
-    fence_seq = ((uintptr_t)this) & 0xFFFF;
+    op_batch         = nullptr;
+    op_queue         = nullptr;
+    fence_buf        = nullptr;
+    fence_seq        = ((uintptr_t)this) & 0xFFFF;
 
     try {
         allocate(config);
         if (mdev_idx == 0 && !config.mdev_group.empty()) {
             for (size_t i = 0; i < config.mdev_group.size(); i++) {
                 mdev_sessions.push_back(std::make_unique<ggml_hexagon_session>(
-                    config.mdev_group[i], nullptr, (uint32_t) (i + 1), this->mdev_count));
+                    config.mdev_group[i], this->dev, (uint32_t) (i + 1), this->mdev_count));
+                mdev_sessions.back()->clone_buffer(this->fence_buf);
             }
         }
     } catch (const std::exception & exc) {
         release();
         throw;
     }
-
-    GGML_UNUSED(dev);
 }
 
 ggml_hexagon_session::~ggml_hexagon_session() noexcept(true) {
@@ -5639,7 +5728,7 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
 
     if (!sess_src->clone_buffer(sbuf_dst)) { return false; }
 
-    volatile uint32_t * fence = (volatile uint32_t *) sbuf_dst->alloc_fence();
+    volatile uint32_t * fence = (volatile uint32_t *) sess_dst->alloc_fence();
     if (!fence) { return false; }
 
     if (++sess_dst->fence_seq == 0) sess_dst->fence_seq = 1;
@@ -5652,7 +5741,7 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
     static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
 
     ggml_tensor fence_tensor {};
-    fence_tensor.buffer = dst->buffer;
+    fence_tensor.buffer = &sess_dst->fence_buf->backend_buffer;
     fence_tensor.extra  = &fence_extra;
     fence_tensor.data   = (void *) fence;
     fence_tensor.type   = GGML_TYPE_I32;
@@ -6344,15 +6433,16 @@ static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct
 
     volatile uint32_t * fences[GGML_HEXAGON_MAX_SESSIONS];
     for (size_t i = 0; i < n_backends; i++) {
-        auto sbuf = (ggml_hexagon_shared_buffer *) tensors[i]->buffer->context;
-        fences[i] = (volatile uint32_t *) sbuf->alloc_fence();
+        auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
+        fences[i] = (volatile uint32_t *) sess_i->alloc_fence();
     }
 
     static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
     ggml_tensor fence_tensors[GGML_HEXAGON_MAX_SESSIONS];
     for (size_t i = 0; i < n_backends; i++) {
+        auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
         fence_tensors[i] = {};
-        fence_tensors[i].buffer = tensors[i]->buffer;
+        fence_tensors[i].buffer = &sess_i->fence_buf->backend_buffer;
         fence_tensors[i].extra  = &fence_extra;
         fence_tensors[i].data   = (void *) fences[i];
         fence_tensors[i].type   = GGML_TYPE_I32;

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -3265,16 +3265,16 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
     this->valid_queue   = false;
     this->valid_iface   = false;
 
-    this->phys_idx   = phys_idx;
-    this->virt_idx   = virt_idx;
-    this->domain_id  = config.domain_id;
-    this->session_id = 0;
     this->name          = config.name;
+    this->phys_idx      = phys_idx;
+    this->virt_idx      = virt_idx;
+    this->domain_id     = config.domain_id;
+    this->session_id    = 0;
     this->batch_req_seq = 0;
     this->batch_rsp_seq = 0;
     this->last_error    = HTP_STATUS_OK;
 
-    GGML_LOG_DEBUG("ggml-hex: %s allocating new session\n", this->name.c_str());
+    GGML_LOG_DEBUG("ggml-hex: %s allocating new session : domain %u phys-idx %u virt-idx %u\n", this->name.c_str(), this->domain_id, phys_idx, virt_idx);
 
     if (config.domain_id < 0 || config.domain_name.empty()) {
         GGML_LOG_ERROR("ggml-hex: %s: invalid physical CDSP core %d\n", config.name.c_str(), config.physical_idx);
@@ -3283,25 +3283,14 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
 
     const std::string & dom_name = config.domain_name;
 
-    // Enable Unsigned PD for all domains
-    {
-        struct remote_rpc_control_unsigned_module u;
-        u.domain = -1;
-        u.enable = 1;
-        int err  = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE, (void *) &u, sizeof(u));
-        if (err != AEE_SUCCESS) {
-            GGML_LOG_ERROR("ggml-hex: %s failed to enable unsigned PD : error 0x%x\n", this->c_name(), err);
-            throw std::runtime_error("ggml-hex: remote_session_control(unsign) failed (see log for details)");
-        }
-    }
-
     // Create new session if virtual_idx > 0
     if (virt_idx > 0) {
-        struct remote_rpc_reserve_new_session n;
+        struct remote_rpc_reserve_new_session n {};
         n.domain_name_len  = dom_name.size();
         n.domain_name      = const_cast<char *>(dom_name.c_str());
         n.session_name     = const_cast<char *>(this->name.c_str());
         n.session_name_len = this->name.size();
+        n.session_id       = virt_idx;
 
         int err = remote_session_control(FASTRPC_RESERVE_NEW_SESSION, (void *) &n, sizeof(n));
         if (err != AEE_SUCCESS) {
@@ -3315,7 +3304,7 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
         this->domain_id     = n.effective_domain_id;
         this->valid_session = true;
     } else {
-        struct remote_rpc_effective_domain_id eff = {};
+        struct remote_rpc_effective_domain_id eff {};
         eff.domain_name     = const_cast<char *>(dom_name.c_str());
         eff.domain_name_len = dom_name.size();
         eff.session_id      = 0;
@@ -3326,6 +3315,18 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
         } else {
             GGML_LOG_DEBUG("ggml-hex: %s FASTRPC_GET_EFFECTIVE_DOMAIN_ID returned 0x%x, using domain_id %d\n",
                            this->name.c_str(), err, this->domain_id);
+        }
+    }
+
+    // Enable unsigned modules
+    {
+        struct remote_rpc_control_unsigned_module u;
+        u.domain = this->domain_id;
+        u.enable = 1;
+        int err  = remote_session_control(DSPRPC_CONTROL_UNSIGNED_MODULE, (void *) &u, sizeof(u));
+        if (err != AEE_SUCCESS) {
+            GGML_LOG_ERROR("ggml-hex: %s failed to enable unsigned PD : error 0x%x\n", this->c_name(), err);
+            throw std::runtime_error("ggml-hex: remote_session_control(unsign) failed (see log for details)");
         }
     }
 
@@ -3356,7 +3357,7 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
     // Open session
     int err = htp_iface_open(session_uri, &this->handle);
     if (err != AEE_SUCCESS) {
-        GGML_LOG_ERROR("ggml-hex: %s failed to open session : error 0x%x\n", this->c_name(), err);
+        GGML_LOG_ERROR("ggml-hex: %s failed to open session : uri %s error 0x%x\n", this->c_name(), session_uri, err);
         throw std::runtime_error("ggml-hex: failed to open session (see log for details)");
     }
 

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -431,6 +431,7 @@ struct ggml_hexagon_session {
     void flush_async();
     void flush_batch(size_t min_ops = 1);
     void flush_peers();
+    void flush_pending(bool all = true);
 
     uint64_t record_event();
     void     wait_event(uint64_t seq);
@@ -2748,11 +2749,9 @@ void ggml_hexagon_session::flush_async() {
     flush_batch();
 }
 
-void ggml_hexagon_session::flush_sync(bool all) {
-    flush_async();
-
+void ggml_hexagon_session::flush_pending(bool all) {
     for (auto & sub : mdev_sessions) {
-        sub->flush_sync(all);
+        sub->flush_pending(all);
     }
 
     while (this->op_pending) {
@@ -2793,6 +2792,11 @@ void ggml_hexagon_session::flush_sync(bool all) {
     }
 }
 
+void ggml_hexagon_session::flush_sync(bool all) {
+    flush_async();
+    flush_pending(all);
+}
+
 void ggml_hexagon_session::flush_batch(size_t min_ops) {
     if (op_batch->n_ops < min_ops) { return; }
 
@@ -2802,7 +2806,7 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
     dspqueue_buffer dbuf{};
 
     if (!op_queue->push(req, dbuf, op_batch)) {
-        flush_sync(false);
+        flush_pending(false);
         op_queue->push(req, dbuf, op_batch);
     }
 
@@ -2814,7 +2818,7 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
         dspqueue_buffer sub_dbuf{};
 
         if (!sub->op_queue->push(sub_req, sub_dbuf, op_batch)) {
-            sub->flush_sync(false);
+            sub->flush_pending(false);
             sub->op_queue->push(sub_req, sub_dbuf, op_batch);
         }
 

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -75,6 +75,8 @@ struct ggml_hexagon_device_config {
     int         domain_id    = 0;
     std::string domain_name;
     std::string name;
+
+    std::vector<ggml_hexagon_device_config> mdev_group;
 };
 
 static ggml_hexagon_device_config opt_device_configs[GGML_HEXAGON_MAX_SESSIONS];
@@ -457,11 +459,9 @@ struct ggml_backend_hexagon_device_context {
     ggml_hexagon_device_config config;
     ggml_backend_dev_t         dev = nullptr;
     size_t                     max_bufsize = 0;
-    bool                       enable_row_split = false;
 
     ggml_backend_buffer_type buffer_type       = {};
     ggml_backend_buffer_type host_buffer_type  = {};
-    ggml_backend_buffer_type split_buffer_type = {};
 
     std::unique_ptr<ggml_hexagon_session> sess;
 
@@ -472,7 +472,7 @@ struct ggml_backend_hexagon_device_context {
 
     ggml_hexagon_session * session() {
         if (!sess) {
-            uint32_t mdev_count = (enable_row_split && opt_ndev > 1) ? (uint32_t) opt_ndev : 1;
+            uint32_t mdev_count = (uint32_t) (1 + config.mdev_group.size());
             sess = std::make_unique<ggml_hexagon_session>(config, dev, dev_id, mdev_count);
         }
         return sess.get();
@@ -1620,7 +1620,7 @@ static ggml_backend_buffer_type_i ggml_backend_hexagon_host_buffer_type_interfac
 };
 
 ggml_backend_hexagon_device_context::ggml_backend_hexagon_device_context(int dev_id, const ggml_hexagon_device_config & config, ggml_backend_dev_t dev)
-    : dev_id(dev_id), config(config), dev(dev), max_bufsize(opt_mbuf), enable_row_split(false) {
+    : dev_id(dev_id), config(config), dev(dev), max_bufsize(opt_mbuf) {
     buffer_type.device  = dev;
     buffer_type.iface   = ggml_backend_hexagon_buffer_type_interface;
     buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name, this);
@@ -1628,16 +1628,11 @@ ggml_backend_hexagon_device_context::ggml_backend_hexagon_device_context(int dev
     host_buffer_type.device  = dev;
     host_buffer_type.iface   = ggml_backend_hexagon_host_buffer_type_interface;
     host_buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name + "-HOST", this);
-
-    split_buffer_type.device  = dev;
-    split_buffer_type.iface   = ggml_backend_hexagon_buffer_type_interface;
-    split_buffer_type.context = new ggml_backend_hexagon_buffer_type_context(config.name + "-SPLIT", this);
 }
 
 ggml_backend_hexagon_device_context::~ggml_backend_hexagon_device_context() {
     delete static_cast<ggml_backend_hexagon_buffer_type_context *>(buffer_type.context);
     delete static_cast<ggml_backend_hexagon_buffer_type_context *>(host_buffer_type.context);
-    delete static_cast<ggml_backend_hexagon_buffer_type_context *>(split_buffer_type.context);
 }
 
 static bool ggml_backend_buffer_is_hexagon(const struct ggml_backend_buffer * b) {
@@ -3385,29 +3380,10 @@ ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & co
 
     try {
         allocate(config);
-        if (mdev_idx == 0 && mdev_count > 1) {
-            std::unordered_set<int> phys_set;
-            phys_set.insert(config.physical_idx);
-
-            std::vector<const ggml_hexagon_device_config *> sub_configs;
-            for (size_t i = 1; i < mdev_count; i++) {
-                if (i < opt_ndev) {
-                    const auto & cfg = opt_device_configs[i];
-                    if (phys_set.count(cfg.physical_idx) == 0) {
-                        phys_set.insert(cfg.physical_idx);
-                        sub_configs.push_back(&cfg);
-                    } else {
-                        GGML_LOG_WARN("ggml-hex: %s skipping device %s with duplicate physical index %d for row-split\n",
-                                      this->c_name(), cfg.name.c_str(), cfg.physical_idx);
-                    }
-                }
-            }
-
-            const uint32_t actual_mdev_count = (uint32_t) (1 + sub_configs.size());
-            this->mdev_count = actual_mdev_count;
-
-            for (size_t i = 0; i < sub_configs.size(); i++) {
-                mdev_sessions.push_back(std::make_unique<ggml_hexagon_session>(*sub_configs[i], nullptr, (uint32_t) (i + 1), actual_mdev_count));
+        if (mdev_idx == 0 && !config.mdev_group.empty()) {
+            for (size_t i = 0; i < config.mdev_group.size(); i++) {
+                mdev_sessions.push_back(std::make_unique<ggml_hexagon_session>(
+                    config.mdev_group[i], nullptr, (uint32_t) (i + 1), mdev_count));
             }
         }
     } catch (const std::exception & exc) {
@@ -6161,7 +6137,7 @@ static bool ggml_backend_hexagon_device_supports_op(ggml_backend_dev_t dev, cons
 static bool ggml_backend_hexagon_device_supports_buft(ggml_backend_dev_t dev, ggml_backend_buffer_type_t buft) {
     auto dev_ctx = static_cast<ggml_backend_hexagon_device_context *>(dev->context);
 
-    bool supp = (buft == &dev_ctx->host_buffer_type) || (buft == &dev_ctx->buffer_type) || (buft == &dev_ctx->split_buffer_type);
+    bool supp = (buft == &dev_ctx->host_buffer_type) || (buft == &dev_ctx->buffer_type);
 
     HEX_VERBOSE("ggml-hex: %s device-supports-buft %s %s\n", dev_ctx->c_name(), ggml_backend_buft_name(buft), supp ? "yes" : "no");
     return supp;
@@ -6194,6 +6170,19 @@ ggml_hexagon_registry::ggml_hexagon_registry(ggml_backend_reg_t reg) {
 
     // Create devices
     for (size_t i = 0; i < opt_ndev; i++) {
+        const auto & cfg = opt_device_configs[i];
+        if (cfg.mdev_group.empty()) {
+            GGML_LOG_INFO("ggml-hex: device %zu: %s (phys=%d, virt=%d, domain=%s:%d)\n",
+                          i, cfg.name.c_str(), cfg.physical_idx, cfg.virtual_idx, cfg.domain_name.c_str(), cfg.domain_id);
+        } else {
+            std::string peers_str;
+            for (const auto & p : cfg.mdev_group) {
+                if (!peers_str.empty()) peers_str += ", ";
+                peers_str += p.name + " (phys=" + std::to_string(p.physical_idx) + ")";
+            }
+            GGML_LOG_INFO("ggml-hex: device %zu: %s (phys=%d, virt=%d, domain=%s:%d) [mdev peers: %s]\n",
+                          i, cfg.name.c_str(), cfg.physical_idx, cfg.virtual_idx, cfg.domain_name.c_str(), cfg.domain_id, peers_str.c_str());
+        }
         devices[i].iface   = ggml_backend_hexagon_device_i;
         devices[i].reg     = reg;
         devices[i].context = new ggml_backend_hexagon_device_context(i, opt_device_configs[i], &devices[i]);
@@ -6351,8 +6340,7 @@ static ggml_backend_buffer_type_t ggml_backend_hexagon_split_buffer_type(int mai
     }
     if (!dev) return nullptr;
     auto dev_ctx = static_cast<ggml_backend_hexagon_device_context *>(dev->context);
-    dev_ctx->enable_row_split = true;
-    return &dev_ctx->split_buffer_type;
+    return &dev_ctx->buffer_type;
 }
 
 static void * ggml_backend_hexagon_get_proc_address(ggml_backend_reg_t reg, const char * name) {
@@ -6390,6 +6378,41 @@ template<typename T, int BASE=10> std::string vec_to_str(std::vector<T> v) {
     for (auto i : v) { ss << i << ','; }
     auto str = ss.str(); str.pop_back(); // drop last comma
     return str;
+}
+
+static void ggml_hexagon_resolve_device_domain(ggml_hexagon_device_config & cfg, bool discovery_supported, const std::unordered_map<int, fastrpc_domain> & cdsp_map) {
+    if (discovery_supported) {
+        auto it = cdsp_map.find(cfg.physical_idx);
+        if (it != cdsp_map.end()) {
+            cfg.domain_id   = it->second.id;
+            cfg.domain_name = it->second.name;
+        } else {
+            GGML_LOG_ERROR("ggml-hex: physical CDSP core %d not found on device (%zu CDSP core(s) available)\n",
+                           cfg.physical_idx, cdsp_map.size());
+            cfg.domain_id   = -1;
+            cfg.domain_name = "";
+        }
+    } else {
+        switch (cfg.physical_idx) {
+            case 0:
+                cfg.domain_id   = 3;
+                cfg.domain_name = CDSP_DOMAIN_NAME;
+                break;
+            case 1:
+                cfg.domain_id   = 4;
+                cfg.domain_name = "cdsp1";
+                break;
+            default:
+                GGML_LOG_ERROR("ggml-hex: physical CDSP core %d not supported without dynamic discovery\n",
+                               cfg.physical_idx);
+                cfg.domain_id   = -1;
+                cfg.domain_name = "";
+                break;
+        }
+    }
+    for (auto & sub_cfg : cfg.mdev_group) {
+        ggml_hexagon_resolve_device_domain(sub_cfg, discovery_supported, cdsp_map);
+    }
 }
 
 // Enumerate NPU (aka CDSP) domains via FASTRPC_GET_DOMAINS if supported,
@@ -6438,36 +6461,7 @@ static void ggml_hexagon_discover_devices() {
 
     // Populate domain IDs and names for all configured devices
     for (size_t i = 0; i < opt_ndev; i++) {
-        auto & cfg = opt_device_configs[i];
-        if (discovery_supported) {
-            auto it = cdsp_map.find(cfg.physical_idx);
-            if (it != cdsp_map.end()) {
-                cfg.domain_id   = it->second.id;
-                cfg.domain_name = it->second.name;
-            } else {
-                GGML_LOG_ERROR("ggml-hex: physical CDSP core %d not found on device (%zu CDSP core(s) available)\n",
-                               cfg.physical_idx, cdsp_map.size());
-                cfg.domain_id   = -1;
-                cfg.domain_name = "";
-            }
-        } else {
-            switch (cfg.physical_idx) {
-                case 0:
-                    cfg.domain_id   = 3;
-                    cfg.domain_name = CDSP_DOMAIN_NAME;
-                    break;
-                case 1:
-                    cfg.domain_id   = 4;
-                    cfg.domain_name = "cdsp1";
-                    break;
-                default:
-                    GGML_LOG_ERROR("ggml-hex: physical CDSP core %d not supported without dynamic discovery\n",
-                                   cfg.physical_idx);
-                    cfg.domain_id   = -1;
-                    cfg.domain_name = "";
-                    break;
-            }
-        }
+        ggml_hexagon_resolve_device_domain(opt_device_configs[i], discovery_supported, cdsp_map);
     }
 }
 
@@ -6575,21 +6569,126 @@ static void ggml_hexagon_init(ggml_backend_reg * reg) {
                 opt_device_configs[i].physical_idx = 0;
                 opt_device_configs[i].virtual_idx  = (int)i;
                 opt_device_configs[i].name         = "HTP" + std::to_string(i);
+                opt_device_configs[i].mdev_group.clear();
             }
         } else {
             std::string s_devices(str_devices);
-            std::stringstream ss(s_devices);
-            std::string item;
-            opt_ndev = 0;
-            while (std::getline(ss, item, ',')) {
-                size_t start = item.find_first_not_of(" \t\r\n");
-                size_t end = item.find_last_not_of(" \t\r\n");
-                if (start == std::string::npos) {
-                    continue;
+            std::vector<std::string> items;
+            std::string curr_item;
+            int bracket_depth = 0;
+            for (char ch : s_devices) {
+                if (ch == '[') {
+                    bracket_depth++;
+                    curr_item += ch;
+                } else if (ch == ']') {
+                    if (bracket_depth > 0) bracket_depth--;
+                    curr_item += ch;
+                } else if (ch == ',' && bracket_depth == 0) {
+                    size_t s = curr_item.find_first_not_of(" \t\r\n");
+                    size_t e = curr_item.find_last_not_of(" \t\r\n");
+                    if (s != std::string::npos) {
+                        items.push_back(curr_item.substr(s, e - s + 1));
+                    }
+                    curr_item.clear();
+                } else {
+                    curr_item += ch;
                 }
-                item = item.substr(start, end - start + 1);
+            }
+            size_t s = curr_item.find_first_not_of(" \t\r\n");
+            size_t e = curr_item.find_last_not_of(" \t\r\n");
+            if (s != std::string::npos) {
+                items.push_back(curr_item.substr(s, e - s + 1));
+            }
 
-                if (item.rfind("HTP", 0) == 0) {
+            opt_ndev = 0;
+            for (const auto & item : items) {
+                size_t b_open  = item.find('[');
+                size_t b_close = item.rfind(']');
+
+                if (b_open != std::string::npos && b_close != std::string::npos && b_close > b_open) {
+                    // Grouped / composite syntax: Name[phys_spec:virt] or Name[phys_spec]
+                    std::string dev_name = item.substr(0, b_open);
+                    std::string content  = item.substr(b_open + 1, b_close - b_open - 1);
+
+                    int virt = 0;
+                    std::string phys_spec = content;
+                    size_t colon_pos = content.find(':');
+                    if (colon_pos != std::string::npos) {
+                        phys_spec = content.substr(0, colon_pos);
+                        try {
+                            virt = std::stoi(content.substr(colon_pos + 1));
+                        } catch (...) {
+                            virt = 0;
+                        }
+                    } else {
+                        size_t dev_colon = dev_name.find(':');
+                        if (dev_colon != std::string::npos) {
+                            try {
+                                virt = std::stoi(dev_name.substr(dev_colon + 1));
+                            } catch (...) {
+                                virt = 0;
+                            }
+                        }
+                    }
+
+                    // Parse physical indices from phys_spec (e.g. 0-1, 0,1, 0-3, etc.)
+                    std::vector<int> phys_list;
+                    std::stringstream pss(phys_spec);
+                    std::string p_part;
+                    while (std::getline(pss, p_part, ',')) {
+                        size_t ps = p_part.find_first_not_of(" \t\r\n");
+                        size_t pe = p_part.find_last_not_of(" \t\r\n");
+                        if (ps == std::string::npos) continue;
+                        p_part = p_part.substr(ps, pe - ps + 1);
+
+                        size_t dash_pos = p_part.find('-');
+                        if (dash_pos != std::string::npos) {
+                            try {
+                                int p_start = std::stoi(p_part.substr(0, dash_pos));
+                                int p_end   = std::stoi(p_part.substr(dash_pos + 1));
+                                for (int p = p_start; p <= p_end; p++) {
+                                    if (std::find(phys_list.begin(), phys_list.end(), p) == phys_list.end()) {
+                                        phys_list.push_back(p);
+                                    }
+                                }
+                            } catch (...) {
+                                GGML_LOG_WARN("ggml-hex: failed to parse physical range in '%s'\n", p_part.c_str());
+                            }
+                        } else {
+                            try {
+                                int p = std::stoi(p_part);
+                                if (std::find(phys_list.begin(), phys_list.end(), p) == phys_list.end()) {
+                                    phys_list.push_back(p);
+                                }
+                            } catch (...) {
+                                GGML_LOG_WARN("ggml-hex: failed to parse physical index in '%s'\n", p_part.c_str());
+                            }
+                        }
+                    }
+
+                    if (phys_list.empty()) {
+                        phys_list.push_back(0);
+                    }
+
+                    if (opt_ndev < GGML_HEXAGON_MAX_SESSIONS) {
+                        auto & cfg = opt_device_configs[opt_ndev];
+                        cfg.name         = dev_name;
+                        cfg.physical_idx = phys_list[0];
+                        cfg.virtual_idx  = virt;
+                        cfg.mdev_group.clear();
+
+                        for (size_t k = 1; k < phys_list.size(); k++) {
+                            ggml_hexagon_device_config sub_cfg;
+                            sub_cfg.physical_idx = phys_list[k];
+                            sub_cfg.virtual_idx  = virt;
+                            sub_cfg.name         = "HTP" + std::to_string(phys_list[k]) + ":" + std::to_string(virt);
+                            cfg.mdev_group.push_back(sub_cfg);
+                        }
+                        opt_ndev++;
+                    } else {
+                        GGML_LOG_WARN("ggml-hex: max sessions limit reached (%d), ignoring device %s\n", GGML_HEXAGON_MAX_SESSIONS, item.c_str());
+                    }
+                } else if (item.rfind("HTP", 0) == 0) {
                     std::string rest = item.substr(3);
                     size_t colon_pos = rest.find(':');
                     int phys = 0;
@@ -6613,6 +6712,7 @@ static void ggml_hexagon_init(ggml_backend_reg * reg) {
                         opt_device_configs[opt_ndev].name         = colon_pos == std::string::npos
                             ? "HTP" + std::to_string(phys)
                             : "HTP" + std::to_string(phys) + ":" + std::to_string(virt);
+                        opt_device_configs[opt_ndev].mdev_group.clear();
                         opt_ndev++;
                     } else {
                         GGML_LOG_WARN("ggml-hex: max sessions limit reached (%d), ignoring device %s\n", GGML_HEXAGON_MAX_SESSIONS, item.c_str());
@@ -6627,6 +6727,7 @@ static void ggml_hexagon_init(ggml_backend_reg * reg) {
         opt_device_configs[0].physical_idx = 0;
         opt_device_configs[0].virtual_idx  = 0;
         opt_device_configs[0].name         = "HTP0";
+        opt_device_configs[0].mdev_group.clear();
     }
 
 #if defined(__ANDROID__)

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -394,7 +394,8 @@ struct ggml_hexagon_session {
     ggml_hexagon_opqueue* op_queue;
 
     std::unordered_map<int, std::unique_ptr<ggml_hexagon_shared_buffer>> cloned_buffers;
-    std::unordered_set<ggml_hexagon_session *>                           sync_peers;
+    std::unordered_set<ggml_hexagon_session *>                           virt_peers;
+    std::unordered_set<ggml_hexagon_session *>                           phys_peers;
 
     uint32_t n_threads   = 0;
     uint32_t n_hvx       = 0;
@@ -426,9 +427,10 @@ struct ggml_hexagon_session {
     void enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq = 0);
     void enqueue_allreduce(const ggml_tensor * dst, const std::vector<const ggml_tensor *> & src_tensors, const std::vector<const ggml_tensor *> & sync_tensors, uint32_t rank, uint32_t n_ranks, uint32_t fence_seq_entry = 0, uint32_t fence_seq_exit = 0);
 
-    void flush(bool all = true);
-    void flush_pending(bool all = false);
+    void flush_sync(bool all = true);
+    void flush_async();
     void flush_batch(size_t min_ops = 1);
+    void flush_peers();
 
     uint64_t record_event();
     void     wait_event(uint64_t seq);
@@ -436,19 +438,11 @@ struct ggml_hexagon_session {
     bool clone_buffer(const ggml_hexagon_shared_buffer*);
     void unclone_buffer(int fd);
 
-    void add_sync_peer(ggml_hexagon_session * peer) {
-        sync_peers.insert(peer);
-    }
-
-    void flush_sync_peers() {
-        if (!sync_peers.empty()) {
-            for (auto * peer : sync_peers) {
-                peer->flush_batch();
-            }
-            sync_peers.clear();
-        }
-        for (auto & sub : mdev_sessions) {
-            sub->flush_sync_peers();
+    void add_peer(ggml_hexagon_session * peer) {
+        if (this->phys_idx == peer->phys_idx) {
+            virt_peers.insert(peer);
+        } else {
+            phys_peers.insert(peer);
         }
     }
 };
@@ -2731,10 +2725,34 @@ struct ggml_hexagon_opqueue {
     }
 };
 
-// Flush HTP response queue i.e wait for all outstanding requests to complete
-void ggml_hexagon_session::flush_pending(bool all) {
+void ggml_hexagon_session::flush_peers() {
+    auto vpeers = std::move(virt_peers);
+    virt_peers.clear();
+    for (auto * peer : vpeers) {
+        peer->flush_sync();
+    }
+
+    auto ppeers = std::move(phys_peers);
+    phys_peers.clear();
+    for (auto * peer : ppeers) {
+        peer->flush_async();
+    }
+
     for (auto & sub : mdev_sessions) {
-        sub->flush_pending(all);
+        sub->flush_peers();
+    }
+}
+
+void ggml_hexagon_session::flush_async() {
+    flush_peers();
+    flush_batch();
+}
+
+void ggml_hexagon_session::flush_sync(bool all) {
+    flush_async();
+
+    for (auto & sub : mdev_sessions) {
+        sub->flush_sync(all);
     }
 
     while (this->op_pending) {
@@ -2780,15 +2798,27 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
 
     op_batch->sort_buffers();
 
+    htp_opbatch_req req {};
+    dspqueue_buffer dbuf{};
+
+    if (!op_queue->push(req, dbuf, op_batch)) {
+        flush_sync(false);
+        op_queue->push(req, dbuf, op_batch);
+    }
+
+    req.mdev_idx   = (uint16_t) this->mdev_idx;
+    req.mdev_count = (uint16_t) this->mdev_count;
+
     for (auto & sub : mdev_sessions) {
         htp_opbatch_req sub_req {};
         dspqueue_buffer sub_dbuf{};
 
         if (!sub->op_queue->push(sub_req, sub_dbuf, op_batch)) {
-            sub->flush_pending(false);
+            sub->flush_sync(false);
             sub->op_queue->push(sub_req, sub_dbuf, op_batch);
         }
 
+        sub_req.seq        = req.seq;
         sub_req.mdev_idx   = (uint16_t) sub->mdev_idx;
         sub_req.mdev_count = (uint16_t) sub->mdev_count;
 
@@ -2803,17 +2833,6 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
         }
     }
 
-    htp_opbatch_req req {};
-    dspqueue_buffer dbuf{};
-
-    if (!op_queue->push(req, dbuf, op_batch)) {
-        flush_pending(false);
-        op_queue->push(req, dbuf, op_batch);
-    }
-
-    req.mdev_idx   = (uint16_t) this->mdev_idx;
-    req.mdev_count = (uint16_t) this->mdev_count;
-
     // Bump pending flag (cleared in the session::flush once we get the response)
     this->op_pending++;  // atomic inc
 
@@ -2825,12 +2844,6 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
     }
 
     op_batch->reset();
-}
-
-void ggml_hexagon_session::flush(bool all) {
-    flush_sync_peers();
-    flush_batch();
-    flush_pending(all);
 }
 
 void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
@@ -2858,7 +2871,7 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
     }
 
     if (!op_batch->fit_op(node)) {
-        flush_batch();
+        flush_async();
     }
     op_batch->add_op(node);
 }
@@ -3060,18 +3073,17 @@ void ggml_hexagon_session::enqueue_allreduce(
 }
 
 void ggml_hexagon_session::wait_event(uint64_t seq) {
-    flush_sync_peers();
     HEX_VERBOSE("ggml-hex: %s opqueue-wait start: seq %llu, current rsp-seq %llu, pending %d\n",
                 this->name.c_str(), (unsigned long long)seq, (unsigned long long)op_queue->rsp_seq, (int)this->op_pending);
     while (op_queue->rsp_seq < seq && this->op_pending > 0) {
-        this->flush_pending(false);
+        flush_sync(false);
     }
     HEX_VERBOSE("ggml-hex: %s opqueue-wait end: seq %llu, current rsp-seq %llu, pending %d\n",
                 this->name.c_str(), (unsigned long long)seq, (unsigned long long)op_queue->rsp_seq, (int)this->op_pending);
 }
 
 uint64_t ggml_hexagon_session::record_event() {
-    flush_batch();
+    flush_async();
     return op_queue->req_seq;
 }
 
@@ -5381,7 +5393,7 @@ static void ggml_backend_hexagon_synchronize(ggml_backend_t backend) {
     HEX_VERBOSE("ggml-hex: %s synchronize\n", sess->c_name());
 
     // Wait until all pending ops complete
-    sess->flush();
+    sess->flush_sync();
 }
 
 enum ggml_hexagon_mem_range_type {
@@ -5621,16 +5633,18 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
     auto sess_dst = static_cast<ggml_hexagon_session *>(backend_dst->context);
     auto sbuf_dst = (ggml_hexagon_shared_buffer *) dst->buffer->context;
 
-    if (sess_dst->fence_seq == 0) sess_dst->fence_seq = 1;
-    uint32_t fence_seq = sess_dst->fence_seq++;
-    if (sess_dst->fence_seq == 0) sess_dst->fence_seq = 1;
+    if (!sess_src->clone_buffer(sbuf_dst)) { return false; }
 
     volatile uint32_t * fence = (volatile uint32_t *) sbuf_dst->alloc_fence();
+    if (!fence) { return false; }
+
+    if (++sess_dst->fence_seq == 0) sess_dst->fence_seq = 1;
+    uint32_t fence_seq = sess_dst->fence_seq;
 
     HEX_VERBOSE("ggml-hex: %s cpy-tensor-async %s -> %s size %zu : seq %u\n",
                 sess_dst->name.c_str(), src->name, dst->name, ggml_nbytes(src), fence_seq);
 
-    // dummy extra (must be static)
+    // dummy fence extra (must be static)
     static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
 
     ggml_tensor fence_tensor {};
@@ -5651,7 +5665,7 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
     sess_src->enqueue_cpy(src, dst, &fence_tensor, fence_seq);
     sess_dst->enqueue_fence(&fence_tensor, fence_seq);
 
-    sess_dst->add_sync_peer(sess_src);
+    sess_dst->add_peer(sess_src);
 
     return true;
 }
@@ -5659,15 +5673,15 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
 static bool ggml_hexagon_cpy_tensor_async_virt(ggml_backend_t backend_src, ggml_backend_t backend_dst, const ggml_tensor * src, ggml_tensor * dst) {
     auto sess_src = static_cast<ggml_hexagon_session *>(backend_src->context);
     auto sess_dst = static_cast<ggml_hexagon_session *>(backend_dst->context);
-    auto sbuf_dst = (ggml_hexagon_shared_buffer *) dst->buffer->context;
+    auto sbuf_src = (ggml_hexagon_shared_buffer *) src->buffer->context;
 
-    if (!sess_src->clone_buffer(sbuf_dst)) { return false; }
+    if (!sess_dst->clone_buffer(sbuf_src)) { return false; }
 
     HEX_VERBOSE("ggml-hex: %s cpy-tensor-async %s -> %s size %zu\n",
                 sess_dst->name.c_str(), src->name, dst->name, ggml_nbytes(src));
 
-    sess_src->enqueue_cpy(src, dst);
-    sess_src->flush(true);
+    sess_dst->enqueue_cpy(src, dst);
+    sess_dst->add_peer(sess_src);
 
     return true;
 }
@@ -5685,7 +5699,6 @@ static bool ggml_backend_hexagon_cpy_tensor_async(ggml_backend_t backend_src, gg
     if (sess_src == sess_dst) {
         HEX_VERBOSE("ggml-hex: %s cpy-tensor-async %s -> %s size %zu\n", sess_dst->name.c_str(), src->name, dst->name, ggml_nbytes(src));
         sess_src->enqueue_cpy(src, dst);
-        sess_src->flush_batch();
         return true;
     }
 
@@ -5761,7 +5774,7 @@ static void ggml_backend_hexagon_get_tensor_async(ggml_backend_t backend, const 
     auto sess = static_cast<ggml_hexagon_session *>(backend->context);
     HEX_VERBOSE("ggml-hex: %s get-tensor-async %s : data %p offset %zu size %zu usage %d\n",
                 sess->c_name(), tensor->name, data, offset, size, tensor->buffer ? (int) tensor->buffer->usage : -1);
-    sess->flush(true);
+    sess->flush_sync();
     ggml_backend_tensor_get(tensor, data, offset, size);
 }
 
@@ -5790,7 +5803,7 @@ static void ggml_backend_hexagon_get_tensor_2d_async(ggml_backend_t backend,
     auto sess = static_cast<ggml_hexagon_session *>(backend->context);
     HEX_VERBOSE("ggml-hex: %s get-tensor-2d-async %s : data %p offset %zu size %zu n_copies %zu stride_tensor %zu stride_data %zu usage %d\n",
                 sess->c_name(), tensor->name, data, offset, size, n_copies, stride_tensor, stride_data, tensor->buffer ? (int) tensor->buffer->usage : -1);
-    sess->flush(true);
+    sess->flush_sync();
     ggml_backend_tensor_get_2d(tensor, data, offset, size, n_copies, stride_tensor, stride_data);
 }
 
@@ -6252,6 +6265,16 @@ static void * ggml_backend_hexagon_comm_init(ggml_backend_t * backends, size_t n
         }
     }
 
+    for (size_t i = 0; i < n_backends; i++) {
+        auto sess_i = static_cast<ggml_hexagon_session *>(backends[i]->context);
+        for (size_t j = i + 1; j < n_backends; j++) {
+            auto sess_j = static_cast<ggml_hexagon_session *>(backends[j]->context);
+            if (sess_i->phys_idx == sess_j->phys_idx) {
+                return nullptr;
+            }
+        }
+    }
+
     auto * ctx = new ggml_backend_hexagon_comm_context();
     ctx->backends.assign(backends, backends + n_backends);
     ctx->n_backends = n_backends;
@@ -6271,6 +6294,16 @@ static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct
     const size_t n_backends = comm_ctx->n_backends;
 
     if (n_backends < 2 || n_backends > 4) return false;
+
+    for (size_t i = 0; i < n_backends; i++) {
+        auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
+        for (size_t j = i + 1; j < n_backends; j++) {
+            auto sess_j = static_cast<ggml_hexagon_session *>(comm_ctx->backends[j]->context);
+            if (sess_i->phys_idx == sess_j->phys_idx) {
+                return false;
+            }
+        }
+    }
 
     for (size_t i = 0; i < n_backends; i++) {
         if (!tensors[i] || !tensors[i]->buffer || !ggml_backend_buffer_is_hexagon(tensors[i]->buffer)) {
@@ -6342,7 +6375,7 @@ static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct
         sess->enqueue_allreduce(tensors[r], data_tensors, sync_tensors, (uint32_t) r, (uint32_t) n_backends, fence_seq_entry, fence_seq_exit);
         for (size_t j = 0; j < n_backends; j++) {
             if (r != j) {
-                sess->add_sync_peer(static_cast<ggml_hexagon_session *>(comm_ctx->backends[j]->context));
+                sess->add_peer(static_cast<ggml_hexagon_session *>(comm_ctx->backends[j]->context));
             }
         }
     }

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -439,8 +439,8 @@ struct ggml_hexagon_session {
     uint8_t * alloc_fence(uint32_t n_slots = 1);
     void      free_fence(void * ptr, uint32_t n_slots = 1);
 
-    uint8_t *           mdev_fence_slot = nullptr;
-    volatile uint32_t * cpy_fence_slots[GGML_HEXAGON_MAX_SESSIONS] = {};
+    uint8_t *                                         mdev_fence_slot = nullptr;
+    std::unordered_map<uint64_t, volatile uint32_t *> cpy_fence_slots;
 
     void enqueue_mdev_group();
     void enqueue_op(const htp_opnode & node);
@@ -3494,6 +3494,11 @@ void ggml_hexagon_session::release() noexcept(true) {
 
     delete this->op_batch;
     delete this->op_queue;
+    for (auto & it : this->cpy_fence_slots) {
+        free_fence((void *) it.second, 1);
+    }
+    this->cpy_fence_slots.clear();
+
     if (this->fence_buf) {
         unclone_buffer(this->fence_buf);
         delete this->fence_buf;
@@ -5778,6 +5783,10 @@ static void ggml_backend_hexagon_graph_optimize(ggml_backend_t backend, ggml_cgr
     GGML_UNUSED(backend);
 }
 
+static uint64_t ggml_hexagon_session_key(const ggml_hexagon_session * sess) {
+    return ((uint64_t) (uint32_t) sess->phys_idx << 32) | (uint32_t) sess->virt_idx;
+}
+
 static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_backend_t backend_dst, const ggml_tensor * src, ggml_tensor * dst) {
     auto sess_src = static_cast<ggml_hexagon_session *>(backend_src->context);
     auto sess_dst = static_cast<ggml_hexagon_session *>(backend_dst->context);
@@ -5785,11 +5794,11 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
 
     if (!sess_src->clone_buffer(sbuf_dst)) { return false; }
 
-    const int src_id = sess_src->phys_idx;
-    if (!sess_dst->cpy_fence_slots[src_id]) {
-        sess_dst->cpy_fence_slots[src_id] = (volatile uint32_t *) sess_dst->alloc_fence(1);
+    const uint64_t src_key = ggml_hexagon_session_key(sess_src);
+    auto & fence_slot = sess_dst->cpy_fence_slots[src_key];
+    if (!fence_slot) {
+        fence_slot = (volatile uint32_t *) sess_dst->alloc_fence(1);
     }
-    volatile uint32_t * fence_slot = sess_dst->cpy_fence_slots[src_id];
 
     if (!sess_src->clone_buffer(sess_dst->fence_buf)) { return false; }
 
@@ -5924,11 +5933,19 @@ static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev
 
     auto * fence = reinterpret_cast<const volatile std::atomic<uint32_t> *>(hex_event->fence_slot);
 
-    if ((int32_t)(fence->load(std::memory_order_relaxed) - hex_event->seq) < 0) {
+    if ((int32_t)(fence[0].load(std::memory_order_relaxed) - hex_event->seq) < 0) {
         hex_event->sess->flush_async();
     }
 
-    while ((int32_t)(fence->load(std::memory_order_relaxed) - hex_event->seq) < 0) {
+    while (true) {
+        if ((int32_t)(fence[0].load(std::memory_order_acquire) - hex_event->seq) >= 0) {
+            uint32_t status = fence[1].load(std::memory_order_acquire);
+            if (status > HTP_STATUS_OK) {
+                GGML_ABORT("ggml-hex: %s event-synchronize failed : dsp-error %s\n",
+                           hex_event->sess->c_name(), status_to_str(status));
+            }
+            break;
+        }
         std::this_thread::yield();
     }
 }

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -1741,8 +1741,8 @@ struct ggml_hexagon_opbatch {
         if (it != b_map.end()) { return it->second; }
 
         // Add new buffer to the batch
-        int bi = n_bufs++;
         GGML_ASSERT(n_bufs < HTP_OP_MAX_BUFS);
+        int bi = n_bufs++;
 
         b_map.insert({sbuf->fd(), bi});
 

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -1984,8 +1984,8 @@ struct ggml_hexagon_opbatch {
 
         const bool is_same_shape = (ar_local->ne[0] == res_tensor->ne[0] && ar_local->ne[1] == res_tensor->ne[1] &&
                                     ar_local->ne[2] == res_tensor->ne[2] && ar_local->ne[3] == res_tensor->ne[3]);
-        const bool is_row_bcast  = (ar_local->ne[0] == res_tensor->ne[0] &&
-                                    res_tensor->ne[1] == 1 && res_tensor->ne[2] == 1 && res_tensor->ne[3] == 1);
+        const bool is_row_bcast  = !is_same_shape && (ar_local->ne[0] == res_tensor->ne[0] && res_tensor->ne[1] == 1 &&
+                                                      res_tensor->ne[2] == 1 && res_tensor->ne[3] == 1);
 
         if (!is_same_shape && !is_row_bcast) return false;
 
@@ -3003,7 +3003,6 @@ static bool ggml_hexagon_precompute_allreduce_params(
     kparams->n_ranks      = (int32_t) n_ranks;
     kparams->is_row_bcast = (has_add && is_row_bcast) ? 1 : 0;
 
-    const uint32_t n_bufs    = n_ranks + 1 + (has_add ? 1 : 0);
     const uint32_t nelem     = (uint32_t) ggml_nelements(dst);
     const uint32_t elem_size = (dst->type == GGML_TYPE_F16) ? sizeof(ggml_fp16_t) : sizeof(float);
     const bool is_contiguous = ggml_is_contiguous(dst);
@@ -3047,6 +3046,7 @@ static bool ggml_hexagon_precompute_allreduce_params(
         const uint32_t rank_nelem = (uint32_t) kparams->rank_nelem;
         const uint32_t n_threads  = (std::min)((uint32_t) sess->n_threads, (std::max)(1u, rank_nelem / 128));
         kparams->n_threads = n_threads;
+        const size_t n_vtcm_buffers = htp_allreduce_vtcm_buffer_count(n_ranks, n_threads, has_add, is_row_bcast);
 
         uint32_t block_elems = 65536;
         if (block_elems > rank_nelem / n_threads && rank_nelem / n_threads > 128) {
@@ -3056,15 +3056,15 @@ static bool ggml_hexagon_precompute_allreduce_params(
 
         kparams->block_elems          = block_elems;
         kparams->vtcm_size_per_thread = 2 * block_elems * elem_size;
-        kparams->vtcm_size            = n_threads * n_bufs * kparams->vtcm_size_per_thread;
+        kparams->vtcm_size            = n_vtcm_buffers * kparams->vtcm_size_per_thread;
 
         while ((size_t) kparams->vtcm_size > sess->vtcm_size && block_elems > 128) {
-            const size_t max_bytes_per_buf = sess->vtcm_size / (n_threads * n_bufs * 2);
+            const size_t max_bytes_per_buf = sess->vtcm_size / (n_vtcm_buffers * 2);
             block_elems = (uint32_t) hex_align_down((size_t) (max_bytes_per_buf / elem_size), 128);
             if (block_elems < 128) break;
             kparams->block_elems          = block_elems;
             kparams->vtcm_size_per_thread = 2 * block_elems * elem_size;
-            kparams->vtcm_size            = n_threads * n_bufs * kparams->vtcm_size_per_thread;
+            kparams->vtcm_size            = n_vtcm_buffers * kparams->vtcm_size_per_thread;
         }
 
         if (sess->vtcm_size < (size_t) kparams->vtcm_size || block_elems < 128) {
@@ -3080,6 +3080,7 @@ static bool ggml_hexagon_precompute_allreduce_params(
         const uint32_t rank_nrows = (uint32_t) kparams->rank_nelem;
         const uint32_t n_threads  = (std::min)((uint32_t) sess->n_threads, (std::max)(1u, rank_nrows));
         kparams->n_threads = n_threads;
+        const size_t n_vtcm_buffers = htp_allreduce_vtcm_buffer_count(n_ranks, n_threads, has_add, is_row_bcast);
 
         const uint32_t row_bytes = ne0 * elem_size;
         const uint32_t row_size_aligned = (uint32_t) hex_align_up(row_bytes, 128);
@@ -3091,14 +3092,14 @@ static bool ggml_hexagon_precompute_allreduce_params(
         kparams->block_elems = block_rows;
 
         kparams->vtcm_size_per_thread = 2 * (block_rows * row_size_aligned);
-        kparams->vtcm_size            = n_threads * n_bufs * kparams->vtcm_size_per_thread;
+        kparams->vtcm_size            = n_vtcm_buffers * kparams->vtcm_size_per_thread;
 
         while ((size_t) kparams->vtcm_size > sess->vtcm_size && block_rows > 1) {
-            const size_t max_rows_per_buf = sess->vtcm_size / (n_threads * n_bufs * 2 * row_size_aligned);
+            const size_t max_rows_per_buf = sess->vtcm_size / (n_vtcm_buffers * 2 * row_size_aligned);
             block_rows = (std::max)(1u, (uint32_t) max_rows_per_buf);
             kparams->block_elems          = block_rows;
             kparams->vtcm_size_per_thread = 2 * (block_rows * row_size_aligned);
-            kparams->vtcm_size            = n_threads * n_bufs * kparams->vtcm_size_per_thread;
+            kparams->vtcm_size            = n_vtcm_buffers * kparams->vtcm_size_per_thread;
             if (max_rows_per_buf == 0) break;
         }
 

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -413,7 +413,7 @@ struct ggml_hexagon_session {
     uint32_t mdev_count  = 1;
     std::vector<std::unique_ptr<ggml_hexagon_session>> mdev_sessions;
 
-    ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev = nullptr, uint32_t mdev_idx = 0, uint32_t mdev_count = 1) noexcept(false);
+    ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev = nullptr, uint32_t mdev_idx = 0, uint32_t mdev_count = 0) noexcept(false);
     ~ggml_hexagon_session() noexcept(true);
 
     const char* c_name() const { return name.c_str(); }
@@ -472,8 +472,7 @@ struct ggml_backend_hexagon_device_context {
 
     ggml_hexagon_session * session() {
         if (!sess) {
-            uint32_t mdev_count = (uint32_t) (1 + config.mdev_group.size());
-            sess = std::make_unique<ggml_hexagon_session>(config, dev, dev_id, mdev_count);
+            sess = std::make_unique<ggml_hexagon_session>(config, dev);
         }
         return sess.get();
     }
@@ -3373,7 +3372,7 @@ void ggml_hexagon_session::release() noexcept(true) {
 
 ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t mdev_idx, uint32_t mdev_count) noexcept(false) {
     this->mdev_idx   = mdev_idx;
-    this->mdev_count = mdev_count;
+    this->mdev_count = mdev_count > 0 ? mdev_count : (uint32_t) (1 + config.mdev_group.size());
     op_batch = nullptr;
     op_queue = nullptr;
     fence_seq = ((uintptr_t)this) & 0xFFFF;
@@ -3383,7 +3382,7 @@ ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & co
         if (mdev_idx == 0 && !config.mdev_group.empty()) {
             for (size_t i = 0; i < config.mdev_group.size(); i++) {
                 mdev_sessions.push_back(std::make_unique<ggml_hexagon_session>(
-                    config.mdev_group[i], nullptr, (uint32_t) (i + 1), mdev_count));
+                    config.mdev_group[i], nullptr, (uint32_t) (i + 1), this->mdev_count));
             }
         }
     } catch (const std::exception & exc) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -576,6 +576,9 @@ struct ggml_hexagon_shared_buffer {
         if (this->mem) return;
 
         this->mem = std::make_shared<ggml_hexagon_rpcmem_block>(size);
+        if (fences_size > 0 && this->size() >= fences_size) {
+            memset(base() + (this->size() - fences_size), 0, fences_size);
+        }
 
         HEX_VERBOSE("ggml-hex: %s allocated buffer: base %p size %zu fd %d pinned %d\n", sess->c_name(),
                     (void *) base(), this->size(), fd(), (int) pinned);

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -668,7 +668,9 @@ struct ggml_hexagon_fence_buffer : public ggml_hexagon_shared_buffer {
 };
 
 inline uint8_t * ggml_hexagon_session::alloc_fence(uint32_t n_slots) {
-    return fence_buf->alloc_slot(n_slots);
+    uint8_t * ptr = fence_buf->alloc_slot(n_slots);
+    GGML_ASSERT(ptr);
+    return ptr;
 }
 
 inline void ggml_hexagon_session::free_fence(void * ptr, uint32_t n_slots) {
@@ -5910,20 +5912,7 @@ static ggml_backend_event_t ggml_backend_hexagon_device_event_new(ggml_backend_d
     };
 }
 
-static void ggml_backend_hexagon_device_event_free(ggml_backend_dev_t dev, ggml_backend_event_t event) {
-    GGML_UNUSED(dev);
-
-    auto * hex_event = static_cast<ggml_hexagon_event *>(event->context);
-    HEX_VERBOSE("ggml-hex: %s event-free : event %p\n", ggml_backend_dev_name(dev), (void *)hex_event);
-    hex_event->sess->free_fence((void *) hex_event->fence_slot, 1);
-    delete hex_event;
-    delete event;
-}
-
-static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev, ggml_backend_event_t event) {
-    GGML_UNUSED(dev);
-
-    auto * hex_event = static_cast<ggml_hexagon_event *>(event->context);
+static void ggml_hexagon_event_synchronize(ggml_backend_dev_t dev, ggml_hexagon_event * hex_event) {
     if (hex_event->seq == 0) {
         return;
     }
@@ -5948,6 +5937,20 @@ static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev
         }
         std::this_thread::yield();
     }
+}
+
+static void ggml_backend_hexagon_device_event_free(ggml_backend_dev_t dev, ggml_backend_event_t event) {
+    auto * hex_event = static_cast<ggml_hexagon_event *>(event->context);
+    ggml_hexagon_event_synchronize(dev, hex_event);
+    HEX_VERBOSE("ggml-hex: %s event-free : event %p\n", ggml_backend_dev_name(dev), (void *)hex_event);
+    hex_event->sess->free_fence((void *) hex_event->fence_slot, 1);
+    delete hex_event;
+    delete event;
+}
+
+static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev, ggml_backend_event_t event) {
+    auto * hex_event = static_cast<ggml_hexagon_event *>(event->context);
+    ggml_hexagon_event_synchronize(dev, hex_event);
 }
 
 static void ggml_backend_hexagon_event_record(ggml_backend_t backend, ggml_backend_event_t event) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -5904,7 +5904,7 @@ static ggml_backend_event_t ggml_backend_hexagon_device_event_new(ggml_backend_d
 static void ggml_backend_hexagon_device_event_free(ggml_backend_dev_t dev, ggml_backend_event_t event) {
     GGML_UNUSED(dev);
 
-    ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
+    auto * hex_event = static_cast<ggml_hexagon_event *>(event->context);
     HEX_VERBOSE("ggml-hex: %s event-free : event %p\n", ggml_backend_dev_name(dev), (void *)hex_event);
     hex_event->sess->free_fence((void *) hex_event->fence_slot, 1);
     delete hex_event;
@@ -5914,7 +5914,7 @@ static void ggml_backend_hexagon_device_event_free(ggml_backend_dev_t dev, ggml_
 static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev, ggml_backend_event_t event) {
     GGML_UNUSED(dev);
 
-    ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
+    auto * hex_event = static_cast<ggml_hexagon_event *>(event->context);
     if (hex_event->seq == 0) {
         return;
     }
@@ -5922,25 +5922,20 @@ static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev
     HEX_VERBOSE("ggml-hex: %s event-synchronize : event %p seq %u fence %p\n",
                 ggml_backend_dev_name(dev), (void *)hex_event, hex_event->seq, (void *)hex_event->fence_slot);
 
-    if ((int32_t)(*hex_event->fence_slot - hex_event->seq) < 0 && hex_event->sess->op_batch->n_ops > 0) {
+    auto * fence = reinterpret_cast<const volatile std::atomic<uint32_t> *>(hex_event->fence_slot);
+
+    if ((int32_t)(fence->load(std::memory_order_relaxed) - hex_event->seq) < 0) {
         hex_event->sess->flush_async();
     }
 
-    while ((int32_t)(*hex_event->fence_slot - hex_event->seq) < 0) {
-        if (hex_event->sess->batch_rsp_seq < hex_event->sess->batch_req_seq) {
-            hex_event->sess->flush_pending(false);
-        }
-        if (hex_event->sess->last_error > HTP_STATUS_OK) {
-            GGML_ABORT("ggml-hex: %s event-synchronize failed : dsp-error %s\n",
-                       hex_event->sess->c_name(), status_to_str(hex_event->sess->last_error));
-        }
+    while ((int32_t)(fence->load(std::memory_order_relaxed) - hex_event->seq) < 0) {
         std::this_thread::yield();
     }
 }
 
 static void ggml_backend_hexagon_event_record(ggml_backend_t backend, ggml_backend_event_t event) {
     auto sess = static_cast<ggml_hexagon_session *>(backend->context);
-    ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
+    auto hex_event = static_cast<ggml_hexagon_event *>(event->context);
 
     if (++sess->fence_seq == 0) sess->fence_seq = 1;
     hex_event->sess = sess;
@@ -5954,7 +5949,7 @@ static void ggml_backend_hexagon_event_record(ggml_backend_t backend, ggml_backe
 
 static void ggml_backend_hexagon_event_wait(ggml_backend_t backend, ggml_backend_event_t event) {
     auto sess = static_cast<ggml_hexagon_session *>(backend->context);
-    ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
+    auto hex_event = static_cast<ggml_hexagon_event *>(event->context);
 
     if (hex_event->seq == 0) {
         return;

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -356,6 +356,15 @@ static inline bool ggml_hexagon_tensor_is_fuseable(const struct ggml_tensor * t)
     return (extra->flags & GGML_HEXAGON_TENSOR_FUSEABLE) != 0;
 }
 
+static inline bool ggml_hexagon_tensors_overlap(const struct ggml_tensor * a, const struct ggml_tensor * b) {
+    const uintptr_t a0 = (uintptr_t) a->data;
+    const uintptr_t b0 = (uintptr_t) b->data;
+    const uintptr_t a1 = a0 + ggml_nbytes(a);
+    const uintptr_t b1 = b0 + ggml_nbytes(b);
+
+    return a0 < b1 && b0 < a1;
+}
+
 struct htp_opnode;
 
 struct ggml_hexagon_opbatch;
@@ -1988,15 +1997,16 @@ struct ggml_hexagon_opbatch {
         if (last_node.opcode != HTP_OP_ALLREDUCE) return false;
 
         auto * ar_kparams = (struct htp_allreduce_kernel_params *) last_node.kernel_params;
-        const uint32_t rank = (uint32_t) ar_kparams->rank;
-        const ggml_tensor * ar_local = (rank < last_node.inputs.size()) ? last_node.inputs[rank] : nullptr;
+        const uint32_t rank    = (uint32_t) ar_kparams->rank;
+        const uint32_t n_ranks = (uint32_t) ar_kparams->n_ranks;
+        const ggml_tensor * ar_local = last_node.inputs[rank];
         const ggml_tensor * add_src0 = node.src0();
         const ggml_tensor * add_src1 = node.src1();
+        const ggml_tensor * add_dst  = node.dst();
 
-        if (!add_src0 || !add_src1 || !ar_local) return false;
         if (!ggml_hexagon_tensor_is_fuseable(ar_local)) return false;
 
-        const ggml_tensor * res_tensor = nullptr;
+        const ggml_tensor * res_tensor;
         if (add_src0 == ar_local || add_src0->data == ar_local->data) {
             res_tensor = add_src1;
         } else if (add_src1 == ar_local || add_src1->data == ar_local->data) {
@@ -2004,8 +2014,6 @@ struct ggml_hexagon_opbatch {
         } else {
             return false;
         }
-
-        if (!res_tensor || !res_tensor->data) return false;
 
         if (ar_local->type != res_tensor->type) return false;
 
@@ -2025,13 +2033,21 @@ struct ggml_hexagon_opbatch {
                 return false;
             }
         }
-        if (ggml_is_contiguous(ar_local) != ggml_is_contiguous(node.dst())) {
+        if (ggml_is_contiguous(ar_local) != ggml_is_contiguous(add_dst)) {
             return false;
+        }
+
+        for (uint32_t r = 0; r < n_ranks; r++) {
+            const ggml_tensor * ar_src = last_node.inputs[r];
+            if (ggml_hexagon_tensors_overlap(add_dst, ar_src)) {
+                HEX_VERBOSE("ggml-hex: %s skip ALLREDUCE_ADD fusion: dst overlaps allreduce src %u\n", sess->c_name(), r);
+                return false;
+            }
         }
 
         struct htp_allreduce_kernel_params new_kparams;
         if (!ggml_hexagon_precompute_allreduce_params(
-            sess, node.dst(), (uint32_t) ar_kparams->rank, (uint32_t) ar_kparams->n_ranks, true, is_row_bcast, &new_kparams
+            sess, add_dst, (uint32_t) ar_kparams->rank, (uint32_t) ar_kparams->n_ranks, true, is_row_bcast, &new_kparams
         )) {
             HEX_VERBOSE("ggml-hex: %s skip ALLREDUCE_ADD fusion: solver failed\n", sess->c_name());
             return false;
@@ -2050,7 +2066,7 @@ struct ggml_hexagon_opbatch {
             }
         };
         fit_t(res_tensor);
-        fit_t(node.dst());
+        fit_t(add_dst);
         if ((extra_bufs + n_bufs) > n_bufs_max || (extra_tens + n_tens) > n_tens_max || (extra_vmem + b_vmem) > b_vmem_max) {
             return false;
         }
@@ -2059,7 +2075,7 @@ struct ggml_hexagon_opbatch {
         last_node.name   = "ALLREDUCE+ADD";
         last_node.inputs.push_back(res_tensor);
         last_node.outputs.clear();
-        last_node.outputs.push_back(node.dst());
+        last_node.outputs.push_back(add_dst);
         last_node.fused.push_back(node.node);
         memcpy(last_node.kernel_params, &new_kparams, sizeof(new_kparams));
 
@@ -2067,9 +2083,8 @@ struct ggml_hexagon_opbatch {
         o.opcode = HTP_OP_ALLREDUCE_ADD;
         memcpy(o.kernel_params, &new_kparams, sizeof(new_kparams));
 
-        const uint32_t n_ranks = (uint32_t) ar_kparams->n_ranks;
         o.src[2 * n_ranks] = add_tensor(res_tensor);
-        o.dst[0]           = add_tensor(node.dst());
+        o.dst[0]           = add_tensor(add_dst);
         for (uint32_t d = 1; d < HTP_OP_MAX_OUTPUTS; d++) {
             o.dst[d] = 0xffff;
         }
@@ -5464,6 +5479,8 @@ static ggml_status ggml_backend_hexagon_graph_compute(ggml_backend_t backend, gg
             auto * extra = (ggml_hexagon_tensor_extra *) graph->nodes[i]->extra;
             if (!extra) continue;
 
+            extra->flags &= ~GGML_HEXAGON_TENSOR_FUSEABLE;
+
             if (graph->nodes[i]->op == GGML_OP_RMS_NORM && ggml_can_fuse(graph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL })) {
                 extra->flags |= GGML_HEXAGON_TENSOR_FUSEABLE;
             } else if (graph->nodes[i]->op == GGML_OP_MUL_MAT || graph->nodes[i]->op == GGML_OP_MUL_MAT_ID) {
@@ -5865,7 +5882,7 @@ static bool ggml_backend_hexagon_cpy_tensor_async(ggml_backend_t backend_src, gg
 
     auto * dst_extra = static_cast<ggml_hexagon_tensor_extra *>(dst->extra);
     const auto * src_extra = static_cast<const ggml_hexagon_tensor_extra *>(src->extra);
-    dst_extra->flags = src_extra->flags;
+    dst_extra->flags = src_extra->flags & ~GGML_HEXAGON_TENSOR_FUSEABLE;
 
     auto sess_src = static_cast<ggml_hexagon_session *>(backend_src->context);
     auto sess_dst = static_cast<ggml_hexagon_session *>(backend_dst->context);

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -374,7 +374,6 @@ struct ggml_hexagon_mdev_group {
 struct ggml_backend_hexagon_comm_context {
     std::vector<ggml_backend_t> backends;
     size_t                      n_backends = 0;
-    uint32_t                    fence_seq  = 0;
 };
 
 struct ggml_hexagon_event {
@@ -6393,7 +6392,6 @@ static void * ggml_backend_hexagon_comm_init(ggml_backend_t * backends, size_t n
     auto * ctx = new ggml_backend_hexagon_comm_context();
     ctx->backends.assign(backends, backends + n_backends);
     ctx->n_backends = n_backends;
-    ctx->fence_seq  = (((uintptr_t) ctx) & 0xFFFF) | 1;
 
     return ctx;
 }
@@ -6447,11 +6445,16 @@ static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct
         }
     }
 
-    if (comm_ctx->fence_seq == 0) comm_ctx->fence_seq = 1;
-    uint32_t fence_seq_entry = comm_ctx->fence_seq++;
-    if (comm_ctx->fence_seq == 0) comm_ctx->fence_seq = 1;
-    uint32_t fence_seq_exit  = comm_ctx->fence_seq++;
-    if (comm_ctx->fence_seq == 0) comm_ctx->fence_seq = 1;
+    auto sess_0 = static_cast<ggml_hexagon_session *>(comm_ctx->backends[0]->context);
+    if (++sess_0->fence_seq == 0) sess_0->fence_seq = 1;
+    uint32_t fence_seq_entry = sess_0->fence_seq;
+    if (++sess_0->fence_seq == 0) sess_0->fence_seq = 1;
+    uint32_t fence_seq_exit  = sess_0->fence_seq;
+
+    for (size_t i = 1; i < n_backends; i++) {
+        auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
+        sess_i->fence_seq = sess_0->fence_seq;
+    }
 
     volatile uint32_t * fences[GGML_HEXAGON_MAX_SESSIONS];
     for (size_t i = 0; i < n_backends; i++) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -374,11 +374,15 @@ struct ggml_hexagon_mdev_group {
 struct ggml_backend_hexagon_comm_context {
     std::vector<ggml_backend_t> backends;
     size_t                      n_backends = 0;
+    volatile uint32_t *         fence_slots[GGML_HEXAGON_MAX_SESSIONS] = {};
+    ggml_tensor                 fence_tensors[GGML_HEXAGON_MAX_SESSIONS] = {};
 };
 
 struct ggml_hexagon_event {
-    ggml_hexagon_session * sess = nullptr;
-    uint64_t               seq  = 0;
+    ggml_hexagon_session * sess         = nullptr;
+    uint32_t               seq          = 0;
+    volatile uint32_t *    fence_slot   = nullptr;
+    ggml_tensor            fence_tensor = {};
 };
 
 struct ggml_hexagon_session {
@@ -433,11 +437,15 @@ struct ggml_hexagon_session {
     void release() noexcept(true);
 
     uint8_t * alloc_fence(uint32_t n_slots = 1);
+    void      free_fence(void * ptr, uint32_t n_slots = 1);
+
+    uint8_t *           mdev_fence_slot = nullptr;
+    volatile uint32_t * cpy_fence_slots[GGML_HEXAGON_MAX_SESSIONS] = {};
 
     void enqueue_mdev_group();
     void enqueue_op(const htp_opnode & node);
     void enqueue_cpy(const ggml_tensor * src, ggml_tensor * dst, const ggml_tensor * sync_tensor = nullptr, uint32_t fence_seq = 0);
-    void enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq = 0);
+    void enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq = 0, bool wait = true);
     void enqueue_allreduce(const ggml_tensor * dst, const std::vector<const ggml_tensor *> & src_tensors,
                            const std::vector<const ggml_tensor *> & sync_tensors, uint32_t rank, uint32_t n_ranks,
                            uint32_t fence_seq_entry = 0, uint32_t fence_seq_exit = 0);
@@ -447,9 +455,6 @@ struct ggml_hexagon_session {
     void flush_batch(size_t min_ops = 1);
     void flush_peers();
     void flush_pending(bool all = true);
-
-    uint64_t record_event();
-    void     wait_event(uint64_t seq);
 
     bool clone_buffer(const ggml_hexagon_shared_buffer*);
     void release_buffer(const ggml_hexagon_shared_buffer*);
@@ -622,35 +627,54 @@ struct ggml_hexagon_shared_buffer {
 };
 
 struct ggml_hexagon_fence_buffer : public ggml_hexagon_shared_buffer {
-    uint32_t            slot_count = 0;
-    uint32_t            slot_start = 0;
-    uint32_t            slot_head  = 0;
-    ggml_backend_buffer backend_buffer{};
+    uint32_t              slot_count = 0;
+    uint32_t              slot_head  = 0;
+    std::vector<uint32_t> free_slots;
+    ggml_backend_buffer   backend_buffer{};
 
-    ggml_hexagon_fence_buffer(ggml_hexagon_session * sess, ggml_backend_buffer_type_t buft, size_t size, uint32_t reserved_slots = 0)
+    ggml_hexagon_fence_buffer(ggml_hexagon_session * sess, ggml_backend_buffer_type_t buft, size_t size)
         : ggml_hexagon_shared_buffer(sess, size, false /* pinned */),
           slot_count(size / GGML_HEXAGON_FENCE_SLOT_SIZE),
-          slot_start(reserved_slots),
-          slot_head(reserved_slots) {
+          slot_head(0) {
         backend_buffer.buft    = buft;
         backend_buffer.context = static_cast<ggml_hexagon_shared_buffer *>(this);
         backend_buffer.size    = size;
-        memset(base(), 0, size);
     }
 
     uint8_t * alloc_slot(uint32_t n_slots = 1) {
-        if (slot_start + n_slots > slot_count) return nullptr;
-        uint32_t slot = slot_head;
-        if (slot + n_slots > slot_count) {
-            slot = slot_start;
+        uint8_t * ptr = nullptr;
+        if (n_slots == 1 && !free_slots.empty()) {
+            uint32_t slot = free_slots.back();
+            free_slots.pop_back();
+            ptr = base() + (size_t) slot * GGML_HEXAGON_FENCE_SLOT_SIZE;
+        } else if (slot_head + n_slots <= slot_count) {
+            uint32_t slot = slot_head;
+            slot_head += n_slots;
+            ptr = base() + (size_t) slot * GGML_HEXAGON_FENCE_SLOT_SIZE;
         }
-        slot_head = slot + n_slots;
-        return base() + (size_t) slot * GGML_HEXAGON_FENCE_SLOT_SIZE;
+        if (ptr) {
+            memset(ptr, 0, (size_t) n_slots * GGML_HEXAGON_FENCE_SLOT_SIZE);
+        }
+        return ptr;
+    }
+
+    void free_slot(void * ptr, uint32_t n_slots = 1) {
+        if (!ptr) return;
+        uint32_t slot = ((uint8_t *) ptr - base()) / GGML_HEXAGON_FENCE_SLOT_SIZE;
+        for (uint32_t i = 0; i < n_slots; i++) {
+            free_slots.push_back(slot + i);
+        }
     }
 };
 
 inline uint8_t * ggml_hexagon_session::alloc_fence(uint32_t n_slots) {
     return fence_buf->alloc_slot(n_slots);
+}
+
+inline void ggml_hexagon_session::free_fence(void * ptr, uint32_t n_slots) {
+    if (fence_buf) {
+        fence_buf->free_slot(ptr, n_slots);
+    }
 }
 
 static ggml_hexagon_session * ggml_backend_hexagon_buffer_get_sess(ggml_backend_buffer_t buffer) {
@@ -2591,14 +2615,14 @@ struct ggml_hexagon_opqueue {
     // Shared buffer for storing batches
     ggml_hexagon_shared_buffer *shm_buf;
     size_t                      shm_blk_size;
+    size_t                      depth;
 
     using opvec = std::vector<htp_opnode>;
 
-    std::queue<unsigned int>    done;           // completed batch ids
     std::vector<opvec>          op_cache;       // per batch op cache
     std::vector<uint64_t>       start_usec;     // per batch start time
 
-    ggml_hexagon_opqueue(ggml_hexagon_session *sess, size_t batch_size, size_t depth) {
+    ggml_hexagon_opqueue(ggml_hexagon_session *sess, size_t batch_size, size_t depth) : depth(depth) {
         size_t n_bufs    = HTP_OP_MAX_BUFS;
         size_t n_ops     = batch_size;
         size_t n_tensors = n_ops * HTP_OP_MAX_OUTPUTS + n_ops * HTP_OP_MAX_INPUTS;
@@ -2618,9 +2642,6 @@ struct ggml_hexagon_opqueue {
 
         op_cache.resize(depth);
         start_usec.resize(depth, 0);
-
-        // init done queue
-        for (unsigned int i = 0; i < depth; i++) { done.push(i); }
 
         if (opt_verbose) {
             GGML_LOG_INFO("ggml-hex: %s allocated opqueue : batch-size %zu depth %zu shm-size %zu shm-block-size %zu\n",
@@ -2643,16 +2664,17 @@ struct ggml_hexagon_opqueue {
         static_assert(sizeof(htp_op_desc)     % 8 == 0, "sizeof(htp_op_desc) must be multiple of 8");
         static_assert(sizeof(htp_prof_desc)   % 8 == 0, "sizeof(htp_prof_desc) must be multiple of 8");
 
-        if (done.empty()) { return false; }
+        if (seq - shm_buf->sess->batch_rsp_seq > depth) { return false; }
 
-        req.id        = done.front(); done.pop(); // batch id
+        const uint32_t slot = (uint32_t) ((seq - 1) % depth);
+
+        req.seq       = seq;
         req.n_bufs    = op_batch->n_bufs;
         req.n_tensors = op_batch->n_tens;
         req.n_ops     = op_batch->n_ops;
-        req.seq       = seq;
 
-        op_cache[req.id]   = op_batch->ops;
-        start_usec[req.id] = ggml_time_us();
+        op_cache[slot]   = op_batch->ops;
+        start_usec[slot] = ggml_time_us();
 
         const size_t b_size = sizeof(htp_buf_desc)  * req.n_bufs;
         const size_t t_size = sizeof(htp_tensor)    * req.n_tensors;
@@ -2667,7 +2689,7 @@ struct ggml_hexagon_opqueue {
             req.n_traces = 0;
         }
 
-        dbuf.ptr      = shm_buf->base() + (req.id * shm_blk_size);
+        dbuf.ptr      = shm_buf->base() + ((size_t) slot * shm_blk_size);
         dbuf.fd       = shm_buf->fd();
         dbuf.flags    = DSPQUEUE_BUFFER_FLAG_FLUSH_SENDER | DSPQUEUE_BUFFER_FLAG_INVALIDATE_RECIPIENT;
         dbuf.offset   = (uint8_t*) dbuf.ptr - (uint8_t*) shm_buf->base();
@@ -2684,8 +2706,8 @@ struct ggml_hexagon_opqueue {
         memcpy(t_ptr, (void *) op_batch->h_tens.data(), t_size);
         memcpy(o_ptr, (void *) op_batch->h_ops.data(),  o_size);
 
-        HEX_VERBOSE("ggml-hex: %s opqueue-push batch #%u : n-bufs %u n-tensors %u n-ops %u vmem %zu : b-size %zu t-size %zu o-size %zu m-size %zu\n",
-                shm_buf->sess->c_name(), req.id, req.n_bufs, req.n_tensors, req.n_ops, op_batch->b_vmem,
+        HEX_VERBOSE("ggml-hex: %s opqueue-push batch #%llu : n-bufs %u n-tensors %u n-ops %u vmem %zu : b-size %zu t-size %zu o-size %zu m-size %zu\n",
+                shm_buf->sess->c_name(), (unsigned long long) req.seq, req.n_bufs, req.n_tensors, req.n_ops, op_batch->b_vmem,
                 b_size, t_size, o_size, (size_t) dbuf.size);
 
         if (opt_verbose > 1) {
@@ -2706,9 +2728,7 @@ struct ggml_hexagon_opqueue {
     }
 
     void pop(htp_opbatch_rsp rsp, dspqueue_buffer dbuf) {
-        GGML_ASSERT(rsp.id < op_cache.size());
-
-        done.push(rsp.id);
+        const uint32_t slot = (uint32_t) ((rsp.seq - 1) % depth);
 
         const size_t b_size = sizeof(htp_buf_desc)  * rsp.n_bufs;
         const size_t t_size = sizeof(htp_tensor)    * rsp.n_tensors;
@@ -2725,15 +2745,15 @@ struct ggml_hexagon_opqueue {
         const size_t m_size = b_size + t_size + o_size + p_size + tr_size;
         GGML_ASSERT(m_size <= shm_blk_size);
 
-        HEX_VERBOSE("ggml-hex: %s opqueue-pop batch #%u : n-bufs %u n-tensors %u n-ops %u : m-size %zu b-size %zu t-size %zu o-size %zu\n",
-                shm_buf->sess->c_name(), rsp.id, rsp.n_bufs, rsp.n_tensors, rsp.n_ops,
+        HEX_VERBOSE("ggml-hex: %s opqueue-pop batch #%llu : n-bufs %u n-tensors %u n-ops %u : m-size %zu b-size %zu t-size %zu o-size %zu\n",
+                shm_buf->sess->c_name(), (unsigned long long) rsp.seq, rsp.n_bufs, rsp.n_tensors, rsp.n_ops,
                 (size_t) dbuf.size, b_size, t_size, o_size);
 
         uint8_t * m_ptr = (uint8_t*) dbuf.ptr;
         uint8_t * p_ptr = m_ptr + (b_size + t_size + o_size);
 
         if (rsp.n_ops > 0) {
-            auto & ops = op_cache[rsp.id];
+            auto & ops = op_cache[slot];
             GGML_ASSERT(rsp.n_ops <= ops.size());
 
             const htp_prof_desc * pd = (const htp_prof_desc *) p_ptr;
@@ -2922,13 +2942,13 @@ void ggml_hexagon_session::enqueue_op(const htp_opnode & node) {
 void ggml_hexagon_session::enqueue_mdev_group() {
     htp_opnode group_node(HTP_OP_MDEV_GROUP);
 
-    uint8_t * fence_ptr = this->fence_buf->base();
+    uint8_t * fence_slot = this->mdev_fence_slot;
 
     static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
     ggml_tensor dummy_t {};
     dummy_t.buffer = &this->fence_buf->backend_buffer;
     dummy_t.extra  = &fence_extra;
-    dummy_t.data   = (void *) fence_ptr;
+    dummy_t.data   = (void *) fence_slot;
     dummy_t.type   = GGML_TYPE_I8;
     dummy_t.ne[0]  = HTP_FENCE_SLOT_SIZE;
     dummy_t.ne[1]  = (int64_t) this->mdev.count;
@@ -2976,16 +2996,17 @@ void ggml_hexagon_session::enqueue_cpy(const ggml_tensor * src, ggml_tensor * ds
     this->enqueue_op(cpy_node);
 }
 
-void ggml_hexagon_session::enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq) {
+void ggml_hexagon_session::enqueue_fence(const ggml_tensor * sync_tensor, uint32_t fence_seq, bool wait) {
     htp_opnode sync_node(HTP_OP_FENCE);
 
     ggml_tensor* node = sync_node.add_dummy(*sync_tensor);
     node->op           = GGML_OP_NONE;
     node->src[0]       = node;
     node->op_params[0] = (int32_t) fence_seq;
+    node->op_params[1] = wait ? 0 : 1;
 
     sync_node.init(node);
-    sync_node.name = "FENCE";
+    sync_node.name = wait ? "FENCE_WAIT" : "FENCE_SIGNAL";
     this->enqueue_op(sync_node);
 }
 
@@ -3153,24 +3174,6 @@ void ggml_hexagon_session::enqueue_allreduce(
 
     ar_node.name = "ALLREDUCE";
     this->enqueue_op(ar_node);
-}
-
-void ggml_hexagon_session::wait_event(uint64_t seq) {
-    HEX_VERBOSE("ggml-hex: %s wait-event start: seq %llu, batch-req %llu, batch-rsp %llu\n",
-                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->batch_req_seq, (unsigned long long)this->batch_rsp_seq);
-    while (this->batch_rsp_seq < seq) {
-        flush_sync(false);
-    }
-    if (this->last_error > HTP_STATUS_OK) {
-        GGML_ABORT("ggml-hex: %s wait-event failed : dsp-error %s\n", this->c_name(), status_to_str(this->last_error));
-    }
-    HEX_VERBOSE("ggml-hex: %s wait-event end: seq %llu, batch-req %llu, batch-rsp %llu\n",
-                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->batch_req_seq, (unsigned long long)this->batch_rsp_seq);
-}
-
-uint64_t ggml_hexagon_session::record_event() {
-    flush_async();
-    return this->batch_req_seq;
 }
 
 bool ggml_hexagon_session::clone_buffer(const ggml_hexagon_shared_buffer *sbuf)
@@ -3441,8 +3444,10 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
     // Allocate buffers and state for op batching
     this->op_queue = new ggml_hexagon_opqueue(this, opt_opbatch, opt_opqueue);
 
-    const uint32_t reserved_slots = this->mdev.count > 1 ? this->mdev.count : 0;
-    this->fence_buf = new ggml_hexagon_fence_buffer(this, &dev_ctx->fence_buffer_type, 64 * 1024, reserved_slots);
+    this->fence_buf = new ggml_hexagon_fence_buffer(this, &dev_ctx->fence_buffer_type, 64 * 1024);
+    if (this->mdev.count > 1) {
+        this->mdev_fence_slot = this->alloc_fence(this->mdev.count);
+    }
 
     if (!opt_vmem) {
         opt_vmem = ggml_hexagon_measure_max_vmem(this);
@@ -5780,8 +5785,13 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
 
     if (!sess_src->clone_buffer(sbuf_dst)) { return false; }
 
-    volatile uint32_t * fence = (volatile uint32_t *) sess_dst->alloc_fence();
-    if (!fence) { return false; }
+    const int src_id = sess_src->phys_idx;
+    if (!sess_dst->cpy_fence_slots[src_id]) {
+        sess_dst->cpy_fence_slots[src_id] = (volatile uint32_t *) sess_dst->alloc_fence(1);
+    }
+    volatile uint32_t * fence_slot = sess_dst->cpy_fence_slots[src_id];
+
+    if (!sess_src->clone_buffer(sess_dst->fence_buf)) { return false; }
 
     if (++sess_dst->fence_seq == 0) sess_dst->fence_seq = 1;
     uint32_t fence_seq = sess_dst->fence_seq;
@@ -5795,7 +5805,7 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
     ggml_tensor fence_tensor {};
     fence_tensor.buffer = &sess_dst->fence_buf->backend_buffer;
     fence_tensor.extra  = &fence_extra;
-    fence_tensor.data   = (void *) fence;
+    fence_tensor.data   = (void *) fence_slot;
     fence_tensor.type   = GGML_TYPE_I32;
     fence_tensor.ne[0]  = 1;
     fence_tensor.ne[1]  = 1;
@@ -5808,7 +5818,7 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
     fence_tensor.op     = GGML_OP_NONE;
 
     sess_src->enqueue_cpy(src, dst, &fence_tensor, fence_seq);
-    sess_dst->enqueue_fence(&fence_tensor, fence_seq);
+    sess_dst->enqueue_fence(&fence_tensor, fence_seq, /* wait = */ true);
 
     sess_dst->add_peer(sess_src);
 
@@ -5861,8 +5871,29 @@ static bool ggml_backend_hexagon_cpy_tensor_async(ggml_backend_t backend_src, gg
 }
 
 static ggml_backend_event_t ggml_backend_hexagon_device_event_new(ggml_backend_dev_t dev) {
+    auto dev_ctx = static_cast<ggml_backend_hexagon_device_context *>(dev->context);
+    auto sess    = dev_ctx->session();
+
     ggml_hexagon_event * hex_event = new ggml_hexagon_event();
-    HEX_VERBOSE("ggml-hex: %s event-new : event %p\n", ggml_backend_dev_name(dev), (void *)hex_event);
+    hex_event->sess       = sess;
+    hex_event->fence_slot = (volatile uint32_t *) sess->alloc_fence(1);
+
+    static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
+    hex_event->fence_tensor.buffer = &sess->fence_buf->backend_buffer;
+    hex_event->fence_tensor.extra  = &fence_extra;
+    hex_event->fence_tensor.data   = (void *) hex_event->fence_slot;
+    hex_event->fence_tensor.type   = GGML_TYPE_I32;
+    hex_event->fence_tensor.ne[0]  = 1;
+    hex_event->fence_tensor.ne[1]  = 1;
+    hex_event->fence_tensor.ne[2]  = 1;
+    hex_event->fence_tensor.ne[3]  = 1;
+    hex_event->fence_tensor.nb[0]  = sizeof(int32_t);
+    hex_event->fence_tensor.nb[1]  = sizeof(int32_t);
+    hex_event->fence_tensor.nb[2]  = sizeof(int32_t);
+    hex_event->fence_tensor.nb[3]  = sizeof(int32_t);
+    hex_event->fence_tensor.op     = GGML_OP_NONE;
+
+    HEX_VERBOSE("ggml-hex: %s event-new : event %p fence %p\n", ggml_backend_dev_name(dev), (void *)hex_event, (void *)hex_event->fence_slot);
 
     return new ggml_backend_event {
         /* .device  = */ dev,
@@ -5873,12 +5904,9 @@ static ggml_backend_event_t ggml_backend_hexagon_device_event_new(ggml_backend_d
 static void ggml_backend_hexagon_device_event_free(ggml_backend_dev_t dev, ggml_backend_event_t event) {
     GGML_UNUSED(dev);
 
-    if (event == nullptr) {
-        return;
-    }
-
     ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
     HEX_VERBOSE("ggml-hex: %s event-free : event %p\n", ggml_backend_dev_name(dev), (void *)hex_event);
+    hex_event->sess->free_fence((void *) hex_event->fence_slot, 1);
     delete hex_event;
     delete event;
 }
@@ -5887,10 +5915,26 @@ static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev
     GGML_UNUSED(dev);
 
     ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
-    HEX_VERBOSE("ggml-hex: %s event-synchronize : event %p seq %llu\n",
-                ggml_backend_dev_name(dev), (void *)hex_event, (unsigned long long)hex_event->seq);
-    if (hex_event->sess != nullptr) {
-        hex_event->sess->wait_event(hex_event->seq);
+    if (hex_event->seq == 0) {
+        return;
+    }
+
+    HEX_VERBOSE("ggml-hex: %s event-synchronize : event %p seq %u fence %p\n",
+                ggml_backend_dev_name(dev), (void *)hex_event, hex_event->seq, (void *)hex_event->fence_slot);
+
+    if ((int32_t)(*hex_event->fence_slot - hex_event->seq) < 0 && hex_event->sess->op_batch->n_ops > 0) {
+        hex_event->sess->flush_async();
+    }
+
+    while ((int32_t)(*hex_event->fence_slot - hex_event->seq) < 0) {
+        if (hex_event->sess->batch_rsp_seq < hex_event->sess->batch_req_seq) {
+            hex_event->sess->flush_pending(false);
+        }
+        if (hex_event->sess->last_error > HTP_STATUS_OK) {
+            GGML_ABORT("ggml-hex: %s event-synchronize failed : dsp-error %s\n",
+                       hex_event->sess->c_name(), status_to_str(hex_event->sess->last_error));
+        }
+        std::this_thread::yield();
     }
 }
 
@@ -5898,21 +5942,38 @@ static void ggml_backend_hexagon_event_record(ggml_backend_t backend, ggml_backe
     auto sess = static_cast<ggml_hexagon_session *>(backend->context);
     ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
 
+    if (++sess->fence_seq == 0) sess->fence_seq = 1;
     hex_event->sess = sess;
-    hex_event->seq  = sess->record_event();
-    HEX_VERBOSE("ggml-hex: %s event-record : event %p seq %llu\n",
-                sess->c_name(), (void *)hex_event, (unsigned long long)hex_event->seq);
+    hex_event->seq  = sess->fence_seq;
+
+    sess->enqueue_fence(&hex_event->fence_tensor, hex_event->seq, /* wait = */ false);
+
+    HEX_VERBOSE("ggml-hex: %s event-record : event %p seq %u fence %p\n",
+                sess->c_name(), (void *)hex_event, hex_event->seq, (void *)hex_event->fence_slot);
 }
 
 static void ggml_backend_hexagon_event_wait(ggml_backend_t backend, ggml_backend_event_t event) {
-    GGML_UNUSED(backend);
-
+    auto sess = static_cast<ggml_hexagon_session *>(backend->context);
     ggml_hexagon_event * hex_event = (ggml_hexagon_event *)event->context;
-    if (hex_event->sess != nullptr) {
-        HEX_VERBOSE("ggml-hex: %s event-wait : event %p seq %llu\n",
-                    hex_event->sess->c_name(), (void *)hex_event, (unsigned long long)hex_event->seq);
-        hex_event->sess->wait_event(hex_event->seq);
+
+    if (hex_event->seq == 0) {
+        return;
     }
+
+    HEX_VERBOSE("ggml-hex: %s event-wait : event %p seq %u fence %p\n",
+                sess->c_name(), (void *)hex_event, hex_event->seq, (void *)hex_event->fence_slot);
+
+    // same physical NPU runs sequentially in FIFO order
+    if (sess->phys_idx == hex_event->sess->phys_idx) {
+        if (sess != hex_event->sess) {
+            sess->add_peer(hex_event->sess);
+        }
+        return;
+    }
+
+    sess->clone_buffer(hex_event->sess->fence_buf);
+    sess->add_peer(hex_event->sess);
+    sess->enqueue_fence(&hex_event->fence_tensor, hex_event->seq, /* wait = */ true);
 }
 
 static void ggml_backend_hexagon_set_tensor_async(ggml_backend_t backend, struct ggml_tensor * tensor, const void * data, size_t offset, size_t size) {
@@ -6437,12 +6498,37 @@ static void * ggml_backend_hexagon_comm_init(ggml_backend_t * backends, size_t n
     ctx->backends.assign(backends, backends + n_backends);
     ctx->n_backends = n_backends;
 
+    static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
+    for (size_t i = 0; i < n_backends; i++) {
+        auto sess_i = static_cast<ggml_hexagon_session *>(backends[i]->context);
+        ctx->fence_slots[i] = (volatile uint32_t *) sess_i->alloc_fence(1);
+        ctx->fence_tensors[i] = {};
+        ctx->fence_tensors[i].buffer = &sess_i->fence_buf->backend_buffer;
+        ctx->fence_tensors[i].extra  = &fence_extra;
+        ctx->fence_tensors[i].data   = (void *) ctx->fence_slots[i];
+        ctx->fence_tensors[i].type   = GGML_TYPE_I32;
+        ctx->fence_tensors[i].ne[0]  = 4;
+        ctx->fence_tensors[i].ne[1]  = 1;
+        ctx->fence_tensors[i].ne[2]  = 1;
+        ctx->fence_tensors[i].ne[3]  = 1;
+        ctx->fence_tensors[i].nb[0]  = sizeof(int32_t);
+        ctx->fence_tensors[i].nb[1]  = sizeof(int32_t);
+        ctx->fence_tensors[i].nb[2]  = sizeof(int32_t);
+        ctx->fence_tensors[i].nb[3]  = sizeof(int32_t);
+        ctx->fence_tensors[i].op     = GGML_OP_NONE;
+    }
+
     return ctx;
 }
 
 static void ggml_backend_hexagon_comm_free(void * comm_ctx_v) {
     if (!comm_ctx_v) return;
-    delete static_cast<ggml_backend_hexagon_comm_context *>(comm_ctx_v);
+    auto * ctx = static_cast<ggml_backend_hexagon_comm_context *>(comm_ctx_v);
+    for (size_t i = 0; i < ctx->n_backends; i++) {
+        auto sess_i = static_cast<ggml_hexagon_session *>(ctx->backends[i]->context);
+        sess_i->free_fence((void *) ctx->fence_slots[i], 1);
+    }
+    delete ctx;
 }
 
 static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct ggml_tensor ** tensors) {
@@ -6506,37 +6592,11 @@ static bool ggml_backend_hexagon_comm_allreduce_tensor(void * comm_ctx_v, struct
         sess_i->fence_seq = max_seq;
     }
 
-    volatile uint32_t * fences[GGML_HEXAGON_MAX_SESSIONS];
-    for (size_t i = 0; i < n_backends; i++) {
-        auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
-        fences[i] = (volatile uint32_t *) sess_i->alloc_fence();
-    }
-
-    static ggml_hexagon_tensor_extra fence_extra { {}, 0, GGML_HEXAGON_TENSOR_FENCE };
-    ggml_tensor fence_tensors[GGML_HEXAGON_MAX_SESSIONS];
-    for (size_t i = 0; i < n_backends; i++) {
-        auto sess_i = static_cast<ggml_hexagon_session *>(comm_ctx->backends[i]->context);
-        fence_tensors[i] = {};
-        fence_tensors[i].buffer = &sess_i->fence_buf->backend_buffer;
-        fence_tensors[i].extra  = &fence_extra;
-        fence_tensors[i].data   = (void *) fences[i];
-        fence_tensors[i].type   = GGML_TYPE_I32;
-        fence_tensors[i].ne[0]  = 4;
-        fence_tensors[i].ne[1]  = 1;
-        fence_tensors[i].ne[2]  = 1;
-        fence_tensors[i].ne[3]  = 1;
-        fence_tensors[i].nb[0]  = sizeof(int32_t);
-        fence_tensors[i].nb[1]  = sizeof(int32_t);
-        fence_tensors[i].nb[2]  = sizeof(int32_t);
-        fence_tensors[i].nb[3]  = sizeof(int32_t);
-        fence_tensors[i].op     = GGML_OP_NONE;
-    }
-
     std::vector<const ggml_tensor *> data_tensors(n_backends);
     std::vector<const ggml_tensor *> sync_tensors(n_backends);
     for (size_t i = 0; i < n_backends; i++) {
         data_tensors[i] = tensors[i];
-        sync_tensors[i] = &fence_tensors[i];
+        sync_tensors[i] = &comm_ctx->fence_tensors[i];
     }
 
     for (size_t r = 0; r < n_backends; r++) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -351,7 +351,7 @@ struct ggml_hexagon_tensor_extra {
 };
 
 static inline bool ggml_hexagon_tensor_is_fuseable(const struct ggml_tensor * t) {
-    if (!t || !t->extra) return false;
+    if (!t->extra) return false;
     auto extra = (const struct ggml_hexagon_tensor_extra *) t->extra;
     return (extra->flags & GGML_HEXAGON_TENSOR_FUSEABLE) != 0;
 }
@@ -2055,7 +2055,6 @@ struct ggml_hexagon_opbatch {
 
         size_t extra_bufs = 0, extra_vmem = 0, extra_tens = 0;
         auto fit_t = [&](const ggml_tensor * t) {
-            if (!t) return;
             if (!t_map.count(t)) {
                 extra_tens++;
                 auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(t->buffer->context);
@@ -2104,10 +2103,9 @@ struct ggml_hexagon_opbatch {
         const ggml_tensor * mul_src1 = node.src1();
         const ggml_tensor * rms_out  = last_node.dst();
 
-        if (!mul_src0 || !mul_src1 || !rms_out) return false;
         if (!ggml_hexagon_tensor_is_fuseable(rms_out)) return false;
 
-        const ggml_tensor * weight = nullptr;
+        const ggml_tensor * weight;
         if (mul_src0 == rms_out || mul_src0->data == rms_out->data) {
             weight = mul_src1;
         } else if (mul_src1 == rms_out || mul_src1->data == rms_out->data) {
@@ -2116,10 +2114,7 @@ struct ggml_hexagon_opbatch {
             return false;
         }
 
-        if (!weight || !weight->data) return false;
-
         const ggml_tensor * src0 = last_node.src0();
-        if (!src0 || !src0->data) return false;
 
         if (src0->ne[0] != weight->ne[0] || src0->ne[0] != node.dst()->ne[0]) {
             return false;
@@ -2150,7 +2145,6 @@ struct ggml_hexagon_opbatch {
 
         size_t extra_bufs = 0, extra_vmem = 0, extra_tens = 0;
         auto fit_t = [&](const ggml_tensor * t) {
-            if (!t) return;
             if (!t_map.count(t)) {
                 extra_tens++;
                 auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(t->buffer->context);
@@ -2205,10 +2199,9 @@ struct ggml_hexagon_opbatch {
         const ggml_tensor * add_src1 = node.src1();
         const ggml_tensor * mm_out   = last_node.dst();
 
-        if (!add_src0 || !add_src1 || !mm_out) return false;
         if (!ggml_hexagon_tensor_is_fuseable(mm_out)) return false;
 
-        const ggml_tensor * src2 = nullptr;
+        const ggml_tensor * src2;
         if (add_src0 == mm_out || add_src0->data == mm_out->data) {
             src2 = add_src1;
         } else if (add_src1 == mm_out || add_src1->data == mm_out->data) {
@@ -2217,11 +2210,8 @@ struct ggml_hexagon_opbatch {
             return false;
         }
 
-        if (!src2 || !src2->data) return false;
-
         const ggml_tensor * src0 = last_node.src0();
         const ggml_tensor * src1 = last_node.src1();
-        if (!src0 || !src1) return false;
 
         struct htp_mm_kernel_params kparams;
         ggml_hexagon_precompute_fused_matmul_add_params(sess, src0, src1, src2, node.dst(), &kparams);
@@ -2237,7 +2227,6 @@ struct ggml_hexagon_opbatch {
 
         size_t extra_bufs = 0, extra_vmem = 0, extra_tens = 0;
         auto fit_t = [&](const ggml_tensor * t) {
-            if (!t) return;
             if (!t_map.count(t)) {
                 extra_tens++;
                 auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(t->buffer->context);
@@ -2290,7 +2279,6 @@ struct ggml_hexagon_opbatch {
         const ggml_tensor * w_in = node.src0();
         const ggml_tensor * x_in = node.src1();
         const ggml_tensor * d_in = node.dst();
-        if (!w_in || !x_in || !d_in) return false;
 
         htp_opnode & last_node = ops[n_ops - 1];
 
@@ -2324,7 +2312,6 @@ struct ggml_hexagon_opbatch {
 
             size_t extra_bufs = 0, extra_vmem = 0, extra_tens = 0;
             auto fit_t = [&](const ggml_tensor * t) {
-                if (!t) return;
                 if (!t_map.count(t)) {
                     extra_tens++;
                     auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(t->buffer->context);
@@ -2375,7 +2362,6 @@ struct ggml_hexagon_opbatch {
             const ggml_tensor * w0 = last_node.src0();
             const ggml_tensor * x  = last_node.src1();
             const ggml_tensor * w1 = node.src0();
-            if (!w0 || !x || !w1) return false;
 
             struct htp_mm_kernel_params kparams;
             ggml_hexagon_precompute_fused_mmnx_params(sess, w0, x, 2, &kparams);
@@ -2390,7 +2376,6 @@ struct ggml_hexagon_opbatch {
 
             size_t extra_bufs = 0, extra_vmem = 0, extra_tens = 0;
             auto fit_t = [&](const ggml_tensor * t) {
-                if (!t) return;
                 if (!t_map.count(t)) {
                     extra_tens++;
                     auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(t->buffer->context);
@@ -2452,7 +2437,6 @@ struct ggml_hexagon_opbatch {
         const ggml_tensor * x_in   = node.src1();
         const ggml_tensor * ids_in = node.node->src[2];
         const ggml_tensor * d_in   = node.dst();
-        if (!w_in || !x_in || !ids_in || !d_in) return false;
 
         htp_opnode & last_node = ops[n_ops - 1];
 
@@ -2487,7 +2471,6 @@ struct ggml_hexagon_opbatch {
 
             size_t extra_bufs = 0, extra_vmem = 0, extra_tens = 0;
             auto fit_t = [&](const ggml_tensor * t) {
-                if (!t) return;
                 if (!t_map.count(t)) {
                     extra_tens++;
                     auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(t->buffer->context);
@@ -2540,7 +2523,6 @@ struct ggml_hexagon_opbatch {
             const ggml_tensor * x   = last_node.src1();
             const ggml_tensor * ids = last_node.node->src[2];
             const ggml_tensor * w1  = node.src0();
-            if (!w0 || !x || !ids || !w1) return false;
 
             struct htp_mm_kernel_params kparams;
             ggml_hexagon_precompute_fused_mmidnx_params(sess, w0, x, node.dst(), 2, &kparams);
@@ -2555,7 +2537,6 @@ struct ggml_hexagon_opbatch {
 
             size_t extra_bufs = 0, extra_vmem = 0, extra_tens = 0;
             auto fit_t = [&](const ggml_tensor * t) {
-                if (!t) return;
                 if (!t_map.count(t)) {
                     extra_tens++;
                     auto sbuf = static_cast<ggml_hexagon_shared_buffer *>(t->buffer->context);
@@ -3799,10 +3780,6 @@ static bool ggml_hexagon_supported_gated_delta_net(const struct ggml_hexagon_ses
     const struct ggml_tensor * beta  = op->src[4];
     const struct ggml_tensor * state = op->src[5];
     const struct ggml_tensor * dst   = op;
-
-    if (!q || !k || !v || !g || !beta || !state) {
-        return false;
-    }
 
     if (q->type != GGML_TYPE_F32 || k->type != GGML_TYPE_F32 || v->type != GGML_TYPE_F32 ||
         g->type != GGML_TYPE_F32 || beta->type != GGML_TYPE_F32 || state->type != GGML_TYPE_F32 ||
@@ -5219,10 +5196,6 @@ static bool ggml_hexagon_supported_solve_tri(const struct ggml_hexagon_session *
     const struct ggml_tensor * src1 = op->src[1]; // B
     const struct ggml_tensor * dst  = op;         // X
 
-    if (!src0 || !src1) {
-        return false;
-    }
-
     if (src0->type != GGML_TYPE_F32 || src1->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32) {
         return false;
     }
@@ -5392,7 +5365,7 @@ static bool is_supported_mul_mat_id_nx_kernel(const ggml_tensor * src0, const st
 }
 
 static bool is_mergeable_mul_mat(const ggml_tensor * t) {
-    if (!t || t->op != GGML_OP_MUL_MAT) return false;
+    if (t->op != GGML_OP_MUL_MAT) return false;
 
     const ggml_tensor * src0 = t->src[0];
     const ggml_tensor * src1 = t->src[1];
@@ -5426,7 +5399,7 @@ static bool is_mergeable_mul_mat_pair(const ggml_tensor * n1, const ggml_tensor 
 }
 
 static bool is_mergeable_mul_mat_id(const ggml_tensor * t) {
-    if (!t || t->op != GGML_OP_MUL_MAT_ID) return false;
+    if (t->op != GGML_OP_MUL_MAT_ID) return false;
 
     const ggml_tensor * src0 = t->src[0];
     return ggml_hexagon_is_repack_type(src0->type);

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -3369,8 +3369,9 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
         unsigned long long hw_vtcm_size = 0;
         int hw_err = htp_iface_hwinfo(this->handle, &hw_n_threads, &hw_n_hvx, &hw_n_hmx, &hw_vtcm_size);
         if (hw_err == 0) {
-            this->n_threads = opt_nhvx > 0 ? (uint32_t)opt_nhvx : (uint32_t)hw_n_threads;
-            this->n_hvx     = opt_nhvx > 0 ? (uint32_t)opt_nhvx : (uint32_t)hw_n_hvx;
+            const uint32_t max_n_threads = (std::min)((uint32_t) HTP_MAX_NTHREADS, (uint32_t) hw_n_threads);
+            this->n_threads = opt_nhvx > 0 ? (uint32_t) (std::min)(opt_nhvx, (size_t) max_n_threads) : max_n_threads;
+            this->n_hvx     = this->n_threads;
             this->n_hmx     = (opt_nhmx != 0) ? (uint32_t)hw_n_hmx : 0;
             this->vtcm_size = (uint64_t)hw_vtcm_size;
             GGML_LOG_INFO("ggml-hex: %s hwinfo: threads %u, hvx %u, hmx %u, vtcm %llu MB\n",
@@ -3378,8 +3379,9 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
                           (unsigned long long)(this->vtcm_size / (1024 * 1024)));
         } else {
             GGML_LOG_WARN("ggml-hex: %s failed to query hwinfo (0x%x), using defaults\n", this->c_name(), hw_err);
-            this->n_threads = opt_nhvx > 0 ? (uint32_t)opt_nhvx : 8;
-            this->n_hvx     = opt_nhvx > 0 ? (uint32_t)opt_nhvx : 8;
+            const uint32_t default_n_threads = (std::min)(8u, (uint32_t) HTP_MAX_NTHREADS);
+            this->n_threads = opt_nhvx > 0 ? (uint32_t) (std::min)(opt_nhvx, (size_t) HTP_MAX_NTHREADS) : default_n_threads;
+            this->n_hvx     = this->n_threads;
             this->n_hmx     = (opt_nhmx != 0) ? 1 : 0;
             this->vtcm_size = 8 * 1024 * 1024;
         }
@@ -3448,7 +3450,7 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
     this->op_batch = new ggml_hexagon_opbatch(this, opt_opbatch, this->max_vmem);
 
     // Start dspqueue/opbatch processing
-    err = htp_iface_start(this->handle, this->session_id, this->queue_id, opt_nhvx, opt_nhmx, this->max_vmem);
+    err = htp_iface_start(this->handle, this->session_id, this->queue_id, this->n_threads, opt_nhmx, this->max_vmem);
     if (err != 0) {
         GGML_LOG_ERROR("ggml-hex: %s failed to start session: 0x%08x\n", this->c_name(), (unsigned) err);
         throw std::runtime_error("ggml-hex: iface start failed (see log for details)");
@@ -3957,6 +3959,7 @@ static void ggml_hexagon_precompute_hvx_mm_params(
     struct htp_mm_kernel_params * kparams
 ) {
     kparams->n_hmx = 0;
+    kparams->n_threads = sess->n_threads;
 
     const bool is_quant = (wtype != GGML_TYPE_F16 && wtype != GGML_TYPE_F32);
     const int src1_nrows = ne11 * ne12 * ne13;
@@ -4396,6 +4399,7 @@ static void ggml_hexagon_precompute_fused_mmnx_params(
     struct htp_mm_kernel_params * kparams
 ) {
     memset(kparams, 0, sizeof(*kparams));
+    kparams->n_threads = sess->n_threads;
 
     const int ne00 = src0->ne[0];
     const int ne01 = src0->ne[1];

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -5805,7 +5805,7 @@ static bool ggml_hexagon_cpy_tensor_async_phys(ggml_backend_t backend_src, ggml_
     if (++sess_dst->fence_seq == 0) sess_dst->fence_seq = 1;
     uint32_t fence_seq = sess_dst->fence_seq;
 
-    HEX_VERBOSE("ggml-hex: %s cpy-tensor-async %s -> %s size %zu : seq %u\n",
+    HEX_VERBOSE("ggml-hex: %s cpy-tensor-async %s -> %s size %zu : seq 0x%x\n",
                 sess_dst->name.c_str(), src->name, dst->name, ggml_nbytes(src), fence_seq);
 
     // dummy fence extra (must be static)
@@ -5928,7 +5928,7 @@ static void ggml_backend_hexagon_device_event_synchronize(ggml_backend_dev_t dev
         return;
     }
 
-    HEX_VERBOSE("ggml-hex: %s event-synchronize : event %p seq %u fence %p\n",
+    HEX_VERBOSE("ggml-hex: %s event-synchronize : event %p seq 0x%x fence %p\n",
                 ggml_backend_dev_name(dev), (void *)hex_event, hex_event->seq, (void *)hex_event->fence_slot);
 
     auto * fence = reinterpret_cast<const volatile std::atomic<uint32_t> *>(hex_event->fence_slot);
@@ -5960,7 +5960,7 @@ static void ggml_backend_hexagon_event_record(ggml_backend_t backend, ggml_backe
 
     sess->enqueue_fence(&hex_event->fence_tensor, hex_event->seq, /* wait = */ false);
 
-    HEX_VERBOSE("ggml-hex: %s event-record : event %p seq %u fence %p\n",
+    HEX_VERBOSE("ggml-hex: %s event-record : event %p seq 0x%x fence %p\n",
                 sess->c_name(), (void *)hex_event, hex_event->seq, (void *)hex_event->fence_slot);
 }
 
@@ -5972,7 +5972,7 @@ static void ggml_backend_hexagon_event_wait(ggml_backend_t backend, ggml_backend
         return;
     }
 
-    HEX_VERBOSE("ggml-hex: %s event-wait : event %p seq %u fence %p\n",
+    HEX_VERBOSE("ggml-hex: %s event-wait : event %p seq 0x%x fence %p\n",
                 sess->c_name(), (void *)hex_event, hex_event->seq, (void *)hex_event->fence_slot);
 
     // same physical NPU runs sequentially in FIFO order

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -380,9 +380,10 @@ struct ggml_backend_hexagon_comm_context {
 
 struct ggml_hexagon_event {
     ggml_hexagon_session * sess         = nullptr;
-    uint32_t               seq          = 0;
+    ggml_hexagon_session * fence_sess   = nullptr;
     volatile uint32_t *    fence_slot   = nullptr;
     ggml_tensor            fence_tensor = {};
+    uint32_t               seq          = 0;
 };
 
 struct ggml_hexagon_session {
@@ -5886,6 +5887,7 @@ static ggml_backend_event_t ggml_backend_hexagon_device_event_new(ggml_backend_d
     auto sess    = dev_ctx->session();
 
     ggml_hexagon_event * hex_event = new ggml_hexagon_event();
+    hex_event->fence_sess = sess;
     hex_event->sess       = sess;
     hex_event->fence_slot = (volatile uint32_t *) sess->alloc_fence(1);
 
@@ -5943,7 +5945,7 @@ static void ggml_backend_hexagon_device_event_free(ggml_backend_dev_t dev, ggml_
     auto * hex_event = static_cast<ggml_hexagon_event *>(event->context);
     ggml_hexagon_event_synchronize(dev, hex_event);
     HEX_VERBOSE("ggml-hex: %s event-free : event %p\n", ggml_backend_dev_name(dev), (void *)hex_event);
-    hex_event->sess->free_fence((void *) hex_event->fence_slot, 1);
+    hex_event->fence_sess->free_fence((void *) hex_event->fence_slot, 1);
     delete hex_event;
     delete event;
 }
@@ -5986,7 +5988,7 @@ static void ggml_backend_hexagon_event_wait(ggml_backend_t backend, ggml_backend
         return;
     }
 
-    sess->clone_buffer(hex_event->sess->fence_buf);
+    sess->clone_buffer(hex_event->fence_sess->fence_buf);
     sess->add_peer(hex_event->sess);
     sess->enqueue_fence(&hex_event->fence_tensor, hex_event->seq, /* wait = */ true);
 }

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -413,6 +413,7 @@ struct ggml_hexagon_session {
 
     std::atomic<uint64_t> batch_req_seq{0};
     std::atomic<uint64_t> batch_rsp_seq{0};
+    std::atomic<uint32_t> last_error{HTP_STATUS_OK};
 
     uint64_t                cached_uid = 0;
     std::vector<htp_opnode> cached_nodes;
@@ -2782,6 +2783,9 @@ void ggml_hexagon_session::flush_async() {
 void ggml_hexagon_session::flush_pending(bool all) {
     for (auto & sub : this->mdev.sessions) {
         sub->flush_pending(all);
+        if (sub->last_error > HTP_STATUS_OK) {
+            this->last_error = sub->last_error.load();
+        }
     }
 
     while (this->batch_rsp_seq < this->batch_req_seq) {
@@ -2809,9 +2813,12 @@ void ggml_hexagon_session::flush_pending(bool all) {
             GGML_ABORT("ggml-hex: %s dspcall : bad response : size %u dspbufs %u\n", this->c_name(), rsp_size, n_dbufs);
         }
 
-        if (rsp.status != HTP_STATUS_OK) {
-            GGML_LOG_ERROR("ggml-hex: %s dspcall : dsp-rsp: %s\n", this->c_name(), status_to_str(rsp.status));
-            // TODO: handle errors
+        if (rsp.status > HTP_STATUS_OK) {
+            GGML_LOG_ERROR("ggml-hex: %s dspcall : dsp-rsp %s\n", this->c_name(), status_to_str(rsp.status));
+            this->last_error = rsp.status;
+            for (auto & sub : this->mdev.sessions) {
+                sub->last_error = rsp.status;
+            }
         }
 
         op_queue->pop(rsp, dbuf);
@@ -3151,6 +3158,9 @@ void ggml_hexagon_session::wait_event(uint64_t seq) {
     while (this->batch_rsp_seq < seq) {
         flush_sync(false);
     }
+    if (this->last_error > HTP_STATUS_OK) {
+        GGML_ABORT("ggml-hex: %s wait-event failed : dsp-error %s\n", this->c_name(), status_to_str(this->last_error));
+    }
     HEX_VERBOSE("ggml-hex: %s wait-event end: seq %llu, batch-req %llu, batch-rsp %llu\n",
                 this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->batch_req_seq, (unsigned long long)this->batch_rsp_seq);
 }
@@ -3237,6 +3247,7 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
     this->name          = config.name;
     this->batch_req_seq = 0;
     this->batch_rsp_seq = 0;
+    this->last_error    = HTP_STATUS_OK;
 
     GGML_LOG_DEBUG("ggml-hex: %s allocating new session\n", this->name.c_str());
 
@@ -5378,6 +5389,10 @@ static bool is_mergeable_mul_mat_id_pair(const ggml_tensor * n1, const ggml_tens
 static ggml_status ggml_backend_hexagon_graph_compute(ggml_backend_t backend, ggml_cgraph * graph) {
     auto sess = static_cast<ggml_hexagon_session *>(backend->context);
 
+    if (sess->last_error > HTP_STATUS_OK) {
+        return GGML_STATUS_FAILED;
+    }
+
     HEX_VERBOSE("ggml-hex: %s graph-compute n_nodes %d\n", sess->c_name(), graph->n_nodes);
 
     const std::vector<htp_opnode> * nodes_ptr = nullptr;
@@ -5464,6 +5479,10 @@ static ggml_status ggml_backend_hexagon_graph_compute(ggml_backend_t backend, gg
         sess->enqueue_op(node);
     }
 
+    if (sess->last_error > HTP_STATUS_OK) {
+        return GGML_STATUS_FAILED;
+    }
+
     return GGML_STATUS_SUCCESS;
 }
 
@@ -5474,6 +5493,9 @@ static void ggml_backend_hexagon_synchronize(ggml_backend_t backend) {
 
     // Wait until all pending ops complete
     sess->flush_sync();
+    if (sess->last_error > HTP_STATUS_OK) {
+        GGML_ABORT("ggml-hex: %s synchronize failed : dsp-error %s\n", sess->c_name(), status_to_str(sess->last_error));
+    }
 }
 
 enum ggml_hexagon_mem_range_type {
@@ -5862,6 +5884,9 @@ static void ggml_backend_hexagon_get_tensor_async(ggml_backend_t backend, const 
     HEX_VERBOSE("ggml-hex: %s get-tensor-async %s : data %p offset %zu size %zu usage %d\n",
                 sess->c_name(), tensor->name, data, offset, size, tensor->buffer ? (int) tensor->buffer->usage : -1);
     sess->flush_sync();
+    if (sess->last_error > HTP_STATUS_OK) {
+        GGML_ABORT("ggml-hex: %s get-tensor-async failed : dsp-error %s\n", sess->c_name(), status_to_str(sess->last_error));
+    }
     ggml_backend_tensor_get(tensor, data, offset, size);
 }
 
@@ -5891,6 +5916,9 @@ static void ggml_backend_hexagon_get_tensor_2d_async(ggml_backend_t backend,
     HEX_VERBOSE("ggml-hex: %s get-tensor-2d-async %s : data %p offset %zu size %zu n_copies %zu stride_tensor %zu stride_data %zu usage %d\n",
                 sess->c_name(), tensor->name, data, offset, size, n_copies, stride_tensor, stride_data, tensor->buffer ? (int) tensor->buffer->usage : -1);
     sess->flush_sync();
+    if (sess->last_error > HTP_STATUS_OK) {
+        GGML_ABORT("ggml-hex: %s get-tensor-2d-async failed : dsp-error %s\n", sess->c_name(), status_to_str(sess->last_error));
+    }
     ggml_backend_tensor_get_2d(tensor, data, offset, size, n_copies, stride_tensor, stride_data);
 }
 

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -450,6 +450,7 @@ struct ggml_hexagon_session {
     void     wait_event(uint64_t seq);
 
     bool clone_buffer(const ggml_hexagon_shared_buffer*);
+    void release_buffer(const ggml_hexagon_shared_buffer*);
     void unclone_buffer(const ggml_hexagon_shared_buffer*);
 
     void add_peer(ggml_hexagon_session * peer) {
@@ -502,6 +503,8 @@ struct ggml_hexagon_rpcmem_block {
     uint8_t * base = nullptr;
     int       fd   = -1;
     size_t    size = 0;
+
+    std::unordered_set<ggml_hexagon_session *> mapped_clones;
 
     ggml_hexagon_rpcmem_block(size_t size) {
         base = (uint8_t *) rpcmem_alloc2(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS, size);
@@ -3169,10 +3172,18 @@ uint64_t ggml_hexagon_session::record_event() {
 
 bool ggml_hexagon_session::clone_buffer(const ggml_hexagon_shared_buffer *sbuf)
 {
-    if (this->cloned_buffers.find(sbuf->fd()) != this->cloned_buffers.end()) return true;
+    GGML_ASSERT(sbuf && sbuf->mem);
+    if (sbuf->sess == this) return true;
+
+    auto mem = sbuf->mem;
+    int   fd = mem->fd;
+
+    GGML_ASSERT(fd >= 0);
+
+    if (this->cloned_buffers.find(fd) != this->cloned_buffers.end()) return true;
 
     HEX_VERBOSE("ggml-hex: %s clone-buffer: %s base %p size %zu fd %d\n", this->name.c_str(),
-                sbuf->c_name(), sbuf->base(), sbuf->size(), sbuf->fd());
+                sbuf->c_name(), sbuf->base(), sbuf->size(), fd);
 
     auto clone = std::make_unique<ggml_hexagon_shared_buffer>(this, *sbuf);
     try {
@@ -3182,22 +3193,35 @@ bool ggml_hexagon_session::clone_buffer(const ggml_hexagon_shared_buffer *sbuf)
         return false;
     }
 
-    this->cloned_buffers[sbuf->fd()] = std::move(clone);
+    this->cloned_buffers[fd] = std::move(clone);
+    mem->mapped_clones.insert(this);
     return true;
 }
 
-void ggml_hexagon_session::unclone_buffer(const ggml_hexagon_shared_buffer * sbuf) {
-    if (!sbuf) return;
-    int fd = sbuf->fd();
-    if (fd < 0) return;
+void ggml_hexagon_session::release_buffer(const ggml_hexagon_shared_buffer * sbuf) {
+    GGML_ASSERT(sbuf && sbuf->mem);
+
+    auto mem = sbuf->mem;
+    int   fd = mem->fd;
+
+    GGML_ASSERT(fd >= 0);
 
     auto it = this->cloned_buffers.find(fd);
     if (it != this->cloned_buffers.end()) {
         auto clone = std::move(it->second);
         this->cloned_buffers.erase(it);
     }
-    for (auto & sub : this->mdev.sessions) {
-        sub->unclone_buffer(sbuf);
+    mem->mapped_clones.erase(this);
+}
+
+void ggml_hexagon_session::unclone_buffer(const ggml_hexagon_shared_buffer * sbuf) {
+    GGML_ASSERT(sbuf && sbuf->mem);
+
+    auto mem = sbuf->mem;
+    std::vector<ggml_hexagon_session *> sessions(mem->mapped_clones.begin(), mem->mapped_clones.end());
+
+    for (auto * sess : sessions) {
+        sess->release_buffer(sbuf);
     }
 }
 
@@ -3464,6 +3488,9 @@ void ggml_hexagon_session::release() noexcept(true) {
         delete this->fence_buf;
         this->fence_buf = nullptr;
     }
+    while (!this->cloned_buffers.empty()) {
+        release_buffer(this->cloned_buffers.begin()->second.get());
+    }
 
     if (opt_etm) {
         err = htp_iface_etm(this->handle, 0);
@@ -3490,8 +3517,6 @@ void ggml_hexagon_session::release() noexcept(true) {
     if (this->valid_handle) {
         htp_iface_close(this->handle);
     }
-
-    this->cloned_buffers.clear();
 }
 
 ggml_hexagon_session::ggml_hexagon_session(const ggml_hexagon_device_config & config, ggml_backend_dev_t dev, uint32_t mdev_idx, uint32_t mdev_count) noexcept(false) {

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -5771,7 +5771,14 @@ static bool ggml_backend_hexagon_cpy_tensor_async(ggml_backend_t backend_src, gg
         return false;
     }
 
-    *(ggml_hexagon_tensor_extra *) dst->extra = *(const ggml_hexagon_tensor_extra *) src->extra;
+    // FIXME: ggml-meta needs to call init_tensor on auxiliary tensors
+    if (!dst->extra) {
+        ggml_backend_buffer_init_tensor(dst->buffer, dst);
+    }
+
+    auto * dst_extra = static_cast<ggml_hexagon_tensor_extra *>(dst->extra);
+    const auto * src_extra = static_cast<const ggml_hexagon_tensor_extra *>(src->extra);
+    dst_extra->flags = src_extra->flags;
 
     auto sess_src = static_cast<ggml_hexagon_session *>(backend_src->context);
     auto sess_dst = static_cast<ggml_hexagon_session *>(backend_dst->context);

--- a/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -396,7 +396,6 @@ struct ggml_hexagon_session {
     bool             valid_queue;
     bool             valid_iface;
 
-    std::atomic<int>      op_pending;
     ggml_hexagon_opbatch* op_batch;
     ggml_hexagon_opqueue* op_queue;
 
@@ -411,8 +410,9 @@ struct ggml_hexagon_session {
     size_t   max_vmem    = 0;
     size_t   max_bufsize = 0;
     uint32_t fence_seq   = 0;
-    uint64_t req_seq     = 0;
-    uint64_t rsp_seq     = 0;
+
+    std::atomic<uint64_t> batch_req_seq{0};
+    std::atomic<uint64_t> batch_rsp_seq{0};
 
     uint64_t                cached_uid = 0;
     std::vector<htp_opnode> cached_nodes;
@@ -2784,7 +2784,7 @@ void ggml_hexagon_session::flush_pending(bool all) {
         sub->flush_pending(all);
     }
 
-    while (this->op_pending) {
+    while (this->batch_rsp_seq < this->batch_req_seq) {
         struct htp_opbatch_rsp rsp;
         uint32_t               rsp_size;
         uint32_t               flags;
@@ -2816,11 +2816,8 @@ void ggml_hexagon_session::flush_pending(bool all) {
 
         op_queue->pop(rsp, dbuf);
 
-        if (rsp.seq > this->rsp_seq) {
-            this->rsp_seq = rsp.seq;
-        }
-
-        this->op_pending--;  // atomic dec
+        GGML_ASSERT(rsp.seq == this->batch_rsp_seq + 1);
+        this->batch_rsp_seq = rsp.seq;
 
         if (!all) break;
     }
@@ -2839,7 +2836,7 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
     htp_opbatch_req req {};
     dspqueue_buffer dbuf{};
 
-    const uint64_t seq = ++this->req_seq;
+    const uint64_t seq = ++this->batch_req_seq;
 
     op_batch->update_mdev_group(this->mdev.idx);
 
@@ -2852,15 +2849,13 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
         htp_opbatch_req sub_req {};
         dspqueue_buffer sub_dbuf{};
 
-        sub->req_seq = seq;
+        sub->batch_req_seq = seq;
         op_batch->update_mdev_group(sub->mdev.idx);
 
         if (!sub->op_queue->push(sub_req, sub_dbuf, op_batch, seq)) {
             sub->flush_pending(false);
             sub->op_queue->push(sub_req, sub_dbuf, op_batch, seq);
         }
-
-        sub->op_pending++;
 
         HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u\n", sub->c_name(), sub_dbuf.ptr, sub_dbuf.size);
 
@@ -2869,9 +2864,6 @@ void ggml_hexagon_session::flush_batch(size_t min_ops) {
             GGML_ABORT("ggml-hex: %s dspqueue_write failed: 0x%08x\n", sub->c_name(), (unsigned) err);
         }
     }
-
-    // Bump pending flag (cleared in the session::flush once we get the response)
-    this->op_pending++;  // atomic inc
 
     HEX_VERBOSE("ggml-hex: %s queue-opbatch: %p size %u\n", this->c_name(), dbuf.ptr, dbuf.size);
 
@@ -3154,18 +3146,18 @@ void ggml_hexagon_session::enqueue_allreduce(
 }
 
 void ggml_hexagon_session::wait_event(uint64_t seq) {
-    HEX_VERBOSE("ggml-hex: %s opqueue-wait start: seq %llu, current rsp-seq %llu, pending %d\n",
-                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->rsp_seq, (int)this->op_pending);
-    while (this->rsp_seq < seq && this->op_pending > 0) {
+    HEX_VERBOSE("ggml-hex: %s wait-event start: seq %llu, batch-req %llu, batch-rsp %llu\n",
+                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->batch_req_seq, (unsigned long long)this->batch_rsp_seq);
+    while (this->batch_rsp_seq < seq) {
         flush_sync(false);
     }
-    HEX_VERBOSE("ggml-hex: %s opqueue-wait end: seq %llu, current rsp-seq %llu, pending %d\n",
-                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->rsp_seq, (int)this->op_pending);
+    HEX_VERBOSE("ggml-hex: %s wait-event end: seq %llu, batch-req %llu, batch-rsp %llu\n",
+                this->name.c_str(), (unsigned long long)seq, (unsigned long long)this->batch_req_seq, (unsigned long long)this->batch_rsp_seq);
 }
 
 uint64_t ggml_hexagon_session::record_event() {
     flush_async();
-    return this->req_seq;
+    return this->batch_req_seq;
 }
 
 bool ggml_hexagon_session::clone_buffer(const ggml_hexagon_shared_buffer *sbuf)
@@ -3242,8 +3234,9 @@ void ggml_hexagon_session::allocate(const ggml_hexagon_device_config & config) n
     this->virt_idx   = virt_idx;
     this->domain_id  = config.domain_id;
     this->session_id = 0;
-    this->name       = config.name;
-    this->op_pending = 0;
+    this->name          = config.name;
+    this->batch_req_seq = 0;
+    this->batch_rsp_seq = 0;
 
     GGML_LOG_DEBUG("ggml-hex: %s allocating new session\n", this->name.c_str());
 

--- a/ggml/src/ggml-hexagon/htp-opnode.h
+++ b/ggml/src/ggml-hexagon/htp-opnode.h
@@ -344,6 +344,12 @@ struct htp_opformat {
         } else if (htp_op_is_unary(node.opcode)) {
             const auto * kparams = (const struct htp_unary_kernel_params *) node.kernel_params;
             snprintf(str, max_size, "%s vtcm %d", kparams->col_tile ? "wide-row" : "row-block", (int) kparams->vtcm_size);
+        } else if (node.opcode == HTP_OP_MDEV_GROUP && node.node) {
+            snprintf(str, max_size, "idx %d count %d", (int) node.node->op_params[0], (int) node.dst()->ne[1]);
+        } else if ((node.opcode == HTP_OP_FENCE || node.opcode == HTP_OP_CPY_FENCE) && node.node) {
+            snprintf(str, max_size, "seq 0x%x", (uint32_t) node.node->op_params[0]);
+        } else if (node.opcode == HTP_OP_ALLREDUCE && node.node) {
+            snprintf(str, max_size, "seq 0x%x -> 0x%x", (uint32_t) node.node->op_params[0], (uint32_t) node.node->op_params[1]);
         } else {
             snprintf(str, max_size, "----");
         }

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -3,7 +3,6 @@
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 
 #include <HAP_farf.h>
-#include <HAP_perf.h>
 
 #include <math.h>
 #include <string.h>
@@ -587,7 +586,7 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     actx.data_src1 = data_src1;
     actx.data_dst  = (uint8_t *) dst->data;
 
-    worker_pool_run_func(octx->ctx->worker_pool, act_op_func, &actx, n_threads);
+    work_queue_run(octx->ctx->work_queue, act_op_func, &actx, n_threads);
     return HTP_STATUS_OK;
 }
 

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -80,6 +80,7 @@ struct htp_act_context {
     uint32_t                 block;
     uint32_t                 src0_nrows;
     uint32_t                 src0_nrows_per_thread;
+    uint32_t                 dev_row_start;
     int                      nc;
 
     uint8_t *                vtcm_src0;
@@ -346,8 +347,8 @@ static void geglu_f32(const float * restrict src0,
         const uint32_t src0_nrows            = actx->src0_nrows;                                                       \
         const uint32_t src0_nrows_per_thread = actx->src0_nrows_per_thread;                                            \
                                                                                                                        \
-        const uint32_t src0_start_row = src0_nrows_per_thread * ith;                                                   \
-        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);                       \
+        const uint32_t src0_start_row = actx->dev_row_start + src0_nrows_per_thread * ith;                             \
+        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, actx->dev_row_start + src0_nrows); \
                                                                                                                        \
         /* no work for this thread */                                                                                  \
         if (src0_start_row >= src0_end_row) {                                                                          \
@@ -473,7 +474,22 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     }
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
-    const uint32_t n_threads  = MIN(octx->n_threads, src0_nrows);
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = src0_nrows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
 
     // row_size   = bytes of useful data per row (what the kernel touches / what DMA copies).
     // row_stride = bytes between successive rows in DDR (may exceed row_size for non-contig src).
@@ -518,7 +534,7 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     struct htp_act_context actx;
     actx.octx = octx;
 
-    actx.src0_nrows_per_thread = (src0_nrows + n_threads - 1) / n_threads;
+    actx.src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
 
     actx.src0_row_size = src0_row_size;
     actx.src1_row_size = src1_row_size;
@@ -545,7 +561,8 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     actx.dst_spad_half_size  = L.dst_bytes_per_thread / 2;
 
     actx.block = actx.src0_spad_half_size / actx.src0_row_size_aligned;
-    actx.src0_nrows = src0_nrows;
+    actx.src0_nrows = dev_nrows;
+    actx.dev_row_start = dev_row_start;
 
     actx.nc = dst->ne[0];
 

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -14,7 +14,7 @@
 #include "ggml-common.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
-#include "htp-ops.h"
+#include "hex-common.h"
 #include "htp-tensor.h"
 #include "htp-vtcm.h"
 
@@ -473,14 +473,39 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     }
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const size_t dst_row_size = dst->ne[0] * SIZEOF_FP32;
 
     uint32_t row_start = 0;
     uint32_t nrows     = src0_nrows;
 
     if (octx->ctx->mdev.count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-        row_start = MIN(octx->ctx->mdev.idx * rows_per_mdev, src0_nrows);
-        nrows     = MIN(rows_per_mdev, src0_nrows - row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
+                nrows = src0_nrows - row_start;
+            } else {
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
+            }
+        }
     }
 
     if (nrows == 0) {
@@ -491,10 +516,9 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
 
     // row_size   = bytes of useful data per row (what the kernel touches / what DMA copies).
     // row_stride = bytes between successive rows in DDR (may exceed row_size for non-contig src).
-    const size_t nc_bytes    = dst->ne[0] * SIZEOF_FP32;
-    const size_t src0_row_size = nc_bytes;
-    const size_t src1_row_size = nc_bytes;
-    const size_t dst_row_size  = nc_bytes;
+    const size_t nc_bytes        = dst_row_size;
+    const size_t src0_row_size   = nc_bytes;
+    const size_t src1_row_size   = nc_bytes;
     const size_t src0_row_stride = src0->nb[1];
     const size_t src1_row_stride = src1 ? src1->nb[1] : src0->nb[1];
 

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -479,34 +479,11 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     uint32_t nrows     = src0_nrows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (((uintptr_t) dst->data & (HEX_L2_LINE_SIZE - 1)) == 0) &&
-                         (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = src0_nrows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, sizeof(float), (uint32_t) dst_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(src0_nrows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -477,7 +477,7 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
         mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
@@ -489,7 +489,7 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     // row_size   = bytes of useful data per row (what the kernel touches / what DMA copies).
     // row_stride = bytes between successive rows in DDR (may exceed row_size for non-contig src).
@@ -534,7 +534,7 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     struct htp_act_context actx;
     actx.octx = octx;
 
-    actx.src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    actx.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
 
     actx.src0_row_size = src0_row_size;
     actx.src1_row_size = src1_row_size;

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -79,7 +79,7 @@ struct htp_act_context {
     uint32_t                 block;
     uint32_t                 src0_nrows;
     uint32_t                 src0_nrows_per_thread;
-    uint32_t                 mdev_row_start;
+    uint32_t                 row_start;
     int                      nc;
 
     uint8_t *                vtcm_src0;
@@ -346,8 +346,8 @@ static void geglu_f32(const float * restrict src0,
         const uint32_t src0_nrows            = actx->src0_nrows;                                                         \
         const uint32_t src0_nrows_per_thread = actx->src0_nrows_per_thread;                                              \
                                                                                                                          \
-        const uint32_t src0_start_row = actx->mdev_row_start + src0_nrows_per_thread * ith;                              \
-        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, actx->mdev_row_start + src0_nrows);  \
+        const uint32_t src0_start_row = actx->row_start + src0_nrows_per_thread * ith;                              \
+        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, actx->row_start + src0_nrows);  \
                                                                                                                          \
         /* no work for this thread */                                                                                    \
         if (src0_start_row >= src0_end_row) {                                                                            \
@@ -474,17 +474,16 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = src0_nrows;
+
     if (octx->mdev_count > 1) {
         const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = src0_nrows;
+        row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        nrows     = MIN(rows_per_mdev, src0_nrows - row_start);
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -533,7 +532,7 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     struct htp_act_context actx;
     actx.octx = octx;
 
-    actx.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+    actx.src0_nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
 
     actx.src0_row_size = src0_row_size;
     actx.src1_row_size = src1_row_size;
@@ -560,8 +559,8 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     actx.dst_spad_half_size  = L.dst_bytes_per_thread / 2;
 
     actx.block = actx.src0_spad_half_size / actx.src0_row_size_aligned;
-    actx.src0_nrows = mdev_nrows;
-    actx.mdev_row_start = mdev_row_start;
+    actx.src0_nrows = nrows;
+    actx.row_start  = row_start;
 
     actx.nc = dst->ne[0];
 

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -80,7 +80,7 @@ struct htp_act_context {
     uint32_t                 block;
     uint32_t                 src0_nrows;
     uint32_t                 src0_nrows_per_thread;
-    uint32_t                 dev_row_start;
+    uint32_t                 mdev_row_start;
     int                      nc;
 
     uint8_t *                vtcm_src0;
@@ -330,104 +330,104 @@ static void geglu_f32(const float * restrict src0,
     }
 }
 
-#define DEFINE_GLU_PER_THREAD(NAME, OP_STR, CORE_EXPR)                                                                 \
-    static void glu_##NAME##_f32_per_thread(unsigned int nth, unsigned int ith, void * data) {                         \
-        struct htp_act_context * actx = (struct htp_act_context *) data;                                               \
-        htp_act_preamble;                                                                                              \
-                                                                                                                       \
-        struct htp_thread_trace * tr = actx->octx->ctx ? &actx->octx->ctx->trace[ith] : NULL;                          \
-                                                                                                                       \
-        size_t src0_row_size = actx->src0_row_size;                                                                    \
-        size_t src1_row_size = actx->src1_row_size;                                                                    \
-        size_t dst_row_size  = actx->dst_row_size;                                                                     \
-                                                                                                                       \
-        size_t src0_row_stride = actx->src0_row_stride;                                                                \
-        size_t src1_row_stride = actx->src1_row_stride;                                                                \
-                                                                                                                       \
-        const uint32_t src0_nrows            = actx->src0_nrows;                                                       \
-        const uint32_t src0_nrows_per_thread = actx->src0_nrows_per_thread;                                            \
-                                                                                                                       \
-        const uint32_t src0_start_row = actx->dev_row_start + src0_nrows_per_thread * ith;                             \
-        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, actx->dev_row_start + src0_nrows); \
-                                                                                                                       \
-        /* no work for this thread */                                                                                  \
-        if (src0_start_row >= src0_end_row) {                                                                          \
-            return;                                                                                                    \
-        }                                                                                                              \
-                                                                                                                       \
-        const uint8_t * restrict data_src0 = actx->data_src0;                                                          \
-        const uint8_t * restrict data_src1 = actx->data_src1;                                                          \
-        uint8_t * restrict data_dst        = actx->data_dst;                                                           \
-                                                                                                                       \
-        const size_t src0_row_size_aligned = actx->src0_row_size_aligned;                                              \
-        const size_t src1_row_size_aligned = actx->src1_row_size_aligned;                                              \
-        const size_t dst_row_size_aligned  = actx->dst_row_size_aligned;                                               \
-                                                                                                                       \
-        uint8_t * restrict src0_spad_data = actx->vtcm_src0 + (ith * actx->vtcm_src0_size_per_thread);                 \
-        uint8_t * restrict src1_spad_data = actx->vtcm_src1 + (ith * actx->vtcm_src1_size_per_thread);                 \
-        uint8_t * restrict dst_spad_data  = actx->vtcm_dst  + (ith * actx->vtcm_dst_size_per_thread);                  \
-                                                                                                                       \
-        size_t src0_spad_half_size = actx->src0_spad_half_size;                                                        \
-        size_t src1_spad_half_size = actx->src1_spad_half_size;                                                        \
-        size_t dst_spad_half_size  = actx->dst_spad_half_size;                                                         \
-                                                                                                                       \
-        const int BLOCK = actx->block;                                                                                 \
-        if (BLOCK == 0) {                                                                                              \
-            FARF(ERROR,                                                                                                \
-                 OP_STR                                                                                                \
-                 " : current VTCM reservation %zu is too small for even 1 row per thread, needed at least %zu\n",      \
-                 actx->vtcm_src0_size_per_thread, src0_row_size_aligned);                                              \
-            return;                                                                                                    \
-        }                                                                                                              \
-                                                                                                                       \
-        dma_queue * dma_queue = actx->octx->ctx->dma[ith];                                                             \
-                                                                                                                       \
-        /* See discussion: https://github.com/ggml-org/llama.cpp/pull/18151#issuecomment-3678235379 */                 \
-        for (uint32_t ir = src0_start_row, spad_idx = 0; ir < src0_end_row && spad_idx < 2; ir += BLOCK, spad_idx++) { \
-            const uint32_t block_size = MIN(BLOCK, src0_end_row - ir);                                                 \
-                                                                                                                       \
-            /* Dummy DMA transation for sequencing (interleaving dst,src,dst,...) */                                   \
-            dma_queue_push_vtcm_to_ddr(dma_queue,                                                                      \
-                                       dma_make_ptr(data_dst, dst_spad_data + (spad_idx * dst_spad_half_size)),        \
-                                       dst_row_size, dst_row_size_aligned, 0);                                         \
-                                                                                                                       \
-            dma_queue_push(                                                                                            \
-                dma_queue,                                                                                             \
-                dma_make_ptr(src0_spad_data + (spad_idx * src0_spad_half_size), data_src0 + (ir * src0_row_stride)),   \
-                src0_row_size_aligned, src0_row_stride, src0_row_size, block_size);                                    \
-            dma_queue_push(                                                                                            \
-                dma_queue,                                                                                             \
-                dma_make_ptr(src1_spad_data + (spad_idx * src1_spad_half_size), data_src1 + (ir * src1_row_stride)),   \
-                src1_row_size_aligned, src1_row_stride, src1_row_size, block_size);                                    \
-        }                                                                                                              \
-                                                                                                                       \
-        for (uint32_t ir = src0_start_row; ir < src0_end_row; ir += BLOCK) {                                           \
-            const uint32_t block_size = MIN(BLOCK, src0_end_row - ir);                                                 \
-                                                                                                                       \
-            float * dst_spad  = (float *) dma_queue_pop(dma_queue).src;                                                \
-            float * src0_spad = (float *) dma_queue_pop(dma_queue).dst;                                                \
-            float * src1_spad = (float *) dma_queue_pop(dma_queue).dst;                                                \
-                                                                                                                       \
-            htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, ir);                                                     \
-            CORE_EXPR;                                                                                                 \
-            htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, ir);                                                      \
-                                                                                                                       \
-            dma_queue_push_vtcm_to_ddr(dma_queue, dma_make_ptr(data_dst + (ir * dst_row_size), dst_spad),              \
-                                       dst_row_size, dst_row_size_aligned, block_size);                                \
-                                                                                                                       \
-            /* prefetch N+2 loop iteration if any */                                                                   \
-            const uint32_t pref_block = (ir + BLOCK * 2);                                                              \
-            if (pref_block < src0_end_row) {                                                                           \
-                const uint32_t pref_block_size = MIN(BLOCK, src0_end_row - pref_block);                                \
-                dma_queue_push(dma_queue, dma_make_ptr(src0_spad, data_src0 + (pref_block * src0_row_stride)),         \
-                               src0_row_size_aligned, src0_row_stride, src0_row_size, pref_block_size);                \
-                dma_queue_push(dma_queue, dma_make_ptr(src1_spad, data_src1 + (pref_block * src1_row_stride)),         \
-                               src1_row_size_aligned, src1_row_stride, src1_row_size, pref_block_size);                \
-            }                                                                                                          \
-        }                                                                                                              \
-                                                                                                                       \
-        dma_queue_flush(dma_queue);                                                                                    \
-                                                                                                                       \
+#define DEFINE_GLU_PER_THREAD(NAME, OP_STR, CORE_EXPR)                                                                   \
+    static void glu_##NAME##_f32_per_thread(unsigned int nth, unsigned int ith, void * data) {                           \
+        struct htp_act_context * actx = (struct htp_act_context *) data;                                                 \
+        htp_act_preamble;                                                                                                \
+                                                                                                                         \
+        struct htp_thread_trace * tr = actx->octx->ctx ? &actx->octx->ctx->trace[ith] : NULL;                            \
+                                                                                                                         \
+        size_t src0_row_size = actx->src0_row_size;                                                                      \
+        size_t src1_row_size = actx->src1_row_size;                                                                      \
+        size_t dst_row_size  = actx->dst_row_size;                                                                       \
+                                                                                                                         \
+        size_t src0_row_stride = actx->src0_row_stride;                                                                  \
+        size_t src1_row_stride = actx->src1_row_stride;                                                                  \
+                                                                                                                         \
+        const uint32_t src0_nrows            = actx->src0_nrows;                                                         \
+        const uint32_t src0_nrows_per_thread = actx->src0_nrows_per_thread;                                              \
+                                                                                                                         \
+        const uint32_t src0_start_row = actx->mdev_row_start + src0_nrows_per_thread * ith;                              \
+        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, actx->mdev_row_start + src0_nrows);  \
+                                                                                                                         \
+        /* no work for this thread */                                                                                    \
+        if (src0_start_row >= src0_end_row) {                                                                            \
+            return;                                                                                                      \
+        }                                                                                                                \
+                                                                                                                         \
+        const uint8_t * restrict data_src0 = actx->data_src0;                                                            \
+        const uint8_t * restrict data_src1 = actx->data_src1;                                                            \
+        uint8_t * restrict data_dst        = actx->data_dst;                                                             \
+                                                                                                                         \
+        const size_t src0_row_size_aligned = actx->src0_row_size_aligned;                                                \
+        const size_t src1_row_size_aligned = actx->src1_row_size_aligned;                                                \
+        const size_t dst_row_size_aligned  = actx->dst_row_size_aligned;                                                 \
+                                                                                                                         \
+        uint8_t * restrict src0_spad_data = actx->vtcm_src0 + (ith * actx->vtcm_src0_size_per_thread);                   \
+        uint8_t * restrict src1_spad_data = actx->vtcm_src1 + (ith * actx->vtcm_src1_size_per_thread);                   \
+        uint8_t * restrict dst_spad_data  = actx->vtcm_dst  + (ith * actx->vtcm_dst_size_per_thread);                    \
+                                                                                                                         \
+        size_t src0_spad_half_size = actx->src0_spad_half_size;                                                          \
+        size_t src1_spad_half_size = actx->src1_spad_half_size;                                                          \
+        size_t dst_spad_half_size  = actx->dst_spad_half_size;                                                           \
+                                                                                                                         \
+        const int BLOCK = actx->block;                                                                                   \
+        if (BLOCK == 0) {                                                                                                \
+            FARF(ERROR,                                                                                                  \
+                 OP_STR                                                                                                  \
+                 " : current VTCM reservation %zu is too small for even 1 row per thread, needed at least %zu\n",        \
+                 actx->vtcm_src0_size_per_thread, src0_row_size_aligned);                                                \
+            return;                                                                                                      \
+        }                                                                                                                \
+                                                                                                                         \
+        dma_queue * dma_queue = actx->octx->ctx->dma[ith];                                                               \
+                                                                                                                         \
+        /* See discussion: https://github.com/ggml-org/llama.cpp/pull/18151#issuecomment-3678235379 */                   \
+        for (uint32_t ir = src0_start_row, spad_idx = 0; ir < src0_end_row && spad_idx < 2; ir += BLOCK, spad_idx++) {   \
+            const uint32_t block_size = MIN(BLOCK, src0_end_row - ir);                                                   \
+                                                                                                                         \
+            /* Dummy DMA transation for sequencing (interleaving dst,src,dst,...) */                                     \
+            dma_queue_push_vtcm_to_ddr(dma_queue,                                                                        \
+                                       dma_make_ptr(data_dst, dst_spad_data + (spad_idx * dst_spad_half_size)),          \
+                                       dst_row_size, dst_row_size_aligned, 0);                                           \
+                                                                                                                         \
+            dma_queue_push(                                                                                              \
+                dma_queue,                                                                                               \
+                dma_make_ptr(src0_spad_data + (spad_idx * src0_spad_half_size), data_src0 + (ir * src0_row_stride)),     \
+                src0_row_size_aligned, src0_row_stride, src0_row_size, block_size);                                      \
+            dma_queue_push(                                                                                              \
+                dma_queue,                                                                                               \
+                dma_make_ptr(src1_spad_data + (spad_idx * src1_spad_half_size), data_src1 + (ir * src1_row_stride)),     \
+                src1_row_size_aligned, src1_row_stride, src1_row_size, block_size);                                      \
+        }                                                                                                                \
+                                                                                                                         \
+        for (uint32_t ir = src0_start_row; ir < src0_end_row; ir += BLOCK) {                                             \
+            const uint32_t block_size = MIN(BLOCK, src0_end_row - ir);                                                   \
+                                                                                                                         \
+            float * dst_spad  = (float *) dma_queue_pop(dma_queue).src;                                                  \
+            float * src0_spad = (float *) dma_queue_pop(dma_queue).dst;                                                  \
+            float * src1_spad = (float *) dma_queue_pop(dma_queue).dst;                                                  \
+                                                                                                                         \
+            htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, ir);                                                       \
+            CORE_EXPR;                                                                                                   \
+            htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, ir);                                                        \
+                                                                                                                         \
+            dma_queue_push_vtcm_to_ddr(dma_queue, dma_make_ptr(data_dst + (ir * dst_row_size), dst_spad),                \
+                                       dst_row_size, dst_row_size_aligned, block_size);                                  \
+                                                                                                                         \
+            /* prefetch N+2 loop iteration if any */                                                                     \
+            const uint32_t pref_block = (ir + BLOCK * 2);                                                                \
+            if (pref_block < src0_end_row) {                                                                             \
+                const uint32_t pref_block_size = MIN(BLOCK, src0_end_row - pref_block);                                  \
+                dma_queue_push(dma_queue, dma_make_ptr(src0_spad, data_src0 + (pref_block * src0_row_stride)),           \
+                               src0_row_size_aligned, src0_row_stride, src0_row_size, pref_block_size);                  \
+                dma_queue_push(dma_queue, dma_make_ptr(src1_spad, data_src1 + (pref_block * src1_row_stride)),           \
+                               src1_row_size_aligned, src1_row_stride, src1_row_size, pref_block_size);                  \
+            }                                                                                                            \
+        }                                                                                                                \
+                                                                                                                         \
+        dma_queue_flush(dma_queue);                                                                                      \
+                                                                                                                         \
     }
 
 DEFINE_GLU_PER_THREAD(swiglu, "swiglu-f32", swiglu_f32(src0_spad, src1_spad, dst_spad, block_size, actx))
@@ -475,21 +475,21 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = src0_nrows;
+        mdev_row_start = 0;
+        mdev_nrows     = src0_nrows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
 
     // row_size   = bytes of useful data per row (what the kernel touches / what DMA copies).
     // row_stride = bytes between successive rows in DDR (may exceed row_size for non-contig src).
@@ -534,7 +534,7 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     struct htp_act_context actx;
     actx.octx = octx;
 
-    actx.src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
+    actx.src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
 
     actx.src0_row_size = src0_row_size;
     actx.src1_row_size = src1_row_size;
@@ -561,8 +561,8 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     actx.dst_spad_half_size  = L.dst_bytes_per_thread / 2;
 
     actx.block = actx.src0_spad_half_size / actx.src0_row_size_aligned;
-    actx.src0_nrows = dev_nrows;
-    actx.dev_row_start = dev_row_start;
+    actx.src0_nrows = mdev_nrows;
+    actx.mdev_row_start = mdev_row_start;
 
     actx.nc = dst->ne[0];
 

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -479,7 +479,8 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     uint32_t nrows     = src0_nrows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        bool can_split = (((uintptr_t) dst->data & (HEX_L2_LINE_SIZE - 1)) == 0) &&
+                         (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
             if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -346,8 +346,8 @@ static void geglu_f32(const float * restrict src0,
         const uint32_t src0_nrows            = actx->src0_nrows;                                                         \
         const uint32_t src0_nrows_per_thread = actx->src0_nrows_per_thread;                                              \
                                                                                                                          \
-        const uint32_t src0_start_row = actx->row_start + src0_nrows_per_thread * ith;                              \
-        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, actx->row_start + src0_nrows);  \
+        const uint32_t src0_start_row = actx->row_start + src0_nrows_per_thread * ith;                                   \
+        const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, actx->row_start + src0_nrows);       \
                                                                                                                          \
         /* no work for this thread */                                                                                    \
         if (src0_start_row >= src0_end_row) {                                                                            \

--- a/ggml/src/ggml-hexagon/htp/act-ops.c
+++ b/ggml/src/ggml-hexagon/htp/act-ops.c
@@ -477,9 +477,9 @@ static int execute_op_activations_f32(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = src0_nrows;
 
-    if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+    if (octx->ctx->mdev.count > 1) {
+        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+        row_start = MIN(octx->ctx->mdev.idx * rows_per_mdev, src0_nrows);
         nrows     = MIN(rows_per_mdev, src0_nrows - row_start);
     }
 

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.c
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.c
@@ -244,6 +244,10 @@ DEFINE_ALLREDUCE_THREAD_DMA_2D(add_bcast_f16, __fp16, hvx_add_f16_aaa, 1, 1)
 DEFINE_ALLREDUCE_THREAD_DMA_2D(add_bcast_f32, float,  hvx_add_f32_aaa, 1, 1)
 
 int op_allreduce(struct htp_ops_context * octx) {
+    if (octx->ctx->mdev.count > 1 && octx->ctx->mdev.idx > 0) {
+        return HTP_STATUS_OK;
+    }
+
     const struct htp_allreduce_kernel_params * kparams = (const struct htp_allreduce_kernel_params *) octx->kernel_params;
     const struct htp_tensor * dst = octx->dst;
 
@@ -254,20 +258,24 @@ int op_allreduce(struct htp_ops_context * octx) {
         return HTP_STATUS_INVAL_PARAMS;
     }
 
+    const uint32_t fence_seq_entry = (uint32_t) octx->op_params[0];
+    const uint32_t fence_seq_exit  = (uint32_t) octx->op_params[1];
+
+    const struct htp_tensor * my_sync = octx->src[n_ranks + rank];
+    atomic_uint * my_fence = (atomic_uint *) (uintptr_t) my_sync->data;
+
     if (dst->type != HTP_TYPE_F16 && dst->type != HTP_TYPE_F32) {
+        FARF(ERROR, "ggml-hex: allreduce unsupported type %d : rank %u\n", dst->type, rank);
+        htp_fence_write(my_fence, fence_seq_entry, HTP_STATUS_NO_SUPPORT);
         return HTP_STATUS_NO_SUPPORT;
     }
 
     const uint32_t nelem = dst->ne[0] * dst->ne[1] * dst->ne[2] * dst->ne[3];
-    const uint32_t fence_seq_entry = (uint32_t) octx->op_params[0];
-    const uint32_t fence_seq_exit  = (uint32_t) octx->op_params[1];
 
     // 1. Entry Barrier: Synchronize all ranks before reading
     struct htp_thread_trace * tr0 = &octx->ctx->trace[0];
     htp_trace_event_start(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
 
-    const struct htp_tensor * my_sync = octx->src[n_ranks + rank];
-    atomic_uint * my_fence = (atomic_uint *) (uintptr_t) my_sync->data;
     htp_fence_write(my_fence, fence_seq_entry, HTP_STATUS_OK);
 
     for (uint32_t j = 0; j < n_ranks; j++) {
@@ -347,6 +355,8 @@ int op_allreduce(struct htp_ops_context * octx) {
                 }
                 break;
             default:
+                FARF(ERROR, "ggml-hex: allreduce unsupported kernel %d : rank %u\n", kparams->kernel_type, rank);
+                htp_fence_write(my_fence, fence_seq_exit, HTP_STATUS_NO_SUPPORT);
                 return HTP_STATUS_NO_SUPPORT;
         }
 

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.c
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.c
@@ -243,6 +243,36 @@ DEFINE_ALLREDUCE_THREAD_DMA_2D(add_f32,       float,  hvx_add_f32_aaa, 1, 0)
 DEFINE_ALLREDUCE_THREAD_DMA_2D(add_bcast_f16, __fp16, hvx_add_f16_aaa, 1, 1)
 DEFINE_ALLREDUCE_THREAD_DMA_2D(add_bcast_f32, float,  hvx_add_f32_aaa, 1, 1)
 
+static int validate_allreduce(
+    struct htp_ops_context * octx,
+    const struct htp_allreduce_kernel_params * kparams,
+    uint32_t n_ranks
+) {
+    if (!htp_ops_context_set_n_threads(octx, (uint32_t) kparams->n_threads)) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+
+    if (kparams->vtcm_size_per_thread <= 0 || kparams->vtcm_size <= 0) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+
+    const bool has_add = (octx->op == HTP_OP_ALLREDUCE_ADD);
+    const size_t n_vtcm_buffers = (size_t) (n_ranks + 1) * octx->n_threads + (has_add ? (kparams->is_row_bcast ? 1 : octx->n_threads) : 0);
+    const size_t vtcm_size = n_vtcm_buffers * (size_t) kparams->vtcm_size_per_thread;
+    if (vtcm_size != (size_t) kparams->vtcm_size) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+    if (vtcm_size > octx->ctx->vtcm_size) {
+        return HTP_STATUS_VTCM_TOO_SMALL;
+    }
+
+    if (octx->dst->type != HTP_TYPE_F16 && octx->dst->type != HTP_TYPE_F32) {
+        return HTP_STATUS_NO_SUPPORT;
+    }
+
+    return HTP_STATUS_OK;
+}
+
 int op_allreduce(struct htp_ops_context * octx) {
     if (octx->ctx->mdev.count > 1 && octx->ctx->mdev.idx > 0) {
         return HTP_STATUS_OK;
@@ -264,12 +294,16 @@ int op_allreduce(struct htp_ops_context * octx) {
     const struct htp_tensor * my_sync = octx->src[n_ranks + rank];
     atomic_uint * my_fence = (atomic_uint *) (uintptr_t) my_sync->data;
 
-    if (dst->type != HTP_TYPE_F16 && dst->type != HTP_TYPE_F32) {
-        FARF(ERROR, "ggml-hex: allreduce unsupported type %d : rank %u\n", dst->type, rank);
-        htp_fence_write(my_fence, fence_seq_entry, HTP_STATUS_NO_SUPPORT);
-        return HTP_STATUS_NO_SUPPORT;
+    const int status = validate_allreduce(octx, kparams, n_ranks);
+    if (status != HTP_STATUS_OK) {
+        if (status == HTP_STATUS_NO_SUPPORT) {
+            FARF(ERROR, "ggml-hex: allreduce unsupported type %d : rank %u\n", dst->type, rank);
+        }
+        htp_fence_write(my_fence, fence_seq_entry, status);
+        return status;
     }
 
+    const bool has_add = (octx->op == HTP_OP_ALLREDUCE_ADD);
     const uint32_t nelem = dst->ne[0] * dst->ne[1] * dst->ne[2] * dst->ne[3];
 
     // 1. Entry Barrier: Synchronize all ranks before reading
@@ -316,8 +350,6 @@ int op_allreduce(struct htp_ops_context * octx) {
         const uint32_t block_elems          = (uint32_t) kparams->block_elems;
         const uint32_t elems_per_thread     = (uint32_t) kparams->elems_per_thread;
         const uint32_t vtcm_size_per_thread = (uint32_t) kparams->vtcm_size_per_thread;
-
-        const bool has_add = (octx->op == HTP_OP_ALLREDUCE_ADD);
 
         struct htp_allreduce_context actx;
         actx.octx                 = octx;

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.c
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.c
@@ -257,7 +257,8 @@ static int validate_allreduce(
     }
 
     const bool has_add = (octx->op == HTP_OP_ALLREDUCE_ADD);
-    const size_t n_vtcm_buffers = (size_t) (n_ranks + 1) * octx->n_threads + (has_add ? (kparams->is_row_bcast ? 1 : octx->n_threads) : 0);
+    const size_t n_vtcm_buffers = htp_allreduce_vtcm_buffer_count(
+        n_ranks, octx->n_threads, has_add, kparams->is_row_bcast != 0);
     const size_t vtcm_size = n_vtcm_buffers * (size_t) kparams->vtcm_size_per_thread;
     if (vtcm_size != (size_t) kparams->vtcm_size) {
         return HTP_STATUS_INVAL_PARAMS;

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.c
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.c
@@ -300,7 +300,7 @@ int op_allreduce(struct htp_ops_context * octx) {
         if (status == HTP_STATUS_NO_SUPPORT) {
             FARF(ERROR, "ggml-hex: allreduce unsupported type %d : rank %u\n", dst->type, rank);
         }
-        htp_fence_write(my_fence, fence_seq_entry, status);
+        htp_fence_write(my_fence, fence_seq_exit, status);
         return status;
     }
 
@@ -311,7 +311,7 @@ int op_allreduce(struct htp_ops_context * octx) {
     struct htp_thread_trace * tr0 = &octx->ctx->trace[0];
     htp_trace_event_start(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
 
-    htp_fence_write(my_fence, fence_seq_entry, HTP_STATUS_OK);
+    htp_fence_write(my_fence, fence_seq_entry, octx->status);
 
     for (uint32_t j = 0; j < n_ranks; j++) {
         if (j == rank) continue;
@@ -322,19 +322,19 @@ int op_allreduce(struct htp_ops_context * octx) {
             uint32_t peer_seq;
             uint32_t peer_status;
             htp_fence_read(peer_fence, &peer_seq, &peer_status);
-            if (peer_status > HTP_STATUS_OK) {
-                FARF(ERROR, "ggml-hex: allreduce entry peer %u failed with status %u\n", j, peer_status);
-                htp_fence_write(my_fence, fence_seq_entry, peer_status);
-                htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
-                return peer_status;
-            }
             if ((int32_t)(peer_seq - fence_seq_entry) >= 0) {
+                if (peer_status > HTP_STATUS_OK) {
+                    FARF(ERROR, "ggml-hex: allreduce entry peer %u failed with status %u\n", j, peer_status);
+                    htp_fence_write(my_fence, fence_seq_exit, peer_status);
+                    htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
+                    return peer_status;
+                }
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
                 FARF(ERROR, "ggml-hex: allreduce entry fence-wait TIMEOUT : rank %u waiting on %u fence %p seq %u peer-seq %u\n",
                      rank, j, peer_fence, fence_seq_entry, peer_seq);
-                htp_fence_write(my_fence, fence_seq_entry, HTP_STATUS_INTERNAL_ERR);
+                htp_fence_write(my_fence, fence_seq_exit, HTP_STATUS_INTERNAL_ERR);
                 htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
                 return HTP_STATUS_INTERNAL_ERR;
             }
@@ -419,7 +419,7 @@ int op_allreduce(struct htp_ops_context * octx) {
     // 4. Exit Barrier: Synchronize all ranks after writing
     htp_trace_event_start(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);
 
-    htp_fence_write(my_fence, fence_seq_exit, HTP_STATUS_OK);
+    htp_fence_write(my_fence, fence_seq_exit, octx->status);
 
     for (uint32_t j = 0; j < n_ranks; j++) {
         if (j == rank) continue;
@@ -430,13 +430,13 @@ int op_allreduce(struct htp_ops_context * octx) {
             uint32_t peer_seq;
             uint32_t peer_status;
             htp_fence_read(peer_fence, &peer_seq, &peer_status);
-            if (peer_status > HTP_STATUS_OK) {
-                FARF(ERROR, "ggml-hex: allreduce exit peer %u failed with status %u\n", j, peer_status);
-                htp_fence_write(my_fence, fence_seq_exit, peer_status);
-                htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);
-                return peer_status;
-            }
             if ((int32_t)(peer_seq - fence_seq_exit) >= 0) {
+                if (peer_status > HTP_STATUS_OK) {
+                    FARF(ERROR, "ggml-hex: allreduce exit peer %u failed with status %u\n", j, peer_status);
+                    htp_fence_write(my_fence, fence_seq_exit, peer_status);
+                    htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);
+                    return peer_status;
+                }
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
@@ -453,5 +453,5 @@ int op_allreduce(struct htp_ops_context * octx) {
 
     htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);
 
-    return HTP_STATUS_OK;
+    return octx->status;
 }

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.c
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.c
@@ -332,7 +332,7 @@ int op_allreduce(struct htp_ops_context * octx) {
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: allreduce entry fence-wait TIMEOUT : rank %u waiting on %u fence %p seq %u peer-seq %u\n",
+                FARF(ERROR, "ggml-hex: allreduce entry fence-wait TIMEOUT : rank %u waiting on %u fence %p seq 0x%x peer-seq 0x%x\n",
                      rank, j, peer_fence, fence_seq_entry, peer_seq);
                 htp_fence_write(my_fence, fence_seq_exit, HTP_STATUS_INTERNAL_ERR);
                 htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
@@ -440,7 +440,7 @@ int op_allreduce(struct htp_ops_context * octx) {
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: allreduce exit fence-wait TIMEOUT : rank %u waiting on %u fence %p seq %u peer-seq %u\n",
+                FARF(ERROR, "ggml-hex: allreduce exit fence-wait TIMEOUT : rank %u waiting on %u fence %p seq 0x%x peer-seq 0x%x\n",
                      rank, j, peer_fence, fence_seq_exit, peer_seq);
                 htp_fence_write(my_fence, fence_seq_exit, HTP_STATUS_INTERNAL_ERR);
                 htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.c
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.c
@@ -17,6 +17,7 @@
 #include "hex-dma.h"
 #include "hex-profile.h"
 #include "allreduce-ops.h"
+#include "htp-fence.h"
 
 struct htp_allreduce_context {
     struct htp_ops_context * octx;
@@ -266,26 +267,32 @@ int op_allreduce(struct htp_ops_context * octx) {
     htp_trace_event_start(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
 
     const struct htp_tensor * my_sync = octx->src[n_ranks + rank];
-    atomic_uint * my_fence = (atomic_uint *) my_sync->data;
-
-    atomic_store(&my_fence[0], fence_seq_entry);
-    asm volatile ("syncht" : : : "memory");
-    Q6_dccleaninva_A((void *) my_fence);
+    atomic_uint * my_fence = (atomic_uint *) (uintptr_t) my_sync->data;
+    htp_fence_write(my_fence, fence_seq_entry, HTP_STATUS_OK);
 
     for (uint32_t j = 0; j < n_ranks; j++) {
         if (j == rank) continue;
         const struct htp_tensor * peer_sync = octx->src[n_ranks + j];
-        atomic_uint * peer_fence = (atomic_uint *) peer_sync->data;
+        atomic_uint * peer_fence = (atomic_uint *) (uintptr_t) peer_sync->data;
         uint64_t spins = 0;
         while (1) {
-            Q6_dccleaninva_A((void *) peer_fence);
-            asm volatile ("syncht" : : : "memory");
-            uint32_t val = atomic_load(&peer_fence[0]);
-            if ((int32_t)(val - fence_seq_entry) >= 0) {
+            uint32_t peer_seq;
+            uint32_t peer_status;
+            htp_fence_read(peer_fence, &peer_seq, &peer_status);
+            if (peer_status > HTP_STATUS_OK) {
+                FARF(ERROR, "ggml-hex: allreduce entry peer %u failed with status %u\n", j, peer_status);
+                htp_fence_write(my_fence, fence_seq_entry, peer_status);
+                htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
+                return peer_status;
+            }
+            if ((int32_t)(peer_seq - fence_seq_entry) >= 0) {
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: allreduce entry fence-wait TIMEOUT: rank %u waiting on %u (fence %p seq %u, val %u)\n", rank, j, peer_fence, fence_seq_entry, val);
+                FARF(ERROR, "ggml-hex: allreduce entry fence-wait TIMEOUT : rank %u waiting on %u fence %p seq %u peer-seq %u\n",
+                     rank, j, peer_fence, fence_seq_entry, peer_seq);
+                htp_fence_write(my_fence, fence_seq_entry, HTP_STATUS_INTERNAL_ERR);
+                htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_entry);
                 return HTP_STATUS_INTERNAL_ERR;
             }
             hex_pause();
@@ -369,24 +376,31 @@ int op_allreduce(struct htp_ops_context * octx) {
     // 4. Exit Barrier: Synchronize all ranks after writing
     htp_trace_event_start(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);
 
-    atomic_store(&my_fence[0], fence_seq_exit);
-    asm volatile ("syncht" : : : "memory");
-    Q6_dccleaninva_A((void *) my_fence);
+    htp_fence_write(my_fence, fence_seq_exit, HTP_STATUS_OK);
 
     for (uint32_t j = 0; j < n_ranks; j++) {
         if (j == rank) continue;
         const struct htp_tensor * peer_sync = octx->src[n_ranks + j];
-        atomic_uint * peer_fence = (atomic_uint *) peer_sync->data;
+        atomic_uint * peer_fence = (atomic_uint *) (uintptr_t) peer_sync->data;
         uint64_t spins = 0;
         while (1) {
-            Q6_dccleaninva_A((void *) peer_fence);
-            asm volatile ("syncht" : : : "memory");
-            uint32_t val = atomic_load(&peer_fence[0]);
-            if ((int32_t)(val - fence_seq_exit) >= 0) {
+            uint32_t peer_seq;
+            uint32_t peer_status;
+            htp_fence_read(peer_fence, &peer_seq, &peer_status);
+            if (peer_status > HTP_STATUS_OK) {
+                FARF(ERROR, "ggml-hex: allreduce exit peer %u failed with status %u\n", j, peer_status);
+                htp_fence_write(my_fence, fence_seq_exit, peer_status);
+                htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);
+                return peer_status;
+            }
+            if ((int32_t)(peer_seq - fence_seq_exit) >= 0) {
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: allreduce exit fence-wait TIMEOUT: rank %u waiting on %u (fence %p seq %u, val %u)\n", rank, j, peer_fence, fence_seq_exit, val);
+                FARF(ERROR, "ggml-hex: allreduce exit fence-wait TIMEOUT : rank %u waiting on %u fence %p seq %u peer-seq %u\n",
+                     rank, j, peer_fence, fence_seq_exit, peer_seq);
+                htp_fence_write(my_fence, fence_seq_exit, HTP_STATUS_INTERNAL_ERR);
+                htp_trace_event_stop(tr0, HTP_TRACE_EVT_FENCE, (uint16_t) fence_seq_exit);
                 return HTP_STATUS_INTERNAL_ERR;
             }
             hex_pause();

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.c
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.c
@@ -279,12 +279,13 @@ int op_allreduce(struct htp_ops_context * octx) {
         uint64_t spins = 0;
         while (1) {
             Q6_dccleaninva_A((void *) peer_fence);
+            asm volatile ("syncht" : : : "memory");
             uint32_t val = atomic_load(&peer_fence[0]);
-            if (val == fence_seq_entry || val == fence_seq_exit) {
+            if ((int32_t)(val - fence_seq_entry) >= 0) {
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: allreduce entry fence-wait TIMEOUT: rank %u waiting on %u (fence %p seq %u)\n", rank, j, peer_fence, fence_seq_entry);
+                FARF(ERROR, "ggml-hex: allreduce entry fence-wait TIMEOUT: rank %u waiting on %u (fence %p seq %u, val %u)\n", rank, j, peer_fence, fence_seq_entry, val);
                 return HTP_STATUS_INTERNAL_ERR;
             }
             hex_pause();
@@ -379,12 +380,13 @@ int op_allreduce(struct htp_ops_context * octx) {
         uint64_t spins = 0;
         while (1) {
             Q6_dccleaninva_A((void *) peer_fence);
+            asm volatile ("syncht" : : : "memory");
             uint32_t val = atomic_load(&peer_fence[0]);
-            if (val == fence_seq_exit) {
+            if ((int32_t)(val - fence_seq_exit) >= 0) {
                 break;
             }
             if (++spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: allreduce exit fence-wait TIMEOUT: rank %u waiting on %u (fence %p seq %u)\n", rank, j, peer_fence, fence_seq_exit);
+                FARF(ERROR, "ggml-hex: allreduce exit fence-wait TIMEOUT: rank %u waiting on %u (fence %p seq %u, val %u)\n", rank, j, peer_fence, fence_seq_exit, val);
                 return HTP_STATUS_INTERNAL_ERR;
             }
             hex_pause();

--- a/ggml/src/ggml-hexagon/htp/allreduce-ops.h
+++ b/ggml/src/ggml-hexagon/htp/allreduce-ops.h
@@ -2,6 +2,8 @@
 #define ALLREDUCE_OPS_H
 
 #include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 #define HTP_ALLREDUCE_MAX_RANKS 4
 
@@ -14,6 +16,15 @@ enum htp_allreduce_kernel_type {
     HTP_ALLREDUCE_KERNEL_DMA_1D,
     HTP_ALLREDUCE_KERNEL_DMA_2D,
 };
+
+static inline size_t htp_allreduce_vtcm_buffer_count(
+    uint32_t n_ranks,
+    uint32_t n_threads,
+    bool has_add,
+    bool is_row_bcast
+) {
+    return (size_t) (n_ranks + 1) * n_threads + (has_add ? (is_row_bcast ? 1 : n_threads) : 0);
+}
 
 struct htp_allreduce_kernel_params {
     int32_t rank;

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -22,6 +22,9 @@
 struct htp_argsort_context {
     struct htp_ops_context * octx;
     uint32_t                 nrows_per_thread;
+    uint32_t                 total_rows;
+    uint32_t                 dev_row_start;
+    uint32_t                 dev_row_end;
     uint8_t *                vtcm_base;
     size_t                   vtcm_per_thread;
 };
@@ -336,10 +339,9 @@ static void htp_argsort_f32_##ne00##_##order_name(unsigned int n, unsigned int i
     const struct htp_tensor * src0 = octx->src[0];                                                             \
     const struct htp_tensor * dst = octx->dst;                                                                 \
     uint8_t * spad = actx->vtcm_base + actx->vtcm_per_thread * i;                                              \
-    uint32_t total_rows = src0->ne[1] * src0->ne[2] * src0->ne[3];                                             \
     uint32_t rows_per_thread = actx->nrows_per_thread;                                                         \
-    uint32_t start_row = rows_per_thread * i;                                                                  \
-    uint32_t end_row = MIN(start_row + rows_per_thread, total_rows);                                           \
+    uint32_t start_row = actx->dev_row_start + rows_per_thread * i;                                            \
+    uint32_t end_row = MIN(start_row + rows_per_thread, actx->dev_row_end);                                     \
     size_t values_size = hex_round_up(ne00 * sizeof(float), 128);                                              \
     float * values_buf = (float *) spad;                                                                       \
     int32_t * indices_buf = (int32_t *) (spad + values_size);                                                  \
@@ -386,9 +388,6 @@ static void htp_argsort_f32_fallback(unsigned int n, unsigned int i, void * data
 
     // Dimensions
     uint32_t ne00 = src0->ne[0];
-    uint32_t ne01 = src0->ne[1];
-    uint32_t ne02 = src0->ne[2];
-    uint32_t ne03 = src0->ne[3];
 
     uint32_t nb01 = src0->nb[1];
 
@@ -398,10 +397,9 @@ static void htp_argsort_f32_fallback(unsigned int n, unsigned int i, void * data
     enum ggml_sort_order order = (enum ggml_sort_order) octx->op_params[0];
 
     // Rows to process
-    uint32_t total_rows = ne01 * ne02 * ne03;
     uint32_t rows_per_thread = actx->nrows_per_thread;
-    uint32_t start_row = rows_per_thread * i;
-    uint32_t end_row = MIN(start_row + rows_per_thread, total_rows);
+    uint32_t start_row = actx->dev_row_start + rows_per_thread * i;
+    uint32_t end_row = MIN(start_row + rows_per_thread, actx->dev_row_end);
 
     size_t values_size = hex_round_up(ne00 * sizeof(float), 128);
     uint32_t num_vec_ind_values = hmx_ceil_div(ne00, VLEN/(sizeof(int32_t)));
@@ -452,7 +450,23 @@ int op_argsort(struct htp_ops_context * octx) {
     }
 
     const uint32_t total_rows = octx->src[0]->ne[1] * octx->src[0]->ne[2] * octx->src[0]->ne[3];
-    const uint32_t n_threads = MIN(total_rows, octx->n_threads);
+
+    uint32_t dev_row_start, dev_row_end;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
+        dev_row_end   = MIN(dev_row_start + rows_per_dev, total_rows);
+    } else {
+        dev_row_start = 0;
+        dev_row_end   = total_rows;
+    }
+
+    const uint32_t dev_nrows = dev_row_end - dev_row_start;
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(dev_nrows, octx->n_threads);
 
     // Allocate scratchpad
     // We need 1 row of float + 1 row of int32 per thread.
@@ -478,7 +492,10 @@ int op_argsort(struct htp_ops_context * octx) {
 
     struct htp_argsort_context actx;
     actx.octx = octx;
-    actx.nrows_per_thread = (total_rows + n_threads - 1) / n_threads;
+    actx.nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
+    actx.total_rows       = dev_nrows;
+    actx.dev_row_start   = dev_row_start;
+    actx.dev_row_end     = dev_row_end;
     actx.vtcm_base = (uint8_t *) octx->ctx->vtcm_base;
     actx.vtcm_per_thread = spad_per_thread;
 

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -24,8 +24,8 @@ struct htp_argsort_context {
     struct htp_ops_context * octx;
     uint32_t                 nrows_per_thread;
     uint32_t                 total_rows;
-    uint32_t                 mdev_row_start;
-    uint32_t                 mdev_row_end;
+    uint32_t                 row_start;
+    uint32_t                 row_end;
     uint8_t *                vtcm_base;
     size_t                   vtcm_per_thread;
 };
@@ -341,8 +341,8 @@ static void htp_argsort_f32_##ne00##_##order_name(unsigned int n, unsigned int i
     const struct htp_tensor * dst = octx->dst;                                                                 \
     uint8_t * spad = actx->vtcm_base + actx->vtcm_per_thread * i;                                              \
     uint32_t rows_per_thread = actx->nrows_per_thread;                                                         \
-    uint32_t start_row = actx->mdev_row_start + rows_per_thread * i;                                           \
-    uint32_t end_row = MIN(start_row + rows_per_thread, actx->mdev_row_end);                                   \
+    uint32_t start_row = actx->row_start + rows_per_thread * i;                                           \
+    uint32_t end_row = MIN(start_row + rows_per_thread, actx->row_end);                                   \
     size_t values_size = hex_round_up(ne00 * sizeof(float), 128);                                              \
     float * values_buf = (float *) spad;                                                                       \
     int32_t * indices_buf = (int32_t *) (spad + values_size);                                                  \
@@ -399,8 +399,8 @@ static void htp_argsort_f32_fallback(unsigned int n, unsigned int i, void * data
 
     // Rows to process
     uint32_t rows_per_thread = actx->nrows_per_thread;
-    uint32_t start_row = actx->mdev_row_start + rows_per_thread * i;
-    uint32_t end_row = MIN(start_row + rows_per_thread, actx->mdev_row_end);
+    uint32_t start_row = actx->row_start + rows_per_thread * i;
+    uint32_t end_row = MIN(start_row + rows_per_thread, actx->row_end);
 
     size_t values_size = hex_round_up(ne00 * sizeof(float), 128);
     uint32_t num_vec_ind_values = hmx_ceil_div(ne00, VLEN/(sizeof(int32_t)));
@@ -456,7 +456,8 @@ int op_argsort(struct htp_ops_context * octx) {
     const uint32_t total_rows  = src0->ne[1] * src0->ne[2] * src0->ne[3];
     const size_t dst_row_size  = dst->ne[0]  * sizeof(int32_t);
 
-    uint32_t mdev_row_start, mdev_row_end;
+    uint32_t row_start = 0;
+    uint32_t row_end   = total_rows;
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(int32_t)) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
@@ -474,24 +475,21 @@ int op_argsort(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-            mdev_row_end   = total_rows;
+            row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+            row_end   = total_rows;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_row_end = total_rows;
+                row_end = total_rows;
             } else {
-                mdev_row_end = MIN(mdev_row_start + chunks_per_mdev * rows_per_chunk, total_rows);
+                row_end = MIN(row_start + chunks_per_mdev * rows_per_chunk, total_rows);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_row_end   = total_rows;
     }
 
-    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
-    if (mdev_nrows == 0) {
+    const uint32_t nrows = row_end - row_start;
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -521,10 +519,10 @@ int op_argsort(struct htp_ops_context * octx) {
 
     struct htp_argsort_context actx;
     actx.octx = octx;
-    actx.nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
-    actx.total_rows       = mdev_nrows;
-    actx.mdev_row_start   = mdev_row_start;
-    actx.mdev_row_end     = mdev_row_end;
+    actx.nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
+    actx.total_rows       = nrows;
+    actx.row_start        = row_start;
+    actx.row_end          = row_end;
     actx.vtcm_base = (uint8_t *) octx->ctx->vtcm_base;
     actx.vtcm_per_thread = spad_per_thread;
 

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -23,8 +23,8 @@ struct htp_argsort_context {
     struct htp_ops_context * octx;
     uint32_t                 nrows_per_thread;
     uint32_t                 total_rows;
-    uint32_t                 dev_row_start;
-    uint32_t                 dev_row_end;
+    uint32_t                 mdev_row_start;
+    uint32_t                 mdev_row_end;
     uint8_t *                vtcm_base;
     size_t                   vtcm_per_thread;
 };
@@ -340,8 +340,8 @@ static void htp_argsort_f32_##ne00##_##order_name(unsigned int n, unsigned int i
     const struct htp_tensor * dst = octx->dst;                                                                 \
     uint8_t * spad = actx->vtcm_base + actx->vtcm_per_thread * i;                                              \
     uint32_t rows_per_thread = actx->nrows_per_thread;                                                         \
-    uint32_t start_row = actx->dev_row_start + rows_per_thread * i;                                            \
-    uint32_t end_row = MIN(start_row + rows_per_thread, actx->dev_row_end);                                     \
+    uint32_t start_row = actx->mdev_row_start + rows_per_thread * i;                                           \
+    uint32_t end_row = MIN(start_row + rows_per_thread, actx->mdev_row_end);                                   \
     size_t values_size = hex_round_up(ne00 * sizeof(float), 128);                                              \
     float * values_buf = (float *) spad;                                                                       \
     int32_t * indices_buf = (int32_t *) (spad + values_size);                                                  \
@@ -398,8 +398,8 @@ static void htp_argsort_f32_fallback(unsigned int n, unsigned int i, void * data
 
     // Rows to process
     uint32_t rows_per_thread = actx->nrows_per_thread;
-    uint32_t start_row = actx->dev_row_start + rows_per_thread * i;
-    uint32_t end_row = MIN(start_row + rows_per_thread, actx->dev_row_end);
+    uint32_t start_row = actx->mdev_row_start + rows_per_thread * i;
+    uint32_t end_row = MIN(start_row + rows_per_thread, actx->mdev_row_end);
 
     size_t values_size = hex_round_up(ne00 * sizeof(float), 128);
     uint32_t num_vec_ind_values = hmx_ceil_div(ne00, VLEN/(sizeof(int32_t)));
@@ -451,22 +451,22 @@ int op_argsort(struct htp_ops_context * octx) {
 
     const uint32_t total_rows = octx->src[0]->ne[1] * octx->src[0]->ne[2] * octx->src[0]->ne[3];
 
-    uint32_t dev_row_start, dev_row_end;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
-        dev_row_end   = MIN(dev_row_start + rows_per_dev, total_rows);
+    uint32_t mdev_row_start, mdev_row_end;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
+        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, total_rows);
     } else {
-        dev_row_start = 0;
-        dev_row_end   = total_rows;
+        mdev_row_start = 0;
+        mdev_row_end   = total_rows;
     }
 
-    const uint32_t dev_nrows = dev_row_end - dev_row_start;
-    if (dev_nrows == 0) {
+    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(dev_nrows, octx->n_threads);
+    const uint32_t n_threads = MIN(mdev_nrows, octx->n_threads);
 
     // Allocate scratchpad
     // We need 1 row of float + 1 row of int32 per thread.
@@ -492,10 +492,10 @@ int op_argsort(struct htp_ops_context * octx) {
 
     struct htp_argsort_context actx;
     actx.octx = octx;
-    actx.nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
-    actx.total_rows       = dev_nrows;
-    actx.dev_row_start   = dev_row_start;
-    actx.dev_row_end     = dev_row_end;
+    actx.nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    actx.total_rows       = mdev_nrows;
+    actx.mdev_row_start   = mdev_row_start;
+    actx.mdev_row_end     = mdev_row_end;
     actx.vtcm_base = (uint8_t *) octx->ctx->vtcm_base;
     actx.vtcm_per_thread = spad_per_thread;
 

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -458,7 +458,7 @@ int op_argsort(struct htp_ops_context * octx) {
 
     uint32_t row_start = 0;
     uint32_t row_end   = total_rows;
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(int32_t)) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -474,13 +474,13 @@ int op_argsort(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
             row_end   = total_rows;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 row_end = total_rows;
             } else {
                 row_end = MIN(row_start + chunks_per_mdev * rows_per_chunk, total_rows);

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -459,33 +459,11 @@ int op_argsort(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t row_end   = total_rows;
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(int32_t)) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
-            row_end   = total_rows;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                row_end = total_rows;
-            } else {
-                row_end = MIN(row_start + chunks_per_mdev * rows_per_chunk, total_rows);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, sizeof(int32_t), (uint32_t) dst_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        row_end   = range.start + range.count;
     }
 
     const uint32_t nrows = row_end - row_start;

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -453,7 +453,7 @@ int op_argsort(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_row_end;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
         mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, total_rows);
     } else {
@@ -466,7 +466,7 @@ int op_argsort(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(mdev_nrows, octx->n_threads);
+    const uint32_t n_threads = octx->n_threads;
 
     // Allocate scratchpad
     // We need 1 row of float + 1 row of int32 per thread.
@@ -492,7 +492,7 @@ int op_argsort(struct htp_ops_context * octx) {
 
     struct htp_argsort_context actx;
     actx.octx = octx;
-    actx.nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    actx.nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
     actx.total_rows       = mdev_nrows;
     actx.mdev_row_start   = mdev_row_start;
     actx.mdev_row_end     = mdev_row_end;

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -11,9 +11,10 @@
 #include "hvx-utils.h"
 #include "hex-dma.h"
 
+#include "hex-common.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
-#include "htp-ops.h"
+#include "htp-tensor.h"
 
 #ifndef MIN
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -449,13 +450,41 @@ int op_argsort(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
-    const uint32_t total_rows = octx->src[0]->ne[1] * octx->src[0]->ne[2] * octx->src[0]->ne[3];
+    const struct htp_tensor * src0 = octx->src[0];
+    const struct htp_tensor * dst  = octx->dst;
+
+    const uint32_t total_rows  = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const size_t dst_row_size  = dst->ne[0]  * sizeof(int32_t);
 
     uint32_t mdev_row_start, mdev_row_end;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
-        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, total_rows);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(int32_t)) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+            mdev_row_end   = total_rows;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_row_end = total_rows;
+            } else {
+                mdev_row_end = MIN(mdev_row_start + chunks_per_mdev * rows_per_chunk, total_rows);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_row_end   = total_rows;

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -341,8 +341,8 @@ static void htp_argsort_f32_##ne00##_##order_name(unsigned int n, unsigned int i
     const struct htp_tensor * dst = octx->dst;                                                                 \
     uint8_t * spad = actx->vtcm_base + actx->vtcm_per_thread * i;                                              \
     uint32_t rows_per_thread = actx->nrows_per_thread;                                                         \
-    uint32_t start_row = actx->row_start + rows_per_thread * i;                                           \
-    uint32_t end_row = MIN(start_row + rows_per_thread, actx->row_end);                                   \
+    uint32_t start_row = actx->row_start + rows_per_thread * i;                                                \
+    uint32_t end_row = MIN(start_row + rows_per_thread, actx->row_end);                                        \
     size_t values_size = hex_round_up(ne00 * sizeof(float), 128);                                              \
     float * values_buf = (float *) spad;                                                                       \
     int32_t * indices_buf = (int32_t *) (spad + values_size);                                                  \

--- a/ggml/src/ggml-hexagon/htp/argsort-ops.c
+++ b/ggml/src/ggml-hexagon/htp/argsort-ops.c
@@ -554,7 +554,7 @@ int op_argsort(struct htp_ops_context * octx) {
     }
 
     // Run jobs
-    worker_pool_run_func(octx->ctx->worker_pool, job_func, &actx, n_threads);
+    work_queue_run(octx->ctx->work_queue, job_func, &actx, n_threads);
 
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -51,27 +51,27 @@ struct htp_binary_context {
     const struct htp_tensor * src0 = octx->src[0]; \
     const struct htp_tensor * src1 = octx->src[1]; \
     const struct htp_tensor * dst  = octx->dst;    \
-                                       \
-    const uint32_t ne00 = src0->ne[0]; \
-    const uint32_t ne01 = src0->ne[1]; \
-    const uint32_t ne02 = src0->ne[2]; \
-    const uint32_t ne03 = src0->ne[3]; \
-                                       \
-    const uint32_t ne10 = src1->ne[0]; \
-    const uint32_t ne11 = src1->ne[1]; \
-    const uint32_t ne12 = src1->ne[2]; \
-    const uint32_t ne13 = src1->ne[3]; \
-                                       \
-    const uint32_t nb01 = src0->nb[1]; \
-    const uint32_t nb02 = src0->nb[2]; \
-    const uint32_t nb03 = src0->nb[3]; \
-                                       \
-    const uint32_t nb11 = src1->nb[1]; \
-    const uint32_t nb12 = src1->nb[2]; \
-    const uint32_t nb13 = src1->nb[3]; \
-                                       \
-    const uint32_t nb1 = dst->nb[1];   \
-    const uint32_t nb2 = dst->nb[2];   \
+                                                   \
+    const uint32_t ne00 = src0->ne[0];             \
+    const uint32_t ne01 = src0->ne[1];             \
+    const uint32_t ne02 = src0->ne[2];             \
+    const uint32_t ne03 = src0->ne[3];             \
+                                                   \
+    const uint32_t ne10 = src1->ne[0];             \
+    const uint32_t ne11 = src1->ne[1];             \
+    const uint32_t ne12 = src1->ne[2];             \
+    const uint32_t ne13 = src1->ne[3];             \
+                                                   \
+    const uint32_t nb01 = src0->nb[1];             \
+    const uint32_t nb02 = src0->nb[2];             \
+    const uint32_t nb03 = src0->nb[3];             \
+                                                   \
+    const uint32_t nb11 = src1->nb[1];             \
+    const uint32_t nb12 = src1->nb[2];             \
+    const uint32_t nb13 = src1->nb[3];             \
+                                                   \
+    const uint32_t nb1 = dst->nb[1];               \
+    const uint32_t nb2 = dst->nb[2];               \
     const uint32_t nb3 = dst->nb[3];
 
 static inline uint32_t calc_block_size(struct htp_binary_context * bctx, uint32_t ir, uint32_t end_row, uint32_t ne01, uint32_t ne02) {
@@ -96,87 +96,87 @@ static inline uint32_t calc_block_size(struct htp_binary_context * bctx, uint32_
 }
 
 // Macro for scalar op switch
-#define COMPUTE_SCALAR_OP(DST, SRC, VAL, TYPE, N) \
-    if(TYPE == HTP_TYPE_F32) { \
-        switch (octx->op) { \
-            case HTP_OP_ADD: hvx_add_scalar_f32_aa(DST, SRC, *(float *)VAL, N); break; \
-            case HTP_OP_SUB: hvx_sub_scalar_f32_aa(DST, SRC, *(float *)VAL, N); break; \
-            case HTP_OP_MUL: hvx_mul_scalar_f32_aa(DST, SRC, *(float *)VAL, N); break; \
+#define COMPUTE_SCALAR_OP(DST, SRC, VAL, TYPE, N)                                               \
+    if(TYPE == HTP_TYPE_F32) {                                                                  \
+        switch (octx->op) {                                                                     \
+            case HTP_OP_ADD: hvx_add_scalar_f32_aa(DST, SRC, *(float *)VAL, N); break;          \
+            case HTP_OP_SUB: hvx_sub_scalar_f32_aa(DST, SRC, *(float *)VAL, N); break;          \
+            case HTP_OP_MUL: hvx_mul_scalar_f32_aa(DST, SRC, *(float *)VAL, N); break;          \
             case HTP_OP_DIV: hvx_mul_scalar_f32_aa(DST, SRC, 1.0f / (*(float *)VAL), N); break; \
-            default: break; \
-        } \
-    } \
-    else { \
-        switch (octx->op) { \
-            case HTP_OP_ADD: hvx_add_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break; \
-            case HTP_OP_SUB: hvx_sub_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break; \
-            case HTP_OP_MUL: hvx_mul_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break; \
-            case HTP_OP_DIV: hvx_div_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break; \
-            default: break; \
-        } \
+            default: break;                                                                     \
+        }                                                                                       \
+    }                                                                                           \
+    else {                                                                                      \
+        switch (octx->op) {                                                                     \
+            case HTP_OP_ADD: hvx_add_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break;       \
+            case HTP_OP_SUB: hvx_sub_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break;       \
+            case HTP_OP_MUL: hvx_mul_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break;       \
+            case HTP_OP_DIV: hvx_div_scalar_f16_aa(DST, SRC, *(_Float16 *)VAL, N); break;       \
+            default: break;                                                                     \
+        }                                                                                       \
     }
 
 // Macro for vector op switch (All Aligned)
-#define COMPUTE_VECTOR_OP_AAA(DST, SRC0, SRC1, TYPE, N) \
-    if(TYPE == HTP_TYPE_F32) { \
-        switch (octx->op) { \
+#define COMPUTE_VECTOR_OP_AAA(DST, SRC0, SRC1, TYPE, N)                  \
+    if(TYPE == HTP_TYPE_F32) {                                           \
+        switch (octx->op) {                                              \
             case HTP_OP_ADD: hvx_add_f32_aaa(DST, SRC0, SRC1, N); break; \
             case HTP_OP_SUB: hvx_sub_f32_aaa(DST, SRC0, SRC1, N); break; \
             case HTP_OP_MUL: hvx_mul_f32_aaa(DST, SRC0, SRC1, N); break; \
             case HTP_OP_DIV: hvx_div_f32_aaa(DST, SRC0, SRC1, N); break; \
-            default: break; \
-        } \
-    } \
-    else { \
-        switch (octx->op) { \
+            default: break;                                              \
+        }                                                                \
+    }                                                                    \
+    else {                                                               \
+        switch (octx->op) {                                              \
             case HTP_OP_ADD: hvx_add_f16_aaa(DST, SRC0, SRC1, N); break; \
             case HTP_OP_SUB: hvx_sub_f16_aaa(DST, SRC0, SRC1, N); break; \
             case HTP_OP_MUL: hvx_mul_f16_aaa(DST, SRC0, SRC1, N); break; \
             case HTP_OP_DIV: hvx_div_f16_aaa(DST, SRC0, SRC1, N); break; \
-            default: break; \
-        } \
+            default: break;                                              \
+        }                                                                \
     }
 
 // Macro for vector op switch (Dst Aligned, Src0 Aligned, Src1 Unaligned)
-#define COMPUTE_VECTOR_OP_AAU(DST, SRC0, SRC1, TYPE, N) \
-    if(TYPE == HTP_TYPE_F32) { \
-        switch (octx->op) { \
+#define COMPUTE_VECTOR_OP_AAU(DST, SRC0, SRC1, TYPE, N)                  \
+    if(TYPE == HTP_TYPE_F32) {                                           \
+        switch (octx->op) {                                              \
             case HTP_OP_ADD: hvx_add_f32_aau(DST, SRC0, SRC1, N); break; \
             case HTP_OP_SUB: hvx_sub_f32_aau(DST, SRC0, SRC1, N); break; \
             case HTP_OP_MUL: hvx_mul_f32_aau(DST, SRC0, SRC1, N); break; \
             case HTP_OP_DIV: hvx_div_f32_aau(DST, SRC0, SRC1, N); break; \
-            default: break; \
-        } \
-    } \
-    else { \
-        switch (octx->op) { \
+            default: break;                                              \
+        }                                                                \
+    }                                                                    \
+    else {                                                               \
+        switch (octx->op) {                                              \
             case HTP_OP_ADD: hvx_add_f16_aau(DST, SRC0, SRC1, N); break; \
             case HTP_OP_SUB: hvx_sub_f16_aau(DST, SRC0, SRC1, N); break; \
             case HTP_OP_MUL: hvx_mul_f16_aau(DST, SRC0, SRC1, N); break; \
             case HTP_OP_DIV: hvx_div_f16_aau(DST, SRC0, SRC1, N); break; \
-            default: break; \
-        } \
+            default: break;                                              \
+        }                                                                \
     }
 
 // Macro for vector op switch (All Unaligned - generic loop used in element repeat)
-#define COMPUTE_VECTOR_OP_UUU(DST, SRC0, SRC1, TYPE, N) \
-    if(TYPE == HTP_TYPE_F32) { \
-        switch (octx->op) { \
+#define COMPUTE_VECTOR_OP_UUU(DST, SRC0, SRC1, TYPE, N)                  \
+    if(TYPE == HTP_TYPE_F32) {                                           \
+        switch (octx->op) {                                              \
             case HTP_OP_ADD: hvx_add_f32_uuu(DST, SRC0, SRC1, N); break; \
             case HTP_OP_SUB: hvx_sub_f32_uuu(DST, SRC0, SRC1, N); break; \
             case HTP_OP_MUL: hvx_mul_f32_uuu(DST, SRC0, SRC1, N); break; \
             case HTP_OP_DIV: hvx_div_f32_uuu(DST, SRC0, SRC1, N); break; \
-            default: break; \
-        } \
-    } \
-    else { \
-        switch (octx->op) { \
+            default: break;                                              \
+        }                                                                \
+    }                                                                    \
+    else {                                                               \
+        switch (octx->op) {                                              \
             case HTP_OP_ADD: hvx_add_f16_uuu(DST, SRC0, SRC1, N); break; \
             case HTP_OP_SUB: hvx_sub_f16_uuu(DST, SRC0, SRC1, N); break; \
             case HTP_OP_MUL: hvx_mul_f16_uuu(DST, SRC0, SRC1, N); break; \
             case HTP_OP_DIV: hvx_div_f16_uuu(DST, SRC0, SRC1, N); break; \
-            default: break; \
-        } \
+            default: break;                                              \
+        }                                                                \
     }
 
 // 1. Scalar src1 (ne10 == 1)

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -38,7 +38,7 @@ struct htp_binary_context {
     uint32_t block_max;
     uint32_t nrows_per_thread;
     uint32_t total_rows;
-    uint32_t mdev_row_start;
+    uint32_t row_start;
     size_t   src0_row_size_aligned;
     size_t   src1_row_size_aligned;
     size_t   dst_row_size_aligned;
@@ -187,8 +187,8 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
+    const uint32_t start_row = bctx->row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-scalar: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -284,8 +284,8 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
+    const uint32_t start_row = bctx->row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-same-shape: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -388,8 +388,8 @@ static void binary_job_vector_row_broadcast(unsigned int nth, unsigned int ith, 
 
     const uint32_t src0_type  = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row  = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
+    const uint32_t start_row  = bctx->row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-row-bcast: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -473,8 +473,8 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row  = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
+    const uint32_t start_row  = bctx->row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-complex: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -563,8 +563,8 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t elem_size_bytes = (src0_type == HTP_TYPE_F32) ? sizeof(float) : sizeof(_Float16);
     const uint32_t row_size_bytes = ne00 * elem_size_bytes;;
-    const uint32_t start_row  = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
+    const uint32_t start_row  = bctx->row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     uint8_t * src0_spad_base = octx->src0_spad.data + (ith * octx->src0_spad.size_per_thread);
@@ -673,8 +673,8 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
     const uint32_t nb2 = dst->nb[2];
     const uint32_t nb3 = dst->nb[3];
 
-    const uint32_t start_row = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
+    const uint32_t start_row = bctx->row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     uint8_t * src0_spad_base = octx->src0_spad.data + (ith * octx->src0_spad.size_per_thread);
@@ -764,7 +764,9 @@ static int execute_op_binary(struct htp_ops_context * octx) {
     const size_t src1_row_size = src1->ne[0] * elem_size;
     const size_t dst_row_size  = dst->ne[0]  * elem_size;
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = src0_nrows;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
@@ -782,23 +784,20 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = src0_nrows - mdev_row_start;
+                nrows = src0_nrows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = src0_nrows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -881,9 +880,9 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
     struct htp_binary_context bctx;
     bctx.octx                  = octx;
-    bctx.nrows_per_thread      = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
-    bctx.total_rows            = mdev_nrows;
-    bctx.mdev_row_start         = mdev_row_start;
+    bctx.nrows_per_thread      = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
+    bctx.total_rows            = nrows;
+    bctx.row_start             = row_start;
     bctx.block_max             = rows_per_buffer;
     bctx.src0_row_size_aligned = src0_row_size_aligned;
     bctx.src1_row_size_aligned = src1_row_size_aligned;

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -768,33 +768,11 @@ static int execute_op_binary(struct htp_ops_context * octx) {
     uint32_t nrows     = src0_nrows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = src0_nrows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, (uint32_t) elem_size, (uint32_t) dst_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(src0_nrows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {
@@ -937,4 +915,3 @@ int op_binary(struct htp_ops_context * octx) {
 
     return HTP_STATUS_NO_SUPPORT;
 }
-

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -13,8 +13,9 @@
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
-#include "htp-ctx.h"
 #include "hex-common.h"
+#include "hex-profile.h"
+#include "htp-ctx.h"
 #include "htp-ops.h"
 #include "htp-tensor.h"
 
@@ -223,6 +224,9 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
     }
 
     // Main loop
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
+
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
 
@@ -267,6 +271,8 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
         }
         ir += current_block_size;
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -323,6 +329,9 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
         spad_idx ^= 1;
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
+
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
         uint8_t * d_spad  = (uint8_t *) dma_queue_pop(q).src;
@@ -366,6 +375,8 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
         }
         ir += current_block_size;
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -415,6 +426,9 @@ static void binary_job_vector_row_broadcast(unsigned int nth, unsigned int ith, 
         spad_idx ^= 1;
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
+
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
         uint8_t * d_spad  = (uint8_t *) dma_queue_pop(q).src;
@@ -446,6 +460,8 @@ static void binary_job_vector_row_broadcast(unsigned int nth, unsigned int ith, 
         }
         ir += current_block_size;
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -491,6 +507,9 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
         spad_idx ^= 1;
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
+
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
         uint8_t * d_spad = (uint8_t *) dma_queue_pop(q).src;
@@ -530,6 +549,8 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
         }
         ir += current_block_size;
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -576,6 +597,9 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
         spad_idx ^= 1;
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
+
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
         uint8_t * d_spad = (uint8_t *) dma_queue_pop(q).src;
@@ -619,6 +643,8 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
         }
         ir += current_block_size;
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -679,6 +705,9 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
         spad_idx ^= 1;
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
+
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
         uint8_t * d_spad = (uint8_t *) dma_queue_pop(q).src;
@@ -716,6 +745,8 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
         }
         ir += current_block_size;
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -887,7 +918,7 @@ static int execute_op_binary(struct htp_ops_context * octx) {
         dma_queue_pop(q);
     }
 
-    worker_pool_run_func(octx->ctx->worker_pool, worker_func, &bctx, n_threads);
+    work_queue_run(octx->ctx->work_queue, worker_func, &bctx, n_threads);
 
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -36,6 +36,8 @@ struct htp_binary_context {
 
     uint32_t block_max;
     uint32_t nrows_per_thread;
+    uint32_t total_rows;
+    uint32_t dev_row_start;
     size_t   src0_row_size_aligned;
     size_t   src1_row_size_aligned;
     size_t   dst_row_size_aligned;
@@ -184,9 +186,8 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t total_rows = ne01 * ne02 * ne03;
-    const uint32_t start_row = bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, total_rows);
+    const uint32_t start_row = bctx->dev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-scalar: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -277,9 +278,8 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t total_rows = ne01 * ne02 * ne03;
-    const uint32_t start_row = bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, total_rows);
+    const uint32_t start_row = bctx->dev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-same-shape: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -377,9 +377,8 @@ static void binary_job_vector_row_broadcast(unsigned int nth, unsigned int ith, 
 
     const uint32_t src0_type  = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t total_rows = ne01 * ne02 * ne03;
-    const uint32_t start_row  = bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, total_rows);
+    const uint32_t start_row  = bctx->dev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-row-bcast: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -458,9 +457,8 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t total_rows = ne01 * ne02 * ne03;
-    const uint32_t start_row  = bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, total_rows);
+    const uint32_t start_row  = bctx->dev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-complex: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -544,9 +542,8 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t elem_size_bytes = (src0_type == HTP_TYPE_F32) ? sizeof(float) : sizeof(_Float16);
     const uint32_t row_size_bytes = ne00 * elem_size_bytes;;
-    const uint32_t total_rows = ne01 * ne02 * ne03;
-    const uint32_t start_row  = bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, total_rows);
+    const uint32_t start_row  = bctx->dev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     uint8_t * src0_spad_base = octx->src0_spad.data + (ith * octx->src0_spad.size_per_thread);
@@ -650,9 +647,8 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
     const uint32_t nb2 = dst->nb[2];
     const uint32_t nb3 = dst->nb[3];
 
-    const uint32_t total_rows = ne01 * ne02 * ne03;
-    const uint32_t start_row = bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, total_rows);
+    const uint32_t start_row = bctx->dev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     uint8_t * src0_spad_base = octx->src0_spad.data + (ith * octx->src0_spad.size_per_thread);
@@ -729,7 +725,22 @@ static int execute_op_binary(struct htp_ops_context * octx) {
     const struct htp_tensor * dst  = octx->dst;
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
-    const uint32_t n_threads  = MIN(octx->n_threads, src0_nrows);
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = src0_nrows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
 
     // Use packed row sizes for VTCM allocation
     const uint32_t src0_type = octx->src[0]->type;
@@ -815,7 +826,9 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
     struct htp_binary_context bctx;
     bctx.octx                  = octx;
-    bctx.nrows_per_thread      = (src0_nrows + n_threads - 1) / n_threads;
+    bctx.nrows_per_thread      = (dev_nrows + n_threads - 1) / n_threads;
+    bctx.total_rows            = dev_nrows;
+    bctx.dev_row_start         = dev_row_start;
     bctx.block_max             = rows_per_buffer;
     bctx.src0_row_size_aligned = src0_row_size_aligned;
     bctx.src1_row_size_aligned = src1_row_size_aligned;

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -37,7 +37,7 @@ struct htp_binary_context {
     uint32_t block_max;
     uint32_t nrows_per_thread;
     uint32_t total_rows;
-    uint32_t dev_row_start;
+    uint32_t mdev_row_start;
     size_t   src0_row_size_aligned;
     size_t   src1_row_size_aligned;
     size_t   dst_row_size_aligned;
@@ -186,8 +186,8 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row = bctx->dev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
+    const uint32_t start_row = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-scalar: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -278,8 +278,8 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row = bctx->dev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
+    const uint32_t start_row = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-same-shape: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -377,8 +377,8 @@ static void binary_job_vector_row_broadcast(unsigned int nth, unsigned int ith, 
 
     const uint32_t src0_type  = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row  = bctx->dev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
+    const uint32_t start_row  = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-row-bcast: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -457,8 +457,8 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
 
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t row_size_bytes = (src0_type == HTP_TYPE_F32) ? ne00 * sizeof(float) : ne00 * sizeof(_Float16);
-    const uint32_t start_row  = bctx->dev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
+    const uint32_t start_row  = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     FARF(HIGH, "binary-complex: %d/%d (%u:%u) row-size %u (%u)", ith, nth, start_row, end_row, nb01, bctx->dst_row_size_aligned);
@@ -542,8 +542,8 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
     const uint32_t src0_type = octx->src[0]->type;
     const uint32_t elem_size_bytes = (src0_type == HTP_TYPE_F32) ? sizeof(float) : sizeof(_Float16);
     const uint32_t row_size_bytes = ne00 * elem_size_bytes;;
-    const uint32_t start_row  = bctx->dev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
+    const uint32_t start_row  = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row    = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     uint8_t * src0_spad_base = octx->src0_spad.data + (ith * octx->src0_spad.size_per_thread);
@@ -647,8 +647,8 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
     const uint32_t nb2 = dst->nb[2];
     const uint32_t nb3 = dst->nb[3];
 
-    const uint32_t start_row = bctx->dev_row_start + bctx->nrows_per_thread * ith;
-    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->dev_row_start + bctx->total_rows);
+    const uint32_t start_row = bctx->mdev_row_start + bctx->nrows_per_thread * ith;
+    const uint32_t end_row   = MIN(start_row + bctx->nrows_per_thread, bctx->mdev_row_start + bctx->total_rows);
     if (start_row >= end_row) return;
 
     uint8_t * src0_spad_base = octx->src0_spad.data + (ith * octx->src0_spad.size_per_thread);
@@ -726,21 +726,21 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = src0_nrows;
+        mdev_row_start = 0;
+        mdev_nrows     = src0_nrows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
 
     // Use packed row sizes for VTCM allocation
     const uint32_t src0_type = octx->src[0]->type;
@@ -826,9 +826,9 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
     struct htp_binary_context bctx;
     bctx.octx                  = octx;
-    bctx.nrows_per_thread      = (dev_nrows + n_threads - 1) / n_threads;
-    bctx.total_rows            = dev_nrows;
-    bctx.dev_row_start         = dev_row_start;
+    bctx.nrows_per_thread      = (mdev_nrows + n_threads - 1) / n_threads;
+    bctx.total_rows            = mdev_nrows;
+    bctx.mdev_row_start         = mdev_row_start;
     bctx.block_max             = rows_per_buffer;
     bctx.src0_row_size_aligned = src0_row_size_aligned;
     bctx.src1_row_size_aligned = src1_row_size_aligned;

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -767,7 +767,7 @@ static int execute_op_binary(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = src0_nrows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -783,13 +783,13 @@ static int execute_op_binary(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = src0_nrows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -728,7 +728,7 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
         mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
@@ -740,7 +740,7 @@ static int execute_op_binary(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     // Use packed row sizes for VTCM allocation
     const uint32_t src0_type = octx->src[0]->type;
@@ -826,7 +826,7 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
     struct htp_binary_context bctx;
     bctx.octx                  = octx;
-    bctx.nrows_per_thread      = (mdev_nrows + n_threads - 1) / n_threads;
+    bctx.nrows_per_thread      = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
     bctx.total_rows            = mdev_nrows;
     bctx.mdev_row_start         = mdev_row_start;
     bctx.block_max             = rows_per_buffer;

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -14,7 +14,7 @@
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
 #include "htp-ctx.h"
-#include "htp-ops.h"
+#include "hex-common.h"
 #include "htp-ops.h"
 #include "htp-tensor.h"
 
@@ -726,11 +726,42 @@ static int execute_op_binary(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
 
+    // Use packed row sizes for VTCM allocation and alignment
+    const uint32_t src0_type = octx->src[0]->type;
+    const size_t elem_size = (src0_type == HTP_TYPE_F32) ? sizeof(float) : sizeof(_Float16);
+    const size_t src0_row_size = src0->ne[0] * elem_size;
+    const size_t src1_row_size = src1->ne[0] * elem_size;
+    const size_t dst_row_size  = dst->ne[0]  * elem_size;
+
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = src0_nrows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = src0_nrows;
@@ -741,13 +772,6 @@ static int execute_op_binary(struct htp_ops_context * octx) {
     }
 
     const uint32_t n_threads = octx->n_threads;
-
-    // Use packed row sizes for VTCM allocation
-    const uint32_t src0_type = octx->src[0]->type;
-    const size_t elem_size = (src0_type == HTP_TYPE_F32) ? sizeof(float) : sizeof(_Float16);
-    const size_t src0_row_size = src0->ne[0] * elem_size;
-    const size_t src1_row_size = src1->ne[0] * elem_size;
-    const size_t dst_row_size  = dst->ne[0]  * elem_size;
 
     size_t src0_row_size_aligned = hex_round_up(src0_row_size, VLEN);
     size_t src1_row_size_aligned = hex_round_up(src1_row_size, VLEN);

--- a/ggml/src/ggml-hexagon/htp/binary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/binary-ops.c
@@ -225,7 +225,6 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
 
     // Main loop
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
 
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
@@ -247,12 +246,14 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
         uint8_t * src1_ptr = (uint8_t *)src1->data + i13 * nb13 + i12 * nb12 + i11 * nb11;
         uint32_t s1_stride = (ne11 == 1) ? 0 : nb11;
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         for (uint32_t r = 0; r < current_block_size; r++) {
             uint8_t * r_src0 = s0_spad + r * bctx->src0_row_size_aligned;
             uint8_t * r_dst  = d_spad + r * bctx->dst_row_size_aligned;
             COMPUTE_SCALAR_OP(r_dst, r_src0, src1_ptr, src0_type, ne00);
             src1_ptr += s1_stride;
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         uint8_t * dst_curr = (uint8_t *)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1;
         dma_queue_push(q, dma_make_ptr(dst_curr, d_spad), nb1, bctx->dst_row_size_aligned, row_size_bytes, current_block_size);
@@ -272,7 +273,6 @@ static void binary_job_scalar(unsigned int nth, unsigned int ith, void * data) {
         ir += current_block_size;
     }
 
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -330,7 +330,6 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
 
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
@@ -338,12 +337,14 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
         uint8_t * s0_spad = (uint8_t *) dma_queue_pop(q).dst;
         uint8_t * s1_spad = (uint8_t *) dma_queue_pop(q).dst;
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         for (uint32_t r = 0; r < current_block_size; r++) {
             uint8_t * r_src0 = s0_spad + r * bctx->src0_row_size_aligned;
             uint8_t * r_src1 = s1_spad + r * bctx->src1_row_size_aligned;
             uint8_t * r_dst  = d_spad  + r * bctx->dst_row_size_aligned;
             COMPUTE_VECTOR_OP_AAA(r_dst, r_src0, r_src1, src0_type, ne00);
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         uint32_t i03, i02, i01, rem;
         i03 = fastdiv(ir, &bctx->src0_dim12_div);
@@ -376,7 +377,6 @@ static void binary_job_vector_same_shape(unsigned int nth, unsigned int ith, voi
         ir += current_block_size;
     }
 
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -427,19 +427,20 @@ static void binary_job_vector_row_broadcast(unsigned int nth, unsigned int ith, 
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
 
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
         uint8_t * d_spad  = (uint8_t *) dma_queue_pop(q).src;
         uint8_t * s0_spad = (uint8_t *) dma_queue_pop(q).dst;
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         for (uint32_t r = 0; r < current_block_size; r++) {
             uint8_t * r_src0 = s0_spad + r * bctx->src0_row_size_aligned;
             uint8_t * r_src1 = (uint8_t *)s1_ptr; // Constant
             uint8_t * r_dst  = d_spad + r * bctx->dst_row_size_aligned;
             COMPUTE_VECTOR_OP_AAA(r_dst, r_src0, r_src1, src0_type, ne00);
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         uint32_t i03 = fastdiv(ir, &bctx->src0_dim12_div);
         uint32_t rem = ir - i03 * (ne02 * ne01);
@@ -461,7 +462,6 @@ static void binary_job_vector_row_broadcast(unsigned int nth, unsigned int ith, 
         ir += current_block_size;
     }
 
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -508,7 +508,6 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
 
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
@@ -520,6 +519,7 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
         uint32_t i02 = fastdiv(rem, &bctx->src0_dim1_div);
         uint32_t i01 = rem - i02 * ne01;
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         for (uint32_t r = 0; r < current_block_size; r++) {
             uint32_t r_i01 = i01 + r;
             uint32_t i13 = fastmodulo(i03, ne13, &bctx->src1_dim3_div);
@@ -533,6 +533,7 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
             // Read src1 from DDR (unaligned)
             COMPUTE_VECTOR_OP_AAU(r_dst, r_src0, r_src1, src0_type, ne00);
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         uint8_t * dst_curr = (uint8_t *)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1;
         dma_queue_push(q, dma_make_ptr(dst_curr, d_spad), nb1, bctx->dst_row_size_aligned, row_size_bytes, current_block_size);
@@ -550,7 +551,6 @@ static void binary_job_vector_complex(unsigned int nth, unsigned int ith, void *
         ir += current_block_size;
     }
 
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -598,7 +598,6 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
 
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
@@ -610,6 +609,7 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
         uint32_t i02 = fastdiv(rem, &bctx->src0_dim1_div);
         uint32_t i01 = rem - i02 * ne01;
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         for (uint32_t r = 0; r < current_block_size; r++) {
             uint32_t r_i01 = i01 + r;
             uint32_t i13 = fastmodulo(i03, ne13, &bctx->src1_dim3_div);
@@ -627,6 +627,7 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
                 COMPUTE_VECTOR_OP_UUU(r_dst + c * elem_size_bytes, r_src0 + c * elem_size_bytes, r_src1_row, src0_type, len);
             }
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         uint8_t * dst_curr = (uint8_t *)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1;
         dma_queue_push(q, dma_make_ptr(dst_curr, d_spad), nb1, bctx->dst_row_size_aligned, row_size_bytes, current_block_size);
@@ -644,7 +645,6 @@ static void binary_job_element_repeat(unsigned int nth, unsigned int ith, void *
         ir += current_block_size;
     }
 
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 
@@ -706,7 +706,6 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
 
     for (uint32_t ir = start_row; ir < end_row; ) {
         uint32_t current_block_size = calc_block_size(bctx, ir, end_row, ne01, ne02);
@@ -718,6 +717,7 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
         uint32_t i02 = fastdiv(rem, &bctx->src0_dim1_div);
         uint32_t i01 = rem - i02 * ne01;
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         for (uint32_t r = 0; r < current_block_size; r++) {
             uint32_t r_i01 = i01 + r; // linear within block since we split at ne01
 
@@ -729,6 +729,7 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
 
             hvx_add_f32_aau(r_dst, r_src0, r_src1, ne00);
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         uint8_t * dst_curr = (uint8_t *)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1;
         dma_queue_push(q, dma_make_ptr(dst_curr, d_spad), nb1, bctx->dst_row_size_aligned, ne00 * sizeof(float), current_block_size);
@@ -746,7 +747,6 @@ static void binary_job_add_id(unsigned int nth, unsigned int ith, void * data) {
         ir += current_block_size;
     }
 
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
     dma_queue_flush(q);
 }
 

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -259,33 +259,11 @@ int op_concat(struct htp_ops_context * octx) {
         uint32_t row_start = 0;
         uint32_t nrows     = total_rows;
         if (octx->ctx->mdev.count > 1) {
-            bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
-            uint32_t rows_per_chunk = 1;
-            if (can_split) {
-                if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                    rows_per_chunk = 1;
-                } else if (dst->nb[1] == dst_data_row_size &&
-                           (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                           (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                    rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
-                } else {
-                    can_split = false;
-                }
-            }
-
-            const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
-            if (total_chunks < octx->ctx->mdev.count) {
-                row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
-                nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
-            } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    nrows = total_rows - row_start;
-                } else {
-                    nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
-                }
-            }
+            uint32_t rows_per_chunk = 0;
+            htp_tensor_mdev_rows_per_chunk(dst, type_size, (uint32_t) dst_data_row_size, &rows_per_chunk);
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            row_start = range.start;
+            nrows     = range.count;
         }
 
         if (nrows == 0) {
@@ -331,20 +309,10 @@ int op_concat(struct htp_ops_context * octx) {
         uint32_t nelems     = total_elements;
         if (octx->ctx->mdev.count > 1) {
             const uint32_t elems_per_chunk = HEX_L2_LINE_SIZE / type_size;
-            bool can_split = htp_tensor_is_contiguous(dst, type_size) && !htp_tensor_is_permuted(dst);
-            const uint32_t total_chunks = can_split ? (total_elements / elems_per_chunk) : 0;
-            if (total_chunks < octx->ctx->mdev.count) {
-                elem_start = (octx->ctx->mdev.idx == 0) ? 0 : total_elements;
-                nelems     = (octx->ctx->mdev.idx == 0) ? total_elements : 0;
-            } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                elem_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * elems_per_chunk, total_elements);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    nelems = total_elements - elem_start;
-                } else {
-                    nelems = MIN(chunks_per_mdev * elems_per_chunk, total_elements - elem_start);
-                }
-            }
+            const bool can_split = htp_tensor_mdev_data_aligned(dst) && htp_tensor_is_contiguous(dst, type_size) && !htp_tensor_is_permuted(dst);
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_elements, can_split ? elems_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            elem_start = range.start;
+            nelems     = range.count;
         }
 
         if (nelems == 0) {

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -13,6 +13,10 @@ struct htp_concat_context {
     struct htp_ops_context * octx;
     uint32_t dim;
     uint32_t nrows_per_thread;
+    uint32_t dev_row_start;
+    uint32_t dev_nrows;
+    uint32_t dev_elem_start;
+    uint32_t dev_nelems;
     struct fastdiv_values div_ne0;
     struct fastdiv_values div_ne1;
     struct fastdiv_values div_ne2;
@@ -28,10 +32,10 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
 
     const uint32_t src0_ne0 = src0->ne[0];
     const uint32_t src1_ne0 = src1->ne[0];
-    const uint32_t ne1      = dst->ne[1];
 
-    const uint32_t start_i = ith * cctx->nrows_per_thread;
-    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < ne1) ? (start_i + cctx->nrows_per_thread) : ne1;
+    const uint32_t dev_row_end = cctx->dev_row_start + cctx->dev_nrows;
+    const uint32_t start_i = cctx->dev_row_start + ith * cctx->nrows_per_thread;
+    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < dev_row_end) ? (start_i + cctx->nrows_per_thread) : dev_row_end;
     if (start_i >= end_i) return;
 
     dma_queue * q = octx->ctx->dma[ith];
@@ -95,10 +99,10 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
 
     const uint32_t src0_ne0 = src0->ne[0];
     const uint32_t src1_ne0 = src1->ne[0];
-    const uint32_t ne1      = dst->ne[1];
 
-    const uint32_t start_i = ith * cctx->nrows_per_thread;
-    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < ne1) ? (start_i + cctx->nrows_per_thread) : ne1;
+    const uint32_t dev_row_end = cctx->dev_row_start + cctx->dev_nrows;
+    const uint32_t start_i = cctx->dev_row_start + ith * cctx->nrows_per_thread;
+    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < dev_row_end) ? (start_i + cctx->nrows_per_thread) : dev_row_end;
     if (start_i >= end_i) return;
 
     dma_queue * q = octx->ctx->dma[ith];
@@ -164,11 +168,14 @@ static void concat_generic(unsigned int nth, unsigned int ith, void * data) {
     const uint32_t type_size = (dst->type == HTP_TYPE_F32 || dst->type == HTP_TYPE_I32) ? 4 : 2;
 
     const uint32_t ne[4] = {dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]};
-    const uint32_t total_elements = ne[0] * ne[1] * ne[2] * ne[3];
-    const uint32_t chunk_size = (total_elements + nth - 1) / nth;
 
-    const uint32_t start_idx = MIN(ith * chunk_size, total_elements);
-    const uint32_t end_idx   = MIN(start_idx + chunk_size, total_elements);
+    // Per-device element range aligned to prevent false sharing
+    const uint32_t dev_elem_start = cctx->dev_elem_start;
+    const uint32_t dev_nelems     = cctx->dev_nelems;
+    const uint32_t chunk_size = (dev_nelems + nth - 1) / nth;
+
+    const uint32_t start_idx = MIN(dev_elem_start + ith * chunk_size, dev_elem_start + dev_nelems);
+    const uint32_t end_idx   = MIN(start_idx + chunk_size, dev_elem_start + dev_nelems);
 
     // Naive scalar element-wise copy
     for (uint32_t idx = start_idx; idx < end_idx; idx++) {
@@ -236,13 +243,31 @@ int op_concat(struct htp_ops_context * octx) {
     void (*worker_func)(unsigned int, unsigned int, void *) = concat_generic;
 
     if (dim == 0 && is_2d && is_src1_transposed && !is_src0_transposed) {
-        n_threads = MIN(dst->ne[1], n_threads);
+        const uint32_t total_rows = dst->ne[1];
+        uint32_t dev_row_start, dev_nrows;
+        if (octx->ndev > 1) {
+            const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
+            dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
+            dev_nrows     = MIN(rows_per_dev, total_rows - dev_row_start);
+        } else {
+            dev_row_start = 0;
+            dev_nrows     = total_rows;
+        }
+
+        if (dev_nrows == 0) {
+            return HTP_STATUS_OK;
+        }
+
+        cctx.dev_row_start = dev_row_start;
+        cctx.dev_nrows     = dev_nrows;
+
+        n_threads = MIN(dev_nrows, n_threads);
         if (n_threads < 1) {
             n_threads = 1;
         }
         uint32_t block_i = (type_size == 4) ? 32 : 64;
 
-        cctx.nrows_per_thread = hmx_ceil_div(dst->ne[1], n_threads);
+        cctx.nrows_per_thread = hmx_ceil_div(dev_nrows, n_threads);
 
         // Allocate VTCM
         uint32_t spad1_stride = block_i * type_size;
@@ -270,6 +295,26 @@ int op_concat(struct htp_ops_context * octx) {
         } else {
             worker_func = concat_2d_f16_transposed;
         }
+    } else {
+        const uint32_t total_elements = dst->ne[0] * dst->ne[1] * dst->ne[2] * dst->ne[3];
+        uint32_t dev_elem_start, dev_nelems;
+        if (octx->ndev > 1) {
+            const uint32_t elems_per_line = MAX(1u, (uint32_t) HEX_L2_LINE_SIZE / type_size);
+            uint32_t elems_per_dev = (total_elements + octx->ndev - 1) / octx->ndev;
+            elems_per_dev = ((elems_per_dev + elems_per_line - 1) / elems_per_line) * elems_per_line;
+            dev_elem_start = MIN(octx->idev * elems_per_dev, total_elements);
+            dev_nelems     = MIN(elems_per_dev, total_elements - dev_elem_start);
+        } else {
+            dev_elem_start = 0;
+            dev_nelems     = total_elements;
+        }
+
+        if (dev_nelems == 0) {
+            return HTP_STATUS_OK;
+        }
+
+        cctx.dev_elem_start = dev_elem_start;
+        cctx.dev_nelems     = dev_nelems;
     }
 
     worker_pool_run_func(octx->ctx->worker_pool, worker_func, &cctx, n_threads);

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -16,10 +16,10 @@ struct htp_concat_context {
     struct htp_ops_context * octx;
     uint32_t dim;
     uint32_t nrows_per_thread;
-    uint32_t mdev_row_start;
-    uint32_t mdev_nrows;
-    uint32_t mdev_elem_start;
-    uint32_t mdev_nelems;
+    uint32_t row_start;
+    uint32_t nrows;
+    uint32_t elem_start;
+    uint32_t nelems;
     struct fastdiv_values div_ne0;
     struct fastdiv_values div_ne1;
     struct fastdiv_values div_ne2;
@@ -36,9 +36,9 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
     const uint32_t src0_ne0 = src0->ne[0];
     const uint32_t src1_ne0 = src1->ne[0];
 
-    const uint32_t mdev_row_end = cctx->mdev_row_start + cctx->mdev_nrows;
-    const uint32_t start_i = cctx->mdev_row_start + ith * cctx->nrows_per_thread;
-    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < mdev_row_end) ? (start_i + cctx->nrows_per_thread) : mdev_row_end;
+    const uint32_t row_end = cctx->row_start + cctx->nrows;
+    const uint32_t start_i = cctx->row_start + ith * cctx->nrows_per_thread;
+    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < row_end) ? (start_i + cctx->nrows_per_thread) : row_end;
     if (start_i >= end_i) return;
 
     dma_queue * q = octx->ctx->dma[ith];
@@ -108,9 +108,9 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
     const uint32_t src0_ne0 = src0->ne[0];
     const uint32_t src1_ne0 = src1->ne[0];
 
-    const uint32_t mdev_row_end = cctx->mdev_row_start + cctx->mdev_nrows;
-    const uint32_t start_i = cctx->mdev_row_start + ith * cctx->nrows_per_thread;
-    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < mdev_row_end) ? (start_i + cctx->nrows_per_thread) : mdev_row_end;
+    const uint32_t row_end = cctx->row_start + cctx->nrows;
+    const uint32_t start_i = cctx->row_start + ith * cctx->nrows_per_thread;
+    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < row_end) ? (start_i + cctx->nrows_per_thread) : row_end;
     if (start_i >= end_i) return;
 
     dma_queue * q = octx->ctx->dma[ith];
@@ -183,12 +183,12 @@ static void concat_generic(unsigned int nth, unsigned int ith, void * data) {
     const uint32_t ne[4] = {dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]};
 
     // Per-device element range aligned to prevent false sharing
-    const uint32_t mdev_elem_start = cctx->mdev_elem_start;
-    const uint32_t mdev_nelems     = cctx->mdev_nelems;
-    const uint32_t chunk_size = (mdev_nelems + nth - 1) / nth;
+    const uint32_t elem_start = cctx->elem_start;
+    const uint32_t nelems     = cctx->nelems;
+    const uint32_t chunk_size = (nelems + nth - 1) / nth;
 
-    const uint32_t start_idx = MIN(mdev_elem_start + ith * chunk_size, mdev_elem_start + mdev_nelems);
-    const uint32_t end_idx   = MIN(start_idx + chunk_size, mdev_elem_start + mdev_nelems);
+    const uint32_t start_idx = MIN(elem_start + ith * chunk_size, elem_start + nelems);
+    const uint32_t end_idx   = MIN(start_idx + chunk_size, elem_start + nelems);
 
     // Naive scalar element-wise copy
     for (uint32_t idx = start_idx; idx < end_idx; idx++) {
@@ -258,7 +258,8 @@ int op_concat(struct htp_ops_context * octx) {
     if (dim == 0 && is_2d && is_src1_transposed && !is_src0_transposed) {
         const uint32_t total_rows = dst->ne[1];
         const size_t dst_data_row_size = dst->ne[0] * type_size;
-        uint32_t mdev_row_start, mdev_nrows;
+        uint32_t row_start = 0;
+        uint32_t nrows     = total_rows;
         if (octx->mdev_count > 1) {
             bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
             uint32_t rows_per_chunk = 1;
@@ -276,32 +277,29 @@ int op_concat(struct htp_ops_context * octx) {
 
             const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
             if (total_chunks < octx->mdev_count) {
-                mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-                mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+                row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+                nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
             } else {
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+                row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_nrows = total_rows - mdev_row_start;
+                    nrows = total_rows - row_start;
                 } else {
-                    mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+                    nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
                 }
             }
-        } else {
-            mdev_row_start = 0;
-            mdev_nrows     = total_rows;
         }
 
-        if (mdev_nrows == 0) {
+        if (nrows == 0) {
             return HTP_STATUS_OK;
         }
 
-        cctx.mdev_row_start = mdev_row_start;
-        cctx.mdev_nrows     = mdev_nrows;
+        cctx.row_start = row_start;
+        cctx.nrows     = nrows;
 
         uint32_t block_i = (type_size == 4) ? 32 : 64;
 
-        cctx.nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+        cctx.nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
 
         // Allocate VTCM
         uint32_t spad1_stride = block_i * type_size;
@@ -331,34 +329,32 @@ int op_concat(struct htp_ops_context * octx) {
         }
     } else {
         const uint32_t total_elements = dst->ne[0] * dst->ne[1] * dst->ne[2] * dst->ne[3];
-        uint32_t mdev_elem_start, mdev_nelems;
+        uint32_t elem_start = 0;
+        uint32_t nelems     = total_elements;
         if (octx->mdev_count > 1) {
             const uint32_t elems_per_chunk = HEX_L2_LINE_SIZE / type_size;
             bool can_split = htp_tensor_is_contiguous(dst, type_size) && !htp_tensor_is_permuted(dst);
             const uint32_t total_chunks = can_split ? (total_elements / elems_per_chunk) : 0;
             if (total_chunks < octx->mdev_count) {
-                mdev_elem_start = (octx->mdev_idx == 0) ? 0 : total_elements;
-                mdev_nelems     = (octx->mdev_idx == 0) ? total_elements : 0;
+                elem_start = (octx->mdev_idx == 0) ? 0 : total_elements;
+                nelems     = (octx->mdev_idx == 0) ? total_elements : 0;
             } else {
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_elem_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, total_elements);
+                elem_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, total_elements);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_nelems = total_elements - mdev_elem_start;
+                    nelems = total_elements - elem_start;
                 } else {
-                    mdev_nelems = MIN(chunks_per_mdev * elems_per_chunk, total_elements - mdev_elem_start);
+                    nelems = MIN(chunks_per_mdev * elems_per_chunk, total_elements - elem_start);
                 }
             }
-        } else {
-            mdev_elem_start = 0;
-            mdev_nelems     = total_elements;
         }
 
-        if (mdev_nelems == 0) {
+        if (nelems == 0) {
             return HTP_STATUS_OK;
         }
 
-        cctx.mdev_elem_start = mdev_elem_start;
-        cctx.mdev_nelems     = mdev_nelems;
+        cctx.elem_start = elem_start;
+        cctx.nelems     = nelems;
     }
 
     work_queue_run(octx->ctx->work_queue, worker_func, &cctx, n_threads);

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -59,7 +59,6 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
     uint32_t mu = src1_ne0_padded * spad1_stride;
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
 
     for (uint32_t i = start_i; i < end_i; i += block_i) {
         uint32_t current_block_i = (end_i - i < block_i) ? (end_i - i) : block_i;
@@ -76,6 +75,7 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
 
         HVX_Vector * vtcm_tmp = (HVX_Vector *)(spad1_base + src1_ne0_padded * spad1_stride);
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) i);
         for (uint32_t j = 0; j < src1_ne0_padded; j += 32) {
             #pragma unroll(4)
             for (uint32_t ii = 0; ii < current_block_i; ii++) {
@@ -85,6 +85,7 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
                 hvx_vmemu(dst_ptr) = vtcm_tmp[ii];
             }
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) i);
 
         dma_queue_pop(q); // src0
 
@@ -93,8 +94,6 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
 
         dma_queue_pop(q);
     }
-
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
 }
 
 static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * data) {
@@ -131,7 +130,6 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
     uint32_t mu = src1_ne0_padded * spad1_stride;
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
 
     for (uint32_t i = start_i; i < end_i; i += block_i) {
         uint32_t current_block_i = (end_i - i < block_i) ? (end_i - i) : block_i;
@@ -148,6 +146,7 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
 
         HVX_Vector * vtcm_tmp = (HVX_Vector *)(spad1_base + src1_ne0_padded * spad1_stride);
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) i);
         for (uint32_t j = 0; j < src1_ne0_padded; j += 64) {
             #pragma unroll(4)
             for (uint32_t ii = 0; ii < current_block_i; ii++) {
@@ -157,6 +156,7 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
                 hvx_vmemu(dst_ptr) = vtcm_tmp[ii];
             }
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) i);
 
         dma_queue_pop(q); // src0
 
@@ -165,8 +165,6 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
 
         dma_queue_pop(q);
     }
-
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
 }
 
 static void concat_generic(unsigned int nth, unsigned int ith, void * data) {

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -260,7 +260,7 @@ int op_concat(struct htp_ops_context * octx) {
         const size_t dst_data_row_size = dst->ne[0] * type_size;
         uint32_t row_start = 0;
         uint32_t nrows     = total_rows;
-        if (octx->mdev_count > 1) {
+        if (octx->ctx->mdev.count > 1) {
             bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
             uint32_t rows_per_chunk = 1;
             if (can_split) {
@@ -276,13 +276,13 @@ int op_concat(struct htp_ops_context * octx) {
             }
 
             const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
-            if (total_chunks < octx->mdev_count) {
-                row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-                nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+            if (total_chunks < octx->ctx->mdev.count) {
+                row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
+                nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
             } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     nrows = total_rows - row_start;
                 } else {
                     nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
@@ -331,17 +331,17 @@ int op_concat(struct htp_ops_context * octx) {
         const uint32_t total_elements = dst->ne[0] * dst->ne[1] * dst->ne[2] * dst->ne[3];
         uint32_t elem_start = 0;
         uint32_t nelems     = total_elements;
-        if (octx->mdev_count > 1) {
+        if (octx->ctx->mdev.count > 1) {
             const uint32_t elems_per_chunk = HEX_L2_LINE_SIZE / type_size;
             bool can_split = htp_tensor_is_contiguous(dst, type_size) && !htp_tensor_is_permuted(dst);
             const uint32_t total_chunks = can_split ? (total_elements / elems_per_chunk) : 0;
-            if (total_chunks < octx->mdev_count) {
-                elem_start = (octx->mdev_idx == 0) ? 0 : total_elements;
-                nelems     = (octx->mdev_idx == 0) ? total_elements : 0;
+            if (total_chunks < octx->ctx->mdev.count) {
+                elem_start = (octx->ctx->mdev.idx == 0) ? 0 : total_elements;
+                nelems     = (octx->ctx->mdev.idx == 0) ? total_elements : 0;
             } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                elem_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, total_elements);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                elem_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * elems_per_chunk, total_elements);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     nelems = total_elements - elem_start;
                 } else {
                     nelems = MIN(chunks_per_mdev * elems_per_chunk, total_elements - elem_start);

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -246,7 +246,7 @@ int op_concat(struct htp_ops_context * octx) {
         const uint32_t total_rows = dst->ne[1];
         uint32_t mdev_row_start, mdev_nrows;
         if (octx->mdev_count > 1) {
-            const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+            const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
             mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
             mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
         } else {
@@ -261,13 +261,9 @@ int op_concat(struct htp_ops_context * octx) {
         cctx.mdev_row_start = mdev_row_start;
         cctx.mdev_nrows     = mdev_nrows;
 
-        n_threads = MIN(mdev_nrows, n_threads);
-        if (n_threads < 1) {
-            n_threads = 1;
-        }
         uint32_t block_i = (type_size == 4) ? 32 : 64;
 
-        cctx.nrows_per_thread = hmx_ceil_div(mdev_nrows, n_threads);
+        cctx.nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
 
         // Allocate VTCM
         uint32_t spad1_stride = block_i * type_size;
@@ -300,7 +296,7 @@ int op_concat(struct htp_ops_context * octx) {
         uint32_t mdev_elem_start, mdev_nelems;
         if (octx->mdev_count > 1) {
             const uint32_t elems_per_line = MAX(1u, (uint32_t) HEX_L2_LINE_SIZE / type_size);
-            uint32_t elems_per_mdev = (total_elements + octx->mdev_count - 1) / octx->mdev_count;
+            uint32_t elems_per_mdev = fastdiv(total_elements + octx->mdev_count - 1, &octx->mdev_count_div);
             elems_per_mdev = ((elems_per_mdev + elems_per_line - 1) / elems_per_line) * elems_per_line;
             mdev_elem_start = MIN(octx->mdev_idx * elems_per_mdev, total_elements);
             mdev_nelems     = MIN(elems_per_mdev, total_elements - mdev_elem_start);

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -1,5 +1,8 @@
+#include "hex-common.h"
+#include "hex-profile.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
+#include "htp-tensor.h"
 #include "hexagon_types.h"
 #include "hexagon_protos.h"
 #include "hvx_hexagon_protos.h"
@@ -55,6 +58,9 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
     const uint32_t spad0_row_bytes = hex_round_up((src0_ne0 + src1_ne0_padded) * sizeof(float), VLEN);
     uint32_t mu = src1_ne0_padded * spad1_stride;
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
+
     for (uint32_t i = start_i; i < end_i; i += block_i) {
         uint32_t current_block_i = (end_i - i < block_i) ? (end_i - i) : block_i;
 
@@ -87,6 +93,8 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
 
         dma_queue_pop(q);
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
 }
 
 static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * data) {
@@ -122,6 +130,9 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
     const uint32_t spad0_row_bytes = hex_round_up((src0_ne0 + src1_ne0_padded) * sizeof(__fp16), VLEN);
     uint32_t mu = src1_ne0_padded * spad1_stride;
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
+
     for (uint32_t i = start_i; i < end_i; i += block_i) {
         uint32_t current_block_i = (end_i - i < block_i) ? (end_i - i) : block_i;
 
@@ -154,6 +165,8 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
 
         dma_queue_pop(q);
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_i);
 }
 
 static void concat_generic(unsigned int nth, unsigned int ith, void * data) {
@@ -244,11 +257,36 @@ int op_concat(struct htp_ops_context * octx) {
 
     if (dim == 0 && is_2d && is_src1_transposed && !is_src0_transposed) {
         const uint32_t total_rows = dst->ne[1];
+        const size_t dst_data_row_size = dst->ne[0] * type_size;
         uint32_t mdev_row_start, mdev_nrows;
         if (octx->mdev_count > 1) {
-            const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
-            mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
+            bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
+            uint32_t rows_per_chunk = 1;
+            if (can_split) {
+                if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                    rows_per_chunk = 1;
+                } else if (dst->nb[1] == dst_data_row_size &&
+                           (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                           (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                    rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+                } else {
+                    can_split = false;
+                }
+            }
+
+            const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
+            if (total_chunks < octx->mdev_count) {
+                mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+                mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+            } else {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_nrows = total_rows - mdev_row_start;
+                } else {
+                    mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+                }
+            }
         } else {
             mdev_row_start = 0;
             mdev_nrows     = total_rows;
@@ -295,11 +333,21 @@ int op_concat(struct htp_ops_context * octx) {
         const uint32_t total_elements = dst->ne[0] * dst->ne[1] * dst->ne[2] * dst->ne[3];
         uint32_t mdev_elem_start, mdev_nelems;
         if (octx->mdev_count > 1) {
-            const uint32_t elems_per_line = MAX(1u, (uint32_t) HEX_L2_LINE_SIZE / type_size);
-            uint32_t elems_per_mdev = fastdiv(total_elements + octx->mdev_count - 1, &octx->mdev_count_div);
-            elems_per_mdev = ((elems_per_mdev + elems_per_line - 1) / elems_per_line) * elems_per_line;
-            mdev_elem_start = MIN(octx->mdev_idx * elems_per_mdev, total_elements);
-            mdev_nelems     = MIN(elems_per_mdev, total_elements - mdev_elem_start);
+            const uint32_t elems_per_chunk = HEX_L2_LINE_SIZE / type_size;
+            bool can_split = htp_tensor_is_contiguous(dst, type_size) && !htp_tensor_is_permuted(dst);
+            const uint32_t total_chunks = can_split ? (total_elements / elems_per_chunk) : 0;
+            if (total_chunks < octx->mdev_count) {
+                mdev_elem_start = (octx->mdev_idx == 0) ? 0 : total_elements;
+                mdev_nelems     = (octx->mdev_idx == 0) ? total_elements : 0;
+            } else {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_elem_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, total_elements);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_nelems = total_elements - mdev_elem_start;
+                } else {
+                    mdev_nelems = MIN(chunks_per_mdev * elems_per_chunk, total_elements - mdev_elem_start);
+                }
+            }
         } else {
             mdev_elem_start = 0;
             mdev_nelems     = total_elements;
@@ -313,6 +361,6 @@ int op_concat(struct htp_ops_context * octx) {
         cctx.mdev_nelems     = mdev_nelems;
     }
 
-    worker_pool_run_func(octx->ctx->worker_pool, worker_func, &cctx, n_threads);
+    work_queue_run(octx->ctx->work_queue, worker_func, &cctx, n_threads);
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/concat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/concat-ops.c
@@ -13,10 +13,10 @@ struct htp_concat_context {
     struct htp_ops_context * octx;
     uint32_t dim;
     uint32_t nrows_per_thread;
-    uint32_t dev_row_start;
-    uint32_t dev_nrows;
-    uint32_t dev_elem_start;
-    uint32_t dev_nelems;
+    uint32_t mdev_row_start;
+    uint32_t mdev_nrows;
+    uint32_t mdev_elem_start;
+    uint32_t mdev_nelems;
     struct fastdiv_values div_ne0;
     struct fastdiv_values div_ne1;
     struct fastdiv_values div_ne2;
@@ -33,9 +33,9 @@ static void concat_2d_f32_transposed(unsigned int nth, unsigned int ith, void * 
     const uint32_t src0_ne0 = src0->ne[0];
     const uint32_t src1_ne0 = src1->ne[0];
 
-    const uint32_t dev_row_end = cctx->dev_row_start + cctx->dev_nrows;
-    const uint32_t start_i = cctx->dev_row_start + ith * cctx->nrows_per_thread;
-    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < dev_row_end) ? (start_i + cctx->nrows_per_thread) : dev_row_end;
+    const uint32_t mdev_row_end = cctx->mdev_row_start + cctx->mdev_nrows;
+    const uint32_t start_i = cctx->mdev_row_start + ith * cctx->nrows_per_thread;
+    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < mdev_row_end) ? (start_i + cctx->nrows_per_thread) : mdev_row_end;
     if (start_i >= end_i) return;
 
     dma_queue * q = octx->ctx->dma[ith];
@@ -100,9 +100,9 @@ static void concat_2d_f16_transposed(unsigned int nth, unsigned int ith, void * 
     const uint32_t src0_ne0 = src0->ne[0];
     const uint32_t src1_ne0 = src1->ne[0];
 
-    const uint32_t dev_row_end = cctx->dev_row_start + cctx->dev_nrows;
-    const uint32_t start_i = cctx->dev_row_start + ith * cctx->nrows_per_thread;
-    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < dev_row_end) ? (start_i + cctx->nrows_per_thread) : dev_row_end;
+    const uint32_t mdev_row_end = cctx->mdev_row_start + cctx->mdev_nrows;
+    const uint32_t start_i = cctx->mdev_row_start + ith * cctx->nrows_per_thread;
+    const uint32_t end_i   = (start_i + cctx->nrows_per_thread < mdev_row_end) ? (start_i + cctx->nrows_per_thread) : mdev_row_end;
     if (start_i >= end_i) return;
 
     dma_queue * q = octx->ctx->dma[ith];
@@ -170,12 +170,12 @@ static void concat_generic(unsigned int nth, unsigned int ith, void * data) {
     const uint32_t ne[4] = {dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]};
 
     // Per-device element range aligned to prevent false sharing
-    const uint32_t dev_elem_start = cctx->dev_elem_start;
-    const uint32_t dev_nelems     = cctx->dev_nelems;
-    const uint32_t chunk_size = (dev_nelems + nth - 1) / nth;
+    const uint32_t mdev_elem_start = cctx->mdev_elem_start;
+    const uint32_t mdev_nelems     = cctx->mdev_nelems;
+    const uint32_t chunk_size = (mdev_nelems + nth - 1) / nth;
 
-    const uint32_t start_idx = MIN(dev_elem_start + ith * chunk_size, dev_elem_start + dev_nelems);
-    const uint32_t end_idx   = MIN(start_idx + chunk_size, dev_elem_start + dev_nelems);
+    const uint32_t start_idx = MIN(mdev_elem_start + ith * chunk_size, mdev_elem_start + mdev_nelems);
+    const uint32_t end_idx   = MIN(start_idx + chunk_size, mdev_elem_start + mdev_nelems);
 
     // Naive scalar element-wise copy
     for (uint32_t idx = start_idx; idx < end_idx; idx++) {
@@ -244,30 +244,30 @@ int op_concat(struct htp_ops_context * octx) {
 
     if (dim == 0 && is_2d && is_src1_transposed && !is_src0_transposed) {
         const uint32_t total_rows = dst->ne[1];
-        uint32_t dev_row_start, dev_nrows;
-        if (octx->ndev > 1) {
-            const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
-            dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
-            dev_nrows     = MIN(rows_per_dev, total_rows - dev_row_start);
+        uint32_t mdev_row_start, mdev_nrows;
+        if (octx->mdev_count > 1) {
+            const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+            mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
+            mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
         } else {
-            dev_row_start = 0;
-            dev_nrows     = total_rows;
+            mdev_row_start = 0;
+            mdev_nrows     = total_rows;
         }
 
-        if (dev_nrows == 0) {
+        if (mdev_nrows == 0) {
             return HTP_STATUS_OK;
         }
 
-        cctx.dev_row_start = dev_row_start;
-        cctx.dev_nrows     = dev_nrows;
+        cctx.mdev_row_start = mdev_row_start;
+        cctx.mdev_nrows     = mdev_nrows;
 
-        n_threads = MIN(dev_nrows, n_threads);
+        n_threads = MIN(mdev_nrows, n_threads);
         if (n_threads < 1) {
             n_threads = 1;
         }
         uint32_t block_i = (type_size == 4) ? 32 : 64;
 
-        cctx.nrows_per_thread = hmx_ceil_div(dev_nrows, n_threads);
+        cctx.nrows_per_thread = hmx_ceil_div(mdev_nrows, n_threads);
 
         // Allocate VTCM
         uint32_t spad1_stride = block_i * type_size;
@@ -297,24 +297,24 @@ int op_concat(struct htp_ops_context * octx) {
         }
     } else {
         const uint32_t total_elements = dst->ne[0] * dst->ne[1] * dst->ne[2] * dst->ne[3];
-        uint32_t dev_elem_start, dev_nelems;
-        if (octx->ndev > 1) {
+        uint32_t mdev_elem_start, mdev_nelems;
+        if (octx->mdev_count > 1) {
             const uint32_t elems_per_line = MAX(1u, (uint32_t) HEX_L2_LINE_SIZE / type_size);
-            uint32_t elems_per_dev = (total_elements + octx->ndev - 1) / octx->ndev;
-            elems_per_dev = ((elems_per_dev + elems_per_line - 1) / elems_per_line) * elems_per_line;
-            dev_elem_start = MIN(octx->idev * elems_per_dev, total_elements);
-            dev_nelems     = MIN(elems_per_dev, total_elements - dev_elem_start);
+            uint32_t elems_per_mdev = (total_elements + octx->mdev_count - 1) / octx->mdev_count;
+            elems_per_mdev = ((elems_per_mdev + elems_per_line - 1) / elems_per_line) * elems_per_line;
+            mdev_elem_start = MIN(octx->mdev_idx * elems_per_mdev, total_elements);
+            mdev_nelems     = MIN(elems_per_mdev, total_elements - mdev_elem_start);
         } else {
-            dev_elem_start = 0;
-            dev_nelems     = total_elements;
+            mdev_elem_start = 0;
+            mdev_nelems     = total_elements;
         }
 
-        if (dev_nelems == 0) {
+        if (mdev_nelems == 0) {
             return HTP_STATUS_OK;
         }
 
-        cctx.dev_elem_start = dev_elem_start;
-        cctx.dev_nelems     = dev_nelems;
+        cctx.mdev_elem_start = mdev_elem_start;
+        cctx.mdev_nelems     = mdev_nelems;
     }
 
     worker_pool_run_func(octx->ctx->worker_pool, worker_func, &cctx, n_threads);

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -29,9 +29,23 @@ struct htp_copy_context {
     uint32_t          src0_blocks_per_row;
     uint32_t          dst_blocks_per_row;
 
+    uint32_t          mdev_elem_start;
+    uint32_t          mdev_nelem;
+    uint32_t          elem_per_thread;
+
     uint32_t          src0_nrows_per_thread;
     uint32_t          mdev_row_start;
     uint32_t          mdev_nrows;
+
+    struct fastdiv_values div_ne01;
+    struct fastdiv_values div_ne02_ne01;
+
+    struct fastdiv_values div_ne0;
+    struct fastdiv_values div_ne1_ne0;
+    struct fastdiv_values div_ne2_ne1_ne0;
+    struct fastdiv_values div_ne00;
+    struct fastdiv_values div_ne01_ne00;
+    struct fastdiv_values div_ne02_ne01_ne00;
 };
 
 #define cpy_preamble                              \
@@ -56,131 +70,113 @@ struct htp_copy_context {
     const uint32_t  nb0 = dst->nb[0];             \
     const uint32_t  nb1 = dst->nb[1];             \
     const uint32_t  nb2 = dst->nb[2];             \
-    const uint32_t  nb3 = dst->nb[3];             \
-                                                  \
-    const uint32_t   nr = ne01;
+    const uint32_t  nb3 = dst->nb[3];
 
-#define DEFINE_CPY_SAMESHAPE(NAME, ELEM_TYPE, ELEM_SIZE)                                                       \
-static void cpy_thread_##NAME##_sameshape(unsigned int nth, unsigned int ith, void * data) {                   \
-    struct htp_copy_context * ct = (struct htp_copy_context *) data;                                           \
-    struct htp_ops_context * octx = ct->octx;                                                                  \
-    cpy_preamble;                                                                                              \
-    const uint32_t dr  = ct->src0_nrows_per_thread;                                                            \
-    const uint32_t ir0 = ct->mdev_row_start + dr * ith;                                                        \
-    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);                                   \
-    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;                                                    \
-    for (uint32_t i03 = 0; i03 < ne03; i03++) {                                                                \
-        for (uint32_t i02 = 0; i02 < ne02; i02++) {                                                            \
-            _Pragma("unroll(4)")                                                                               \
-            for (uint32_t i01 = ir0; i01 < ir1; i01++) {                                                       \
-                uint8_t* dst_ptr  = (uint8_t*) dst->data  + i01*nb1  + i02*nb2  + i03*nb3;                     \
-                uint8_t* src0_ptr = (uint8_t*) src0->data + i01*nb01 + i02*nb02 + i03*nb03;                    \
-                hex_l2fetch(src0_ptr, ne00 * ELEM_SIZE, nb01, 2);                                              \
-                hvx_copy_uu(dst_ptr, src0_ptr, ne00, ELEM_SIZE);                                               \
-            }                                                                                                  \
-        }                                                                                                      \
-    }                                                                                                          \
+#define DEFINE_CPY_SAMESHAPE(NAME, ELEM_TYPE, ELEM_SIZE)                                       \
+static void cpy_thread_##NAME##_sameshape(unsigned int nth, unsigned int ith, void * data) {   \
+    struct htp_copy_context * ct = (struct htp_copy_context *) data;                           \
+    struct htp_ops_context * octx = ct->octx;                                                  \
+    cpy_preamble;                                                                              \
+    const uint32_t dr  = ct->src0_nrows_per_thread;                                            \
+    const uint32_t ir0 = ct->mdev_row_start + dr * ith;                                        \
+    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);                   \
+    if (ir0 >= ir1) return;                                                                    \
+    const bool contiguous = (nb01 == ne00 * ELEM_SIZE) && (nb1 == nb01) &&                     \
+                            (nb02 == ne01 * nb01)      && (nb2 == nb02) &&                     \
+                            (nb03 == ne02 * nb02)      && (nb3 == nb03);                       \
+    const uint32_t ne02_ne01 = ne02 * ne01;                                                    \
+    uint32_t i03 = fastdiv(ir0, &ct->div_ne02_ne01);                                           \
+    uint32_t rem = ir0 - i03 * ne02_ne01;                                                      \
+    uint32_t i02 = fastdiv(rem, &ct->div_ne01);                                                \
+    uint32_t i01 = rem - i02 * ne01;                                                           \
+    uint8_t * dst_ptr  = (uint8_t *) dst->data  + i01*nb1  + i02*nb2  + i03*nb3;               \
+    uint8_t * src0_ptr = (uint8_t *) src0->data + i01*nb01 + i02*nb02 + i03*nb03;              \
+    if (contiguous) {                                                                          \
+        hvx_copy_uu(dst_ptr, src0_ptr, (ir1 - ir0) * ne00, ELEM_SIZE);                         \
+        return;                                                                                \
+    }                                                                                          \
+    for (uint32_t r = ir0; r < ir1; r++) {                                                     \
+        hex_l2fetch(src0_ptr, ne00 * ELEM_SIZE, nb01, 2);                                      \
+        hvx_copy_uu(dst_ptr, src0_ptr, ne00, ELEM_SIZE);                                       \
+        dst_ptr  += nb1;                                                                       \
+        src0_ptr += nb01;                                                                      \
+        if (++i01 == ne01) {                                                                   \
+            i01 = 0;                                                                           \
+            if (++i02 == ne02) {                                                               \
+                i02 = 0;                                                                       \
+                i03++;                                                                         \
+            }                                                                                  \
+            dst_ptr  = (uint8_t *) dst->data  + i02*nb2  + i03*nb3;                            \
+            src0_ptr = (uint8_t *) src0->data + i02*nb02 + i03*nb03;                           \
+        }                                                                                      \
+    }                                                                                          \
 }
 
 DEFINE_CPY_SAMESHAPE(f32,  float, 4)
 DEFINE_CPY_SAMESHAPE(f16, __fp16, 2)
 
-#define DEFINE_CPY_RESHAPE(NAME, ELEM_TYPE, ELEM_SIZE)                                                         \
-static void cpy_thread_##NAME##_reshape(unsigned int nth, unsigned int ith, void * data) {                     \
-    struct htp_copy_context * ct = (struct htp_copy_context *) data;                                           \
-    struct htp_ops_context * octx = ct->octx;                                                                  \
-    cpy_preamble;                                                                                              \
-    const uint32_t dr  = ct->src0_nrows_per_thread;                                                            \
-    const uint32_t ir0 = ct->mdev_row_start + dr * ith;                                                        \
-    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);                                   \
-    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;                                                    \
-    const bool src0_contig = (nb00 == ELEM_SIZE)   &&                                                          \
-                             (nb01 == ne00 * nb00) &&                                                          \
-                             (nb02 == ne01 * nb01) &&                                                          \
-                             (nb03 == ne02 * nb02);                                                            \
-    const bool dst_contig  = (nb0  == ELEM_SIZE)   &&                                                          \
-                             (nb1  == ne0  * nb0)  &&                                                          \
-                             (nb2  == ne1  * nb1)  &&                                                          \
-                             (nb3  == ne2  * nb2);                                                             \
-    if (src0_contig && dst_contig) {                                                                           \
-        for (int64_t i03 = 0; i03 < ne03; i03++) {                                                             \
-            for (int64_t i02 = 0; i02 < ne02; i02++) {                                                         \
-                uint8_t * src_ptr = (uint8_t *) src0->data + i03*nb03 + i02*nb02 + ir0*nb01;                   \
-                uint32_t  flat    = ((i03*ne02 + i02)*ne01 + ir0) * ne00;                                      \
-                uint8_t * dst_ptr = (uint8_t *) dst->data  + flat * ELEM_SIZE;                                 \
-                hvx_copy_uu(dst_ptr, src_ptr, (ir1 - ir0) * ne00, ELEM_SIZE);                                  \
-            }                                                                                                  \
-        }                                                                                                      \
-        return;                                                                                                \
-    }                                                                                                          \
-    const bool reshape_flat_fast = (ne03 == 1 && ne2 == 1 && ne3 == 1) &&                                      \
-                                   (ne0 == ne00 * ne01) && (ne1 == ne02) &&                                    \
-                                   (nb00 == ELEM_SIZE) && (nb0 == ELEM_SIZE);                                  \
-    if (reshape_flat_fast) {                                                                                   \
-        for (uint32_t i02 = 0; i02 < ne02; i02++) {                                                            \
-            for (uint32_t i01 = ir0; i01 < ir1; i01++) {                                                       \
-                uint8_t * src0_ptr = (uint8_t *) src0->data + i01 * nb01 + i02 * nb02;                         \
-                uint8_t * dst_ptr  = (uint8_t *) dst->data  + i01 * ne00 * ELEM_SIZE + i02 * nb1;              \
-                hvx_copy_uu(dst_ptr, src0_ptr, ne00, ELEM_SIZE);                                               \
-            }                                                                                                  \
-        }                                                                                                      \
-        return;                                                                                                \
-    }                                                                                                          \
-    int64_t k10 = 0;                                                                                           \
-    int64_t i11 = 0;                                                                                           \
-    int64_t i12 = 0;                                                                                           \
-    int64_t i13 = 0;                                                                                           \
-    const int64_t nk00 = ct->src0_blocks_per_row;                                                              \
-    const int64_t nk0  = ct->dst_blocks_per_row;                                                               \
-    for (int64_t i03 = 0; i03 < ne03; i03++) {                                                                 \
-        for (int64_t i02 = 0; i02 < ne02; i02++) {                                                             \
-            k10 += nk00 * ir0;                                                                                 \
-            while (k10 >= nk0) {                                                                               \
-                k10 -= nk0;                                                                                    \
-                if (++i11 == ne1) {                                                                            \
-                    i11 = 0;                                                                                   \
-                    if (++i12 == ne2) {                                                                        \
-                        i12 = 0;                                                                               \
-                        if (++i13 == ne3) {                                                                    \
-                            i13 = 0;                                                                           \
-                        }                                                                                      \
-                    }                                                                                          \
-                }                                                                                              \
-            }                                                                                                  \
-            for (int64_t i01 = ir0; i01 < ir1; i01++) {                                                        \
-                for (int64_t k00 = 0; k00 < nk00; k00++) {                                                     \
-                    const char * src0_ptr = ((char *) src0->data + k00*nb00 + i01*nb01 + i02*nb02 + i03*nb03); \
-                          char * dst_ptr  = ((char *)  dst->data + k10*nb0  + i11*nb1  + i12*nb2  + i13*nb3);  \
-                    memcpy(dst_ptr, src0_ptr, ELEM_SIZE);                                                      \
-                    if (++k10 == nk0) {                                                                        \
-                        k10 = 0;                                                                               \
-                        if (++i11 == ne1) {                                                                    \
-                            i11 = 0;                                                                           \
-                            if (++i12 == ne2) {                                                                \
-                                i12 = 0;                                                                       \
-                                if (++i13 == ne3) {                                                            \
-                                    i13 = 0;                                                                   \
-                                }                                                                              \
-                            }                                                                                  \
-                        }                                                                                      \
-                    }                                                                                          \
-                }                                                                                              \
-            }                                                                                                  \
-            k10 += nk00 * (ne01 - ir1);                                                                        \
-            while (k10 >= nk0) {                                                                               \
-                k10 -= nk0;                                                                                    \
-                if (++i11 == ne1) {                                                                            \
-                    i11 = 0;                                                                                   \
-                    if (++i12 == ne2) {                                                                        \
-                        i12 = 0;                                                                               \
-                        if (++i13 == ne3) {                                                                    \
-                            i13 = 0;                                                                           \
-                        }                                                                                      \
-                    }                                                                                          \
-                }                                                                                              \
-            }                                                                                                  \
-        }                                                                                                      \
-    }                                                                                                          \
+#define DEFINE_CPY_RESHAPE(NAME, ELEM_TYPE, ELEM_SIZE)                                               \
+static void cpy_thread_##NAME##_reshape(unsigned int nth, unsigned int ith, void * data) {           \
+    struct htp_copy_context * ct = (struct htp_copy_context *) data;                                 \
+    struct htp_ops_context * octx = ct->octx;                                                        \
+    cpy_preamble;                                                                                    \
+    const uint32_t th_nelem = ct->elem_per_thread;                                                   \
+    const uint32_t th_start = ct->mdev_elem_start + ith * th_nelem;                                  \
+    const uint32_t th_end   = MIN(th_start + th_nelem, ct->mdev_elem_start + ct->mdev_nelem);        \
+    if (th_start >= th_end) return;                                                                  \
+                                                                                                     \
+    const uint32_t ne01_ne00      = ne01 * ne00;                                                     \
+    const uint32_t ne02_ne01_ne00 = ne02 * ne01_ne00;                                                \
+    const uint32_t ne1_ne0        = ne1 * ne0;                                                       \
+    const uint32_t ne2_ne1_ne0    = ne2 * ne1_ne0;                                                   \
+                                                                                                     \
+    uint32_t e = th_start;                                                                           \
+    uint32_t i13 = fastdiv(e, &ct->div_ne2_ne1_ne0);                                                 \
+    uint32_t rem = e - i13 * ne2_ne1_ne0;                                                            \
+    uint32_t i12 = fastdiv(rem, &ct->div_ne1_ne0);                                                   \
+    uint32_t rem2 = rem - i12 * ne1_ne0;                                                             \
+    uint32_t i11 = fastdiv(rem2, &ct->div_ne0);                                                      \
+    uint32_t i10 = rem2 - i11 * ne0;                                                                 \
+                                                                                                     \
+    uint32_t i03 = fastdiv(e, &ct->div_ne02_ne01_ne00);                                              \
+    uint32_t rem_s = e - i03 * ne02_ne01_ne00;                                                       \
+    uint32_t i02 = fastdiv(rem_s, &ct->div_ne01_ne00);                                               \
+    uint32_t rem2_s = rem_s - i02 * ne01_ne00;                                                       \
+    uint32_t i01 = fastdiv(rem2_s, &ct->div_ne00);                                                   \
+    uint32_t i00 = rem2_s - i01 * ne00;                                                              \
+                                                                                                     \
+    char * dst_ptr        = (char *)       dst->data  + i10*nb0  + i11*nb1  + i12*nb2  + i13*nb3;    \
+    const char * src0_ptr = (const char *) src0->data + i00*nb00 + i01*nb01 + i02*nb02 + i03*nb03;   \
+                                                                                                     \
+    for (; e < th_end; e++) {                                                                        \
+        *((ELEM_TYPE *) dst_ptr) = *((const ELEM_TYPE *) src0_ptr);                                  \
+                                                                                                     \
+        dst_ptr += nb0;                                                                              \
+        if (++i10 == ne0) {                                                                          \
+            i10 = 0;                                                                                 \
+            if (++i11 == ne1) {                                                                      \
+                i11 = 0;                                                                             \
+                if (++i12 == ne2) {                                                                  \
+                    i12 = 0;                                                                         \
+                    i13++;                                                                           \
+                }                                                                                    \
+            }                                                                                        \
+            dst_ptr = (char *) dst->data + i11*nb1 + i12*nb2 + i13*nb3;                              \
+        }                                                                                            \
+                                                                                                     \
+        src0_ptr += nb00;                                                                            \
+        if (++i00 == ne00) {                                                                         \
+            i00 = 0;                                                                                 \
+            if (++i01 == ne01) {                                                                     \
+                i01 = 0;                                                                             \
+                if (++i02 == ne02) {                                                                 \
+                    i02 = 0;                                                                         \
+                    i03++;                                                                           \
+                }                                                                                    \
+            }                                                                                        \
+            src0_ptr = (const char *) src0->data + i01*nb01 + i02*nb02 + i03*nb03;                   \
+        }                                                                                            \
+    }                                                                                                \
 }
 
 DEFINE_CPY_RESHAPE(f32,  float, 4)
@@ -191,22 +187,33 @@ static void cpy_thread_f16_f32_sameshape(unsigned int nth, unsigned int ith, voi
     struct htp_ops_context * octx = ct->octx;
     cpy_preamble;
 
-    // parallelize by src0 rows
     const uint32_t dr  = ct->src0_nrows_per_thread;
     const uint32_t ir0 = ct->mdev_row_start + dr * ith;
     const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);
-    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;
+    if (ir0 >= ir1) return;
 
-    // copy by rows
-    for (uint32_t i03 = 0; i03 < ne03; i03++) {
-        for (uint32_t i02 = 0; i02 < ne02; i02++) {
-            #pragma unroll(2)
-            for (uint32_t i01 = ir0; i01 < ir1; i01++) {
-                uint8_t* dst_ptr  = (uint8_t*) dst->data  + i01*nb1  + i02*nb2  + i03*nb3;
-                uint8_t* src0_ptr = (uint8_t*) src0->data + i01*nb01 + i02*nb02 + i03*nb03;
-                hex_l2fetch(src0_ptr, ne00 * sizeof(float), nb01, 2);
-                hvx_copy_f16_f32_uu(dst_ptr, src0_ptr, ne00);
+    const uint32_t ne02_ne01 = ne02 * ne01;
+    uint32_t i03 = fastdiv(ir0, &ct->div_ne02_ne01);
+    uint32_t rem = ir0 - i03 * ne02_ne01;
+    uint32_t i02 = fastdiv(rem, &ct->div_ne01);
+    uint32_t i01 = rem - i02 * ne01;
+
+    uint8_t* dst_ptr  = (uint8_t*) dst->data  + i01*nb1  + i02*nb2  + i03*nb3;
+    uint8_t* src0_ptr = (uint8_t*) src0->data + i01*nb01 + i02*nb02 + i03*nb03;
+
+    for (uint32_t r = ir0; r < ir1; r++) {
+        hex_l2fetch(src0_ptr, ne00 * sizeof(float), nb01, 2);
+        hvx_copy_f16_f32_uu(dst_ptr, src0_ptr, ne00);
+        dst_ptr  += nb1;
+        src0_ptr += nb01;
+        if (++i01 == ne01) {
+            i01 = 0;
+            if (++i02 == ne02) {
+                i02 = 0;
+                i03++;
             }
+            dst_ptr  = (uint8_t*) dst->data  + i02*nb2  + i03*nb3;
+            src0_ptr = (uint8_t*) src0->data + i02*nb02 + i03*nb03;
         }
     }
 }
@@ -216,22 +223,33 @@ static void cpy_thread_f32_f16_sameshape(unsigned int nth, unsigned int ith, voi
     struct htp_ops_context * octx = ct->octx;
     cpy_preamble;
 
-    // parallelize by src0 rows
     const uint32_t dr  = ct->src0_nrows_per_thread;
     const uint32_t ir0 = ct->mdev_row_start + dr * ith;
     const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);
-    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;
+    if (ir0 >= ir1) return;
 
-    // copy by rows
-    for (uint32_t i03 = 0; i03 < ne03; i03++) {
-        for (uint32_t i02 = 0; i02 < ne02; i02++) {
-            #pragma unroll(2)
-            for (uint32_t i01 = ir0; i01 < ir1; i01++) {
-                uint8_t* dst_ptr  = (uint8_t*) dst->data  + i01*nb1  + i02*nb2  + i03*nb3;
-                uint8_t* src0_ptr = (uint8_t*) src0->data + i01*nb01 + i02*nb02 + i03*nb03;
-                hex_l2fetch(src0_ptr, ne00 * sizeof(__fp16), nb01, 2);
-                hvx_copy_f32_f16_uu(dst_ptr, src0_ptr, ne00);
+    const uint32_t ne02_ne01 = ne02 * ne01;
+    uint32_t i03 = fastdiv(ir0, &ct->div_ne02_ne01);
+    uint32_t rem = ir0 - i03 * ne02_ne01;
+    uint32_t i02 = fastdiv(rem, &ct->div_ne01);
+    uint32_t i01 = rem - i02 * ne01;
+
+    uint8_t* dst_ptr  = (uint8_t*) dst->data  + i01*nb1  + i02*nb2  + i03*nb3;
+    uint8_t* src0_ptr = (uint8_t*) src0->data + i01*nb01 + i02*nb02 + i03*nb03;
+
+    for (uint32_t r = ir0; r < ir1; r++) {
+        hex_l2fetch(src0_ptr, ne00 * sizeof(__fp16), nb01, 2);
+        hvx_copy_f32_f16_uu(dst_ptr, src0_ptr, ne00);
+        dst_ptr  += nb1;
+        src0_ptr += nb01;
+        if (++i01 == ne01) {
+            i01 = 0;
+            if (++i02 == ne02) {
+                i02 = 0;
+                i03++;
             }
+            dst_ptr  = (uint8_t*) dst->data  + i02*nb2  + i03*nb3;
+            src0_ptr = (uint8_t*) src0->data + i02*nb02 + i03*nb03;
         }
     }
 }
@@ -252,15 +270,19 @@ static inline void cpy_dma_sametype_sameshape(
     dma_queue * q = octx->ctx->dma[0];
 
     if (contiguous_outer) {
-        dma_queue_push(q, dma_make_ptr((void *) dst->data, (const void *) src0->data), nb1, nb01, ne00 * elem_size, ne01 * ne02 * ne03);
-        dma_queue_pop(q);
+        if (!dma_queue_push(q, dma_make_ptr((void *) dst->data, (const void *) src0->data), nb1, nb01, ne00 * elem_size, ne01 * ne02 * ne03)) {
+            dma_queue_flush(q);
+            dma_queue_push(q, dma_make_ptr((void *) dst->data, (const void *) src0->data), nb1, nb01, ne00 * elem_size, ne01 * ne02 * ne03);
+        }
+        dma_queue_flush(q);
         return;
     }
 
     for (uint32_t i03 = 0; i03 < ne03; i03++) {
         for (uint32_t i02 = 0; i02 < ne02; i02++) {
-            uint8_t* dst_ptr  = (uint8_t*) dst->data  + i02*nb2  + i03*nb3;
-            uint8_t* src0_ptr = (uint8_t*) src0->data + i02*nb02 + i03*nb03;
+            uint8_t * dst_ptr  = (uint8_t *) dst->data  + i02 * nb2  + i03 * nb3;
+            uint8_t * src0_ptr = (uint8_t *) src0->data + i02 * nb02 + i03 * nb03;
+
             if (!dma_queue_push(q, dma_make_ptr(dst_ptr, src0_ptr), nb1, nb01, ne00 * elem_size, ne01)) {
                 dma_queue_flush(q);
                 dma_queue_push(q, dma_make_ptr(dst_ptr, src0_ptr), nb1, nb01, ne00 * elem_size, ne01);
@@ -273,22 +295,6 @@ static inline void cpy_dma_sametype_sameshape(
 
 int op_cpy(struct htp_ops_context * octx) {
     cpy_preamble;
-
-    uint32_t mdev_row_start, mdev_nrows;
-    if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(nr + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, nr);
-        mdev_nrows     = MIN(rows_per_mdev, nr - mdev_row_start);
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = nr;
-    }
-
-    if (mdev_nrows == 0) {
-        return HTP_STATUS_OK;
-    }
-
-    const uint32_t n_threads = octx->n_threads;
 
     struct htp_copy_context ct;
     ct.octx = octx;
@@ -317,47 +323,106 @@ int op_cpy(struct htp_ops_context * octx) {
                             (nb01 < ne00 * ct.src0_type_size) || (nb1 < ne0 * ct.dst_type_size);
     const bool sameshape  = !transposed && (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
 
-    ct.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
-    ct.mdev_row_start = mdev_row_start;
-    ct.mdev_nrows     = mdev_nrows;
-
-    worker_callback_t copy_fun = NULL;
+    const uint32_t n_threads = octx->n_threads;
     bool use_dma = false;
 
-    if (sametype && sameshape && octx->mdev_count <= 1) {
-        use_dma = true;
-    } else if (sameshape) {
-        if (sametype) {
-            if (src0->type == HTP_TYPE_F32) {
-                copy_fun = cpy_thread_f32_sameshape;
+    if (sameshape) {
+        const uint32_t total_rows = ne01 * ne02 * ne03;
+        const uint32_t row_size   = ne00 * ct.dst_type_size;
+
+        ct.div_ne01      = init_fastdiv_values(ne01);
+        ct.div_ne02_ne01 = init_fastdiv_values(ne02 * ne01);
+
+        uint32_t mdev_row_start, mdev_nrows;
+        if (octx->mdev_count > 1) {
+            const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
+            struct fastdiv_values div_chunk = init_fastdiv_values(rows_per_chunk);
+            const uint32_t total_chunks   = fastdiv(total_rows, &div_chunk);
+            if (total_chunks < octx->mdev_count) {
+                mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+                mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
             } else {
-                copy_fun = cpy_thread_f16_sameshape;
+                uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_nrows = total_rows - mdev_row_start;
+                } else {
+                    mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+                }
             }
-        } else if (dst->type == HTP_TYPE_F16 && src0->type == HTP_TYPE_F32) {
-            copy_fun = cpy_thread_f16_f32_sameshape;
-        } else if (dst->type == HTP_TYPE_F32 && src0->type == HTP_TYPE_F16) {
-            copy_fun = cpy_thread_f32_f16_sameshape;
         } else {
-            return HTP_STATUS_NO_SUPPORT;
+            mdev_row_start = 0;
+            mdev_nrows     = total_rows;
+        }
+
+        if (mdev_nrows == 0) {
+            return HTP_STATUS_OK;
+        }
+
+        ct.mdev_row_start = mdev_row_start;
+        ct.mdev_nrows     = mdev_nrows;
+        ct.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+
+        if (sametype && octx->mdev_count <= 1) {
+            use_dma = true;
+            cpy_dma_sametype_sameshape(octx, dst, src0, ct.src0_type_size, ne00, ne01, ne02, ne03, nb01, nb02, nb03, nb1, nb2, nb3);
+        } else {
+            work_queue_func_t copy_fun = NULL;
+            if (sametype) {
+                copy_fun = (src0->type == HTP_TYPE_F32) ? cpy_thread_f32_sameshape : cpy_thread_f16_sameshape;
+            } else if (dst->type == HTP_TYPE_F16 && src0->type == HTP_TYPE_F32) {
+                copy_fun = cpy_thread_f16_f32_sameshape;
+            } else if (dst->type == HTP_TYPE_F32 && src0->type == HTP_TYPE_F16) {
+                copy_fun = cpy_thread_f32_f16_sameshape;
+            } else {
+                return HTP_STATUS_NO_SUPPORT;
+            }
+            work_queue_run(octx->ctx->work_queue, copy_fun, &ct, n_threads);
         }
     } else if (sametype) {
-        if (src0->type == HTP_TYPE_F32) {
-            copy_fun = cpy_thread_f32_reshape;
+        const uint32_t total_elems = ne0 * ne1 * ne2 * ne3;
+        const uint32_t total_bytes = total_elems * ct.dst_type_size;
+        const uint32_t n_lines     = total_bytes >> 7;
+        const uint32_t elems_per_line = (ct.dst_type_size == 4) ? 32 : 64;
+
+        ct.div_ne0            = init_fastdiv_values(ne0);
+        ct.div_ne1_ne0        = init_fastdiv_values(ne1 * ne0);
+        ct.div_ne2_ne1_ne0    = init_fastdiv_values(ne2 * ne1 * ne0);
+        ct.div_ne00           = init_fastdiv_values(ne00);
+        ct.div_ne01_ne00      = init_fastdiv_values(ne01 * ne00);
+        ct.div_ne02_ne01_ne00 = init_fastdiv_values(ne02 * ne01 * ne00);
+
+        uint32_t mdev_elem_start, mdev_nelem;
+        if (octx->mdev_count > 1) {
+            if (n_lines < octx->mdev_count) {
+                mdev_elem_start = (octx->mdev_idx == 0) ? 0 : total_elems;
+                mdev_nelem      = (octx->mdev_idx == 0) ? total_elems : 0;
+            } else {
+                uint32_t lines_per_mdev = fastdiv(n_lines + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_elem_start = MIN(octx->mdev_idx * lines_per_mdev * elems_per_line, total_elems);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_nelem = total_elems - mdev_elem_start;
+                } else {
+                    mdev_nelem = MIN(lines_per_mdev * elems_per_line, total_elems - mdev_elem_start);
+                }
+            }
         } else {
-            copy_fun = cpy_thread_f16_reshape;
+            mdev_elem_start = 0;
+            mdev_nelem      = total_elems;
         }
+
+        if (mdev_nelem == 0) {
+            return HTP_STATUS_OK;
+        }
+
+        ct.mdev_elem_start = mdev_elem_start;
+        ct.mdev_nelem      = mdev_nelem;
+        ct.elem_per_thread = fastdiv(mdev_nelem + n_threads - 1, &octx->n_threads_div);
+
+        work_queue_func_t copy_fun = (src0->type == HTP_TYPE_F32) ? cpy_thread_f32_reshape : cpy_thread_f16_reshape;
+        work_queue_run(octx->ctx->work_queue, copy_fun, &ct, n_threads);
     } else {
         return HTP_STATUS_NO_SUPPORT;
-    }
-
-    FARF(HIGH, "cpy-%s-%s: (%ux%ux%ux%u) -> (%ux%ux%ux%u) : use_dma=%d n_threads %u\n",
-         src0->type == HTP_TYPE_F32 ? "f32" : "f16", dst->type == HTP_TYPE_F32 ? "f32" : "f16",
-         ne00, ne01, ne02, ne03, ne0, ne1, ne2, ne3, use_dma, n_threads);
-
-    if (use_dma) {
-        cpy_dma_sametype_sameshape(octx, dst, src0, ct.src0_type_size, ne00, ne01, ne02, ne03, nb01, nb02, nb03, nb1, nb2, nb3);
-    } else {
-        worker_pool_run_func(octx->ctx->worker_pool, copy_fun, &ct, n_threads);
     }
 
     const struct htp_tensor *sync = octx->src[1];

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -326,6 +326,8 @@ int op_cpy(struct htp_ops_context * octx) {
     const uint32_t n_threads = octx->n_threads;
     bool use_dma = false;
 
+    const bool dst_is_contiguous = htp_tensor_is_contiguous(dst, ct.dst_type_size);
+
     if (sameshape) {
         const uint32_t total_rows = ne01 * ne02 * ne03;
         const uint32_t row_size   = ne00 * ct.dst_type_size;
@@ -337,7 +339,7 @@ int op_cpy(struct htp_ops_context * octx) {
         if (octx->mdev_count > 1) {
             const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
             struct fastdiv_values div_chunk = init_fastdiv_values(rows_per_chunk);
-            const uint32_t total_chunks   = fastdiv(total_rows, &div_chunk);
+            const uint32_t total_chunks   = dst_is_contiguous ? fastdiv(total_rows, &div_chunk) : 0;
             if (total_chunks < octx->mdev_count) {
                 mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
                 mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
@@ -394,11 +396,12 @@ int op_cpy(struct htp_ops_context * octx) {
 
         uint32_t mdev_elem_start, mdev_nelem;
         if (octx->mdev_count > 1) {
-            if (n_lines < octx->mdev_count) {
+            const uint32_t aligned_lines = dst_is_contiguous ? n_lines : 0;
+            if (aligned_lines < octx->mdev_count) {
                 mdev_elem_start = (octx->mdev_idx == 0) ? 0 : total_elems;
                 mdev_nelem      = (octx->mdev_idx == 0) ? total_elems : 0;
             } else {
-                uint32_t lines_per_mdev = fastdiv(n_lines + octx->mdev_count - 1, &octx->mdev_count_div);
+                uint32_t lines_per_mdev = fastdiv(aligned_lines + octx->mdev_count - 1, &octx->mdev_count_div);
                 mdev_elem_start = MIN(octx->mdev_idx * lines_per_mdev * elems_per_line, total_elems);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
                     mdev_nelem = total_elems - mdev_elem_start;

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -79,7 +79,7 @@ static void cpy_thread_##NAME##_sameshape(unsigned int nth, unsigned int ith, vo
     cpy_preamble;                                                                              \
     const uint32_t dr  = ct->src0_nrows_per_thread;                                            \
     const uint32_t ir0 = ct->row_start + dr * ith;                                             \
-    const uint32_t ir1 = MIN(ir0 + dr, ct->row_start + ct->nrows);                            \
+    const uint32_t ir1 = MIN(ir0 + dr, ct->row_start + ct->nrows);                             \
     if (ir0 >= ir1) return;                                                                    \
     const bool contiguous = (nb01 == ne00 * ELEM_SIZE) && (nb1 == nb01) &&                     \
                             (nb02 == ne01 * nb01)      && (nb2 == nb02) &&                     \
@@ -121,8 +121,8 @@ static void cpy_thread_##NAME##_reshape(unsigned int nth, unsigned int ith, void
     struct htp_ops_context * octx = ct->octx;                                                        \
     cpy_preamble;                                                                                    \
     const uint32_t th_nelem = ct->elem_per_thread;                                                   \
-    const uint32_t th_start = ct->elem_start + ith * th_nelem;                                        \
-    const uint32_t th_end   = MIN(th_start + th_nelem, ct->elem_start + ct->nelem);                   \
+    const uint32_t th_start = ct->elem_start + ith * th_nelem;                                       \
+    const uint32_t th_end   = MIN(th_start + th_nelem, ct->elem_start + ct->nelem);                  \
     if (th_start >= th_end) return;                                                                  \
                                                                                                      \
     const uint32_t ne01_ne00      = ne01 * ne00;                                                     \

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -424,7 +424,6 @@ int op_cpy(struct htp_ops_context * octx) {
 
         if (octx->ctx->mdev.idx == 0) {
             const struct htp_tensor * sync = octx->src[1];
-            assert(sync && (sync->flags & HTP_TENSOR_FENCE));
             const uint32_t seq = (uint32_t) octx->op_params[0];
             atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
             htp_fence_write(sync_fence, seq, octx->status);

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -16,6 +16,7 @@
 #include "htp-ops.h"
 #include "hvx-utils.h"
 #include "htp-tensor.h"
+#include "htp-fence.h"
 
 struct htp_copy_context {
     struct htp_ops_context * octx;
@@ -433,12 +434,9 @@ int op_cpy(struct htp_ops_context * octx) {
             qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
         }
 
-        atomic_uint * sync_fence = (atomic_uint *) sync->data;
         const uint32_t seq = (uint32_t) octx->op_params[0];
-
-        atomic_store(&sync_fence[0], seq);
-        asm volatile ("syncht" : : : "memory");
-        Q6_dccleaninva_A((void *) sync_fence);
+        atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
+        htp_fence_write(sync_fence, seq, HTP_STATUS_OK);
 
         FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u\n", sync_fence, seq);
     }

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -341,19 +341,10 @@ static int exec_cpy(struct htp_ops_context * octx, bool * use_dma) {
 
         if (octx->ctx->mdev.count > 1) {
             const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
-            const uint32_t total_chunks   = dst_is_contiguous ? (total_rows / rows_per_chunk) : 0;
-            if (total_chunks < octx->ctx->mdev.count) {
-                row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
-                nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
-            } else {
-                uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    nrows = total_rows - row_start;
-                } else {
-                    nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
-                }
-            }
+            const bool can_split = htp_tensor_mdev_data_aligned(dst) && dst_is_contiguous;
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, can_split ? rows_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            row_start = range.start;
+            nrows     = range.count;
         }
 
         if (nrows == 0) {
@@ -382,8 +373,6 @@ static int exec_cpy(struct htp_ops_context * octx, bool * use_dma) {
         }
     } else if (sametype) {
         const uint32_t total_elems = ne0 * ne1 * ne2 * ne3;
-        const uint32_t total_bytes = total_elems * ct.dst_type_size;
-        const uint32_t n_lines     = total_bytes >> 7;
         const uint32_t elems_per_line = (ct.dst_type_size == 4) ? 32 : 64;
 
         ct.div_ne0            = init_fastdiv_values(ne0);
@@ -397,19 +386,10 @@ static int exec_cpy(struct htp_ops_context * octx, bool * use_dma) {
         uint32_t nelem      = total_elems;
 
         if (octx->ctx->mdev.count > 1) {
-            const uint32_t aligned_lines = dst_is_contiguous ? n_lines : 0;
-            if (aligned_lines < octx->ctx->mdev.count) {
-                elem_start = (octx->ctx->mdev.idx == 0) ? 0 : total_elems;
-                nelem      = (octx->ctx->mdev.idx == 0) ? total_elems : 0;
-            } else {
-                uint32_t lines_per_mdev = fastdiv(aligned_lines + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                elem_start = MIN(octx->ctx->mdev.idx * lines_per_mdev * elems_per_line, total_elems);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    nelem = total_elems - elem_start;
-                } else {
-                    nelem = MIN(lines_per_mdev * elems_per_line, total_elems - elem_start);
-                }
-            }
+            const bool can_split = htp_tensor_mdev_data_aligned(dst) && dst_is_contiguous;
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_elems, can_split ? elems_per_line : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            elem_start = range.start;
+            nelem      = range.count;
         }
 
         if (nelem == 0) {

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -30,8 +30,8 @@ struct htp_copy_context {
     uint32_t          dst_blocks_per_row;
 
     uint32_t          src0_nrows_per_thread;
-    uint32_t          dev_row_start;
-    uint32_t          dev_nrows;
+    uint32_t          mdev_row_start;
+    uint32_t          mdev_nrows;
 };
 
 #define cpy_preamble                              \
@@ -66,9 +66,9 @@ static void cpy_thread_##NAME##_sameshape(unsigned int nth, unsigned int ith, vo
     struct htp_ops_context * octx = ct->octx;                                                                  \
     cpy_preamble;                                                                                              \
     const uint32_t dr  = ct->src0_nrows_per_thread;                                                            \
-    const uint32_t ir0 = ct->dev_row_start + dr * ith;                                                        \
-    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);                                   \
-    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;                                                     \
+    const uint32_t ir0 = ct->mdev_row_start + dr * ith;                                                        \
+    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);                                   \
+    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;                                                    \
     for (uint32_t i03 = 0; i03 < ne03; i03++) {                                                                \
         for (uint32_t i02 = 0; i02 < ne02; i02++) {                                                            \
             _Pragma("unroll(4)")                                                                               \
@@ -91,9 +91,9 @@ static void cpy_thread_##NAME##_reshape(unsigned int nth, unsigned int ith, void
     struct htp_ops_context * octx = ct->octx;                                                                  \
     cpy_preamble;                                                                                              \
     const uint32_t dr  = ct->src0_nrows_per_thread;                                                            \
-    const uint32_t ir0 = ct->dev_row_start + dr * ith;                                                        \
-    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);                                   \
-    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;                                                                                     \
+    const uint32_t ir0 = ct->mdev_row_start + dr * ith;                                                        \
+    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);                                   \
+    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;                                                    \
     const bool src0_contig = (nb00 == ELEM_SIZE)   &&                                                          \
                              (nb01 == ne00 * nb00) &&                                                          \
                              (nb02 == ne01 * nb01) &&                                                          \
@@ -193,9 +193,9 @@ static void cpy_thread_f16_f32_sameshape(unsigned int nth, unsigned int ith, voi
 
     // parallelize by src0 rows
     const uint32_t dr  = ct->src0_nrows_per_thread;
-    const uint32_t ir0 = ct->dev_row_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);
-    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;
+    const uint32_t ir0 = ct->mdev_row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);
+    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;
 
     // copy by rows
     for (uint32_t i03 = 0; i03 < ne03; i03++) {
@@ -218,9 +218,9 @@ static void cpy_thread_f32_f16_sameshape(unsigned int nth, unsigned int ith, voi
 
     // parallelize by src0 rows
     const uint32_t dr  = ct->src0_nrows_per_thread;
-    const uint32_t ir0 = ct->dev_row_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);
-    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;
+    const uint32_t ir0 = ct->mdev_row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);
+    if (ir0 >= ct->mdev_row_start + ct->mdev_nrows) return;
 
     // copy by rows
     for (uint32_t i03 = 0; i03 < ne03; i03++) {
@@ -274,21 +274,21 @@ static inline void cpy_dma_sametype_sameshape(
 int op_cpy(struct htp_ops_context * octx) {
     cpy_preamble;
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (nr + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, nr);
-        dev_nrows     = MIN(rows_per_dev, nr - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (nr + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, nr);
+        mdev_nrows     = MIN(rows_per_mdev, nr - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = nr;
+        mdev_row_start = 0;
+        mdev_nrows     = nr;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(dev_nrows, octx->n_threads);
+    const uint32_t n_threads = MIN(mdev_nrows, octx->n_threads);
 
     struct htp_copy_context ct;
     ct.octx = octx;
@@ -315,14 +315,14 @@ int op_cpy(struct htp_ops_context * octx) {
     const bool transposed = (nb00 > nb01) || (nb0 > nb1);
     const bool sameshape  = !transposed && (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
 
-    ct.src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
-    ct.dev_row_start = dev_row_start;
-    ct.dev_nrows     = dev_nrows;
+    ct.src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    ct.mdev_row_start = mdev_row_start;
+    ct.mdev_nrows     = mdev_nrows;
 
     worker_callback_t copy_fun = NULL;
     bool use_dma = false;
 
-    if (sametype && sameshape && octx->ndev <= 1) {
+    if (sametype && sameshape && octx->mdev_count <= 1) {
         use_dma = true;
     } else if (sameshape) {
         if (sametype) {

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -276,7 +276,7 @@ int op_cpy(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (nr + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(nr + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, nr);
         mdev_nrows     = MIN(rows_per_mdev, nr - mdev_row_start);
     } else {
@@ -288,7 +288,7 @@ int op_cpy(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(mdev_nrows, octx->n_threads);
+    const uint32_t n_threads = octx->n_threads;
 
     struct htp_copy_context ct;
     ct.octx = octx;
@@ -315,7 +315,7 @@ int op_cpy(struct htp_ops_context * octx) {
     const bool transposed = (nb00 > nb01) || (nb0 > nb1);
     const bool sameshape  = !transposed && (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
 
-    ct.src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    ct.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
     ct.mdev_row_start = mdev_row_start;
     ct.mdev_nrows     = mdev_nrows;
 

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -416,14 +416,11 @@ int op_cpy(struct htp_ops_context * octx) {
     htp_ops_context_set_status(octx, status);
 
     if (octx->op == HTP_OP_CPY_FENCE) {
-        if (status == HTP_STATUS_OK && !use_dma) {
-            // htp_tensor_flush_all(octx->ctx, octx->dsts, 1);
-            qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
+        if (!use_dma) {
+            htp_flush_dirty_ranges(octx->ctx);
         }
 
-        if (octx->ctx->mdev.count > 1) {
-            htp_mdev_group_barrier(octx);
-        }
+        htp_mdev_group_barrier(octx);
 
         if (octx->ctx->mdev.idx == 0) {
             const struct htp_tensor * sync = octx->src[1];

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -432,7 +432,7 @@ int op_cpy(struct htp_ops_context * octx) {
             atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
             htp_fence_write(sync_fence, seq, octx->status);
 
-            FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u status %d\n", sync_fence, seq, octx->status);
+            FARF(HIGH, "ggml-hex: sync-release : fence %p seq 0x%x status %d\n", sync_fence, seq, octx->status);
         }
     }
 

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -338,8 +338,7 @@ int op_cpy(struct htp_ops_context * octx) {
         uint32_t mdev_row_start, mdev_nrows;
         if (octx->mdev_count > 1) {
             const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
-            struct fastdiv_values div_chunk = init_fastdiv_values(rows_per_chunk);
-            const uint32_t total_chunks   = dst_is_contiguous ? fastdiv(total_rows, &div_chunk) : 0;
+            const uint32_t total_chunks   = dst_is_contiguous ? (total_rows / rows_per_chunk) : 0;
             if (total_chunks < octx->mdev_count) {
                 mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
                 mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -312,7 +312,9 @@ int op_cpy(struct htp_ops_context * octx) {
     }
 
     const bool sametype   = (src0->type == dst->type);
-    const bool transposed = (nb00 > nb01) || (nb0 > nb1);
+    const bool transposed = (nb00 > nb01) || (nb0 > nb1) ||
+                            (nb00 != ct.src0_type_size) || (nb0 != ct.dst_type_size) ||
+                            (nb01 < ne00 * ct.src0_type_size) || (nb1 < ne0 * ct.dst_type_size);
     const bool sameshape  = !transposed && (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
 
     ct.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -419,8 +419,12 @@ int op_cpy(struct htp_ops_context * octx) {
             qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
         }
 
+        if (status > HTP_STATUS_OK && octx->status == HTP_STATUS_OK) {
+            octx->status = status;
+        }
+
         if (octx->ctx->mdev.count > 1) {
-            status = htp_mdev_group_barrier(octx, status);
+            htp_mdev_group_barrier(octx);
         }
 
         if (octx->ctx->mdev.idx == 0) {
@@ -428,11 +432,11 @@ int op_cpy(struct htp_ops_context * octx) {
             assert(sync && (sync->flags & HTP_TENSOR_FENCE));
             const uint32_t seq = (uint32_t) octx->op_params[0];
             atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
-            htp_fence_write(sync_fence, seq, status);
+            htp_fence_write(sync_fence, seq, octx->status);
 
-            FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u status %d\n", sync_fence, seq, status);
+            FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u status %d\n", sync_fence, seq, octx->status);
         }
     }
 
-    return status;
+    return octx->status;
 }

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -413,14 +413,12 @@ int op_cpy(struct htp_ops_context * octx) {
     bool use_dma = false;
     int status = exec_cpy(octx, &use_dma);
 
+    htp_ops_context_set_status(octx, status);
+
     if (octx->op == HTP_OP_CPY_FENCE) {
         if (status == HTP_STATUS_OK && !use_dma) {
             // htp_tensor_flush_all(octx->ctx, octx->dsts, 1);
             qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
-        }
-
-        if (status > HTP_STATUS_OK && octx->status == HTP_STATUS_OK) {
-            octx->status = status;
         }
 
         if (octx->ctx->mdev.count > 1) {

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -30,6 +30,8 @@ struct htp_copy_context {
     uint32_t          dst_blocks_per_row;
 
     uint32_t          src0_nrows_per_thread;
+    uint32_t          dev_row_start;
+    uint32_t          dev_nrows;
 };
 
 #define cpy_preamble                              \
@@ -64,9 +66,9 @@ static void cpy_thread_##NAME##_sameshape(unsigned int nth, unsigned int ith, vo
     struct htp_ops_context * octx = ct->octx;                                                                  \
     cpy_preamble;                                                                                              \
     const uint32_t dr  = ct->src0_nrows_per_thread;                                                            \
-    const uint32_t ir0 = dr * ith;                                                                             \
-    const uint32_t ir1 = (ir0 + dr) < nr ? (ir0 + dr) : nr;                                                    \
-    if (ir0 >= nr) return;                                                                                     \
+    const uint32_t ir0 = ct->dev_row_start + dr * ith;                                                        \
+    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);                                   \
+    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;                                                     \
     for (uint32_t i03 = 0; i03 < ne03; i03++) {                                                                \
         for (uint32_t i02 = 0; i02 < ne02; i02++) {                                                            \
             _Pragma("unroll(4)")                                                                               \
@@ -89,9 +91,9 @@ static void cpy_thread_##NAME##_reshape(unsigned int nth, unsigned int ith, void
     struct htp_ops_context * octx = ct->octx;                                                                  \
     cpy_preamble;                                                                                              \
     const uint32_t dr  = ct->src0_nrows_per_thread;                                                            \
-    const uint32_t ir0 = dr * ith;                                                                             \
-    const uint32_t ir1 = (ir0 + dr) < nr ? (ir0 + dr) : nr;                                                    \
-    if (ir0 >= nr) return;                                                                                     \
+    const uint32_t ir0 = ct->dev_row_start + dr * ith;                                                        \
+    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);                                   \
+    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;                                                                                     \
     const bool src0_contig = (nb00 == ELEM_SIZE)   &&                                                          \
                              (nb01 == ne00 * nb00) &&                                                          \
                              (nb02 == ne01 * nb01) &&                                                          \
@@ -191,9 +193,9 @@ static void cpy_thread_f16_f32_sameshape(unsigned int nth, unsigned int ith, voi
 
     // parallelize by src0 rows
     const uint32_t dr  = ct->src0_nrows_per_thread;
-    const uint32_t ir0 = dr * ith;
-    const uint32_t ir1 = (ir0 + dr) < nr ? (ir0 + dr) : nr;
-    if (ir0 >= nr) return;
+    const uint32_t ir0 = ct->dev_row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);
+    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;
 
     // copy by rows
     for (uint32_t i03 = 0; i03 < ne03; i03++) {
@@ -216,9 +218,9 @@ static void cpy_thread_f32_f16_sameshape(unsigned int nth, unsigned int ith, voi
 
     // parallelize by src0 rows
     const uint32_t dr  = ct->src0_nrows_per_thread;
-    const uint32_t ir0 = dr * ith;
-    const uint32_t ir1 = (ir0 + dr) < nr ? (ir0 + dr) : nr;
-    if (ir0 >= nr) return;
+    const uint32_t ir0 = ct->dev_row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, ct->dev_row_start + ct->dev_nrows);
+    if (ir0 >= ct->dev_row_start + ct->dev_nrows) return;
 
     // copy by rows
     for (uint32_t i03 = 0; i03 < ne03; i03++) {
@@ -272,7 +274,21 @@ static inline void cpy_dma_sametype_sameshape(
 int op_cpy(struct htp_ops_context * octx) {
     cpy_preamble;
 
-    const uint32_t n_threads = MIN(nr, octx->n_threads);
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (nr + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, nr);
+        dev_nrows     = MIN(rows_per_dev, nr - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = nr;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(dev_nrows, octx->n_threads);
 
     struct htp_copy_context ct;
     ct.octx = octx;
@@ -299,20 +315,29 @@ int op_cpy(struct htp_ops_context * octx) {
     const bool transposed = (nb00 > nb01) || (nb0 > nb1);
     const bool sameshape  = !transposed && (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
 
-    ct.src0_nrows_per_thread = (nr + n_threads - 1) / n_threads;
+    ct.src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
+    ct.dev_row_start = dev_row_start;
+    ct.dev_nrows     = dev_nrows;
 
     worker_callback_t copy_fun = NULL;
     bool use_dma = false;
 
-    if (sametype && sameshape) {
+    if (sametype && sameshape && octx->ndev <= 1) {
         use_dma = true;
     } else if (sameshape) {
-        /**/ if (dst->type == HTP_TYPE_F16 && src0->type == HTP_TYPE_F32)
+        if (sametype) {
+            if (src0->type == HTP_TYPE_F32) {
+                copy_fun = cpy_thread_f32_sameshape;
+            } else {
+                copy_fun = cpy_thread_f16_sameshape;
+            }
+        } else if (dst->type == HTP_TYPE_F16 && src0->type == HTP_TYPE_F32) {
             copy_fun = cpy_thread_f16_f32_sameshape;
-        else if (dst->type == HTP_TYPE_F32 && src0->type == HTP_TYPE_F16)
+        } else if (dst->type == HTP_TYPE_F32 && src0->type == HTP_TYPE_F16) {
             copy_fun = cpy_thread_f32_f16_sameshape;
-        else
+        } else {
             return HTP_STATUS_NO_SUPPORT;
+        }
     } else if (sametype) {
         if (src0->type == HTP_TYPE_F32) {
             copy_fun = cpy_thread_f32_reshape;

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -425,8 +425,9 @@ int op_cpy(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
-    const struct htp_tensor *sync = octx->src[1];
-    if (sync && (sync->flags & HTP_TENSOR_FENCE)) {
+    if (octx->op == HTP_OP_CPY_FENCE) {
+        const struct htp_tensor *sync = octx->src[1];
+        assert(sync && (sync->flags & HTP_TENSOR_FENCE));
         if (!use_dma) {
             // htp_tensor_flush_all(octx->ctx, octx->dsts, 1);
             qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -338,16 +338,16 @@ int op_cpy(struct htp_ops_context * octx) {
         uint32_t row_start = 0;
         uint32_t nrows     = total_rows;
 
-        if (octx->mdev_count > 1) {
+        if (octx->ctx->mdev.count > 1) {
             const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
             const uint32_t total_chunks   = dst_is_contiguous ? (total_rows / rows_per_chunk) : 0;
-            if (total_chunks < octx->mdev_count) {
-                row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-                nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+            if (total_chunks < octx->ctx->mdev.count) {
+                row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
+                nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
             } else {
-                uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     nrows = total_rows - row_start;
                 } else {
                     nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
@@ -363,7 +363,7 @@ int op_cpy(struct htp_ops_context * octx) {
         ct.nrows     = nrows;
         ct.src0_nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
 
-        if (sametype && octx->mdev_count <= 1) {
+        if (sametype && octx->ctx->mdev.count <= 1) {
             use_dma = true;
             cpy_dma_sametype_sameshape(octx, dst, src0, ct.src0_type_size, ne00, ne01, ne02, ne03, nb01, nb02, nb03, nb1, nb2, nb3);
         } else {
@@ -395,15 +395,15 @@ int op_cpy(struct htp_ops_context * octx) {
         uint32_t elem_start = 0;
         uint32_t nelem      = total_elems;
 
-        if (octx->mdev_count > 1) {
+        if (octx->ctx->mdev.count > 1) {
             const uint32_t aligned_lines = dst_is_contiguous ? n_lines : 0;
-            if (aligned_lines < octx->mdev_count) {
-                elem_start = (octx->mdev_idx == 0) ? 0 : total_elems;
-                nelem      = (octx->mdev_idx == 0) ? total_elems : 0;
+            if (aligned_lines < octx->ctx->mdev.count) {
+                elem_start = (octx->ctx->mdev.idx == 0) ? 0 : total_elems;
+                nelem      = (octx->ctx->mdev.idx == 0) ? total_elems : 0;
             } else {
-                uint32_t lines_per_mdev = fastdiv(aligned_lines + octx->mdev_count - 1, &octx->mdev_count_div);
-                elem_start = MIN(octx->mdev_idx * lines_per_mdev * elems_per_line, total_elems);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                uint32_t lines_per_mdev = fastdiv(aligned_lines + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                elem_start = MIN(octx->ctx->mdev.idx * lines_per_mdev * elems_per_line, total_elems);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     nelem = total_elems - elem_start;
                 } else {
                     nelem = MIN(lines_per_mdev * elems_per_line, total_elems - elem_start);

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -434,18 +434,24 @@ int op_cpy(struct htp_ops_context * octx) {
     int status = exec_cpy(octx, &use_dma);
 
     if (octx->op == HTP_OP_CPY_FENCE) {
-        const struct htp_tensor * sync = octx->src[1];
-        assert(sync && (sync->flags & HTP_TENSOR_FENCE));
         if (status == HTP_STATUS_OK && !use_dma) {
             // htp_tensor_flush_all(octx->ctx, octx->dsts, 1);
             qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
         }
 
-        const uint32_t seq = (uint32_t) octx->op_params[0];
-        atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
-        htp_fence_write(sync_fence, seq, status);
+        if (octx->ctx->mdev.count > 1) {
+            status = htp_mdev_group_barrier(octx, status);
+        }
 
-        FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u status %d\n", sync_fence, seq, status);
+        if (octx->ctx->mdev.idx == 0) {
+            const struct htp_tensor * sync = octx->src[1];
+            assert(sync && (sync->flags & HTP_TENSOR_FENCE));
+            const uint32_t seq = (uint32_t) octx->op_params[0];
+            atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
+            htp_fence_write(sync_fence, seq, status);
+
+            FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u status %d\n", sync_fence, seq, status);
+        }
     }
 
     return status;

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -294,8 +294,9 @@ static inline void cpy_dma_sametype_sameshape(
     dma_queue_flush(q);
 }
 
-int op_cpy(struct htp_ops_context * octx) {
+static int exec_cpy(struct htp_ops_context * octx, bool * use_dma) {
     cpy_preamble;
+    *use_dma = false;
 
     struct htp_copy_context ct;
     ct.octx = octx;
@@ -325,7 +326,6 @@ int op_cpy(struct htp_ops_context * octx) {
     const bool sameshape  = !transposed && (ne00 == ne0 && ne01 == ne1 && ne02 == ne2 && ne03 == ne3);
 
     const uint32_t n_threads = octx->n_threads;
-    bool use_dma = false;
 
     const bool dst_is_contiguous = htp_tensor_is_contiguous(dst, ct.dst_type_size);
 
@@ -365,7 +365,7 @@ int op_cpy(struct htp_ops_context * octx) {
         ct.src0_nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
 
         if (sametype && octx->ctx->mdev.count <= 1) {
-            use_dma = true;
+            *use_dma = true;
             cpy_dma_sametype_sameshape(octx, dst, src0, ct.src0_type_size, ne00, ne01, ne02, ne03, nb01, nb02, nb03, nb1, nb2, nb3);
         } else {
             work_queue_func_t copy_fun = NULL;
@@ -426,20 +426,27 @@ int op_cpy(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
+    return HTP_STATUS_OK;
+}
+
+int op_cpy(struct htp_ops_context * octx) {
+    bool use_dma = false;
+    int status = exec_cpy(octx, &use_dma);
+
     if (octx->op == HTP_OP_CPY_FENCE) {
-        const struct htp_tensor *sync = octx->src[1];
+        const struct htp_tensor * sync = octx->src[1];
         assert(sync && (sync->flags & HTP_TENSOR_FENCE));
-        if (!use_dma) {
+        if (status == HTP_STATUS_OK && !use_dma) {
             // htp_tensor_flush_all(octx->ctx, octx->dsts, 1);
             qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
         }
 
         const uint32_t seq = (uint32_t) octx->op_params[0];
         atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
-        htp_fence_write(sync_fence, seq, HTP_STATUS_OK);
+        htp_fence_write(sync_fence, seq, status);
 
-        FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u\n", sync_fence, seq);
+        FARF(HIGH, "ggml-hex: sync-release : fence %p seq %u status %d\n", sync_fence, seq, status);
     }
 
-    return HTP_STATUS_OK;
+    return status;
 }

--- a/ggml/src/ggml-hexagon/htp/cpy-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cpy-ops.c
@@ -29,13 +29,13 @@ struct htp_copy_context {
     uint32_t          src0_blocks_per_row;
     uint32_t          dst_blocks_per_row;
 
-    uint32_t          mdev_elem_start;
-    uint32_t          mdev_nelem;
+    uint32_t          elem_start;
+    uint32_t          nelem;
     uint32_t          elem_per_thread;
 
     uint32_t          src0_nrows_per_thread;
-    uint32_t          mdev_row_start;
-    uint32_t          mdev_nrows;
+    uint32_t          row_start;
+    uint32_t          nrows;
 
     struct fastdiv_values div_ne01;
     struct fastdiv_values div_ne02_ne01;
@@ -78,8 +78,8 @@ static void cpy_thread_##NAME##_sameshape(unsigned int nth, unsigned int ith, vo
     struct htp_ops_context * octx = ct->octx;                                                  \
     cpy_preamble;                                                                              \
     const uint32_t dr  = ct->src0_nrows_per_thread;                                            \
-    const uint32_t ir0 = ct->mdev_row_start + dr * ith;                                        \
-    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);                   \
+    const uint32_t ir0 = ct->row_start + dr * ith;                                             \
+    const uint32_t ir1 = MIN(ir0 + dr, ct->row_start + ct->nrows);                            \
     if (ir0 >= ir1) return;                                                                    \
     const bool contiguous = (nb01 == ne00 * ELEM_SIZE) && (nb1 == nb01) &&                     \
                             (nb02 == ne01 * nb01)      && (nb2 == nb02) &&                     \
@@ -121,8 +121,8 @@ static void cpy_thread_##NAME##_reshape(unsigned int nth, unsigned int ith, void
     struct htp_ops_context * octx = ct->octx;                                                        \
     cpy_preamble;                                                                                    \
     const uint32_t th_nelem = ct->elem_per_thread;                                                   \
-    const uint32_t th_start = ct->mdev_elem_start + ith * th_nelem;                                  \
-    const uint32_t th_end   = MIN(th_start + th_nelem, ct->mdev_elem_start + ct->mdev_nelem);        \
+    const uint32_t th_start = ct->elem_start + ith * th_nelem;                                        \
+    const uint32_t th_end   = MIN(th_start + th_nelem, ct->elem_start + ct->nelem);                   \
     if (th_start >= th_end) return;                                                                  \
                                                                                                      \
     const uint32_t ne01_ne00      = ne01 * ne00;                                                     \
@@ -188,8 +188,8 @@ static void cpy_thread_f16_f32_sameshape(unsigned int nth, unsigned int ith, voi
     cpy_preamble;
 
     const uint32_t dr  = ct->src0_nrows_per_thread;
-    const uint32_t ir0 = ct->mdev_row_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);
+    const uint32_t ir0 = ct->row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, ct->row_start + ct->nrows);
     if (ir0 >= ir1) return;
 
     const uint32_t ne02_ne01 = ne02 * ne01;
@@ -224,8 +224,8 @@ static void cpy_thread_f32_f16_sameshape(unsigned int nth, unsigned int ith, voi
     cpy_preamble;
 
     const uint32_t dr  = ct->src0_nrows_per_thread;
-    const uint32_t ir0 = ct->mdev_row_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, ct->mdev_row_start + ct->mdev_nrows);
+    const uint32_t ir0 = ct->row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, ct->row_start + ct->nrows);
     if (ir0 >= ir1) return;
 
     const uint32_t ne02_ne01 = ne02 * ne01;
@@ -335,34 +335,33 @@ int op_cpy(struct htp_ops_context * octx) {
         ct.div_ne01      = init_fastdiv_values(ne01);
         ct.div_ne02_ne01 = init_fastdiv_values(ne02 * ne01);
 
-        uint32_t mdev_row_start, mdev_nrows;
+        uint32_t row_start = 0;
+        uint32_t nrows     = total_rows;
+
         if (octx->mdev_count > 1) {
             const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
             const uint32_t total_chunks   = dst_is_contiguous ? (total_rows / rows_per_chunk) : 0;
             if (total_chunks < octx->mdev_count) {
-                mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-                mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+                row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+                nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
             } else {
                 uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+                row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_nrows = total_rows - mdev_row_start;
+                    nrows = total_rows - row_start;
                 } else {
-                    mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+                    nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
                 }
             }
-        } else {
-            mdev_row_start = 0;
-            mdev_nrows     = total_rows;
         }
 
-        if (mdev_nrows == 0) {
+        if (nrows == 0) {
             return HTP_STATUS_OK;
         }
 
-        ct.mdev_row_start = mdev_row_start;
-        ct.mdev_nrows     = mdev_nrows;
-        ct.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+        ct.row_start = row_start;
+        ct.nrows     = nrows;
+        ct.src0_nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
 
         if (sametype && octx->mdev_count <= 1) {
             use_dma = true;
@@ -393,33 +392,32 @@ int op_cpy(struct htp_ops_context * octx) {
         ct.div_ne01_ne00      = init_fastdiv_values(ne01 * ne00);
         ct.div_ne02_ne01_ne00 = init_fastdiv_values(ne02 * ne01 * ne00);
 
-        uint32_t mdev_elem_start, mdev_nelem;
+        uint32_t elem_start = 0;
+        uint32_t nelem      = total_elems;
+
         if (octx->mdev_count > 1) {
             const uint32_t aligned_lines = dst_is_contiguous ? n_lines : 0;
             if (aligned_lines < octx->mdev_count) {
-                mdev_elem_start = (octx->mdev_idx == 0) ? 0 : total_elems;
-                mdev_nelem      = (octx->mdev_idx == 0) ? total_elems : 0;
+                elem_start = (octx->mdev_idx == 0) ? 0 : total_elems;
+                nelem      = (octx->mdev_idx == 0) ? total_elems : 0;
             } else {
                 uint32_t lines_per_mdev = fastdiv(aligned_lines + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_elem_start = MIN(octx->mdev_idx * lines_per_mdev * elems_per_line, total_elems);
+                elem_start = MIN(octx->mdev_idx * lines_per_mdev * elems_per_line, total_elems);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_nelem = total_elems - mdev_elem_start;
+                    nelem = total_elems - elem_start;
                 } else {
-                    mdev_nelem = MIN(lines_per_mdev * elems_per_line, total_elems - mdev_elem_start);
+                    nelem = MIN(lines_per_mdev * elems_per_line, total_elems - elem_start);
                 }
             }
-        } else {
-            mdev_elem_start = 0;
-            mdev_nelem      = total_elems;
         }
 
-        if (mdev_nelem == 0) {
+        if (nelem == 0) {
             return HTP_STATUS_OK;
         }
 
-        ct.mdev_elem_start = mdev_elem_start;
-        ct.mdev_nelem      = mdev_nelem;
-        ct.elem_per_thread = fastdiv(mdev_nelem + n_threads - 1, &octx->n_threads_div);
+        ct.elem_start      = elem_start;
+        ct.nelem           = nelem;
+        ct.elem_per_thread = fastdiv(nelem + n_threads - 1, &octx->n_threads_div);
 
         work_queue_func_t copy_fun = (src0->type == HTP_TYPE_F32) ? cpy_thread_f32_reshape : cpy_thread_f16_reshape;
         work_queue_run(octx->ctx->work_queue, copy_fun, &ct, n_threads);

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -219,7 +219,7 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
         mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
     } else {
@@ -231,7 +231,7 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     const size_t src_row_size         = src0->nb[1];
     const size_t dst_row_size         = dst->nb[1];
@@ -256,7 +256,7 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
         .dst_row_size         = dst_row_size,
         .src_row_size_aligned = src_row_size_aligned,
         .dst_row_size_aligned = dst_row_size_aligned,
-        .rows_per_thread      = (mdev_nrows + n_threads - 1) / n_threads,
+        .rows_per_thread      = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
         .total_rows           = mdev_nrows,
         .mdev_row_start       = mdev_row_start,
     };

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -222,33 +222,11 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
     uint32_t nrows     = total_rows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_data_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = total_rows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, sizeof(float), (uint32_t) dst_data_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -46,7 +46,7 @@ struct htp_cumsum_context {
     size_t          dst_row_size_aligned;
     uint32_t        rows_per_thread;
     uint32_t        total_rows;
-    uint32_t        dev_row_start;
+    uint32_t        mdev_row_start;
 };
 
 #define htp_cumsum_preamble                                                \
@@ -120,8 +120,8 @@ static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * dat
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
 
-    const uint32_t ir0 = cctx->dev_row_start + cctx->rows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->dev_row_start + cctx->total_rows);
+    const uint32_t ir0 = cctx->mdev_row_start + cctx->rows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->mdev_row_start + cctx->total_rows);
 
     if (ir0 >= ir1) {
         return;
@@ -190,8 +190,8 @@ static void cumsum_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
-    const uint32_t ir0 = cctx->dev_row_start + cctx->rows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->dev_row_start + cctx->total_rows);
+    const uint32_t ir0 = cctx->mdev_row_start + cctx->rows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->mdev_row_start + cctx->total_rows);
 
     for (uint32_t ir = ir0; ir < ir1; ir++) {
         const float * restrict src_row = (const float *) (src_data + ir * cctx->src_row_size);
@@ -217,21 +217,21 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
 
     const uint32_t total_rows = src0->ne[1] * src0->ne[2] * src0->ne[3];
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
-        dev_nrows     = MIN(rows_per_dev, total_rows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
+        mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = total_rows;
+        mdev_row_start = 0;
+        mdev_nrows     = total_rows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
 
     const size_t src_row_size         = src0->nb[1];
     const size_t dst_row_size         = dst->nb[1];
@@ -256,9 +256,9 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
         .dst_row_size         = dst_row_size,
         .src_row_size_aligned = src_row_size_aligned,
         .dst_row_size_aligned = dst_row_size_aligned,
-        .rows_per_thread      = (dev_nrows + n_threads - 1) / n_threads,
-        .total_rows           = dev_nrows,
-        .dev_row_start       = dev_row_start,
+        .rows_per_thread      = (mdev_nrows + n_threads - 1) / n_threads,
+        .total_rows           = mdev_nrows,
+        .mdev_row_start       = mdev_row_start,
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -46,6 +46,7 @@ struct htp_cumsum_context {
     size_t          dst_row_size_aligned;
     uint32_t        rows_per_thread;
     uint32_t        total_rows;
+    uint32_t        dev_row_start;
 };
 
 #define htp_cumsum_preamble                                                \
@@ -119,8 +120,8 @@ static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * dat
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
 
-    const uint32_t ir0 = cctx->rows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->total_rows);
+    const uint32_t ir0 = cctx->dev_row_start + cctx->rows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->dev_row_start + cctx->total_rows);
 
     if (ir0 >= ir1) {
         return;
@@ -189,8 +190,8 @@ static void cumsum_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
-    const uint32_t ir0 = cctx->rows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->total_rows);
+    const uint32_t ir0 = cctx->dev_row_start + cctx->rows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->dev_row_start + cctx->total_rows);
 
     for (uint32_t ir = ir0; ir < ir1; ir++) {
         const float * restrict src_row = (const float *) (src_data + ir * cctx->src_row_size);
@@ -215,7 +216,22 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
     }
 
     const uint32_t total_rows = src0->ne[1] * src0->ne[2] * src0->ne[3];
-    const uint32_t n_threads  = MIN(octx->n_threads, total_rows);
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
+        dev_nrows     = MIN(rows_per_dev, total_rows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = total_rows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
 
     const size_t src_row_size         = src0->nb[1];
     const size_t dst_row_size         = dst->nb[1];
@@ -240,8 +256,9 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
         .dst_row_size         = dst_row_size,
         .src_row_size_aligned = src_row_size_aligned,
         .dst_row_size_aligned = dst_row_size_aligned,
-        .rows_per_thread      = (total_rows + n_threads - 1) / n_threads,
-        .total_rows           = total_rows,
+        .rows_per_thread      = (dev_nrows + n_threads - 1) / n_threads,
+        .total_rows           = dev_nrows,
+        .dev_row_start       = dev_row_start,
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -7,6 +7,8 @@
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
+#include "hex-common.h"
+#include "hex-profile.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
 #include "htp-tensor.h"
@@ -117,9 +119,6 @@ static inline void hvx_cumsum_row_f32(const float * restrict src, float * restri
 static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * data) {
     htp_cumsum_preamble;
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
-
     const uint32_t ir0 = cctx->mdev_row_start + cctx->rows_per_thread * ith;
     const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->mdev_row_start + cctx->total_rows);
 
@@ -150,6 +149,9 @@ static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * dat
                                    src_row_size_aligned, src_row_size, 1);
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
+
     for (uint32_t ir = ir0; ir < ir1; ir++) {
         float * dst_spad_row = (float *) dma_queue_pop(dma_queue).src;
         float * src_spad_row = (float *) dma_queue_pop(dma_queue).dst;
@@ -168,13 +170,13 @@ static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * dat
         }
     }
 
-    dma_queue_flush(dma_queue);
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
 
-    FARF(HIGH, "cumsum-f32-dma %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u usec %u\n",
+    dma_queue_flush(dma_queue);
+
+    FARF(HIGH, "cumsum-f32-dma %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u\n",
          ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ir0, ir1,
-         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
 }
 
 // ---------------------------------------------------------------------------
@@ -184,14 +186,14 @@ static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * dat
 static void cumsum_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     htp_cumsum_preamble;
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
-
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
     const uint32_t ir0 = cctx->mdev_row_start + cctx->rows_per_thread * ith;
     const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->mdev_row_start + cctx->total_rows);
+
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
 
     for (uint32_t ir = ir0; ir < ir1; ir++) {
         const float * restrict src_row = (const float *) (src_data + ir * cctx->src_row_size);
@@ -199,12 +201,11 @@ static void cumsum_thread_f32(unsigned int nth, unsigned int ith, void * data) {
         hvx_cumsum_row_f32(src_row, dst_row, ne00);
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
 
-    FARF(HIGH, "cumsum-f32 %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u usec %u\n",
+    FARF(HIGH, "cumsum-f32 %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u\n",
          ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ir0, ir1,
-         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
 }
 
 int op_cumsum_f32(struct htp_ops_context * octx) {
@@ -215,13 +216,38 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t total_rows = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const uint32_t total_rows      = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
-        mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_data_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = total_rows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = total_rows;
@@ -262,9 +288,9 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {
-        worker_pool_run_func(octx->ctx->worker_pool, cumsum_thread_f32, &cctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, cumsum_thread_f32, &cctx, n_threads);
     } else {
-        worker_pool_run_func(octx->ctx->worker_pool, cumsum_thread_f32_dma, &cctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, cumsum_thread_f32_dma, &cctx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -48,7 +48,7 @@ struct htp_cumsum_context {
     size_t          dst_row_size_aligned;
     uint32_t        rows_per_thread;
     uint32_t        total_rows;
-    uint32_t        mdev_row_start;
+    uint32_t        row_start;
 };
 
 #define htp_cumsum_preamble                                                \
@@ -119,8 +119,8 @@ static inline void hvx_cumsum_row_f32(const float * restrict src, float * restri
 static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * data) {
     htp_cumsum_preamble;
 
-    const uint32_t ir0 = cctx->mdev_row_start + cctx->rows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->mdev_row_start + cctx->total_rows);
+    const uint32_t ir0 = cctx->row_start + cctx->rows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->row_start + cctx->total_rows);
 
     if (ir0 >= ir1) {
         return;
@@ -189,8 +189,8 @@ static void cumsum_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
-    const uint32_t ir0 = cctx->mdev_row_start + cctx->rows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->mdev_row_start + cctx->total_rows);
+    const uint32_t ir0 = cctx->row_start + cctx->rows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + cctx->rows_per_thread, cctx->row_start + cctx->total_rows);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
     htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
@@ -219,7 +219,9 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
     const uint32_t total_rows      = src0->ne[1] * src0->ne[2] * src0->ne[3];
     const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = total_rows;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
@@ -237,23 +239,20 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+            nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = total_rows - mdev_row_start;
+                nrows = total_rows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = total_rows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -282,9 +281,9 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
         .dst_row_size         = dst_row_size,
         .src_row_size_aligned = src_row_size_aligned,
         .dst_row_size_aligned = dst_row_size_aligned,
-        .rows_per_thread      = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
-        .total_rows           = mdev_nrows,
-        .mdev_row_start       = mdev_row_start,
+        .rows_per_thread      = fastdiv(nrows + n_threads - 1, &octx->n_threads_div),
+        .total_rows           = nrows,
+        .row_start            = row_start,
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -19,25 +19,25 @@
 #define htp_cumsum_tensors_preamble                         \
     const struct htp_tensor * restrict src0 = octx->src[0]; \
     const struct htp_tensor * restrict dst  = octx->dst;    \
-                                                     \
-    const uint32_t ne00 = src0->ne[0];               \
-    const uint32_t ne01 = src0->ne[1];               \
-    const uint32_t ne02 = src0->ne[2];               \
-    const uint32_t ne03 = src0->ne[3];               \
-                                                     \
-    const uint32_t ne0 = dst->ne[0];                 \
-    const uint32_t ne1 = dst->ne[1];                 \
-    const uint32_t ne2 = dst->ne[2];                 \
-    const uint32_t ne3 = dst->ne[3];                 \
-                                                     \
-    const uint32_t nb00 = src0->nb[0];               \
-    const uint32_t nb01 = src0->nb[1];               \
-    const uint32_t nb02 = src0->nb[2];               \
-    const uint32_t nb03 = src0->nb[3];               \
-                                                     \
-    const uint32_t nb0 = dst->nb[0];                 \
-    const uint32_t nb1 = dst->nb[1];                 \
-    const uint32_t nb2 = dst->nb[2];                 \
+                                                            \
+    const uint32_t ne00 = src0->ne[0];                      \
+    const uint32_t ne01 = src0->ne[1];                      \
+    const uint32_t ne02 = src0->ne[2];                      \
+    const uint32_t ne03 = src0->ne[3];                      \
+                                                            \
+    const uint32_t ne0 = dst->ne[0];                        \
+    const uint32_t ne1 = dst->ne[1];                        \
+    const uint32_t ne2 = dst->ne[2];                        \
+    const uint32_t ne3 = dst->ne[3];                        \
+                                                            \
+    const uint32_t nb00 = src0->nb[0];                      \
+    const uint32_t nb01 = src0->nb[1];                      \
+    const uint32_t nb02 = src0->nb[2];                      \
+    const uint32_t nb03 = src0->nb[3];                      \
+                                                            \
+    const uint32_t nb0 = dst->nb[0];                        \
+    const uint32_t nb1 = dst->nb[1];                        \
+    const uint32_t nb2 = dst->nb[2];                        \
     const uint32_t nb3 = dst->nb[3];
 
 struct htp_cumsum_context {
@@ -150,13 +150,14 @@ static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * dat
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
 
     for (uint32_t ir = ir0; ir < ir1; ir++) {
         float * dst_spad_row = (float *) dma_queue_pop(dma_queue).src;
         float * src_spad_row = (float *) dma_queue_pop(dma_queue).dst;
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         hvx_cumsum_row_f32(src_spad_row, dst_spad_row, ne00);
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         dma_queue_push_vtcm_to_ddr(dma_queue,
                                    dma_make_ptr(dst_data + (ir * dst_row_size), (uint8_t *) dst_spad_row),
@@ -169,8 +170,6 @@ static void cumsum_thread_f32_dma(unsigned int nth, unsigned int ith, void * dat
                                        src_row_size_aligned, src_row_size, 1);
         }
     }
-
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
 
     dma_queue_flush(dma_queue);
 

--- a/ggml/src/ggml-hexagon/htp/cumsum-ops.c
+++ b/ggml/src/ggml-hexagon/htp/cumsum-ops.c
@@ -222,7 +222,7 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = total_rows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -238,13 +238,13 @@ int op_cumsum_f32(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (total_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-            nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = total_rows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -36,6 +36,7 @@ struct htp_diag_context {
     size_t          dst_row_size_aligned;
     uint32_t        batches_per_thread;
     uint32_t        total_batches;
+    uint32_t        dev_batch_start;
 };
 
 #define htp_diag_preamble                                              \
@@ -60,8 +61,8 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
 
-    const uint32_t ib0 = dctx->batches_per_thread * ith;
-    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->total_batches);
+    const uint32_t ib0 = dctx->dev_batch_start + dctx->batches_per_thread * ith;
+    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->dev_batch_start + dctx->total_batches);
 
     if (ib0 >= ib1) {
         return;
@@ -128,8 +129,8 @@ static void diag_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
-    const uint32_t ib0 = dctx->batches_per_thread * ith;
-    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->total_batches);
+    const uint32_t ib0 = dctx->dev_batch_start + dctx->batches_per_thread * ith;
+    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->dev_batch_start + dctx->total_batches);
 
     for (uint32_t ib = ib0; ib < ib1; ib++) {
         const uint32_t i3 = ib / ne02;
@@ -160,7 +161,22 @@ int op_diag_f32(struct htp_ops_context * octx) {
     }
 
     const uint32_t total_batches = src0->ne[2] * src0->ne[3];
-    const uint32_t n_threads     = MIN(octx->n_threads, total_batches);
+
+    uint32_t dev_batch_start, dev_nbatches;
+    if (octx->ndev > 1) {
+        const uint32_t batches_per_dev = (total_batches + octx->ndev - 1) / octx->ndev;
+        dev_batch_start = MIN(octx->idev * batches_per_dev, total_batches);
+        dev_nbatches    = MIN(batches_per_dev, total_batches - dev_batch_start);
+    } else {
+        dev_batch_start = 0;
+        dev_nbatches    = total_batches;
+    }
+
+    if (dev_nbatches == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads     = MIN(octx->n_threads, dev_nbatches);
 
     const size_t src_batch_size         = src0->ne[0] * sizeof(float);
     const size_t dst_row_size           = dst->ne[0] * sizeof(float);
@@ -185,8 +201,9 @@ int op_diag_f32(struct htp_ops_context * octx) {
         .dst_row_size           = dst_row_size,
         .src_batch_size_aligned = src_batch_size_aligned,
         .dst_row_size_aligned   = dst_row_size_aligned,
-        .batches_per_thread     = (total_batches + n_threads - 1) / n_threads,
-        .total_batches          = total_batches,
+        .batches_per_thread     = (dev_nbatches + n_threads - 1) / n_threads,
+        .total_batches          = dev_nbatches,
+        .dev_batch_start       = dev_batch_start,
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -36,7 +36,7 @@ struct htp_diag_context {
     size_t          dst_row_size_aligned;
     uint32_t        batches_per_thread;
     uint32_t        total_batches;
-    uint32_t        dev_batch_start;
+    uint32_t        mdev_batch_start;
 };
 
 #define htp_diag_preamble                                              \
@@ -61,8 +61,8 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
 
-    const uint32_t ib0 = dctx->dev_batch_start + dctx->batches_per_thread * ith;
-    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->dev_batch_start + dctx->total_batches);
+    const uint32_t ib0 = dctx->mdev_batch_start + dctx->batches_per_thread * ith;
+    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->mdev_batch_start + dctx->total_batches);
 
     if (ib0 >= ib1) {
         return;
@@ -129,8 +129,8 @@ static void diag_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
-    const uint32_t ib0 = dctx->dev_batch_start + dctx->batches_per_thread * ith;
-    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->dev_batch_start + dctx->total_batches);
+    const uint32_t ib0 = dctx->mdev_batch_start + dctx->batches_per_thread * ith;
+    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->mdev_batch_start + dctx->total_batches);
 
     for (uint32_t ib = ib0; ib < ib1; ib++) {
         const uint32_t i3 = ib / ne02;
@@ -162,21 +162,21 @@ int op_diag_f32(struct htp_ops_context * octx) {
 
     const uint32_t total_batches = src0->ne[2] * src0->ne[3];
 
-    uint32_t dev_batch_start, dev_nbatches;
-    if (octx->ndev > 1) {
-        const uint32_t batches_per_dev = (total_batches + octx->ndev - 1) / octx->ndev;
-        dev_batch_start = MIN(octx->idev * batches_per_dev, total_batches);
-        dev_nbatches    = MIN(batches_per_dev, total_batches - dev_batch_start);
+    uint32_t mdev_batch_start, mdev_nbatches;
+    if (octx->mdev_count > 1) {
+        const uint32_t batches_per_mdev = (total_batches + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_batch_start = MIN(octx->mdev_idx * batches_per_mdev, total_batches);
+        mdev_nbatches    = MIN(batches_per_mdev, total_batches - mdev_batch_start);
     } else {
-        dev_batch_start = 0;
-        dev_nbatches    = total_batches;
+        mdev_batch_start = 0;
+        mdev_nbatches    = total_batches;
     }
 
-    if (dev_nbatches == 0) {
+    if (mdev_nbatches == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads     = MIN(octx->n_threads, dev_nbatches);
+    const uint32_t n_threads     = MIN(octx->n_threads, mdev_nbatches);
 
     const size_t src_batch_size         = src0->ne[0] * sizeof(float);
     const size_t dst_row_size           = dst->ne[0] * sizeof(float);
@@ -201,9 +201,9 @@ int op_diag_f32(struct htp_ops_context * octx) {
         .dst_row_size           = dst_row_size,
         .src_batch_size_aligned = src_batch_size_aligned,
         .dst_row_size_aligned   = dst_row_size_aligned,
-        .batches_per_thread     = (dev_nbatches + n_threads - 1) / n_threads,
-        .total_batches          = dev_nbatches,
-        .dev_batch_start       = dev_batch_start,
+        .batches_per_thread     = (mdev_nbatches + n_threads - 1) / n_threads,
+        .total_batches          = mdev_nbatches,
+        .mdev_batch_start       = mdev_batch_start,
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -167,7 +167,7 @@ int op_diag_f32(struct htp_ops_context * octx) {
     uint32_t batch_start = 0;
     uint32_t nbatches    = total_batches;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t batches_per_chunk = 1;
         if (can_split) {
@@ -182,13 +182,13 @@ int op_diag_f32(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (total_batches / batches_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            batch_start = (octx->mdev_idx == 0) ? 0 : total_batches;
-            nbatches    = (octx->mdev_idx == 0) ? total_batches : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            batch_start = (octx->ctx->mdev.idx == 0) ? 0 : total_batches;
+            nbatches    = (octx->ctx->mdev.idx == 0) ? total_batches : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            batch_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            batch_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * batches_per_chunk, total_batches);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nbatches = total_batches - batch_start;
             } else {
                 nbatches = MIN(chunks_per_mdev * batches_per_chunk, total_batches - batch_start);

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -167,10 +167,11 @@ int op_diag_f32(struct htp_ops_context * octx) {
     uint32_t nbatches    = total_batches;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        bool can_split = htp_tensor_mdev_data_aligned(dst) && (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t batches_per_chunk = 1;
         if (can_split) {
-            if (dst->ne[2] > 1 && (dst->nb[2] & 127) == 0) {
+            if (dst->ne[2] > 1 && (dst->nb[2] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0 &&
+                (dst->ne[3] <= 1 || (dst->nb[3] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0)) {
                 batches_per_chunk = 1;
             } else if (dst->nb[2] == dst_batch_size &&
                        (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
@@ -180,19 +181,9 @@ int op_diag_f32(struct htp_ops_context * octx) {
             }
         }
 
-        const uint32_t total_chunks = can_split ? (total_batches / batches_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            batch_start = (octx->ctx->mdev.idx == 0) ? 0 : total_batches;
-            nbatches    = (octx->ctx->mdev.idx == 0) ? total_batches : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            batch_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * batches_per_chunk, total_batches);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nbatches = total_batches - batch_start;
-            } else {
-                nbatches = MIN(chunks_per_mdev * batches_per_chunk, total_batches - batch_start);
-            }
-        }
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_batches, can_split ? batches_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        batch_start = range.start;
+        nbatches    = range.count;
     }
 
     if (nbatches == 0) {

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -18,17 +18,17 @@
 #define htp_diag_tensors_preamble                           \
     const struct htp_tensor * restrict src0 = octx->src[0]; \
     const struct htp_tensor * restrict dst  = octx->dst;    \
-                                                     \
-    const uint32_t ne02 = src0->ne[2];               \
-                                                     \
-    const uint32_t ne0 = dst->ne[0];                 \
-    const uint32_t ne1 = dst->ne[1];                 \
-                                                     \
-    const uint32_t nb02 = src0->nb[2];               \
-    const uint32_t nb03 = src0->nb[3];               \
-                                                     \
-    const uint32_t nb1 = dst->nb[1];                 \
-    const uint32_t nb2 = dst->nb[2];                 \
+                                                            \
+    const uint32_t ne02 = src0->ne[2];                      \
+                                                            \
+    const uint32_t ne0 = dst->ne[0];                        \
+    const uint32_t ne1 = dst->ne[1];                        \
+                                                            \
+    const uint32_t nb02 = src0->nb[2];                      \
+    const uint32_t nb03 = src0->nb[3];                      \
+                                                            \
+    const uint32_t nb1 = dst->nb[1];                        \
+    const uint32_t nb2 = dst->nb[2];                        \
     const uint32_t nb3 = dst->nb[3];
 
 struct htp_diag_context {
@@ -81,7 +81,6 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
     uint8_t * dst_spad = octx->dst_spad.data  + (ith * dst_row_size_aligned);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ib0);
 
     for (uint32_t ib = ib0; ib < ib1; ib++) {
         const uint32_t i3 = ib / ne02;
@@ -100,7 +99,9 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
 
         for (uint32_t i1 = 0; i1 < ne1; i1++) {
             // Compute row in VTCM
+            htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (ib * ne1 + i1));
             hvx_diag_row_f32(src_spad_f32, dst_spad_f32, i1, ne0);
+            htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (ib * ne1 + i1));
 
             // Write completed row back to DDR
             uint8_t * dst_row = dst_data + i3 * nb3 + i2 * nb2 + i1 * nb1;
@@ -110,8 +111,6 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
             dma_queue_flush(dma_queue);
         }
     }
-
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ib0);
 
     FARF(HIGH, "diag-f32-dma %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u\n",
          ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ib0, ib1,

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -164,7 +164,7 @@ int op_diag_f32(struct htp_ops_context * octx) {
 
     uint32_t mdev_batch_start, mdev_nbatches;
     if (octx->mdev_count > 1) {
-        const uint32_t batches_per_mdev = (total_batches + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t batches_per_mdev = fastdiv(total_batches + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_batch_start = MIN(octx->mdev_idx * batches_per_mdev, total_batches);
         mdev_nbatches    = MIN(batches_per_mdev, total_batches - mdev_batch_start);
     } else {
@@ -176,7 +176,7 @@ int op_diag_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads     = MIN(octx->n_threads, mdev_nbatches);
+    const uint32_t n_threads     = octx->n_threads;
 
     const size_t src_batch_size         = src0->ne[0] * sizeof(float);
     const size_t dst_row_size           = dst->ne[0] * sizeof(float);
@@ -201,7 +201,7 @@ int op_diag_f32(struct htp_ops_context * octx) {
         .dst_row_size           = dst_row_size,
         .src_batch_size_aligned = src_batch_size_aligned,
         .dst_row_size_aligned   = dst_row_size_aligned,
-        .batches_per_thread     = (mdev_nbatches + n_threads - 1) / n_threads,
+        .batches_per_thread     = fastdiv(mdev_nbatches + n_threads - 1, &octx->n_threads_div),
         .total_batches          = mdev_nbatches,
         .mdev_batch_start       = mdev_batch_start,
     };

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -5,8 +5,11 @@
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
+#include "hex-common.h"
+#include "hex-profile.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
+#include "htp-tensor.h"
 #include "hvx-types.h"
 #include "hex-utils.h"
 #include "hvx-copy.h"
@@ -58,9 +61,6 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
     htp_diag_preamble;
     dma_queue * dma_queue = octx->ctx->dma[ith];
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
-
     const uint32_t ib0 = dctx->mdev_batch_start + dctx->batches_per_thread * ith;
     const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->mdev_batch_start + dctx->total_batches);
 
@@ -79,6 +79,9 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
     // 1 src buffer + 1 dst row buffer per thread in VTCM
     uint8_t * src_spad = octx->src0_spad.data + (ith * src_batch_size_aligned);
     uint8_t * dst_spad = octx->dst_spad.data  + (ith * dst_row_size_aligned);
+
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ib0);
 
     for (uint32_t ib = ib0; ib < ib1; ib++) {
         const uint32_t i3 = ib / ne02;
@@ -108,12 +111,11 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ib0);
 
-    FARF(HIGH, "diag-f32-dma %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u usec %u\n",
+    FARF(HIGH, "diag-f32-dma %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u\n",
          ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ib0, ib1,
-         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
 }
 
 // ---------------------------------------------------------------------------
@@ -123,14 +125,14 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
 static void diag_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     htp_diag_preamble;
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
-
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
     const uint32_t ib0 = dctx->mdev_batch_start + dctx->batches_per_thread * ith;
     const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->mdev_batch_start + dctx->total_batches);
+
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ib0);
 
     for (uint32_t ib = ib0; ib < ib1; ib++) {
         const uint32_t i3 = ib / ne02;
@@ -144,12 +146,11 @@ static void diag_thread_f32(unsigned int nth, unsigned int ith, void * data) {
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ib0);
 
-    FARF(HIGH, "diag-f32 %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u usec %u\n",
+    FARF(HIGH, "diag-f32 %d/%d: %ux%ux%ux%u (%u:%u) -> %ux%ux%ux%u\n",
          ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ib0, ib1,
-         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
 }
 
 int op_diag_f32(struct htp_ops_context * octx) {
@@ -161,12 +162,36 @@ int op_diag_f32(struct htp_ops_context * octx) {
     }
 
     const uint32_t total_batches = src0->ne[2] * src0->ne[3];
+    const size_t dst_batch_size  = dst->ne[1] * dst->nb[1];
 
     uint32_t mdev_batch_start, mdev_nbatches;
     if (octx->mdev_count > 1) {
-        const uint32_t batches_per_mdev = fastdiv(total_batches + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_batch_start = MIN(octx->mdev_idx * batches_per_mdev, total_batches);
-        mdev_nbatches    = MIN(batches_per_mdev, total_batches - mdev_batch_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        uint32_t batches_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[2] > 1 && (dst->nb[2] & 127) == 0) {
+                batches_per_chunk = 1;
+            } else if (dst->nb[2] == dst_batch_size &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                batches_per_chunk = (dst_batch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_batch_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (total_batches / batches_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_batch_start = (octx->mdev_idx == 0) ? 0 : total_batches;
+            mdev_nbatches    = (octx->mdev_idx == 0) ? total_batches : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_batch_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nbatches = total_batches - mdev_batch_start;
+            } else {
+                mdev_nbatches = MIN(chunks_per_mdev * batches_per_chunk, total_batches - mdev_batch_start);
+            }
+        }
     } else {
         mdev_batch_start = 0;
         mdev_nbatches    = total_batches;
@@ -207,9 +232,9 @@ int op_diag_f32(struct htp_ops_context * octx) {
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {
-        worker_pool_run_func(octx->ctx->worker_pool, diag_thread_f32, &dctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, diag_thread_f32, &dctx, n_threads);
     } else {
-        worker_pool_run_func(octx->ctx->worker_pool, diag_thread_f32_dma, &dctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, diag_thread_f32_dma, &dctx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/diag-ops.c
+++ b/ggml/src/ggml-hexagon/htp/diag-ops.c
@@ -39,7 +39,7 @@ struct htp_diag_context {
     size_t          dst_row_size_aligned;
     uint32_t        batches_per_thread;
     uint32_t        total_batches;
-    uint32_t        mdev_batch_start;
+    uint32_t        batch_start;
 };
 
 #define htp_diag_preamble                                              \
@@ -61,8 +61,8 @@ static void diag_thread_f32_dma(unsigned int nth, unsigned int ith, void * data)
     htp_diag_preamble;
     dma_queue * dma_queue = octx->ctx->dma[ith];
 
-    const uint32_t ib0 = dctx->mdev_batch_start + dctx->batches_per_thread * ith;
-    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->mdev_batch_start + dctx->total_batches);
+    const uint32_t ib0 = dctx->batch_start + dctx->batches_per_thread * ith;
+    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->batch_start + dctx->total_batches);
 
     if (ib0 >= ib1) {
         return;
@@ -128,8 +128,8 @@ static void diag_thread_f32(unsigned int nth, unsigned int ith, void * data) {
     const uint8_t * src_data = (const uint8_t *) src0->data;
     uint8_t *       dst_data = (uint8_t *) dst->data;
 
-    const uint32_t ib0 = dctx->mdev_batch_start + dctx->batches_per_thread * ith;
-    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->mdev_batch_start + dctx->total_batches);
+    const uint32_t ib0 = dctx->batch_start + dctx->batches_per_thread * ith;
+    const uint32_t ib1 = MIN(ib0 + dctx->batches_per_thread, dctx->batch_start + dctx->total_batches);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
     htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ib0);
@@ -164,7 +164,9 @@ int op_diag_f32(struct htp_ops_context * octx) {
     const uint32_t total_batches = src0->ne[2] * src0->ne[3];
     const size_t dst_batch_size  = dst->ne[1] * dst->nb[1];
 
-    uint32_t mdev_batch_start, mdev_nbatches;
+    uint32_t batch_start = 0;
+    uint32_t nbatches    = total_batches;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t batches_per_chunk = 1;
@@ -181,23 +183,20 @@ int op_diag_f32(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (total_batches / batches_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_batch_start = (octx->mdev_idx == 0) ? 0 : total_batches;
-            mdev_nbatches    = (octx->mdev_idx == 0) ? total_batches : 0;
+            batch_start = (octx->mdev_idx == 0) ? 0 : total_batches;
+            nbatches    = (octx->mdev_idx == 0) ? total_batches : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_batch_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
+            batch_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nbatches = total_batches - mdev_batch_start;
+                nbatches = total_batches - batch_start;
             } else {
-                mdev_nbatches = MIN(chunks_per_mdev * batches_per_chunk, total_batches - mdev_batch_start);
+                nbatches = MIN(chunks_per_mdev * batches_per_chunk, total_batches - batch_start);
             }
         }
-    } else {
-        mdev_batch_start = 0;
-        mdev_nbatches    = total_batches;
     }
 
-    if (mdev_nbatches == 0) {
+    if (nbatches == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -226,9 +225,9 @@ int op_diag_f32(struct htp_ops_context * octx) {
         .dst_row_size           = dst_row_size,
         .src_batch_size_aligned = src_batch_size_aligned,
         .dst_row_size_aligned   = dst_row_size_aligned,
-        .batches_per_thread     = fastdiv(mdev_nbatches + n_threads - 1, &octx->n_threads_div),
-        .total_batches          = mdev_nbatches,
-        .mdev_batch_start       = mdev_batch_start,
+        .batches_per_thread     = fastdiv(nbatches + n_threads - 1, &octx->n_threads_div),
+        .total_batches          = nbatches,
+        .batch_start            = batch_start,
     };
 
     if (octx->ctx->vtcm_size < spad_per_thread * n_threads) {

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -94,19 +94,19 @@ int op_fill(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = nr;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         const uint32_t row_size = nb1;
         const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
         const uint32_t total_chunks = nr / rows_per_chunk;
-        const bool can_split = total_chunks >= octx->mdev_count;
+        const bool can_split = total_chunks >= octx->ctx->mdev.count;
 
         if (!can_split) {
-            row_start = (octx->mdev_idx == 0) ? 0 : nr;
-            nrows     = (octx->mdev_idx == 0) ? nr : 0;
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : nr;
+            nrows     = (octx->ctx->mdev.idx == 0) ? nr : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, nr);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, nr);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = nr - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, nr - row_start);

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -36,7 +36,7 @@ struct htp_fill_context {
     struct htp_ops_context * octx;
     uint32_t nrows_per_thread;
     uint32_t total_rows;  // ne1 * ne2 * ne3
-    uint32_t dev_row_start;
+    uint32_t mdev_row_start;
     bool     opt_path;
     HVX_Vector splat_vec;
     uint32_t   elem_size;
@@ -48,8 +48,8 @@ static void fill_thread(unsigned int nth, unsigned int ith, void * data) {
     fill_preamble;
 
     // Parallelise over the flat row index spanning ne1*ne2*ne3
-    const uint32_t ir0 = fctx->dev_row_start + fctx->nrows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + fctx->nrows_per_thread, fctx->dev_row_start + fctx->total_rows);
+    const uint32_t ir0 = fctx->mdev_row_start + fctx->nrows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + fctx->nrows_per_thread, fctx->mdev_row_start + fctx->total_rows);
 
     uint64_t t1 = HAP_perf_get_qtimer_count();
 
@@ -86,22 +86,22 @@ int op_fill(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (nr + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, nr);
-        dev_nrows     = MIN(rows_per_dev, nr - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (nr + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, nr);
+        mdev_nrows     = MIN(rows_per_mdev, nr - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = nr;
+        mdev_row_start = 0;
+        mdev_nrows     = nr;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
     // nr = ne1*ne2*ne3 (flat row count across all outer dims); parallelise over it.
-    const uint32_t n_threads = MIN(dev_nrows, octx->n_threads);
+    const uint32_t n_threads = MIN(mdev_nrows, octx->n_threads);
 
     // Optimize if fully contiguous: skip stride arithmetic, treat as flat array
     const bool opt_path = (nb2 == nb1 * ne1) && (nb3 == nb2 * ne2);
@@ -114,9 +114,9 @@ int op_fill(struct htp_ops_context * octx) {
 
     struct htp_fill_context fctx = {
         .octx             = octx,
-        .nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
-        .total_rows       = dev_nrows,
-        .dev_row_start    = dev_row_start,
+        .nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+        .total_rows       = mdev_nrows,
+        .mdev_row_start    = mdev_row_start,
         .opt_path         = opt_path,
     };
 

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -36,6 +36,7 @@ struct htp_fill_context {
     struct htp_ops_context * octx;
     uint32_t nrows_per_thread;
     uint32_t total_rows;  // ne1 * ne2 * ne3
+    uint32_t dev_row_start;
     bool     opt_path;
     HVX_Vector splat_vec;
     uint32_t   elem_size;
@@ -47,8 +48,8 @@ static void fill_thread(unsigned int nth, unsigned int ith, void * data) {
     fill_preamble;
 
     // Parallelise over the flat row index spanning ne1*ne2*ne3
-    const uint32_t ir0 = fctx->nrows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + fctx->nrows_per_thread, fctx->total_rows);
+    const uint32_t ir0 = fctx->dev_row_start + fctx->nrows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + fctx->nrows_per_thread, fctx->dev_row_start + fctx->total_rows);
 
     uint64_t t1 = HAP_perf_get_qtimer_count();
 
@@ -85,8 +86,22 @@ int op_fill(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (nr + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, nr);
+        dev_nrows     = MIN(rows_per_dev, nr - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = nr;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
     // nr = ne1*ne2*ne3 (flat row count across all outer dims); parallelise over it.
-    const uint32_t n_threads = MIN(nr, octx->n_threads);
+    const uint32_t n_threads = MIN(dev_nrows, octx->n_threads);
 
     // Optimize if fully contiguous: skip stride arithmetic, treat as flat array
     const bool opt_path = (nb2 == nb1 * ne1) && (nb3 == nb2 * ne2);
@@ -99,8 +114,9 @@ int op_fill(struct htp_ops_context * octx) {
 
     struct htp_fill_context fctx = {
         .octx             = octx,
-        .nrows_per_thread = (nr + n_threads - 1) / n_threads,
-        .total_rows       = nr,
+        .nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
+        .total_rows       = dev_nrows,
+        .dev_row_start    = dev_row_start,
         .opt_path         = opt_path,
     };
 

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -19,18 +19,18 @@
 // ggml op_params layout for FILL:
 //   op_params[0] (as float) - the scalar fill value
 
-#define fill_preamble \
+#define fill_preamble                          \
     const struct htp_tensor * dst = octx->dst; \
-    \
-    const uint32_t ne0 = dst->ne[0]; \
-    const uint32_t ne1 = dst->ne[1]; \
-    const uint32_t ne2 = dst->ne[2]; \
-    const uint32_t ne3 = dst->ne[3]; \
-    \
-    const uint32_t nb1 = dst->nb[1]; \
-    const uint32_t nb2 = dst->nb[2]; \
-    const uint32_t nb3 = dst->nb[3]; \
-    \
+                                               \
+    const uint32_t ne0 = dst->ne[0];           \
+    const uint32_t ne1 = dst->ne[1];           \
+    const uint32_t ne2 = dst->ne[2];           \
+    const uint32_t ne3 = dst->ne[3];           \
+                                               \
+    const uint32_t nb1 = dst->nb[1];           \
+    const uint32_t nb2 = dst->nb[2];           \
+    const uint32_t nb3 = dst->nb[3];           \
+                                               \
     const uint32_t nr = ne1 * ne2 * ne3;
 
 struct htp_fill_context {

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -51,6 +51,10 @@ static void fill_thread(unsigned int nth, unsigned int ith, void * data) {
     const uint32_t ir0 = fctx->mdev_row_start + fctx->nrows_per_thread * ith;
     const uint32_t ir1 = MIN(ir0 + fctx->nrows_per_thread, fctx->mdev_row_start + fctx->total_rows);
 
+    if (ir0 >= ir1) {
+        return;
+    }
+
     uint64_t t1 = HAP_perf_get_qtimer_count();
 
     if (fctx->opt_path) {
@@ -88,7 +92,7 @@ int op_fill(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (nr + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(nr + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, nr);
         mdev_nrows     = MIN(rows_per_mdev, nr - mdev_row_start);
     } else {
@@ -101,7 +105,7 @@ int op_fill(struct htp_ops_context * octx) {
     }
 
     // nr = ne1*ne2*ne3 (flat row count across all outer dims); parallelise over it.
-    const uint32_t n_threads = MIN(mdev_nrows, octx->n_threads);
+    const uint32_t n_threads = octx->n_threads;
 
     // Optimize if fully contiguous: skip stride arithmetic, treat as flat array
     const bool opt_path = (nb2 == nb1 * ne1) && (nb3 == nb2 * ne2);
@@ -114,9 +118,9 @@ int op_fill(struct htp_ops_context * octx) {
 
     struct htp_fill_context fctx = {
         .octx             = octx,
-        .nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+        .nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
         .total_rows       = mdev_nrows,
-        .mdev_row_start    = mdev_row_start,
+        .mdev_row_start   = mdev_row_start,
         .opt_path         = opt_path,
     };
 

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -3,9 +3,10 @@
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 
 #include <HAP_farf.h>
-#include <HAP_perf.h>
-
 #include <string.h>
+
+#include "hex-common.h"
+#include "hex-profile.h"
 
 #include "hvx-copy.h"
 #include "hvx-utils.h"
@@ -55,7 +56,8 @@ static void fill_thread(unsigned int nth, unsigned int ith, void * data) {
         return;
     }
 
-    uint64_t t1 = HAP_perf_get_qtimer_count();
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
 
     if (fctx->opt_path) {
         // Opt path: tensor is fully contiguous, treat as flat array
@@ -74,9 +76,8 @@ static void fill_thread(unsigned int nth, unsigned int ith, void * data) {
         }
     }
 
-    uint64_t t2 = HAP_perf_get_qtimer_count();
-    FARF(HIGH, "fill %u/%u: rows %u:%u usec %u\n",
-         ith, nth, ir0, ir1, (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir1);
+    FARF(HIGH, "fill %u/%u: rows %u:%u\n", ith, nth, ir0, ir1);
 }
 
 int op_fill(struct htp_ops_context * octx) {
@@ -92,9 +93,23 @@ int op_fill(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(nr + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, nr);
-        mdev_nrows     = MIN(rows_per_mdev, nr - mdev_row_start);
+        const uint32_t row_size = nb1;
+        const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
+        const uint32_t total_chunks = nr / rows_per_chunk;
+        const bool can_split = total_chunks >= octx->mdev_count;
+
+        if (!can_split) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : nr;
+            mdev_nrows     = (octx->mdev_idx == 0) ? nr : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, nr);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = nr - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, nr - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = nr;
@@ -137,7 +152,7 @@ int op_fill(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
-    worker_pool_run_func(octx->ctx->worker_pool, fill_thread, &fctx, n_threads);
+    work_queue_run(octx->ctx->work_queue, fill_thread, &fctx, n_threads);
 
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -15,6 +15,7 @@
 #include "ggml-common.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
+#include "htp-tensor.h"
 
 // ggml op_params layout for FILL:
 //   op_params[0] (as float) - the scalar fill value
@@ -97,21 +98,9 @@ int op_fill(struct htp_ops_context * octx) {
     if (octx->ctx->mdev.count > 1) {
         const uint32_t row_size = nb1;
         const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
-        const uint32_t total_chunks = nr / rows_per_chunk;
-        const bool can_split = total_chunks >= octx->ctx->mdev.count;
-
-        if (!can_split) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : nr;
-            nrows     = (octx->ctx->mdev.idx == 0) ? nr : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, nr);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = nr - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, nr - row_start);
-            }
-        }
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(nr, htp_tensor_mdev_data_aligned(dst) ? rows_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/fill-ops.c
+++ b/ggml/src/ggml-hexagon/htp/fill-ops.c
@@ -37,7 +37,7 @@ struct htp_fill_context {
     struct htp_ops_context * octx;
     uint32_t nrows_per_thread;
     uint32_t total_rows;  // ne1 * ne2 * ne3
-    uint32_t mdev_row_start;
+    uint32_t row_start;
     bool     opt_path;
     HVX_Vector splat_vec;
     uint32_t   elem_size;
@@ -49,8 +49,8 @@ static void fill_thread(unsigned int nth, unsigned int ith, void * data) {
     fill_preamble;
 
     // Parallelise over the flat row index spanning ne1*ne2*ne3
-    const uint32_t ir0 = fctx->mdev_row_start + fctx->nrows_per_thread * ith;
-    const uint32_t ir1 = MIN(ir0 + fctx->nrows_per_thread, fctx->mdev_row_start + fctx->total_rows);
+    const uint32_t ir0 = fctx->row_start + fctx->nrows_per_thread * ith;
+    const uint32_t ir1 = MIN(ir0 + fctx->nrows_per_thread, fctx->row_start + fctx->total_rows);
 
     if (ir0 >= ir1) {
         return;
@@ -91,7 +91,9 @@ int op_fill(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = nr;
+
     if (octx->mdev_count > 1) {
         const uint32_t row_size = nb1;
         const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
@@ -99,23 +101,20 @@ int op_fill(struct htp_ops_context * octx) {
         const bool can_split = total_chunks >= octx->mdev_count;
 
         if (!can_split) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : nr;
-            mdev_nrows     = (octx->mdev_idx == 0) ? nr : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : nr;
+            nrows     = (octx->mdev_idx == 0) ? nr : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, nr);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, nr);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = nr - mdev_row_start;
+                nrows = nr - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, nr - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, nr - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = nr;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -133,9 +132,9 @@ int op_fill(struct htp_ops_context * octx) {
 
     struct htp_fill_context fctx = {
         .octx             = octx,
-        .nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
-        .total_rows       = mdev_nrows,
-        .mdev_row_start   = mdev_row_start,
+        .nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div),
+        .total_rows       = nrows,
+        .row_start        = row_start,
         .opt_path         = opt_path,
     };
 

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -1891,9 +1891,9 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
     uint32_t q_start_max = neq1;
 
     if (octx->ctx->mdev.count > 1) {
-        const uint32_t blocks_per_mdev = fastdiv(n_q_blocks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-        const uint32_t block_start     = MIN(octx->ctx->mdev.idx * blocks_per_mdev, n_q_blocks);
-        const uint32_t block_end       = MIN(block_start + blocks_per_mdev, n_q_blocks);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(n_q_blocks, htp_tensor_mdev_data_aligned(dst) ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        const uint32_t block_start = range.start;
+        const uint32_t block_end   = range.start + range.count;
 
         if (block_start >= block_end) {
             return HTP_STATUS_OK;
@@ -2474,19 +2474,10 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
     uint32_t qrows      = total_qrows;
 
     if (octx->ctx->mdev.count > 1) {
-        const bool can_split = ((dst->nb[1] & 127) == 0) && (total_qrows >= octx->ctx->mdev.count);
-        if (!can_split) {
-            qrow_start = (octx->ctx->mdev.idx == 0) ? 0 : total_qrows;
-            qrows      = (octx->ctx->mdev.idx == 0) ? total_qrows : 0;
-        } else {
-            const uint32_t rows_per_mdev = fastdiv(total_qrows + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            qrow_start = MIN(octx->ctx->mdev.idx * rows_per_mdev, total_qrows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                qrows = total_qrows - qrow_start;
-            } else {
-                qrows = MIN(rows_per_mdev, total_qrows - qrow_start);
-            }
-        }
+        const bool can_split = htp_tensor_mdev_data_aligned(dst) && ((dst->nb[1] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_qrows, can_split ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        qrow_start = range.start;
+        qrows      = range.count;
     }
 
     if (qrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -2414,6 +2414,10 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
+    if (!htp_ops_context_set_n_threads(octx, kparams->n_threads)) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+
     if (kparams->kernel_type == HTP_FA_KERNEL_HMX) {
         return hmx_flash_attn_ext(octx);
     }

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -1894,7 +1894,7 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
     uint32_t dev_q_end   = neq1;
 
     if (octx->mdev_count > 1) {
-        const uint32_t blocks_per_mdev  = (n_q_blocks + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t blocks_per_mdev  = fastdiv(n_q_blocks + octx->mdev_count - 1, &octx->mdev_count_div);
         const uint32_t mdev_block_start = MIN(octx->mdev_idx * blocks_per_mdev, n_q_blocks);
         const uint32_t mdev_block_end   = MIN(mdev_block_start + blocks_per_mdev, n_q_blocks);
 
@@ -2477,7 +2477,7 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
 
     uint32_t mdev_qrow_start, mdev_qrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (total_qrows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(total_qrows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_qrow_start = MIN(octx->mdev_idx * rows_per_mdev, total_qrows);
         mdev_qrows      = MIN(rows_per_mdev, total_qrows - mdev_qrow_start);
     } else {
@@ -2489,11 +2489,11 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(mdev_qrows, octx->n_threads);
+    const uint32_t n_threads = octx->n_threads;
 
     factx.qrows            = mdev_qrows;
     factx.mdev_qrow_start   = mdev_qrow_start;
-    factx.qrows_per_thread = (mdev_qrows + n_threads - 1) / n_threads;
+    factx.qrows_per_thread = fastdiv(mdev_qrows + n_threads - 1, &octx->n_threads_div);
 
     size_t size_vkq_acc = hex_round_up(v->ne[0] * sizeof(float), 128); // VKQ32
 

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -5,7 +5,6 @@
 #include <assert.h>
 #include <HAP_compute_res.h>
 #include <HAP_farf.h>
-#include <HAP_perf.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdatomic.h>
@@ -90,8 +89,6 @@ struct htp_fa_context {
 
     const struct htp_tensor * k;
     const struct htp_tensor * v;
-
-    uint64_t t_start;
 };
 
 struct hmx_fa_context {
@@ -2426,8 +2423,6 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
     factx.k = k;
     factx.v = v;
 
-    factx.t_start = HAP_perf_get_qtimer_count();
-
     factx.src0_div21 = kparams->u.hvx.src0_div21;
     factx.src0_div1  = kparams->u.hvx.src0_div1;
 
@@ -2477,9 +2472,19 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
 
     uint32_t mdev_qrow_start, mdev_qrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(total_qrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_qrow_start = MIN(octx->mdev_idx * rows_per_mdev, total_qrows);
-        mdev_qrows      = MIN(rows_per_mdev, total_qrows - mdev_qrow_start);
+        const bool can_split = ((dst->nb[1] & 127) == 0) && (total_qrows >= octx->mdev_count);
+        if (!can_split) {
+            mdev_qrow_start = (octx->mdev_idx == 0) ? 0 : total_qrows;
+            mdev_qrows      = (octx->mdev_idx == 0) ? total_qrows : 0;
+        } else {
+            const uint32_t rows_per_mdev = fastdiv(total_qrows + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_qrow_start = MIN(octx->mdev_idx * rows_per_mdev, total_qrows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_qrows = total_qrows - mdev_qrow_start;
+            } else {
+                mdev_qrows = MIN(rows_per_mdev, total_qrows - mdev_qrow_start);
+            }
+        }
     } else {
         mdev_qrow_start = 0;
         mdev_qrows      = total_qrows;

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -75,6 +75,7 @@ struct htp_fa_context {
 
     uint32_t qrows;
     uint32_t qrows_per_thread;
+    uint32_t dev_qrow_start;
 
     bool is_q_fp32;
 
@@ -206,10 +207,9 @@ static void flash_attn_ext_f16_thread(unsigned int nth, unsigned int ith, void *
     const uint32_t nb3 = dst->nb[3];
 
     // total rows in q
-    const uint32_t nr = factx->qrows;
-    const uint32_t dr = factx->qrows_per_thread;
-    const uint32_t ir0 = dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, nr);
+    const uint32_t dr  = factx->qrows_per_thread;
+    const uint32_t ir0 = factx->dev_qrow_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, factx->dev_qrow_start + factx->qrows);
 
     if (ir0 >= ir1) return;
 
@@ -1888,6 +1888,24 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
     const uint32_t n_threads = factx.n_threads;
     const uint32_t G = factx.G;
 
+    // Multi-device: split Q blocks across devices
+    const uint32_t n_q_blocks = (neq1 + Br - 1) / Br;
+    uint32_t dev_q_start = 0;
+    uint32_t dev_q_end   = neq1;
+
+    if (octx->ndev > 1) {
+        const uint32_t blocks_per_dev  = (n_q_blocks + octx->ndev - 1) / octx->ndev;
+        const uint32_t dev_block_start = MIN(octx->idev * blocks_per_dev, n_q_blocks);
+        const uint32_t dev_block_end   = MIN(dev_block_start + blocks_per_dev, n_q_blocks);
+
+        if (dev_block_start >= dev_block_end) {
+            return HTP_STATUS_OK;
+        }
+
+        dev_q_start = dev_block_start * Br;
+        dev_q_end   = MIN(dev_block_end * Br, neq1);
+    }
+
     // ======== VTCM allocation (GQA-aware) ========
     // K/V row sizes drive the DMA descriptors (not the VTCM layout) and are used
     // throughout the KV loop below.
@@ -1977,7 +1995,7 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
     // ======== Main loop ========
     for (uint32_t ib3 = 0; ib3 < neq3; ++ib3) {
         const uint32_t im3 = mask ? fastmodulo(ib3, mask->ne[3], &factx.src3_div3) : 0;
-        for (uint32_t q_start = 0; q_start < neq1; q_start += Br) {
+        for (uint32_t q_start = dev_q_start; q_start < dev_q_end; q_start += Br) {
             const uint32_t n_rows_q    = hex_smin(Br, neq1 - q_start);
             const size_t   n_rows_g    = n_rows_q * G;
             const size_t   g_br_actual = hex_align_up(n_rows_g, HMX_FP16_TILE_N_ROWS);
@@ -1991,8 +2009,9 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
 
                 // 1. Push Q and KV DMAs for the very first iteration.
                 // Subsequent iterations are enqueued early at the end of the previous iteration.
-                if (ib3 == 0 && q_start == 0 && kv_head == 0) {
-                    const uint8_t * q_ptr = (const uint8_t *) q->data;
+                if (ib3 == 0 && q_start == dev_q_start && kv_head == 0) {
+                    const uint8_t * q_ptr = (const uint8_t *) q->data + q_start * q->nb[1] +
+                                            (kv_head * factx.G) * q->nb[2] + ib3 * q->nb[3];
                     const size_t q_row_bytes = q_transposed ? n_rows_q * q_row_bytes_trans_factor : q_row_bytes_untransposed;
                     const size_t n_rows      = q_transposed ? factx.G : n_rows_q;
                     dma_queue_push(dma, dma_make_ptr(factx.vtcm_q_dma, q_ptr), q_row_bytes, hex_smax(q_src_stride, q_row_bytes), q_row_bytes, n_rows);
@@ -2311,8 +2330,8 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
                 if (next_kv_head >= n_kv_heads) {
                     next_kv_head = 0;
                     next_q_start = q_start + Br;
-                    if (next_q_start >= neq1) {
-                        next_q_start = 0;
+                    if (next_q_start >= dev_q_end) {
+                        next_q_start = dev_q_start;
                         next_ib3     = ib3 + 1;
                     }
                 }
@@ -2451,8 +2470,30 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
     }
 
     // total rows in q
-    factx.qrows = kparams->qrows;
-    factx.qrows_per_thread = kparams->qrows_per_thread;
+    const uint32_t neq1 = q->ne[1];
+    const uint32_t neq2 = q->ne[2];
+    const uint32_t neq3 = q->ne[3];
+    const uint32_t total_qrows = neq1 * neq2 * neq3;
+
+    uint32_t dev_qrow_start, dev_qrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (total_qrows + octx->ndev - 1) / octx->ndev;
+        dev_qrow_start = MIN(octx->idev * rows_per_dev, total_qrows);
+        dev_qrows      = MIN(rows_per_dev, total_qrows - dev_qrow_start);
+    } else {
+        dev_qrow_start = 0;
+        dev_qrows      = total_qrows;
+    }
+
+    if (dev_qrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(dev_qrows, octx->n_threads);
+
+    factx.qrows            = dev_qrows;
+    factx.dev_qrow_start   = dev_qrow_start;
+    factx.qrows_per_thread = (dev_qrows + n_threads - 1) / n_threads;
 
     size_t size_vkq_acc = hex_round_up(v->ne[0] * sizeof(float), 128); // VKQ32
 
@@ -2461,18 +2502,18 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
 
     uint8_t * vtcm_cur = octx->ctx->vtcm_base;
 
-    factx.spad_q = vtcm_seq_alloc(&vtcm_cur, size_q_block * octx->n_threads);
-    factx.spad_k = vtcm_seq_alloc(&vtcm_cur, factx.size_k_block * 2 * octx->n_threads);
-    factx.spad_v = vtcm_seq_alloc(&vtcm_cur, factx.size_v_block * 2 * octx->n_threads);
-    factx.spad_m = vtcm_seq_alloc(&vtcm_cur, (mask ? factx.size_m_block * HVX_FA_DMA_CACHE_SIZE : 0) * octx->n_threads);
-    factx.spad_a = vtcm_seq_alloc(&vtcm_cur, size_vkq_acc * octx->n_threads);
+    factx.spad_q = vtcm_seq_alloc(&vtcm_cur, size_q_block * n_threads);
+    factx.spad_k = vtcm_seq_alloc(&vtcm_cur, factx.size_k_block * 2 * n_threads);
+    factx.spad_v = vtcm_seq_alloc(&vtcm_cur, factx.size_v_block * 2 * n_threads);
+    factx.spad_m = vtcm_seq_alloc(&vtcm_cur, (mask ? factx.size_m_block * HVX_FA_DMA_CACHE_SIZE : 0) * n_threads);
+    factx.spad_a = vtcm_seq_alloc(&vtcm_cur, size_vkq_acc * n_threads);
 
     if ((size_t) (vtcm_cur - octx->ctx->vtcm_base) > octx->ctx->vtcm_size) {
         return HTP_STATUS_VTCM_TOO_SMALL;
     }
 
     if (!(octx->flags & HTP_OPFLAGS_SKIP_COMPUTE)) {
-        work_queue_run(octx->ctx->work_queue, flash_attn_ext_f16_thread, &factx, octx->n_threads);
+        work_queue_run(octx->ctx->work_queue, flash_attn_ext_f16_thread, &factx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -74,7 +74,7 @@ struct htp_fa_context {
 
     uint32_t qrows;
     uint32_t qrows_per_thread;
-    uint32_t mdev_qrow_start;
+    uint32_t qrow_start;
 
     bool is_q_fp32;
 
@@ -205,8 +205,8 @@ static void flash_attn_ext_f16_thread(unsigned int nth, unsigned int ith, void *
 
     // total rows in q
     const uint32_t dr  = factx->qrows_per_thread;
-    const uint32_t ir0 = factx->mdev_qrow_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, factx->mdev_qrow_start + factx->qrows);
+    const uint32_t ir0 = factx->qrow_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, factx->qrow_start + factx->qrows);
 
     if (ir0 >= ir1) return;
 
@@ -1887,20 +1887,20 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
 
     // Multi-device: split Q blocks across devices
     const uint32_t n_q_blocks = (neq1 + Br - 1) / Br;
-    uint32_t dev_q_start = 0;
-    uint32_t dev_q_end   = neq1;
+    uint32_t q_start_min = 0;
+    uint32_t q_start_max = neq1;
 
     if (octx->mdev_count > 1) {
-        const uint32_t blocks_per_mdev  = fastdiv(n_q_blocks + octx->mdev_count - 1, &octx->mdev_count_div);
-        const uint32_t mdev_block_start = MIN(octx->mdev_idx * blocks_per_mdev, n_q_blocks);
-        const uint32_t mdev_block_end   = MIN(mdev_block_start + blocks_per_mdev, n_q_blocks);
+        const uint32_t blocks_per_mdev = fastdiv(n_q_blocks + octx->mdev_count - 1, &octx->mdev_count_div);
+        const uint32_t block_start     = MIN(octx->mdev_idx * blocks_per_mdev, n_q_blocks);
+        const uint32_t block_end       = MIN(block_start + blocks_per_mdev, n_q_blocks);
 
-        if (mdev_block_start >= mdev_block_end) {
+        if (block_start >= block_end) {
             return HTP_STATUS_OK;
         }
 
-        dev_q_start = mdev_block_start * Br;
-        dev_q_end   = MIN(mdev_block_end * Br, neq1);
+        q_start_min = block_start * Br;
+        q_start_max = MIN(block_end * Br, neq1);
     }
 
     // ======== VTCM allocation (GQA-aware) ========
@@ -1992,7 +1992,7 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
     // ======== Main loop ========
     for (uint32_t ib3 = 0; ib3 < neq3; ++ib3) {
         const uint32_t im3 = mask ? fastmodulo(ib3, mask->ne[3], &factx.src3_div3) : 0;
-        for (uint32_t q_start = dev_q_start; q_start < dev_q_end; q_start += Br) {
+        for (uint32_t q_start = q_start_min; q_start < q_start_max; q_start += Br) {
             const uint32_t n_rows_q    = hex_smin(Br, neq1 - q_start);
             const size_t   n_rows_g    = n_rows_q * G;
             const size_t   g_br_actual = hex_align_up(n_rows_g, HMX_FP16_TILE_N_ROWS);
@@ -2006,7 +2006,7 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
 
                 // 1. Push Q and KV DMAs for the very first iteration.
                 // Subsequent iterations are enqueued early at the end of the previous iteration.
-                if (ib3 == 0 && q_start == dev_q_start && kv_head == 0) {
+                if (ib3 == 0 && q_start == q_start_min && kv_head == 0) {
                     const uint8_t * q_ptr = (const uint8_t *) q->data + q_start * q->nb[1] +
                                             (kv_head * factx.G) * q->nb[2] + ib3 * q->nb[3];
                     const size_t q_row_bytes = q_transposed ? n_rows_q * q_row_bytes_trans_factor : q_row_bytes_untransposed;
@@ -2327,8 +2327,8 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
                 if (next_kv_head >= n_kv_heads) {
                     next_kv_head = 0;
                     next_q_start = q_start + Br;
-                    if (next_q_start >= dev_q_end) {
-                        next_q_start = dev_q_start;
+                    if (next_q_start >= q_start_max) {
+                        next_q_start = q_start_min;
                         next_ib3     = ib3 + 1;
                     }
                 }
@@ -2470,35 +2470,34 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
     const uint32_t neq3 = q->ne[3];
     const uint32_t total_qrows = neq1 * neq2 * neq3;
 
-    uint32_t mdev_qrow_start, mdev_qrows;
+    uint32_t qrow_start = 0;
+    uint32_t qrows      = total_qrows;
+
     if (octx->mdev_count > 1) {
         const bool can_split = ((dst->nb[1] & 127) == 0) && (total_qrows >= octx->mdev_count);
         if (!can_split) {
-            mdev_qrow_start = (octx->mdev_idx == 0) ? 0 : total_qrows;
-            mdev_qrows      = (octx->mdev_idx == 0) ? total_qrows : 0;
+            qrow_start = (octx->mdev_idx == 0) ? 0 : total_qrows;
+            qrows      = (octx->mdev_idx == 0) ? total_qrows : 0;
         } else {
             const uint32_t rows_per_mdev = fastdiv(total_qrows + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_qrow_start = MIN(octx->mdev_idx * rows_per_mdev, total_qrows);
+            qrow_start = MIN(octx->mdev_idx * rows_per_mdev, total_qrows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_qrows = total_qrows - mdev_qrow_start;
+                qrows = total_qrows - qrow_start;
             } else {
-                mdev_qrows = MIN(rows_per_mdev, total_qrows - mdev_qrow_start);
+                qrows = MIN(rows_per_mdev, total_qrows - qrow_start);
             }
         }
-    } else {
-        mdev_qrow_start = 0;
-        mdev_qrows      = total_qrows;
     }
 
-    if (mdev_qrows == 0) {
+    if (qrows == 0) {
         return HTP_STATUS_OK;
     }
 
     const uint32_t n_threads = octx->n_threads;
 
-    factx.qrows            = mdev_qrows;
-    factx.mdev_qrow_start   = mdev_qrow_start;
-    factx.qrows_per_thread = fastdiv(mdev_qrows + n_threads - 1, &octx->n_threads_div);
+    factx.qrows            = qrows;
+    factx.qrow_start       = qrow_start;
+    factx.qrows_per_thread = fastdiv(qrows + n_threads - 1, &octx->n_threads_div);
 
     size_t size_vkq_acc = hex_round_up(v->ne[0] * sizeof(float), 128); // VKQ32
 

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -75,7 +75,7 @@ struct htp_fa_context {
 
     uint32_t qrows;
     uint32_t qrows_per_thread;
-    uint32_t dev_qrow_start;
+    uint32_t mdev_qrow_start;
 
     bool is_q_fp32;
 
@@ -208,8 +208,8 @@ static void flash_attn_ext_f16_thread(unsigned int nth, unsigned int ith, void *
 
     // total rows in q
     const uint32_t dr  = factx->qrows_per_thread;
-    const uint32_t ir0 = factx->dev_qrow_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, factx->dev_qrow_start + factx->qrows);
+    const uint32_t ir0 = factx->mdev_qrow_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, factx->mdev_qrow_start + factx->qrows);
 
     if (ir0 >= ir1) return;
 
@@ -1893,17 +1893,17 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
     uint32_t dev_q_start = 0;
     uint32_t dev_q_end   = neq1;
 
-    if (octx->ndev > 1) {
-        const uint32_t blocks_per_dev  = (n_q_blocks + octx->ndev - 1) / octx->ndev;
-        const uint32_t dev_block_start = MIN(octx->idev * blocks_per_dev, n_q_blocks);
-        const uint32_t dev_block_end   = MIN(dev_block_start + blocks_per_dev, n_q_blocks);
+    if (octx->mdev_count > 1) {
+        const uint32_t blocks_per_mdev  = (n_q_blocks + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t mdev_block_start = MIN(octx->mdev_idx * blocks_per_mdev, n_q_blocks);
+        const uint32_t mdev_block_end   = MIN(mdev_block_start + blocks_per_mdev, n_q_blocks);
 
-        if (dev_block_start >= dev_block_end) {
+        if (mdev_block_start >= mdev_block_end) {
             return HTP_STATUS_OK;
         }
 
-        dev_q_start = dev_block_start * Br;
-        dev_q_end   = MIN(dev_block_end * Br, neq1);
+        dev_q_start = mdev_block_start * Br;
+        dev_q_end   = MIN(mdev_block_end * Br, neq1);
     }
 
     // ======== VTCM allocation (GQA-aware) ========
@@ -2475,25 +2475,25 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
     const uint32_t neq3 = q->ne[3];
     const uint32_t total_qrows = neq1 * neq2 * neq3;
 
-    uint32_t dev_qrow_start, dev_qrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (total_qrows + octx->ndev - 1) / octx->ndev;
-        dev_qrow_start = MIN(octx->idev * rows_per_dev, total_qrows);
-        dev_qrows      = MIN(rows_per_dev, total_qrows - dev_qrow_start);
+    uint32_t mdev_qrow_start, mdev_qrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (total_qrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_qrow_start = MIN(octx->mdev_idx * rows_per_mdev, total_qrows);
+        mdev_qrows      = MIN(rows_per_mdev, total_qrows - mdev_qrow_start);
     } else {
-        dev_qrow_start = 0;
-        dev_qrows      = total_qrows;
+        mdev_qrow_start = 0;
+        mdev_qrows      = total_qrows;
     }
 
-    if (dev_qrows == 0) {
+    if (mdev_qrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(dev_qrows, octx->n_threads);
+    const uint32_t n_threads = MIN(mdev_qrows, octx->n_threads);
 
-    factx.qrows            = dev_qrows;
-    factx.dev_qrow_start   = dev_qrow_start;
-    factx.qrows_per_thread = (dev_qrows + n_threads - 1) / n_threads;
+    factx.qrows            = mdev_qrows;
+    factx.mdev_qrow_start   = mdev_qrow_start;
+    factx.qrows_per_thread = (mdev_qrows + n_threads - 1) / n_threads;
 
     size_t size_vkq_acc = hex_round_up(v->ne[0] * sizeof(float), 128); // VKQ32
 

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.c
@@ -1890,9 +1890,9 @@ int hmx_flash_attn_ext(struct htp_ops_context * octx) {
     uint32_t q_start_min = 0;
     uint32_t q_start_max = neq1;
 
-    if (octx->mdev_count > 1) {
-        const uint32_t blocks_per_mdev = fastdiv(n_q_blocks + octx->mdev_count - 1, &octx->mdev_count_div);
-        const uint32_t block_start     = MIN(octx->mdev_idx * blocks_per_mdev, n_q_blocks);
+    if (octx->ctx->mdev.count > 1) {
+        const uint32_t blocks_per_mdev = fastdiv(n_q_blocks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+        const uint32_t block_start     = MIN(octx->ctx->mdev.idx * blocks_per_mdev, n_q_blocks);
         const uint32_t block_end       = MIN(block_start + blocks_per_mdev, n_q_blocks);
 
         if (block_start >= block_end) {
@@ -2473,15 +2473,15 @@ int op_flash_attn_ext(struct htp_ops_context * octx) {
     uint32_t qrow_start = 0;
     uint32_t qrows      = total_qrows;
 
-    if (octx->mdev_count > 1) {
-        const bool can_split = ((dst->nb[1] & 127) == 0) && (total_qrows >= octx->mdev_count);
+    if (octx->ctx->mdev.count > 1) {
+        const bool can_split = ((dst->nb[1] & 127) == 0) && (total_qrows >= octx->ctx->mdev.count);
         if (!can_split) {
-            qrow_start = (octx->mdev_idx == 0) ? 0 : total_qrows;
-            qrows      = (octx->mdev_idx == 0) ? total_qrows : 0;
+            qrow_start = (octx->ctx->mdev.idx == 0) ? 0 : total_qrows;
+            qrows      = (octx->ctx->mdev.idx == 0) ? total_qrows : 0;
         } else {
-            const uint32_t rows_per_mdev = fastdiv(total_qrows + octx->mdev_count - 1, &octx->mdev_count_div);
-            qrow_start = MIN(octx->mdev_idx * rows_per_mdev, total_qrows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t rows_per_mdev = fastdiv(total_qrows + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            qrow_start = MIN(octx->ctx->mdev.idx * rows_per_mdev, total_qrows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 qrows = total_qrows - qrow_start;
             } else {
                 qrows = MIN(rows_per_mdev, total_qrows - qrow_start);

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.h
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.h
@@ -51,7 +51,7 @@ struct htp_fa_kernel_params {
 
     uint32_t qrows;
     uint32_t qrows_per_thread;
-    uint32_t mdev_qrow_start;
+    uint32_t qrow_start;
     float    m0;
     float    m1;
     uint32_t n_head_log2;

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.h
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.h
@@ -51,7 +51,7 @@ struct htp_fa_kernel_params {
 
     uint32_t qrows;
     uint32_t qrows_per_thread;
-    uint32_t dev_qrow_start;
+    uint32_t mdev_qrow_start;
     float    m0;
     float    m1;
     uint32_t n_head_log2;

--- a/ggml/src/ggml-hexagon/htp/flash-attn-ops.h
+++ b/ggml/src/ggml-hexagon/htp/flash-attn-ops.h
@@ -51,6 +51,7 @@ struct htp_fa_kernel_params {
 
     uint32_t qrows;
     uint32_t qrows_per_thread;
+    uint32_t dev_qrow_start;
     float    m0;
     float    m1;
     uint32_t n_head_log2;

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -22,6 +22,8 @@ struct htp_gdn_context {
     size_t   state_bytes;
     uint8_t * vtcm_base;
     size_t   vtcm_per_thread;
+    uint32_t dev_row_start;
+    uint32_t dev_nrows;
 };
 
 static inline HVX_Vector gdn_mul_dot_f32(float * restrict dst, const float * restrict mul, const float * restrict dot, uint32_t n) {
@@ -586,8 +588,9 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     const uint32_t n_seqs   = v->ne[3];
     const uint32_t K        = octx->op_params[0];
 
-    const uint32_t total_rows = H * n_seqs;
-    if (ith >= total_rows) {
+    const uint32_t row_end = gctx->dev_row_start + gctx->dev_nrows;
+
+    if (ith >= gctx->dev_nrows) {
         return;
     }
 
@@ -621,11 +624,11 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     const uint64_t state_seq_stride = state->nb[3] / sizeof(float);
     const uint64_t state_size_per_snap = (uint64_t) S_v * S_v * H * n_seqs;
 
-    uint32_t ir_prefetch = ith;
+    uint32_t ir_prefetch = gctx->dev_row_start + ith;
     int spad_idx = 0;
 
     // Prefetch preamble (up to 2 steps)
-    for (int k = 0; k < 2 && ir_prefetch < total_rows; k++) {
+    for (int k = 0; k < 2 && ir_prefetch < row_end; k++) {
         const uint32_t piv1 = fastmodulo(ir_prefetch, H, &fd_H);
         const uint32_t piv3 = fastdiv(ir_prefetch, &fd_H);
         const float * ps_in = state_in_base + (uint64_t) piv3 * state_seq_stride + (uint64_t) piv1 * S_v * S_v;
@@ -647,7 +650,7 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     }
 
     int curr_spad_idx = 0;
-    for (uint32_t ir = ith; ir < total_rows; ir += nth) {
+    for (uint32_t ir = gctx->dev_row_start + ith; ir < row_end; ir += nth) {
         dma_queue_pop(dma);
         dma_queue_pop(dma);
 
@@ -812,7 +815,7 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
                        S_v * sizeof(float), S_v);
 
         // Prefetch next block (if any)
-        if (ir_prefetch < total_rows) {
+        if (ir_prefetch < row_end) {
             const uint32_t piv1 = fastmodulo(ir_prefetch, H, &fd_H);
             const uint32_t piv3 = fastdiv(ir_prefetch, &fd_H);
             const float * ps_in = state_in_base + (uint64_t) piv3 * state_seq_stride + (uint64_t) piv1 * S_v * S_v;
@@ -847,8 +850,9 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
     const uint32_t H        = v->ne[1];
     const uint32_t n_seqs   = v->ne[3];
 
-    const uint32_t total_rows = H * n_seqs;
-    if (ith >= total_rows) {
+    const uint32_t row_end = gctx->dev_row_start + gctx->dev_nrows;
+
+    if (ith >= gctx->dev_nrows) {
         return;
     }
 
@@ -881,11 +885,11 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
 
     const uint64_t state_seq_stride = state->nb[3] / sizeof(float);
 
-    uint32_t ir_prefetch = ith;
+    uint32_t ir_prefetch = gctx->dev_row_start + ith;
     int spad_idx = 0;
 
     // Prefetch preamble (up to 2 steps)
-    for (int k = 0; k < 2 && ir_prefetch < total_rows; k++) {
+    for (int k = 0; k < 2 && ir_prefetch < row_end; k++) {
         const uint32_t piv1 = fastmodulo(ir_prefetch, H, &fd_H);
         const uint32_t piv3 = fastdiv(ir_prefetch, &fd_H);
         const float * ps_in = state_in_base + (uint64_t) piv3 * state_seq_stride + (uint64_t) piv1 * S_v * S_v;
@@ -907,7 +911,7 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
     }
 
     int curr_spad_idx = 0;
-    for (uint32_t ir = ith; ir < total_rows; ir += nth) {
+    for (uint32_t ir = gctx->dev_row_start + ith; ir < row_end; ir += nth) {
         dma_queue_pop(dma);
         dma_queue_pop(dma);
 
@@ -1057,7 +1061,7 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
                        S_v * sizeof(float), S_v);
 
         // Prefetch next block (if any)
-        if (ir_prefetch < total_rows) {
+        if (ir_prefetch < row_end) {
             const uint32_t piv1 = fastmodulo(ir_prefetch, H, &fd_H);
             const uint32_t piv3 = fastdiv(ir_prefetch, &fd_H);
             const float * ps_in = state_in_base + (uint64_t) piv3 * state_seq_stride + (uint64_t) piv1 * S_v * S_v;
@@ -1124,16 +1128,36 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
+    const uint32_t total_rows = H * n_seqs;
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
+        dev_nrows     = MIN(rows_per_dev, total_rows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = total_rows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
+
     struct htp_gdn_context gctx;
     gctx.octx = octx;
-    gctx.rows_per_thread = (H * n_seqs + octx->n_threads - 1) / octx->n_threads;
+    gctx.dev_row_start   = dev_row_start;
+    gctx.dev_nrows       = dev_nrows;
+    gctx.rows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
     gctx.state_bytes = (size_t) S_v * S_v * sizeof(float);
 
     size_t state_aligned = (size_t) S_v * S_v * sizeof(float);
     state_aligned = (state_aligned + 127) & ~(size_t)127;
 
     assert(octx->ctx->vtcm_base != NULL);
-    assert(octx->ctx->vtcm_size >= 2 * state_aligned * octx->n_threads);
+    assert(octx->ctx->vtcm_size >= 2 * state_aligned * n_threads);
 
     gctx.vtcm_base = octx->ctx->vtcm_base;
     gctx.vtcm_per_thread = 2 * state_aligned;
@@ -1148,9 +1172,9 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
          gctx.vtcm_per_thread * octx->n_threads, octx->n_threads);
 
     if (n_tokens == 1) {
-        worker_pool_run_func(octx->ctx->worker_pool, gated_delta_net_f32_tg_thread, &gctx, octx->n_threads);
+        worker_pool_run_func(octx->ctx->worker_pool, gated_delta_net_f32_tg_thread, &gctx, n_threads);
     } else {
-        worker_pool_run_func(octx->ctx->worker_pool, gated_delta_net_f32_pp_thread, &gctx, octx->n_threads);
+        worker_pool_run_func(octx->ctx->worker_pool, gated_delta_net_f32_pp_thread, &gctx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -1100,10 +1100,6 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
     const struct htp_tensor * state = octx->src[5];
     const struct htp_tensor * dst   = octx->dst;
 
-    if (!q || !k || !v || !g || !beta || !state || !dst) {
-        return HTP_STATUS_INVAL_PARAMS;
-    }
-
     if (q->type != HTP_TYPE_F32 || k->type != HTP_TYPE_F32 || v->type != HTP_TYPE_F32 ||
         g->type != HTP_TYPE_F32 || beta->type != HTP_TYPE_F32 || state->type != HTP_TYPE_F32 ||
         dst->type != HTP_TYPE_F32) {

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -1147,7 +1147,8 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
     if (octx->ctx->mdev.count > 1) {
         const uint32_t head_bytes = S_v * sizeof(float);
         const uint32_t rows_per_chunk = (head_bytes > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(head_bytes, HEX_L2_LINE_SIZE)) : 1;
-        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, htp_tensor_mdev_data_aligned(dst) ? rows_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, htp_tensor_mdev_data_aligned(dst) ? rows_per_chunk : 0,
+                                                                             octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
         row_start = range.start;
         nrows     = range.count;
     }
@@ -1168,7 +1169,6 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
     size_t state_aligned = (size_t) S_v * S_v * sizeof(float);
     state_aligned = (state_aligned + 127) & ~(size_t)127;
 
-    assert(octx->ctx->vtcm_base != NULL);
     assert(octx->ctx->vtcm_size >= 2 * state_aligned * n_threads);
 
     gctx.vtcm_base = octx->ctx->vtcm_base;

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -10,6 +10,7 @@
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
 #include "htp-ctx.h"
+#include "htp-tensor.h"
 
 #ifndef MIN
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
@@ -1146,21 +1147,9 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
     if (octx->ctx->mdev.count > 1) {
         const uint32_t head_bytes = S_v * sizeof(float);
         const uint32_t rows_per_chunk = (head_bytes > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(head_bytes, HEX_L2_LINE_SIZE)) : 1;
-        const uint32_t total_chunks = total_rows / rows_per_chunk;
-        const bool can_split = total_chunks >= octx->ctx->mdev.count;
-
-        if (!can_split) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = total_rows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
-            }
-        }
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, htp_tensor_mdev_data_aligned(dst) ? rows_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -4,6 +4,8 @@
 
 #include "hvx-utils.h"
 #include "hex-fastdiv.h"
+#include "hex-common.h"
+#include "hex-profile.h"
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
@@ -649,6 +651,9 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
         spad_idx ^= 1;
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (gctx->mdev_row_start + ith));
+
     int curr_spad_idx = 0;
     for (uint32_t ir = gctx->mdev_row_start + ith; ir < row_end; ir += nth) {
         dma_queue_pop(dma);
@@ -831,6 +836,7 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
         curr_spad_idx ^= 1;
     }
     dma_queue_flush(dma);
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) row_end);
 }
 
 
@@ -909,6 +915,9 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
         ir_prefetch += nth;
         spad_idx ^= 1;
     }
+
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (gctx->mdev_row_start + ith));
 
     int curr_spad_idx = 0;
     for (uint32_t ir = gctx->mdev_row_start + ith; ir < row_end; ir += nth) {
@@ -1077,6 +1086,7 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
         curr_spad_idx ^= 1;
     }
     dma_queue_flush(dma);
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) row_end);
 }
 
 
@@ -1132,9 +1142,23 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
-        mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
+        const uint32_t head_bytes = S_v * sizeof(float);
+        const uint32_t rows_per_chunk = (head_bytes > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(head_bytes, HEX_L2_LINE_SIZE)) : 1;
+        const uint32_t total_chunks = total_rows / rows_per_chunk;
+        const bool can_split = total_chunks >= octx->mdev_count;
+
+        if (!can_split) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = total_rows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = total_rows;
@@ -1172,9 +1196,9 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
          gctx.vtcm_per_thread * octx->n_threads, octx->n_threads);
 
     if (n_tokens == 1) {
-        worker_pool_run_func(octx->ctx->worker_pool, gated_delta_net_f32_tg_thread, &gctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, gated_delta_net_f32_tg_thread, &gctx, n_threads);
     } else {
-        worker_pool_run_func(octx->ctx->worker_pool, gated_delta_net_f32_pp_thread, &gctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, gated_delta_net_f32_pp_thread, &gctx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -1132,7 +1132,7 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(total_rows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
         mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
     } else {
@@ -1144,13 +1144,13 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     struct htp_gdn_context gctx;
     gctx.octx = octx;
-    gctx.mdev_row_start   = mdev_row_start;
-    gctx.mdev_nrows       = mdev_nrows;
-    gctx.rows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    gctx.mdev_row_start  = mdev_row_start;
+    gctx.mdev_nrows      = mdev_nrows;
+    gctx.rows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
     gctx.state_bytes = (size_t) S_v * S_v * sizeof(float);
 
     size_t state_aligned = (size_t) S_v * S_v * sizeof(float);

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -1143,19 +1143,19 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = total_rows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         const uint32_t head_bytes = S_v * sizeof(float);
         const uint32_t rows_per_chunk = (head_bytes > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(head_bytes, HEX_L2_LINE_SIZE)) : 1;
         const uint32_t total_chunks = total_rows / rows_per_chunk;
-        const bool can_split = total_chunks >= octx->mdev_count;
+        const bool can_split = total_chunks >= octx->ctx->mdev.count;
 
         if (!can_split) {
-            row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-            nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = total_rows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -24,8 +24,8 @@ struct htp_gdn_context {
     size_t   state_bytes;
     uint8_t * vtcm_base;
     size_t   vtcm_per_thread;
-    uint32_t mdev_row_start;
-    uint32_t mdev_nrows;
+    uint32_t row_start;
+    uint32_t nrows;
 };
 
 static inline HVX_Vector gdn_mul_dot_f32(float * restrict dst, const float * restrict mul, const float * restrict dot, uint32_t n) {
@@ -590,9 +590,9 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     const uint32_t n_seqs   = v->ne[3];
     const uint32_t K        = octx->op_params[0];
 
-    const uint32_t row_end = gctx->mdev_row_start + gctx->mdev_nrows;
+    const uint32_t row_end = gctx->row_start + gctx->nrows;
 
-    if (ith >= gctx->mdev_nrows) {
+    if (ith >= gctx->nrows) {
         return;
     }
 
@@ -626,7 +626,7 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     const uint64_t state_seq_stride = state->nb[3] / sizeof(float);
     const uint64_t state_size_per_snap = (uint64_t) S_v * S_v * H * n_seqs;
 
-    uint32_t ir_prefetch = gctx->mdev_row_start + ith;
+    uint32_t ir_prefetch = gctx->row_start + ith;
     int spad_idx = 0;
 
     // Prefetch preamble (up to 2 steps)
@@ -652,10 +652,10 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (gctx->mdev_row_start + ith));
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (gctx->row_start + ith));
 
     int curr_spad_idx = 0;
-    for (uint32_t ir = gctx->mdev_row_start + ith; ir < row_end; ir += nth) {
+    for (uint32_t ir = gctx->row_start + ith; ir < row_end; ir += nth) {
         dma_queue_pop(dma);
         dma_queue_pop(dma);
 
@@ -856,9 +856,9 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
     const uint32_t H        = v->ne[1];
     const uint32_t n_seqs   = v->ne[3];
 
-    const uint32_t row_end = gctx->mdev_row_start + gctx->mdev_nrows;
+    const uint32_t row_end = gctx->row_start + gctx->nrows;
 
-    if (ith >= gctx->mdev_nrows) {
+    if (ith >= gctx->nrows) {
         return;
     }
 
@@ -891,7 +891,7 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
 
     const uint64_t state_seq_stride = state->nb[3] / sizeof(float);
 
-    uint32_t ir_prefetch = gctx->mdev_row_start + ith;
+    uint32_t ir_prefetch = gctx->row_start + ith;
     int spad_idx = 0;
 
     // Prefetch preamble (up to 2 steps)
@@ -917,10 +917,10 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
     }
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (gctx->mdev_row_start + ith));
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) (gctx->row_start + ith));
 
     int curr_spad_idx = 0;
-    for (uint32_t ir = gctx->mdev_row_start + ith; ir < row_end; ir += nth) {
+    for (uint32_t ir = gctx->row_start + ith; ir < row_end; ir += nth) {
         dma_queue_pop(dma);
         dma_queue_pop(dma);
 
@@ -1140,7 +1140,9 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
 
     const uint32_t total_rows = H * n_seqs;
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = total_rows;
+
     if (octx->mdev_count > 1) {
         const uint32_t head_bytes = S_v * sizeof(float);
         const uint32_t rows_per_chunk = (head_bytes > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(head_bytes, HEX_L2_LINE_SIZE)) : 1;
@@ -1148,23 +1150,20 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
         const bool can_split = total_chunks >= octx->mdev_count;
 
         if (!can_split) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : total_rows;
+            nrows     = (octx->mdev_idx == 0) ? total_rows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = total_rows - mdev_row_start;
+                nrows = total_rows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = total_rows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -1172,9 +1171,9 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
 
     struct htp_gdn_context gctx;
     gctx.octx = octx;
-    gctx.mdev_row_start  = mdev_row_start;
-    gctx.mdev_nrows      = mdev_nrows;
-    gctx.rows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+    gctx.row_start       = row_start;
+    gctx.nrows           = nrows;
+    gctx.rows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
     gctx.state_bytes = (size_t) S_v * S_v * sizeof(float);
 
     size_t state_aligned = (size_t) S_v * S_v * sizeof(float);

--- a/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
+++ b/ggml/src/ggml-hexagon/htp/gated-delta-net-ops.c
@@ -22,8 +22,8 @@ struct htp_gdn_context {
     size_t   state_bytes;
     uint8_t * vtcm_base;
     size_t   vtcm_per_thread;
-    uint32_t dev_row_start;
-    uint32_t dev_nrows;
+    uint32_t mdev_row_start;
+    uint32_t mdev_nrows;
 };
 
 static inline HVX_Vector gdn_mul_dot_f32(float * restrict dst, const float * restrict mul, const float * restrict dot, uint32_t n) {
@@ -588,9 +588,9 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     const uint32_t n_seqs   = v->ne[3];
     const uint32_t K        = octx->op_params[0];
 
-    const uint32_t row_end = gctx->dev_row_start + gctx->dev_nrows;
+    const uint32_t row_end = gctx->mdev_row_start + gctx->mdev_nrows;
 
-    if (ith >= gctx->dev_nrows) {
+    if (ith >= gctx->mdev_nrows) {
         return;
     }
 
@@ -624,7 +624,7 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     const uint64_t state_seq_stride = state->nb[3] / sizeof(float);
     const uint64_t state_size_per_snap = (uint64_t) S_v * S_v * H * n_seqs;
 
-    uint32_t ir_prefetch = gctx->dev_row_start + ith;
+    uint32_t ir_prefetch = gctx->mdev_row_start + ith;
     int spad_idx = 0;
 
     // Prefetch preamble (up to 2 steps)
@@ -650,7 +650,7 @@ static void gated_delta_net_f32_pp_thread(unsigned int nth, unsigned int ith, vo
     }
 
     int curr_spad_idx = 0;
-    for (uint32_t ir = gctx->dev_row_start + ith; ir < row_end; ir += nth) {
+    for (uint32_t ir = gctx->mdev_row_start + ith; ir < row_end; ir += nth) {
         dma_queue_pop(dma);
         dma_queue_pop(dma);
 
@@ -850,9 +850,9 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
     const uint32_t H        = v->ne[1];
     const uint32_t n_seqs   = v->ne[3];
 
-    const uint32_t row_end = gctx->dev_row_start + gctx->dev_nrows;
+    const uint32_t row_end = gctx->mdev_row_start + gctx->mdev_nrows;
 
-    if (ith >= gctx->dev_nrows) {
+    if (ith >= gctx->mdev_nrows) {
         return;
     }
 
@@ -885,7 +885,7 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
 
     const uint64_t state_seq_stride = state->nb[3] / sizeof(float);
 
-    uint32_t ir_prefetch = gctx->dev_row_start + ith;
+    uint32_t ir_prefetch = gctx->mdev_row_start + ith;
     int spad_idx = 0;
 
     // Prefetch preamble (up to 2 steps)
@@ -911,7 +911,7 @@ static void gated_delta_net_f32_tg_thread(unsigned int nth, unsigned int ith, vo
     }
 
     int curr_spad_idx = 0;
-    for (uint32_t ir = gctx->dev_row_start + ith; ir < row_end; ir += nth) {
+    for (uint32_t ir = gctx->mdev_row_start + ith; ir < row_end; ir += nth) {
         dma_queue_pop(dma);
         dma_queue_pop(dma);
 
@@ -1130,27 +1130,27 @@ int op_gated_delta_net(struct htp_ops_context * octx) {
 
     const uint32_t total_rows = H * n_seqs;
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (total_rows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, total_rows);
-        dev_nrows     = MIN(rows_per_dev, total_rows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (total_rows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_rows);
+        mdev_nrows     = MIN(rows_per_mdev, total_rows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = total_rows;
+        mdev_row_start = 0;
+        mdev_nrows     = total_rows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
 
     struct htp_gdn_context gctx;
     gctx.octx = octx;
-    gctx.dev_row_start   = dev_row_start;
-    gctx.dev_nrows       = dev_nrows;
-    gctx.rows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
+    gctx.mdev_row_start   = mdev_row_start;
+    gctx.mdev_nrows       = mdev_nrows;
+    gctx.rows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
     gctx.state_bytes = (size_t) S_v * S_v * sizeof(float);
 
     size_t state_aligned = (size_t) S_v * S_v * sizeof(float);

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -23,8 +23,8 @@ struct get_rows_context {
     const struct htp_get_rows_kernel_params * kparams;
     struct htp_get_rows_vtcm_layout vtcm_layout;
     uint8_t * vtcm_base;
-    uint32_t dev_task_start;
-    uint32_t dev_tasks;
+    uint32_t mdev_task_start;
+    uint32_t mdev_tasks;
     uint32_t tasks_per_thread;
 };
 
@@ -65,11 +65,11 @@ static void get_rows_thread_st_##IDX_TYPE(unsigned int nth, unsigned int ith, vo
     const struct htp_get_rows_kernel_params * kparams = grctx->kparams;                                                \
     get_rows_preamble;                                                                                                 \
     const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
-    const uint32_t ir0 = grctx->dev_task_start + dr * ith;                                                             \
-    if (ir0 >= grctx->dev_task_start + grctx->dev_tasks) {                                                             \
+    const uint32_t ir0 = grctx->mdev_task_start + dr * ith;                                                            \
+    if (ir0 >= grctx->mdev_task_start + grctx->mdev_tasks) {                                                           \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, grctx->dev_task_start + grctx->dev_tasks);                                      \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->mdev_task_start + grctx->mdev_tasks);                                    \
     const uint32_t row_size_bytes = htp_tensor_get_row_size(octx->src[0]->type, ne00);                                 \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \
     for (uint32_t i = ir0; i < ir1; ++i) {                                                                             \
@@ -105,11 +105,11 @@ static void get_rows_thread_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsigned 
     get_rows_preamble;                                                                                                 \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                             \
     const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
-    const uint32_t ir0 = grctx->dev_task_start + dr * ith;                                                             \
-    if (ir0 >= grctx->dev_task_start + grctx->dev_tasks) {                                                             \
+    const uint32_t ir0 = grctx->mdev_task_start + dr * ith;                                                            \
+    if (ir0 >= grctx->mdev_task_start + grctx->mdev_tasks) {                                                           \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, grctx->dev_task_start + grctx->dev_tasks);                                      \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->mdev_task_start + grctx->mdev_tasks);                                    \
     const uint32_t chunks_per_row = kparams->chunks_per_row;                                                           \
     const uint32_t chunk_size     = kparams->chunk_size;                                                               \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \
@@ -229,31 +229,31 @@ int op_get_rows(struct htp_ops_context * octx) {
     }
 
     const uint32_t total_tasks = kparams->total_tasks;
-    uint32_t dev_task_start, dev_tasks;
-    if (octx->ndev > 1) {
+    uint32_t mdev_task_start, mdev_tasks;
+    if (octx->mdev_count > 1) {
         const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
-        uint32_t tasks_per_dev = (total_tasks + octx->ndev - 1) / octx->ndev;
-        tasks_per_dev = ((tasks_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        dev_task_start = MIN(octx->idev * tasks_per_dev, total_tasks);
-        dev_tasks      = MIN(tasks_per_dev, total_tasks - dev_task_start);
+        uint32_t tasks_per_mdev = (total_tasks + octx->mdev_count - 1) / octx->mdev_count;
+        tasks_per_mdev = ((tasks_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
+        mdev_tasks      = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
     } else {
-        dev_task_start = 0;
-        dev_tasks      = total_tasks;
+        mdev_task_start = 0;
+        mdev_tasks      = total_tasks;
     }
 
-    if (dev_tasks == 0) {
+    if (mdev_tasks == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(kparams->n_threads, dev_tasks);
+    const uint32_t n_threads = MIN(kparams->n_threads, mdev_tasks);
 
     struct get_rows_context grctx;
     grctx.octx = octx;
     grctx.kparams = kparams;
     grctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;
-    grctx.dev_task_start = dev_task_start;
-    grctx.dev_tasks = dev_tasks;
-    grctx.tasks_per_thread = (dev_tasks + n_threads - 1) / n_threads;
+    grctx.mdev_task_start = mdev_task_start;
+    grctx.mdev_tasks = mdev_tasks;
+    grctx.tasks_per_thread = (mdev_tasks + n_threads - 1) / n_threads;
 
     const uint32_t ne00 = octx->src[0]->ne[0];
     htp_get_rows_vtcm_layout_build(&grctx.vtcm_layout, octx->src[0]->type, ne00, n_threads);

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -29,7 +29,7 @@ struct get_rows_context {
     uint32_t tasks_per_thread;
 };
 
-#define get_rows_preamble \
+#define get_rows_preamble                      \
     const uint32_t ne00 = octx->src[0]->ne[0]; \
     const uint32_t ne01 = octx->src[0]->ne[1]; \
     const uint32_t ne02 = octx->src[0]->ne[2]; \

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -232,7 +232,7 @@ int op_get_rows(struct htp_ops_context * octx) {
     uint32_t mdev_task_start, mdev_tasks;
     if (octx->mdev_count > 1) {
         const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
-        uint32_t tasks_per_mdev = (total_tasks + octx->mdev_count - 1) / octx->mdev_count;
+        uint32_t tasks_per_mdev = fastdiv(total_tasks + octx->mdev_count - 1, &octx->mdev_count_div);
         tasks_per_mdev = ((tasks_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
         mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
         mdev_tasks      = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
@@ -245,7 +245,7 @@ int op_get_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(kparams->n_threads, mdev_tasks);
+    const uint32_t n_threads = octx->n_threads;
 
     struct get_rows_context grctx;
     grctx.octx = octx;
@@ -253,7 +253,7 @@ int op_get_rows(struct htp_ops_context * octx) {
     grctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;
     grctx.mdev_task_start = mdev_task_start;
     grctx.mdev_tasks = mdev_tasks;
-    grctx.tasks_per_thread = (mdev_tasks + n_threads - 1) / n_threads;
+    grctx.tasks_per_thread = fastdiv(mdev_tasks + n_threads - 1, &octx->n_threads_div);
 
     const uint32_t ne00 = octx->src[0]->ne[0];
     htp_get_rows_vtcm_layout_build(&grctx.vtcm_layout, octx->src[0]->type, ne00, n_threads);

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -10,6 +10,7 @@
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
+#include "hex-common.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
 #include "htp-tensor.h"
@@ -228,14 +229,39 @@ int op_get_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t total_tasks = kparams->total_tasks;
+    const struct htp_tensor * dst = octx->dst;
+    const uint32_t total_tasks    = kparams->total_tasks;
+    const size_t dst_row_size     = htp_tensor_get_row_size(dst->type, dst->ne[0]);
+
     uint32_t mdev_task_start, mdev_tasks;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
-        uint32_t tasks_per_mdev = fastdiv(total_tasks + octx->mdev_count - 1, &octx->mdev_count_div);
-        tasks_per_mdev = ((tasks_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
-        mdev_tasks      = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == (dst_row_size / dst->ne[0])) && !htp_tensor_is_permuted(dst);
+        uint32_t tasks_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                tasks_per_chunk = 1;
+            } else if (dst->nb[1] == dst_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                tasks_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (total_tasks / tasks_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
+            mdev_tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_task_start = MIN(octx->mdev_idx * chunks_per_mdev * tasks_per_chunk, total_tasks);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_tasks = total_tasks - mdev_task_start;
+            } else {
+                mdev_tasks = MIN(chunks_per_mdev * tasks_per_chunk, total_tasks - mdev_task_start);
+            }
+        }
     } else {
         mdev_task_start = 0;
         mdev_tasks      = total_tasks;

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -66,11 +66,11 @@ static void get_rows_thread_st_##IDX_TYPE(unsigned int nth, unsigned int ith, vo
     const struct htp_get_rows_kernel_params * kparams = grctx->kparams;                                                \
     get_rows_preamble;                                                                                                 \
     const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
-    const uint32_t ir0 = grctx->task_start + dr * ith;                                                            \
-    if (ir0 >= grctx->task_start + grctx->tasks) {                                                           \
+    const uint32_t ir0 = grctx->task_start + dr * ith;                                                                 \
+    if (ir0 >= grctx->task_start + grctx->tasks) {                                                                     \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, grctx->task_start + grctx->tasks);                                    \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->task_start + grctx->tasks);                                              \
     const uint32_t row_size_bytes = htp_tensor_get_row_size(octx->src[0]->type, ne00);                                 \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \
     for (uint32_t i = ir0; i < ir1; ++i) {                                                                             \
@@ -106,11 +106,11 @@ static void get_rows_thread_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsigned 
     get_rows_preamble;                                                                                                 \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                             \
     const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
-    const uint32_t ir0 = grctx->task_start + dr * ith;                                                            \
-    if (ir0 >= grctx->task_start + grctx->tasks) {                                                           \
+    const uint32_t ir0 = grctx->task_start + dr * ith;                                                                 \
+    if (ir0 >= grctx->task_start + grctx->tasks) {                                                                     \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, grctx->task_start + grctx->tasks);                                    \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->task_start + grctx->tasks);                                              \
     const uint32_t chunks_per_row = kparams->chunks_per_row;                                                           \
     const uint32_t chunk_size     = kparams->chunk_size;                                                               \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -24,8 +24,8 @@ struct get_rows_context {
     const struct htp_get_rows_kernel_params * kparams;
     struct htp_get_rows_vtcm_layout vtcm_layout;
     uint8_t * vtcm_base;
-    uint32_t mdev_task_start;
-    uint32_t mdev_tasks;
+    uint32_t task_start;
+    uint32_t tasks;
     uint32_t tasks_per_thread;
 };
 
@@ -66,11 +66,11 @@ static void get_rows_thread_st_##IDX_TYPE(unsigned int nth, unsigned int ith, vo
     const struct htp_get_rows_kernel_params * kparams = grctx->kparams;                                                \
     get_rows_preamble;                                                                                                 \
     const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
-    const uint32_t ir0 = grctx->mdev_task_start + dr * ith;                                                            \
-    if (ir0 >= grctx->mdev_task_start + grctx->mdev_tasks) {                                                           \
+    const uint32_t ir0 = grctx->task_start + dr * ith;                                                            \
+    if (ir0 >= grctx->task_start + grctx->tasks) {                                                           \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, grctx->mdev_task_start + grctx->mdev_tasks);                                    \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->task_start + grctx->tasks);                                    \
     const uint32_t row_size_bytes = htp_tensor_get_row_size(octx->src[0]->type, ne00);                                 \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \
     for (uint32_t i = ir0; i < ir1; ++i) {                                                                             \
@@ -106,11 +106,11 @@ static void get_rows_thread_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsigned 
     get_rows_preamble;                                                                                                 \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                             \
     const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
-    const uint32_t ir0 = grctx->mdev_task_start + dr * ith;                                                            \
-    if (ir0 >= grctx->mdev_task_start + grctx->mdev_tasks) {                                                           \
+    const uint32_t ir0 = grctx->task_start + dr * ith;                                                            \
+    if (ir0 >= grctx->task_start + grctx->tasks) {                                                           \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, grctx->mdev_task_start + grctx->mdev_tasks);                                    \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->task_start + grctx->tasks);                                    \
     const uint32_t chunks_per_row = kparams->chunks_per_row;                                                           \
     const uint32_t chunk_size     = kparams->chunk_size;                                                               \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \
@@ -233,7 +233,9 @@ int op_get_rows(struct htp_ops_context * octx) {
     const uint32_t total_tasks    = kparams->total_tasks;
     const size_t dst_row_size     = htp_tensor_get_row_size(dst->type, dst->ne[0]);
 
-    uint32_t mdev_task_start, mdev_tasks;
+    uint32_t task_start = 0;
+    uint32_t tasks      = total_tasks;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == (dst_row_size / dst->ne[0])) && !htp_tensor_is_permuted(dst);
         uint32_t tasks_per_chunk = 1;
@@ -251,23 +253,20 @@ int op_get_rows(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (total_tasks / tasks_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
-            mdev_tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
+            task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
+            tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_task_start = MIN(octx->mdev_idx * chunks_per_mdev * tasks_per_chunk, total_tasks);
+            task_start = MIN(octx->mdev_idx * chunks_per_mdev * tasks_per_chunk, total_tasks);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_tasks = total_tasks - mdev_task_start;
+                tasks = total_tasks - task_start;
             } else {
-                mdev_tasks = MIN(chunks_per_mdev * tasks_per_chunk, total_tasks - mdev_task_start);
+                tasks = MIN(chunks_per_mdev * tasks_per_chunk, total_tasks - task_start);
             }
         }
-    } else {
-        mdev_task_start = 0;
-        mdev_tasks      = total_tasks;
     }
 
-    if (mdev_tasks == 0) {
+    if (tasks == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -277,9 +276,9 @@ int op_get_rows(struct htp_ops_context * octx) {
     grctx.octx = octx;
     grctx.kparams = kparams;
     grctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;
-    grctx.mdev_task_start = mdev_task_start;
-    grctx.mdev_tasks = mdev_tasks;
-    grctx.tasks_per_thread = fastdiv(mdev_tasks + n_threads - 1, &octx->n_threads_div);
+    grctx.task_start = task_start;
+    grctx.tasks = tasks;
+    grctx.tasks_per_thread = fastdiv(tasks + n_threads - 1, &octx->n_threads_div);
 
     const uint32_t ne00 = octx->src[0]->ne[0];
     htp_get_rows_vtcm_layout_build(&grctx.vtcm_layout, octx->src[0]->type, ne00, n_threads);

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -248,6 +248,10 @@ int op_get_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
+    if (!htp_ops_context_set_n_threads(octx, (uint32_t) kparams->n_threads)) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+
     const uint32_t n_threads = octx->n_threads;
 
     struct get_rows_context grctx;

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -23,6 +23,9 @@ struct get_rows_context {
     const struct htp_get_rows_kernel_params * kparams;
     struct htp_get_rows_vtcm_layout vtcm_layout;
     uint8_t * vtcm_base;
+    uint32_t dev_task_start;
+    uint32_t dev_tasks;
+    uint32_t tasks_per_thread;
 };
 
 #define get_rows_preamble \
@@ -61,12 +64,12 @@ static void get_rows_thread_st_##IDX_TYPE(unsigned int nth, unsigned int ith, vo
     struct htp_ops_context * octx = grctx->octx;                                                                       \
     const struct htp_get_rows_kernel_params * kparams = grctx->kparams;                                                \
     get_rows_preamble;                                                                                                 \
-    const uint32_t dr  = kparams->tasks_per_thread;                                                                    \
-    const uint32_t ir0 = dr * ith;                                                                                     \
-    if (ir0 >= kparams->total_tasks) {                                                                                 \
+    const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
+    const uint32_t ir0 = grctx->dev_task_start + dr * ith;                                                             \
+    if (ir0 >= grctx->dev_task_start + grctx->dev_tasks) {                                                             \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, kparams->total_tasks);                                                          \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->dev_task_start + grctx->dev_tasks);                                      \
     const uint32_t row_size_bytes = htp_tensor_get_row_size(octx->src[0]->type, ne00);                                 \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \
     for (uint32_t i = ir0; i < ir1; ++i) {                                                                             \
@@ -101,12 +104,12 @@ static void get_rows_thread_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsigned 
     const struct htp_get_rows_kernel_params * kparams = grctx->kparams;                                                \
     get_rows_preamble;                                                                                                 \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                             \
-    const uint32_t dr  = kparams->tasks_per_thread;                                                                    \
-    const uint32_t ir0 = dr * ith;                                                                                     \
-    if (ir0 >= kparams->total_tasks) {                                                                                 \
+    const uint32_t dr  = grctx->tasks_per_thread;                                                                      \
+    const uint32_t ir0 = grctx->dev_task_start + dr * ith;                                                             \
+    if (ir0 >= grctx->dev_task_start + grctx->dev_tasks) {                                                             \
         return;                                                                                                        \
     }                                                                                                                  \
-    const uint32_t ir1 = MIN(ir0 + dr, kparams->total_tasks);                                                          \
+    const uint32_t ir1 = MIN(ir0 + dr, grctx->dev_task_start + grctx->dev_tasks);                                      \
     const uint32_t chunks_per_row = kparams->chunks_per_row;                                                           \
     const uint32_t chunk_size     = kparams->chunk_size;                                                               \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                       \
@@ -225,13 +228,35 @@ int op_get_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
+    const uint32_t total_tasks = kparams->total_tasks;
+    uint32_t dev_task_start, dev_tasks;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
+        uint32_t tasks_per_dev = (total_tasks + octx->ndev - 1) / octx->ndev;
+        tasks_per_dev = ((tasks_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        dev_task_start = MIN(octx->idev * tasks_per_dev, total_tasks);
+        dev_tasks      = MIN(tasks_per_dev, total_tasks - dev_task_start);
+    } else {
+        dev_task_start = 0;
+        dev_tasks      = total_tasks;
+    }
+
+    if (dev_tasks == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(kparams->n_threads, dev_tasks);
+
     struct get_rows_context grctx;
     grctx.octx = octx;
     grctx.kparams = kparams;
     grctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;
+    grctx.dev_task_start = dev_task_start;
+    grctx.dev_tasks = dev_tasks;
+    grctx.tasks_per_thread = (dev_tasks + n_threads - 1) / n_threads;
 
     const uint32_t ne00 = octx->src[0]->ne[0];
-    htp_get_rows_vtcm_layout_build(&grctx.vtcm_layout, octx->src[0]->type, ne00, kparams->n_threads);
+    htp_get_rows_vtcm_layout_build(&grctx.vtcm_layout, octx->src[0]->type, ne00, n_threads);
 
     const bool is_i32 = (octx->src[1]->type == HTP_TYPE_I32);
 
@@ -247,14 +272,14 @@ int op_get_rows(struct htp_ops_context * octx) {
         }
     }
 
-    FARF(HIGH, "get-rows: (%ux%ux%ux%u) x (%ux%ux%ux%u) -> (%ux%ux%ux%u) : src0-vtcm-size %zu dst-vtcm-size %zu use_dma=%d n_threads %d\n",
+    FARF(HIGH, "get-rows: (%ux%ux%ux%u) x (%ux%ux%ux%u) -> (%ux%ux%ux%u) : src0-vtcm-size %zu dst-vtcm-size %zu use-dma %d n-threads %d\n",
          octx->src[0]->ne[0], octx->src[0]->ne[1], octx->src[0]->ne[2], octx->src[0]->ne[3],
          octx->src[1]->ne[0], octx->src[1]->ne[1], octx->src[1]->ne[2], octx->src[1]->ne[3],
          octx->dst->ne[0], octx->dst->ne[1], octx->dst->ne[2], octx->dst->ne[3],
-         grctx.vtcm_layout.src0_bytes_per_thread * kparams->n_threads,
-         grctx.vtcm_layout.dst_bytes_per_thread  * kparams->n_threads,
-         kparams->use_dma, kparams->n_threads);
+         grctx.vtcm_layout.src0_bytes_per_thread * n_threads,
+         grctx.vtcm_layout.dst_bytes_per_thread  * n_threads,
+         kparams->use_dma, n_threads);
 
-    work_queue_run(octx->ctx->work_queue, q_func, &grctx, kparams->n_threads);
+    work_queue_run(octx->ctx->work_queue, q_func, &grctx, n_threads);
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -236,7 +236,7 @@ int op_get_rows(struct htp_ops_context * octx) {
     uint32_t task_start = 0;
     uint32_t tasks      = total_tasks;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == (dst_row_size / dst->ne[0])) && !htp_tensor_is_permuted(dst);
         uint32_t tasks_per_chunk = 1;
         if (can_split) {
@@ -252,13 +252,13 @@ int op_get_rows(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (total_tasks / tasks_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
-            tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            task_start = (octx->ctx->mdev.idx == 0) ? 0 : total_tasks;
+            tasks      = (octx->ctx->mdev.idx == 0) ? total_tasks : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            task_start = MIN(octx->mdev_idx * chunks_per_mdev * tasks_per_chunk, total_tasks);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            task_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * tasks_per_chunk, total_tasks);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 tasks = total_tasks - task_start;
             } else {
                 tasks = MIN(chunks_per_mdev * tasks_per_chunk, total_tasks - task_start);

--- a/ggml/src/ggml-hexagon/htp/get-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/get-rows-ops.c
@@ -237,33 +237,11 @@ int op_get_rows(struct htp_ops_context * octx) {
     uint32_t tasks      = total_tasks;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == (dst_row_size / dst->ne[0])) && !htp_tensor_is_permuted(dst);
         uint32_t tasks_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                tasks_per_chunk = 1;
-            } else if (dst->nb[1] == dst_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                tasks_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (total_tasks / tasks_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            task_start = (octx->ctx->mdev.idx == 0) ? 0 : total_tasks;
-            tasks      = (octx->ctx->mdev.idx == 0) ? total_tasks : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            task_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * tasks_per_chunk, total_tasks);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                tasks = total_tasks - task_start;
-            } else {
-                tasks = MIN(chunks_per_mdev * tasks_per_chunk, total_tasks - task_start);
-            }
-        }
+        htp_tensor_mdev_rows_per_chunk(dst, dst_row_size / dst->ne[0], (uint32_t) dst_row_size, &tasks_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_tasks, tasks_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        task_start = range.start;
+        tasks      = range.count;
     }
 
     if (tasks == 0) {

--- a/ggml/src/ggml-hexagon/htp/hex-common.h
+++ b/ggml/src/ggml-hexagon/htp/hex-common.h
@@ -77,4 +77,13 @@ static inline bool hex_add_overflow(size_t a, size_t b, size_t *out) {
     return false;
 }
 
+static inline uint32_t hex_gcd_u32(uint32_t a, uint32_t b) {
+    while (b != 0) {
+        uint32_t t = b;
+        b = a % b;
+        a = t;
+    }
+    return a;
+}
+
 #endif // HEX_COMMON_H

--- a/ggml/src/ggml-hexagon/htp/hex-utils.h
+++ b/ggml/src/ggml-hexagon/htp/hex-utils.h
@@ -39,7 +39,6 @@ static inline void hex_l2fetch_block(const void * addr, size_t size) {
 
 #define HEX_L2_LINE_SIZE           128
 #define HEX_L2_BLOCK_SIZE          (HEX_L2_LINE_SIZE * 4) // flush granularity (lines per loop iteration)
-#define HEX_L2_FLUSH_IL_THRESHOLD  1024                   // inline flush threshold
 #define HEX_L2_FLUSH_WQ_THRESHOLD  (4 * 1024)
 #define HEX_L2_FLUSH_ALL_THRESHOLD (4 * 1024 * 1024)
 

--- a/ggml/src/ggml-hexagon/htp/hmx-utils.h
+++ b/ggml/src/ggml-hexagon/htp/hmx-utils.h
@@ -27,7 +27,7 @@ static inline void hmx_init_column_scales(void *out_scales, HVX_Vector v_scale) 
 // vscatter offsets for fused dequant+transpose: write K-values directly to [K][N] tile.
 // word[i] = i*128 maps K-row-pair i to byte offset i*128.
 // Column offset (n*4) is added at runtime.  Entries 0..15 cover one tile (region 2047);
-// entries 16..31 cover the next adjacent tile (region 4095) — pick region size at the
+// entries 16..31 cover the next adjacent tile (region 4095) - pick region size at the
 // call site to scatter into one tile (masked) or two contiguous tiles (unmasked).
 static const int32_t hmx_transpose_scatter_offsets[32] __attribute__((aligned(VLEN))) = {
     0 * 128,  1 * 128,  2 * 128,  3 * 128,  4 * 128,  5 * 128,  6 * 128,  7 * 128,  8 * 128,  9 * 128,  10 * 128,
@@ -198,16 +198,16 @@ static inline void hmx_interleave_cols_to_tiles(__fp16 * restrict tiles_out,
 }
 
 // --- HMX inline asm macros for load-store packetization ---
-#define HMX_LOAD_MPY_F16(act, wt, range) \
-    "{\n" \
+#define HMX_LOAD_MPY_F16(act, wt, range)              \
+    "{\n"                                             \
     "    activation.hf = mxmem(" act ", " range ")\n" \
-    "    weight.hf = mxmem(" wt ", " range ")\n" \
+    "    weight.hf = mxmem(" wt ", " range ")\n"      \
     "}\n"
 
-#define HMX_LOAD_MPY_DEEP_F16(act, wt, range) \
-    "{\n" \
+#define HMX_LOAD_MPY_DEEP_F16(act, wt, range)              \
+    "{\n"                                                  \
     "    activation.hf = mxmem(" act ", " range "):deep\n" \
-    "    weight.hf = mxmem(" wt ", " range ")\n" \
+    "    weight.hf = mxmem(" wt ", " range ")\n"           \
     "}\n"
 
 #define HMX_STORE_AFTER_F16(out, scale_reg) \

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -67,8 +67,8 @@ struct htp_ops_context {
 
     uint32_t n_threads;
     uint32_t flags;
-    uint16_t idev;
-    uint16_t ndev;
+    uint16_t mdev_idx;
+    uint16_t mdev_count;
 };
 
 // Main context for htp DSP backend

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -66,9 +66,11 @@ struct htp_ops_context {
     struct htp_spad dst_spad;
 
     uint32_t n_threads;
+    struct fastdiv_values n_threads_div;
     uint32_t flags;
     uint16_t mdev_idx;
     uint16_t mdev_count;
+    struct fastdiv_values mdev_count_div;
 };
 
 // Main context for htp DSP backend

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -111,6 +111,9 @@ struct htp_context {
     void *                 ddr_spad_base;
     size_t                 ddr_spad_size;
 
+    uint8_t *              fence_base;
+    uint32_t               fence_seq;
+
     struct htp_ops_context octx;
 
     qurt_thread_t          main_thread;

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -71,6 +71,8 @@ struct htp_ops_context {
     uint16_t mdev_idx;
     uint16_t mdev_count;
     struct fastdiv_values mdev_count_div;
+    uint8_t * fence_base;
+    uint32_t  fence_seq;
 };
 
 // Main context for htp DSP backend
@@ -110,9 +112,6 @@ struct htp_context {
     // Persistent DDR scratchpad for MUL_MAT_ID mappings
     void *                 ddr_spad_base;
     size_t                 ddr_spad_size;
-
-    uint8_t *              fence_base;
-    uint32_t               fence_seq;
 
     struct htp_ops_context octx;
 

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -38,6 +38,14 @@ struct htp_spad {
     uint32_t                  size_per_thread; // size per thread
 };
 
+struct htp_mdev_group {
+    uint16_t              idx;
+    uint16_t              count;
+    struct fastdiv_values count_div;
+    uint8_t *             fence_base;
+    uint32_t              fence_seq;
+};
+
 struct htp_context;
 
 // Context while processing an Op
@@ -65,14 +73,9 @@ struct htp_ops_context {
     struct htp_spad src3_spad;
     struct htp_spad dst_spad;
 
-    uint32_t n_threads;
+    uint32_t              flags;
+    uint32_t              n_threads;
     struct fastdiv_values n_threads_div;
-    uint32_t flags;
-    uint16_t mdev_idx;
-    uint16_t mdev_count;
-    struct fastdiv_values mdev_count_div;
-    uint8_t * fence_base;
-    uint32_t  fence_seq;
 };
 
 // Main context for htp DSP backend
@@ -82,6 +85,7 @@ struct htp_context {
     struct htp_mmap        mmap[HTP_MAX_MMAPS];
     dma_queue_t            dma[HTP_MAX_NTHREADS];
     dma_queue_t            dma_cached[HTP_MAX_NTHREADS];
+    struct htp_thread_trace trace[HTP_MAX_NTHREADS + 1];
     work_queue_t           work_queue;
     hmx_queue_t            hmx_queue;
 
@@ -94,7 +98,6 @@ struct htp_context {
     bool                   hmx_enabled;
     bool                   etm;
     uint32_t               profiler;
-    struct htp_thread_trace trace[HTP_MAX_NTHREADS + 1];
 
     uint8_t *              vtcm_base;
     size_t                 vtcm_size;
@@ -113,6 +116,7 @@ struct htp_context {
     void *                 ddr_spad_base;
     size_t                 ddr_spad_size;
 
+    struct htp_mdev_group  mdev;
     struct htp_ops_context octx;
 
     qurt_thread_t          main_thread;

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -125,6 +125,21 @@ struct htp_context {
     size_t                 footprint;
 };
 
+static inline bool htp_ops_context_set_n_threads(struct htp_ops_context * octx, uint32_t n_threads) {
+    if (n_threads == 0 || n_threads > octx->ctx->n_threads) {
+        return false;
+    }
+
+    if (n_threads != octx->n_threads) {
+        octx->n_threads = n_threads;
+        octx->n_threads_div = n_threads == octx->ctx->n_threads
+            ? octx->ctx->n_threads_div
+            : init_fastdiv_values(n_threads);
+    }
+
+    return true;
+}
+
 int op_matmul(struct htp_ops_context * octx);
 int op_matmul_id(struct htp_ops_context * octx);
 int op_matmul_nx(struct htp_ops_context * octx);

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -19,7 +19,7 @@
 #endif
 #define HTP_MAX_MMAPS    16
 
-#define HTP_MAX_DIRTY_RANGES 16
+#define HTP_MAX_DIRTY_RANGES 32
 
 // Memory mapping
 struct htp_mmap {
@@ -27,6 +27,11 @@ struct htp_mmap {
     uint64_t base;
     uint32_t fd;
     uint32_t reserved;
+};
+
+struct htp_dirty_range {
+    uint32_t start;
+    uint32_t end;
 };
 
 // Scratchpad state
@@ -107,11 +112,7 @@ struct htp_context {
     atomic_bool            vtcm_needs_release;
 
     uint64_t               max_vmem;
-    struct htp_dirty_range {
-        uint32_t start;
-        uint32_t end;
-        uint32_t bi;
-    } dirty_ranges[HTP_MAX_DIRTY_RANGES];
+    struct htp_dirty_range dirty_ranges[HTP_MAX_DIRTY_RANGES];
 
     // Persistent DDR scratchpad for MUL_MAT_ID mappings
     void *                 ddr_spad_base;

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -141,6 +141,12 @@ static inline bool htp_ops_context_set_n_threads(struct htp_ops_context * octx, 
     return true;
 }
 
+static inline void htp_ops_context_set_status(struct htp_ops_context * octx, int status) {
+    if (status > HTP_STATUS_OK && octx->status == HTP_STATUS_OK) {
+        octx->status = status;
+    }
+}
+
 int op_matmul(struct htp_ops_context * octx);
 int op_matmul_id(struct htp_ops_context * octx);
 int op_matmul_nx(struct htp_ops_context * octx);

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -67,6 +67,8 @@ struct htp_ops_context {
 
     uint32_t n_threads;
     uint32_t flags;
+    uint16_t idev;
+    uint16_t ndev;
 };
 
 // Main context for htp DSP backend

--- a/ggml/src/ggml-hexagon/htp/htp-ctx.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ctx.h
@@ -76,6 +76,7 @@ struct htp_ops_context {
     uint32_t              flags;
     uint32_t              n_threads;
     struct fastdiv_values n_threads_div;
+    int                   status;
 };
 
 // Main context for htp DSP backend

--- a/ggml/src/ggml-hexagon/htp/htp-fence.h
+++ b/ggml/src/ggml-hexagon/htp/htp-fence.h
@@ -1,0 +1,30 @@
+#ifndef HTP_FENCE_H
+#define HTP_FENCE_H
+
+#include <stdatomic.h>
+#include <stdint.h>
+
+#include "hex-utils.h"
+#include "htp-ops.h"
+
+static inline atomic_uint * htp_mdev_fence(const void * fence_base, uint32_t idx) {
+    return (atomic_uint *) ((const uint8_t *) fence_base + (size_t) idx * HTP_FENCE_SLOT_SIZE);
+}
+
+static inline void htp_fence_write(void * fence_ptr, uint32_t seq, uint32_t status) {
+    atomic_uint * fence = (atomic_uint *) fence_ptr;
+    atomic_store(&fence[0], seq);
+    atomic_store(&fence[1], status);
+    asm volatile ("syncht" : : : "memory");
+    Q6_dccleaninva_A((void *) fence);
+}
+
+static inline void htp_fence_read(const void * fence_ptr, uint32_t * seq, uint32_t * status) {
+    const atomic_uint * fence = (const atomic_uint *) fence_ptr;
+    Q6_dccleaninva_A((void *) fence);
+    asm volatile ("syncht" : : : "memory");
+    *seq = atomic_load(&fence[0]);
+    *status = atomic_load(&fence[1]);
+}
+
+#endif // HTP_FENCE_H

--- a/ggml/src/ggml-hexagon/htp/htp-fence.h
+++ b/ggml/src/ggml-hexagon/htp/htp-fence.h
@@ -17,8 +17,8 @@ static inline atomic_uint * htp_mdev_fence_slot(const void * fence_base, uint32_
 
 static inline void htp_fence_write(void * fence_ptr, uint32_t seq, uint32_t status) {
     atomic_uint * fence = (atomic_uint *) fence_ptr;
-    atomic_store(&fence[0], seq);
     atomic_store(&fence[1], status);
+    atomic_store(&fence[0], seq);
     asm volatile ("syncht" : : : "memory");
     Q6_dccleaninva_A((void *) fence);
 }

--- a/ggml/src/ggml-hexagon/htp/htp-fence.h
+++ b/ggml/src/ggml-hexagon/htp/htp-fence.h
@@ -31,10 +31,10 @@ static inline void htp_fence_read(const void * fence_ptr, uint32_t * seq, uint32
     *status = atomic_load(&fence[1]);
 }
 
-static inline int htp_mdev_group_barrier(struct htp_ops_context * octx, int op_status) {
+static inline void htp_mdev_group_barrier(struct htp_ops_context * octx) {
     struct htp_context * ctx = octx->ctx;
     if (ctx->mdev.count <= 1) {
-        return op_status;
+        return;
     }
 
     assert(ctx->mdev.fence_base != NULL);
@@ -49,11 +49,11 @@ static inline int htp_mdev_group_barrier(struct htp_ops_context * octx, int op_s
 
     uint8_t * fence_base   = ctx->mdev.fence_base;
     atomic_uint * my_fence = htp_mdev_fence_slot(fence_base, mdev_idx);
-    htp_fence_write(my_fence, seq, op_status);
+    htp_fence_write(my_fence, seq, octx->status);
 
-    if (op_status > HTP_STATUS_OK) {
+    if (octx->status > HTP_STATUS_OK) {
         htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-        return op_status;
+        return;
     }
 
     for (uint32_t d = 0; d < mdev_count; d++) {
@@ -64,14 +64,17 @@ static inline int htp_mdev_group_barrier(struct htp_ops_context * octx, int op_s
             uint32_t peer_seq;
             uint32_t peer_status;
             htp_fence_read(peer_fence, &peer_seq, &peer_status);
-            if (peer_status > HTP_STATUS_OK) {
-                FARF(ERROR, "ggml-hex: mdev %u peer %u failed with status %u : seq 0x%08x\n",
-                     mdev_idx, d, peer_status, seq);
-                htp_fence_write(my_fence, seq, peer_status);
-                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-                return peer_status;
-            }
             if ((int32_t)(peer_seq - seq) >= 0) {
+                if (peer_status > HTP_STATUS_OK) {
+                    FARF(ERROR, "ggml-hex: mdev %u peer %u failed with status %u : seq 0x%08x\n",
+                         mdev_idx, d, peer_status, seq);
+                    htp_fence_write(my_fence, seq, peer_status);
+                    htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+                    if (octx->status == HTP_STATUS_OK) {
+                        octx->status = peer_status;
+                    }
+                    return;
+                }
                 break;
             }
             if (++spins == 10000) {
@@ -83,7 +86,10 @@ static inline int htp_mdev_group_barrier(struct htp_ops_context * octx, int op_s
                      mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, peer_seq);
                 htp_fence_write(my_fence, seq, HTP_STATUS_INTERNAL_ERR);
                 htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-                return HTP_STATUS_INTERNAL_ERR;
+                if (octx->status == HTP_STATUS_OK) {
+                    octx->status = HTP_STATUS_INTERNAL_ERR;
+                }
+                return;
             }
             hex_pause();
         }
@@ -91,7 +97,6 @@ static inline int htp_mdev_group_barrier(struct htp_ops_context * octx, int op_s
     asm volatile ("syncht" : : : "memory");
 
     htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-    return HTP_STATUS_OK;
 }
 
 #endif // HTP_FENCE_H

--- a/ggml/src/ggml-hexagon/htp/htp-fence.h
+++ b/ggml/src/ggml-hexagon/htp/htp-fence.h
@@ -1,13 +1,17 @@
 #ifndef HTP_FENCE_H
 #define HTP_FENCE_H
 
+#include <assert.h>
 #include <stdatomic.h>
 #include <stdint.h>
 
+#include <HAP_farf.h>
+
 #include "hex-utils.h"
 #include "htp-ops.h"
+#include "htp-ctx.h"
 
-static inline atomic_uint * htp_mdev_fence(const void * fence_base, uint32_t idx) {
+static inline atomic_uint * htp_mdev_fence_slot(const void * fence_base, uint32_t idx) {
     return (atomic_uint *) ((const uint8_t *) fence_base + (size_t) idx * HTP_FENCE_SLOT_SIZE);
 }
 
@@ -25,6 +29,69 @@ static inline void htp_fence_read(const void * fence_ptr, uint32_t * seq, uint32
     asm volatile ("syncht" : : : "memory");
     *seq = atomic_load(&fence[0]);
     *status = atomic_load(&fence[1]);
+}
+
+static inline int htp_mdev_group_barrier(struct htp_ops_context * octx, int op_status) {
+    struct htp_context * ctx = octx->ctx;
+    if (ctx->mdev.count <= 1) {
+        return op_status;
+    }
+
+    assert(ctx->mdev.fence_base != NULL);
+
+    const uint32_t seq = ++ctx->mdev.fence_seq;
+
+    struct htp_thread_trace * tr = &ctx->trace[0];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+
+    const uint32_t mdev_idx   = ctx->mdev.idx;
+    const uint32_t mdev_count = ctx->mdev.count;
+
+    uint8_t * fence_base   = ctx->mdev.fence_base;
+    atomic_uint * my_fence = htp_mdev_fence_slot(fence_base, mdev_idx);
+    htp_fence_write(my_fence, seq, op_status);
+
+    if (op_status > HTP_STATUS_OK) {
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+        return op_status;
+    }
+
+    for (uint32_t d = 0; d < mdev_count; d++) {
+        if (d == mdev_idx) continue;
+        atomic_uint * peer_fence = htp_mdev_fence_slot(fence_base, d);
+        uint64_t spins = 0;
+        while (1) {
+            uint32_t peer_seq;
+            uint32_t peer_status;
+            htp_fence_read(peer_fence, &peer_seq, &peer_status);
+            if (peer_status > HTP_STATUS_OK) {
+                FARF(ERROR, "ggml-hex: mdev %u peer %u failed with status %u : seq 0x%08x\n",
+                     mdev_idx, d, peer_status, seq);
+                htp_fence_write(my_fence, seq, peer_status);
+                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+                return peer_status;
+            }
+            if ((int32_t)(peer_seq - seq) >= 0) {
+                break;
+            }
+            if (++spins == 10000) {
+                FARF(ALWAYS, "ggml-hex: mdev %u waiting for mdev %u : seq 0x%08x (b %u op %u) my-fence %p peer-fence %p peer-seq 0x%08x (diff %d)\n",
+                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, my_fence, peer_fence, peer_seq, (int32_t)(peer_seq - seq));
+            }
+            if (spins > HTP_FENCE_TIMEOUT) {
+                FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u : seq 0x%08x (b %u op %u) peer-fence %p peer-seq 0x%08x\n",
+                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, peer_seq);
+                htp_fence_write(my_fence, seq, HTP_STATUS_INTERNAL_ERR);
+                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+                return HTP_STATUS_INTERNAL_ERR;
+            }
+            hex_pause();
+        }
+    }
+    asm volatile ("syncht" : : : "memory");
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+    return HTP_STATUS_OK;
 }
 
 #endif // HTP_FENCE_H

--- a/ggml/src/ggml-hexagon/htp/htp-fence.h
+++ b/ggml/src/ggml-hexagon/htp/htp-fence.h
@@ -51,11 +51,6 @@ static inline void htp_mdev_group_barrier(struct htp_ops_context * octx) {
     atomic_uint * my_fence = htp_mdev_fence_slot(fence_base, mdev_idx);
     htp_fence_write(my_fence, seq, octx->status);
 
-    if (octx->status > HTP_STATUS_OK) {
-        htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-        return;
-    }
-
     for (uint32_t d = 0; d < mdev_count; d++) {
         if (d == mdev_idx) continue;
         atomic_uint * peer_fence = htp_mdev_fence_slot(fence_base, d);
@@ -68,12 +63,7 @@ static inline void htp_mdev_group_barrier(struct htp_ops_context * octx) {
                 if (peer_status > HTP_STATUS_OK) {
                     FARF(ERROR, "ggml-hex: mdev %u peer %u failed with status %u : seq 0x%08x\n",
                          mdev_idx, d, peer_status, seq);
-                    htp_fence_write(my_fence, seq, peer_status);
-                    htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-                    if (octx->status == HTP_STATUS_OK) {
-                        octx->status = peer_status;
-                    }
-                    return;
+                    htp_ops_context_set_status(octx, peer_status);
                 }
                 break;
             }
@@ -84,17 +74,17 @@ static inline void htp_mdev_group_barrier(struct htp_ops_context * octx) {
             if (spins > HTP_FENCE_TIMEOUT) {
                 FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u : seq 0x%08x (b %u op %u) peer-fence %p peer-seq 0x%08x\n",
                      mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, peer_seq);
-                htp_fence_write(my_fence, seq, HTP_STATUS_INTERNAL_ERR);
-                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-                if (octx->status == HTP_STATUS_OK) {
-                    octx->status = HTP_STATUS_INTERNAL_ERR;
-                }
-                return;
+                htp_ops_context_set_status(octx, HTP_STATUS_INTERNAL_ERR);
+                break;
             }
             hex_pause();
         }
     }
     asm volatile ("syncht" : : : "memory");
+
+    if (octx->status > HTP_STATUS_OK) {
+        htp_fence_write(my_fence, seq, octx->status);
+    }
 
     htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
 }

--- a/ggml/src/ggml-hexagon/htp/htp-fence.h
+++ b/ggml/src/ggml-hexagon/htp/htp-fence.h
@@ -1,7 +1,6 @@
 #ifndef HTP_FENCE_H
 #define HTP_FENCE_H
 
-#include <assert.h>
 #include <stdatomic.h>
 #include <stdint.h>
 
@@ -36,8 +35,6 @@ static inline void htp_mdev_group_barrier(struct htp_ops_context * octx) {
     if (ctx->mdev.count <= 1) {
         return;
     }
-
-    assert(ctx->mdev.fence_base != NULL);
 
     const uint32_t seq = ++ctx->mdev.fence_seq;
 

--- a/ggml/src/ggml-hexagon/htp/htp-ops.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ops.h
@@ -114,6 +114,7 @@ enum htp_op_code {
 #define HTP_OP_MAX_TENSORS 8192 // must stay under 64K (uint16)
 
 #define HTP_FENCE_TIMEOUT  (1000000000ULL)
+#define HTP_FENCE_SLOT_SIZE 128
 
 #define HTP_OP_MAX_VMEM_DEFAULT (3355443200u)
 
@@ -219,7 +220,8 @@ struct htp_opbatch_req {
     uint32_t n_tensors;   // Number of tensors
     uint32_t n_ops;       // Number of ops
     uint32_t n_traces;    // Number of trace descriptors per thread
-    uint32_t pad;         // unused
+    uint16_t idev;        // Device index (0..ndev-1)
+    uint16_t ndev;        // Number of devices
     uint64_t seq;         // Sequence number
     // struct htp_buf_desc  bufs[];    -- dspqueue buf 0
     // struct htp_tensor    tensors[]; -- dspqueue buf 0

--- a/ggml/src/ggml-hexagon/htp/htp-ops.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ops.h
@@ -77,6 +77,7 @@ enum htp_op_code {
     HTP_OP_GET_ROWS,
     HTP_OP_SCALE,
     HTP_OP_CPY,
+    HTP_OP_CPY_FENCE,
     HTP_OP_ARGSORT,
     HTP_OP_SQR,
     HTP_OP_SQRT,
@@ -100,7 +101,7 @@ enum htp_op_code {
     HTP_OP_ALLREDUCE,
     HTP_OP_ALLREDUCE_ADD,
     HTP_OP_GLU_SWIGLU_CLAMP,
-    HTP_OP_MDEV_SETUP,
+    HTP_OP_MDEV_GROUP,
 
     HTP_OP_INVALID
 };
@@ -221,8 +222,6 @@ struct htp_opbatch_req {
     uint32_t n_tensors;   // Number of tensors
     uint32_t n_ops;       // Number of ops
     uint32_t n_traces;    // Number of trace descriptors per thread
-    uint16_t mdev_idx;    // Device index (0..mdev_count-1)
-    uint16_t mdev_count;  // Number of devices
     uint64_t seq;         // Sequence number
     // struct htp_buf_desc  bufs[];    -- dspqueue buf 0
     // struct htp_tensor    tensors[]; -- dspqueue buf 0

--- a/ggml/src/ggml-hexagon/htp/htp-ops.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ops.h
@@ -100,6 +100,7 @@ enum htp_op_code {
     HTP_OP_ALLREDUCE,
     HTP_OP_ALLREDUCE_ADD,
     HTP_OP_GLU_SWIGLU_CLAMP,
+    HTP_OP_MDEV_SETUP,
 
     HTP_OP_INVALID
 };
@@ -220,8 +221,8 @@ struct htp_opbatch_req {
     uint32_t n_tensors;   // Number of tensors
     uint32_t n_ops;       // Number of ops
     uint32_t n_traces;    // Number of trace descriptors per thread
-    uint16_t mdev_idx;   // Device index (0..mdev_count-1)
-    uint16_t mdev_count; // Number of devices
+    uint16_t mdev_idx;    // Device index (0..mdev_count-1)
+    uint16_t mdev_count;  // Number of devices
     uint64_t seq;         // Sequence number
     // struct htp_buf_desc  bufs[];    -- dspqueue buf 0
     // struct htp_tensor    tensors[]; -- dspqueue buf 0

--- a/ggml/src/ggml-hexagon/htp/htp-ops.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ops.h
@@ -220,8 +220,8 @@ struct htp_opbatch_req {
     uint32_t n_tensors;   // Number of tensors
     uint32_t n_ops;       // Number of ops
     uint32_t n_traces;    // Number of trace descriptors per thread
-    uint16_t idev;        // Device index (0..ndev-1)
-    uint16_t ndev;        // Number of devices
+    uint16_t mdev_idx;   // Device index (0..mdev_count-1)
+    uint16_t mdev_count; // Number of devices
     uint64_t seq;         // Sequence number
     // struct htp_buf_desc  bufs[];    -- dspqueue buf 0
     // struct htp_tensor    tensors[]; -- dspqueue buf 0

--- a/ggml/src/ggml-hexagon/htp/htp-ops.h
+++ b/ggml/src/ggml-hexagon/htp/htp-ops.h
@@ -217,29 +217,26 @@ struct htp_prof_desc {
 };
 
 struct htp_opbatch_req {
-    uint32_t id;          // Batch id
+    uint64_t seq;         // Sequence number
     uint32_t n_bufs;      // Number of buffers
     uint32_t n_tensors;   // Number of tensors
     uint32_t n_ops;       // Number of ops
     uint32_t n_traces;    // Number of trace descriptors per thread
-    uint64_t seq;         // Sequence number
     // struct htp_buf_desc  bufs[];    -- dspqueue buf 0
     // struct htp_tensor    tensors[]; -- dspqueue buf 0
     // struct htp_op_desc   ops[];     -- dspqueue buf 0
 };
 
 struct htp_opbatch_rsp {
-    uint32_t id;         // Batch id
-    uint32_t status;     // HTP_STATUS_...
-    uint32_t n_bufs;     // Number of buffers
-    uint32_t n_tensors;  // Number of tensors
-    uint32_t n_ops;      // Number of op profile descriptors
-    uint32_t n_traces[HTP_MAX_NTHREADS + 1];
-    uint32_t usecs;          // Number of usec
-    uint32_t pad;            // align to 8 bytes
+    uint64_t seq;            // Sequence number
     uint64_t cycles_start;   // Start cycle counter
     uint64_t cycles_stop;    // Stop cycle counter
-    uint64_t seq;            // Sequence number
+    uint32_t status;         // HTP_STATUS_...
+    uint32_t n_bufs;         // Number of buffers
+    uint32_t n_tensors;      // Number of tensors
+    uint32_t n_ops;          // Number of op profile descriptors
+    uint32_t usecs;          // Number of usec
+    uint32_t n_traces[HTP_MAX_NTHREADS + 1];
     // struct htp_prof_desc profs[];  -- dspqueue buf 0
 };
 

--- a/ggml/src/ggml-hexagon/htp/htp-tensor.c
+++ b/ggml/src/ggml-hexagon/htp/htp-tensor.c
@@ -73,6 +73,26 @@ static void l2flush_multi_worker(unsigned int n, unsigned int i, void * data) {
     htp_trace_event_stop(tr, HTP_TRACE_EVT_L2FLUSH, gb_first);
 }
 
+static void merge_dirty_ranges(struct htp_context * ctx) {
+    for (uint32_t i = 0; i < HTP_MAX_DIRTY_RANGES; i++) {
+        struct htp_dirty_range * r = &ctx->dirty_ranges[i];
+        if (!r->start) continue;
+
+        for (uint32_t j = 0; j < HTP_MAX_DIRTY_RANGES;) {
+            struct htp_dirty_range * s = &ctx->dirty_ranges[j];
+            if (i == j || !s->start || r->end < s->start || s->end < r->start) {
+                j++;
+                continue;
+            }
+
+            r->start = MIN(r->start, s->start);
+            r->end   = MAX(r->end, s->end);
+            s->start = 0;
+            j = 0;
+        }
+    }
+}
+
 void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * const * tensors, uint32_t n) {
     const struct htp_tensor * pending[HTP_OP_MAX_OUTPUTS];
     uint32_t n_pending = 0;
@@ -105,6 +125,8 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
         }
     }
 
+    merge_dirty_ranges(ctx);
+
     if (n_pending == 0) {
         return;
     }
@@ -128,6 +150,7 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
             r->start = pending[i]->data;
             r->end   = pending[i]->data + pending[i]->size;
         }
+        merge_dirty_ranges(ctx);
         return;
     }
 
@@ -146,6 +169,7 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
             r->start = pending[i]->data;
             r->end   = pending[i]->data + pending[i]->size;
         }
+        merge_dirty_ranges(ctx);
         return;
     }
 
@@ -196,6 +220,8 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
         r->start = pending[n_evict + i]->data;
         r->end   = pending[n_evict + i]->data + pending[n_evict + i]->size;
     }
+
+    merge_dirty_ranges(ctx);
 }
 
 static void make_tensor_clean(struct htp_context * ctx, const struct htp_tensor * t) {

--- a/ggml/src/ggml-hexagon/htp/htp-tensor.c
+++ b/ggml/src/ggml-hexagon/htp/htp-tensor.c
@@ -20,7 +20,7 @@ struct l2flush_range {
 
 struct l2flush_multi_task {
     struct htp_thread_trace * trace;
-    struct l2flush_range      ranges[HTP_OP_MAX_INPUTS];
+    struct l2flush_range      ranges[HTP_MAX_DIRTY_RANGES];
     uint32_t                  n_ranges;
     uint32_t                  total_blocks;
     uint32_t                  blocks_per_thread;
@@ -83,11 +83,6 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
             continue;
         }
 
-        if (t->size <= HEX_L2_FLUSH_IL_THRESHOLD) {
-            hex_l2flush((void *) (uintptr_t) t->data, t->size);
-            continue;
-        }
-
         uint32_t t_start = t->data;
         uint32_t t_end   = t_start + t->size;
 
@@ -132,7 +127,6 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
             struct htp_dirty_range * r = &ctx->dirty_ranges[idx];
             r->start = pending[i]->data;
             r->end   = pending[i]->data + pending[i]->size;
-            r->bi    = pending[i]->bi;
         }
         return;
     }
@@ -151,7 +145,6 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
             struct htp_dirty_range * r = &ctx->dirty_ranges[i];
             r->start = pending[i]->data;
             r->end   = pending[i]->data + pending[i]->size;
-            r->bi    = pending[i]->bi;
         }
         return;
     }
@@ -195,7 +188,6 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
         struct htp_dirty_range * r = &ctx->dirty_ranges[idx];
         r->start = pending[i]->data;
         r->end   = pending[i]->data + pending[i]->size;
-        r->bi    = pending[i]->bi;
     }
 
     for (uint32_t i = 0; i < n_empty; i++) {
@@ -203,7 +195,6 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
         struct htp_dirty_range * r = &ctx->dirty_ranges[idx];
         r->start = pending[n_evict + i]->data;
         r->end   = pending[n_evict + i]->data + pending[n_evict + i]->size;
-        r->bi    = pending[n_evict + i]->bi;
     }
 }
 
@@ -242,15 +233,77 @@ static inline bool is_tensor_dirty(struct htp_context * ctx, const struct htp_te
     return false;
 }
 
+static void flush_dirty_ranges(struct htp_context * ctx, const struct htp_dirty_range * ranges, uint32_t n_ranges, uint64_t total_dirty) {
+    if (total_dirty >= HEX_L2_FLUSH_WQ_THRESHOLD && ctx->n_threads > 1) {
+        struct l2flush_multi_task task;
+        task.trace    = ctx->trace;
+        task.n_ranges = n_ranges;
+
+        uint32_t block_acc = 0;
+        for (uint32_t i = 0; i < n_ranges; i++) {
+            const struct htp_dirty_range * r = &ranges[i];
+            struct l2flush_range * rg = &task.ranges[i];
+            rg->start = hex_align_down((size_t) r->start, HEX_L2_LINE_SIZE);
+            rg->end   = hex_align_up((size_t) r->end, HEX_L2_LINE_SIZE);
+            rg->block_first = block_acc;
+            rg->n_blocks = (rg->end - rg->start + HEX_L2_BLOCK_SIZE - 1) / HEX_L2_BLOCK_SIZE;
+            block_acc += rg->n_blocks;
+        }
+
+        task.total_blocks      = block_acc;
+        task.blocks_per_thread = fastdiv(block_acc + ctx->n_threads - 1, &ctx->n_threads_div);
+
+        work_queue_run(ctx->work_queue, l2flush_multi_worker, &task, ctx->n_threads);
+    } else {
+        struct htp_thread_trace * tr = &ctx->trace[0];
+        htp_trace_event_start(tr, HTP_TRACE_EVT_L2FLUSH, 0);
+        for (uint32_t i = 0; i < n_ranges; i++) {
+            const struct htp_dirty_range * r = &ranges[i];
+            hex_l2flush((void *) (uintptr_t) r->start, r->end - r->start);
+        }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_L2FLUSH, 0);
+    }
+}
+
+void htp_flush_dirty_ranges(struct htp_context * ctx) {
+    struct htp_dirty_range ranges[HTP_MAX_DIRTY_RANGES];
+    uint32_t n_ranges = 0;
+    uint64_t total_dirty = 0;
+
+    for (uint32_t i = 0; i < HTP_MAX_DIRTY_RANGES; i++) {
+        const struct htp_dirty_range * r = &ctx->dirty_ranges[i];
+        if (!r->start) {
+            continue;
+        }
+        ranges[n_ranges++] = *r;
+        total_dirty += r->end - r->start;
+    }
+
+    if (total_dirty == 0) {
+        return;
+    }
+
+    if (total_dirty > HEX_L2_FLUSH_ALL_THRESHOLD) {
+        flush_all_dcache(ctx);
+        return;
+    }
+
+    flush_dirty_ranges(ctx, ranges, n_ranges, total_dirty);
+    memset(ctx->dirty_ranges, 0, sizeof(ctx->dirty_ranges));
+}
+
 void htp_tensor_flush_all(struct htp_context * ctx, const struct htp_tensor * const * tensors, uint32_t n) {
     const struct htp_tensor * dirty_tensors[HTP_OP_MAX_INPUTS];
+    struct htp_dirty_range ranges[HTP_OP_MAX_INPUTS];
     uint32_t n_dirty = 0;
     uint64_t total_dirty = 0;
 
     for (uint32_t i = 0; i < n; i++) {
         const struct htp_tensor * t = tensors[i];
-        if (t && !(t->flags & (HTP_TENSOR_WEIGHT | HTP_TENSOR_FENCE)) && is_tensor_dirty(ctx, t)) {
+        if (t && is_tensor_dirty(ctx, t)) {
             dirty_tensors[n_dirty++] = t;
+            ranges[n_dirty - 1].start = t->data;
+            ranges[n_dirty - 1].end   = t->data + t->size;
             total_dirty += t->size;
         }
     }
@@ -264,37 +317,8 @@ void htp_tensor_flush_all(struct htp_context * ctx, const struct htp_tensor * co
         return;
     }
 
-    if (total_dirty >= HEX_L2_FLUSH_WQ_THRESHOLD && ctx->n_threads > 1) {
-        struct l2flush_multi_task task;
-        task.trace    = ctx->trace;
-        task.n_ranges = 0;
-
-        uint32_t block_acc = 0;
-        for (uint32_t i = 0; i < n_dirty; i++) {
-            const struct htp_tensor * t = dirty_tensors[i];
-            make_tensor_clean(ctx, t);
-
-            struct l2flush_range * rg = &task.ranges[task.n_ranges++];
-            rg->start = hex_align_down((size_t) t->data, HEX_L2_LINE_SIZE);
-            rg->end   = hex_align_up((size_t) t->data + t->size, HEX_L2_LINE_SIZE);
-            rg->block_first = block_acc;
-            rg->n_blocks = (rg->end - rg->start + HEX_L2_BLOCK_SIZE - 1) / HEX_L2_BLOCK_SIZE;
-            block_acc += rg->n_blocks;
-        }
-
-        task.total_blocks      = block_acc;
-        task.blocks_per_thread = fastdiv(block_acc + ctx->n_threads - 1, &ctx->n_threads_div);
-
-        work_queue_run(ctx->work_queue, l2flush_multi_worker, &task, ctx->n_threads);
-        return;
-    }
-
-    struct htp_thread_trace * tr = &ctx->trace[0];
+    flush_dirty_ranges(ctx, ranges, n_dirty, total_dirty);
     for (uint32_t i = 0; i < n_dirty; i++) {
-        const struct htp_tensor * t = dirty_tensors[i];
-        htp_trace_event_start(tr, HTP_TRACE_EVT_L2FLUSH, t->ti);
-        hex_l2flush((void *) (uintptr_t) t->data, t->size);
-        htp_trace_event_stop(tr, HTP_TRACE_EVT_L2FLUSH, t->ti);
-        make_tensor_clean(ctx, t);
+        make_tensor_clean(ctx, dirty_tensors[i]);
     }
 }

--- a/ggml/src/ggml-hexagon/htp/htp-tensor.c
+++ b/ggml/src/ggml-hexagon/htp/htp-tensor.c
@@ -88,6 +88,7 @@ static void merge_dirty_ranges(struct htp_context * ctx) {
             r->start = MIN(r->start, s->start);
             r->end   = MAX(r->end, s->end);
             s->start = 0;
+            s->end   = 0;
             j = 0;
         }
     }
@@ -173,7 +174,7 @@ void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * co
         return;
     }
 
-    if (total_evict_size > HEX_L2_FLUSH_WQ_THRESHOLD && ctx->n_threads > 1 && n_evict <= HTP_OP_MAX_INPUTS) {
+    if (total_evict_size > HEX_L2_FLUSH_WQ_THRESHOLD && ctx->n_threads > 1 && n_evict <= HTP_MAX_DIRTY_RANGES) {
         struct l2flush_multi_task task;
         task.trace    = ctx->trace;
         task.n_ranges = n_evict;

--- a/ggml/src/ggml-hexagon/htp/htp-tensor.h
+++ b/ggml/src/ggml-hexagon/htp/htp-tensor.h
@@ -2,6 +2,7 @@
 #define HTP_TENSOR_H
 
 #include <stdint.h>
+#include <stdbool.h>
 #include "htp-ops.h"
 #include "hex-bitmap.h"
 
@@ -11,6 +12,21 @@ static inline void * htp_tensor_data(const struct htp_tensor * t) {
 
 static inline uint32_t * htp_tensor_flags(const struct htp_tensor * t) {
     return (uint32_t *) &t->flags;
+}
+
+static inline bool htp_tensor_is_contiguous(const struct htp_tensor * t, uint32_t type_size) {
+    uint32_t next_nb = type_size;
+    if (t->ne[0] != 1 && t->nb[0] != next_nb) {
+        return false;
+    }
+    next_nb *= t->ne[0];
+    for (int i = 1; i < HTP_OP_MAX_DIMS; i++) {
+        if (t->ne[i] != 1 && t->nb[i] != next_nb) {
+            return false;
+        }
+        next_nb *= t->ne[i];
+    }
+    return true;
 }
 
 static inline uint32_t htp_tensor_get_row_size(int type, uint32_t ne00) {

--- a/ggml/src/ggml-hexagon/htp/htp-tensor.h
+++ b/ggml/src/ggml-hexagon/htp/htp-tensor.h
@@ -29,6 +29,23 @@ static inline bool htp_tensor_is_contiguous(const struct htp_tensor * t, uint32_
     return true;
 }
 
+static inline bool htp_tensor_is_permuted(const struct htp_tensor * t) {
+    return t->nb[0] > t->nb[1] || t->nb[1] > t->nb[2] || t->nb[2] > t->nb[3];
+}
+
+static inline bool htp_tensor_can_row_partition(const struct htp_tensor * t, uint32_t elem_size) {
+    if (t->ne[0] != 1 && t->nb[0] != elem_size) {
+        return false;
+    }
+    if (htp_tensor_is_permuted(t)) {
+        return false;
+    }
+    if (t->ne[1] > 1 && (t->nb[1] & 127) != 0) return false;
+    if (t->ne[2] > 1 && (t->nb[2] & 127) != 0) return false;
+    if (t->ne[3] > 1 && (t->nb[3] & 127) != 0) return false;
+    return true;
+}
+
 static inline uint32_t htp_tensor_get_row_size(int type, uint32_t ne00) {
     switch (type) {
         case HTP_TYPE_F32:  return ne00 * 4;

--- a/ggml/src/ggml-hexagon/htp/htp-tensor.h
+++ b/ggml/src/ggml-hexagon/htp/htp-tensor.h
@@ -5,6 +5,17 @@
 #include <stdbool.h>
 #include "htp-ops.h"
 #include "hex-bitmap.h"
+#include "hex-common.h"
+#include "hex-fastdiv.h"
+
+enum {
+    HTP_TENSOR_MDEV_LINE_SIZE = 128,
+};
+
+struct htp_tensor_mdev_range {
+    uint32_t start;
+    uint32_t count;
+};
 
 static inline void * htp_tensor_data(const struct htp_tensor * t) {
     return (void *) (uintptr_t) t->data;
@@ -33,17 +44,81 @@ static inline bool htp_tensor_is_permuted(const struct htp_tensor * t) {
     return t->nb[0] > t->nb[1] || t->nb[1] > t->nb[2] || t->nb[2] > t->nb[3];
 }
 
+static inline bool htp_tensor_mdev_data_aligned(const struct htp_tensor * t) {
+    return ((uintptr_t) t->data & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0;
+}
+
 static inline bool htp_tensor_can_row_partition(const struct htp_tensor * t, uint32_t elem_size) {
+    if (!htp_tensor_mdev_data_aligned(t)) {
+        return false;
+    }
     if (t->ne[0] != 1 && t->nb[0] != elem_size) {
         return false;
     }
     if (htp_tensor_is_permuted(t)) {
         return false;
     }
-    if (t->ne[1] > 1 && (t->nb[1] & 127) != 0) return false;
-    if (t->ne[2] > 1 && (t->nb[2] & 127) != 0) return false;
-    if (t->ne[3] > 1 && (t->nb[3] & 127) != 0) return false;
+    if (t->ne[1] > 1 && (t->nb[1] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) != 0) return false;
+    if (t->ne[2] > 1 && (t->nb[2] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) != 0) return false;
+    if (t->ne[3] > 1 && (t->nb[3] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) != 0) return false;
     return true;
+}
+
+static inline bool htp_tensor_mdev_rows_per_chunk(const struct htp_tensor * t, uint32_t elem_size, uint32_t row_size, uint32_t * rows_per_chunk) {
+    *rows_per_chunk = 0;
+
+    if (!htp_tensor_mdev_data_aligned(t)) {
+        return false;
+    }
+    if (t->ne[0] != 1 && t->nb[0] != elem_size) {
+        return false;
+    }
+    if (htp_tensor_is_permuted(t)) {
+        return false;
+    }
+    if (t->ne[1] > 1 && (t->nb[1] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0 &&
+        (t->ne[2] <= 1 || (t->nb[2] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0) &&
+        (t->ne[3] <= 1 || (t->nb[3] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0)) {
+        *rows_per_chunk = 1;
+        return true;
+    }
+    if (t->nb[1] == row_size &&
+        (t->ne[2] <= 1 || t->nb[2] == t->nb[1] * t->ne[1]) &&
+        (t->ne[3] <= 1 || t->nb[3] == t->nb[2] * t->ne[2])) {
+        *rows_per_chunk = (row_size > 0) ? (HTP_TENSOR_MDEV_LINE_SIZE / hex_gcd_u32(row_size, HTP_TENSOR_MDEV_LINE_SIZE)) : 1;
+        return true;
+    }
+    return false;
+}
+
+static inline struct htp_tensor_mdev_range htp_tensor_mdev_partition(uint32_t total_units, uint32_t units_per_chunk, uint32_t mdev_idx, uint32_t mdev_count, const struct fastdiv_values * mdev_count_div) {
+    struct htp_tensor_mdev_range range = { 0, total_units };
+
+    if (mdev_count <= 1) {
+        return range;
+    }
+
+    if (units_per_chunk == 0) {
+        range.start = (mdev_idx == 0) ? 0 : total_units;
+        range.count = (mdev_idx == 0) ? total_units : 0;
+        return range;
+    }
+
+    const uint32_t total_chunks = total_units / units_per_chunk;
+    if (total_chunks < mdev_count) {
+        range.start = (mdev_idx == 0) ? 0 : total_units;
+        range.count = (mdev_idx == 0) ? total_units : 0;
+        return range;
+    }
+
+    const uint32_t chunks_per_mdev = fastdiv(total_chunks + mdev_count - 1, mdev_count_div);
+    range.start = MIN(mdev_idx * chunks_per_mdev * units_per_chunk, total_units);
+    if (mdev_idx == mdev_count - 1) {
+        range.count = total_units - range.start;
+    } else {
+        range.count = MIN(chunks_per_mdev * units_per_chunk, total_units - range.start);
+    }
+    return range;
 }
 
 static inline uint32_t htp_tensor_get_row_size(int type, uint32_t ne00) {

--- a/ggml/src/ggml-hexagon/htp/htp-tensor.h
+++ b/ggml/src/ggml-hexagon/htp/htp-tensor.h
@@ -131,6 +131,7 @@ static inline uint32_t htp_tensor_get_row_size(int type, uint32_t ne00) {
 }
 
 struct htp_context;
+void htp_flush_dirty_ranges(struct htp_context * ctx);
 void htp_tensor_flush_all(struct htp_context * ctx, const struct htp_tensor * const * tensors, uint32_t n);
 void htp_tensor_dirty_all(struct htp_context * ctx, const struct htp_tensor * const * tensors, uint32_t n);
 

--- a/ggml/src/ggml-hexagon/htp/hvx-arith.h
+++ b/ggml/src/ggml-hexagon/htp/hvx-arith.h
@@ -16,25 +16,25 @@
 #define UNUSED(x) (void)(x)
 
 #define hvx_arith_loop_body(dst_type, src0_type, src1_type, elem_size, vec_store, vec_op) \
-    do {                                                                       \
-        dst_type * vdst  = (dst_type *) dst;                                   \
-        src0_type * vsrc0 = (src0_type *) src0;                                \
-        src1_type * vsrc1 = (src1_type *) src1;                                \
-                                                                               \
-        const uint32_t epv  = 128 / (elem_size);                               \
-        const uint32_t nvec = n / epv;                                         \
-        const uint32_t nloe = n % epv;                                         \
-                                                                               \
-        uint32_t i = 0;                                                        \
-                                                                               \
-        _Pragma("unroll(4)")                                                   \
-        for (; i < nvec; i++) {                                                \
-            vdst[i] = vec_op(vsrc0[i], vsrc1[i]);                              \
-        }                                                                      \
-        if (nloe) {                                                            \
-            HVX_Vector v = vec_op(vsrc0[i], vsrc1[i]);                         \
-            vec_store((void *) &vdst[i], nloe * (elem_size), v);               \
-        }                                                                      \
+    do {                                                                                  \
+        dst_type * vdst  = (dst_type *) dst;                                              \
+        src0_type * vsrc0 = (src0_type *) src0;                                           \
+        src1_type * vsrc1 = (src1_type *) src1;                                           \
+                                                                                          \
+        const uint32_t epv  = 128 / (elem_size);                                          \
+        const uint32_t nvec = n / epv;                                                    \
+        const uint32_t nloe = n % epv;                                                    \
+                                                                                          \
+        uint32_t i = 0;                                                                   \
+                                                                                          \
+        _Pragma("unroll(4)")                                                              \
+        for (; i < nvec; i++) {                                                           \
+            vdst[i] = vec_op(vsrc0[i], vsrc1[i]);                                         \
+        }                                                                                 \
+        if (nloe) {                                                                       \
+            HVX_Vector v = vec_op(vsrc0[i], vsrc1[i]);                                    \
+            vec_store((void *) &vdst[i], nloe * (elem_size), v);                          \
+        }                                                                                 \
     } while(0)
 
 #if __HVX_ARCH__ < 79
@@ -56,43 +56,43 @@
 #define HVX_OP_MUL_F16(a, b) hvx_vec_mul_f16_f16(a, b)
 
 // Generic macro to define alignment permutations for an op
-#define DEFINE_HVX_BINARY_OP_VARIANTS(OP_NAME, OP_MACRO, ELEM_TYPE) \
-static inline void OP_NAME##_aaa(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src0 % 128 == 0); \
-    assert((uintptr_t) src1 % 128 == 0); \
-    hvx_arith_loop_body(HVX_Vector, HVX_Vector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO); \
-} \
-static inline void OP_NAME##_aau(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src0 % 128 == 0); \
-    hvx_arith_loop_body(HVX_Vector, HVX_Vector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO); \
-} \
-static inline void OP_NAME##_aua(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src1 % 128 == 0); \
-    hvx_arith_loop_body(HVX_Vector, HVX_UVector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO); \
-} \
-static inline void OP_NAME##_auu(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    hvx_arith_loop_body(HVX_Vector, HVX_UVector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO); \
-} \
-static inline void OP_NAME##_uaa(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
-    assert((uintptr_t) src0 % 128 == 0); \
-    assert((uintptr_t) src1 % 128 == 0); \
-    hvx_arith_loop_body(HVX_UVector, HVX_Vector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO); \
-} \
-static inline void OP_NAME##_uau(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
-    assert((uintptr_t) src0 % 128 == 0); \
-    hvx_arith_loop_body(HVX_UVector, HVX_Vector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO); \
-} \
-static inline void OP_NAME##_uua(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
-    assert((uintptr_t) src1 % 128 == 0); \
-    hvx_arith_loop_body(HVX_UVector, HVX_UVector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO); \
-} \
-static inline void OP_NAME##_uuu(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) { \
+#define DEFINE_HVX_BINARY_OP_VARIANTS(OP_NAME, OP_MACRO, ELEM_TYPE)                                           \
+static inline void OP_NAME##_aaa(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
+    assert((uintptr_t) dst % 128 == 0);                                                                       \
+    assert((uintptr_t) src0 % 128 == 0);                                                                      \
+    assert((uintptr_t) src1 % 128 == 0);                                                                      \
+    hvx_arith_loop_body(HVX_Vector, HVX_Vector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO);    \
+}                                                                                                             \
+static inline void OP_NAME##_aau(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
+    assert((uintptr_t) dst % 128 == 0);                                                                       \
+    assert((uintptr_t) src0 % 128 == 0);                                                                      \
+    hvx_arith_loop_body(HVX_Vector, HVX_Vector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO);   \
+}                                                                                                             \
+static inline void OP_NAME##_aua(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
+    assert((uintptr_t) dst % 128 == 0);                                                                       \
+    assert((uintptr_t) src1 % 128 == 0);                                                                      \
+    hvx_arith_loop_body(HVX_Vector, HVX_UVector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO);   \
+}                                                                                                             \
+static inline void OP_NAME##_auu(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
+    assert((uintptr_t) dst % 128 == 0);                                                                       \
+    hvx_arith_loop_body(HVX_Vector, HVX_UVector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO);  \
+}                                                                                                             \
+static inline void OP_NAME##_uaa(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
+    assert((uintptr_t) src0 % 128 == 0);                                                                      \
+    assert((uintptr_t) src1 % 128 == 0);                                                                      \
+    hvx_arith_loop_body(HVX_UVector, HVX_Vector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO);   \
+}                                                                                                             \
+static inline void OP_NAME##_uau(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
+    assert((uintptr_t) src0 % 128 == 0);                                                                      \
+    hvx_arith_loop_body(HVX_UVector, HVX_Vector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO);  \
+}                                                                                                             \
+static inline void OP_NAME##_uua(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
+    assert((uintptr_t) src1 % 128 == 0);                                                                      \
+    hvx_arith_loop_body(HVX_UVector, HVX_UVector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO);  \
+}                                                                                                             \
+static inline void OP_NAME##_uuu(uint8_t * dst, const uint8_t * src0, const uint8_t * src1, uint32_t n) {     \
     hvx_arith_loop_body(HVX_UVector, HVX_UVector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO); \
-} \
+}                                                                                                             \
 
 DEFINE_HVX_BINARY_OP_VARIANTS(hvx_add_f32, HVX_OP_ADD_F32, float)
 DEFINE_HVX_BINARY_OP_VARIANTS(hvx_sub_f32, HVX_OP_SUB_F32, float)
@@ -103,25 +103,25 @@ DEFINE_HVX_BINARY_OP_VARIANTS(hvx_sub_f16, HVX_OP_SUB_F16, _Float16)
 DEFINE_HVX_BINARY_OP_VARIANTS(hvx_mul_f16, HVX_OP_MUL_F16, _Float16)
 
 // Dispatcher logic
-#define HVX_BINARY_DISPATCHER(OP_NAME) \
+#define HVX_BINARY_DISPATCHER(OP_NAME)                                                                                                       \
 static inline void OP_NAME(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, const uint32_t num_elems) { \
-    if (hex_is_aligned((void *) dst, 128)) { \
-        if (hex_is_aligned((void *) src0, 128)) { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aaa(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_aau(dst, src0, src1, num_elems); \
-        } else { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aua(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_auu(dst, src0, src1, num_elems); \
-        } \
-    } else { \
-        if (hex_is_aligned((void *) src0, 128)) { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uaa(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_uau(dst, src0, src1, num_elems); \
-        } else { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uua(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_uuu(dst, src0, src1, num_elems); \
-        } \
-    } \
+    if (hex_is_aligned((void *) dst, 128)) {                                                                                                 \
+        if (hex_is_aligned((void *) src0, 128)) {                                                                                            \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aaa(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_aau(dst, src0, src1, num_elems);                                               \
+        } else {                                                                                                                             \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aua(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_auu(dst, src0, src1, num_elems);                                               \
+        }                                                                                                                                    \
+    } else {                                                                                                                                 \
+        if (hex_is_aligned((void *) src0, 128)) {                                                                                            \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uaa(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_uau(dst, src0, src1, num_elems);                                               \
+        } else {                                                                                                                             \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uua(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_uuu(dst, src0, src1, num_elems);                                               \
+        }                                                                                                                                    \
+    }                                                                                                                                        \
 }
 
 HVX_BINARY_DISPATCHER(hvx_add_f32)
@@ -166,44 +166,44 @@ static inline void hvx_mul_mul_f32_aa(uint8_t * restrict dst, const uint8_t * re
 
 // Scalar Operations
 
-#define hvx_scalar_loop_body(dst_type, src_type, elem_size, vec_store, scalar_op_macro)   \
-    do {                                                                       \
-        dst_type * restrict vdst = (dst_type *) dst;                           \
-        src_type * restrict vsrc = (src_type *) src;                           \
-                                                                               \
-        const uint32_t epv  = 128 / (elem_size);                               \
-        const uint32_t nvec = n / epv;                                         \
-        const uint32_t nloe = n % epv;                                         \
-                                                                               \
-        uint32_t i = 0;                                                        \
-                                                                               \
-        _Pragma("unroll(4)")                                                   \
-        for (; i < nvec; i++) {                                                \
-            HVX_Vector v = vsrc[i];                                            \
-            vdst[i] = scalar_op_macro(v);                                      \
-        }                                                                      \
-        if (nloe) {                                                            \
-            HVX_Vector v = vsrc[i];                                            \
-            v = scalar_op_macro(v);                                            \
-            vec_store((void *) &vdst[i], nloe * (elem_size), v);               \
-        }                                                                      \
+#define hvx_scalar_loop_body(dst_type, src_type, elem_size, vec_store, scalar_op_macro) \
+    do {                                                                                \
+        dst_type * restrict vdst = (dst_type *) dst;                                    \
+        src_type * restrict vsrc = (src_type *) src;                                    \
+                                                                                        \
+        const uint32_t epv  = 128 / (elem_size);                                        \
+        const uint32_t nvec = n / epv;                                                  \
+        const uint32_t nloe = n % epv;                                                  \
+                                                                                        \
+        uint32_t i = 0;                                                                 \
+                                                                                        \
+        _Pragma("unroll(4)")                                                            \
+        for (; i < nvec; i++) {                                                         \
+            HVX_Vector v = vsrc[i];                                                     \
+            vdst[i] = scalar_op_macro(v);                                               \
+        }                                                                               \
+        if (nloe) {                                                                     \
+            HVX_Vector v = vsrc[i];                                                     \
+            v = scalar_op_macro(v);                                                     \
+            vec_store((void *) &vdst[i], nloe * (elem_size), v);                        \
+        }                                                                               \
     } while(0)
 
-#define HVX_OP_ADD_SCALAR_F32(v) \
-    ({ \
+#define HVX_OP_ADD_SCALAR_F32(v)                                   \
+    ({                                                             \
         const HVX_VectorPred pred_inf = Q6_Q_vcmp_eq_VwVw(inf, v); \
-        HVX_Vector out = HVX_OP_ADD_F32(v, val_vec); \
-        Q6_V_vmux_QVV(pred_inf, inf, out); \
+        HVX_Vector out = HVX_OP_ADD_F32(v, val_vec);               \
+        Q6_V_vmux_QVV(pred_inf, inf, out);                         \
     })
 
 #define HVX_OP_MUL_SCALAR_F32(v) HVX_OP_MUL_F32(v, val_vec)
 #define HVX_OP_SUB_SCALAR_F32(v) HVX_OP_SUB_F32(v, val_vec)
 
-#define HVX_OP_ADD_SCALAR_F16(v) \
-    ({ \
+#define HVX_OP_ADD_SCALAR_F16(v)                                   \
+    ({                                                             \
         const HVX_VectorPred pred_inf = Q6_Q_vcmp_eq_VhVh(inf, v); \
-        HVX_Vector out = HVX_OP_ADD_F16(v, val_vec); \
-        Q6_V_vmux_QVV(pred_inf, inf, out); \
+        HVX_Vector out = HVX_OP_ADD_F16(v, val_vec);               \
+        Q6_V_vmux_QVV(pred_inf, inf, out);                         \
     })
 
 #define HVX_OP_MUL_SCALAR_F16(v) HVX_OP_MUL_F16(v, val_vec)
@@ -212,31 +212,31 @@ static inline void hvx_mul_mul_f32_aa(uint8_t * restrict dst, const uint8_t * re
 // Scalar Variants
 
 // Generic macro to define alignment permutations for an op
-#define DEFINE_HVX_BINARY_SCALAR_OP_VARIANTS(OP_NAME, OP_MACRO, SPLAT_MACRO, ELEM_TYPE) \
+#define DEFINE_HVX_BINARY_SCALAR_OP_VARIANTS(OP_NAME, OP_MACRO, SPLAT_MACRO, ELEM_TYPE)                                  \
 static inline void OP_NAME##_aa(uint8_t * restrict dst, const uint8_t * restrict src, const ELEM_TYPE val, uint32_t n) { \
-    const HVX_Vector val_vec = SPLAT_MACRO(val); \
-    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf); \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src % 128 == 0); \
-    hvx_scalar_loop_body(HVX_Vector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO); \
-} \
+    const HVX_Vector val_vec = SPLAT_MACRO(val);                                                                         \
+    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf);                                                \
+    assert((uintptr_t) dst % 128 == 0);                                                                                  \
+    assert((uintptr_t) src % 128 == 0);                                                                                  \
+    hvx_scalar_loop_body(HVX_Vector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO);                          \
+}                                                                                                                        \
 static inline void OP_NAME##_au(uint8_t * restrict dst, const uint8_t * restrict src, const ELEM_TYPE val, uint32_t n) { \
-    const HVX_Vector val_vec = SPLAT_MACRO(val); \
-    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf); \
-    assert((uintptr_t) dst % 128 == 0); \
-    hvx_scalar_loop_body(HVX_Vector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO); \
-} \
+    const HVX_Vector val_vec = SPLAT_MACRO(val);                                                                         \
+    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf);                                                \
+    assert((uintptr_t) dst % 128 == 0);                                                                                  \
+    hvx_scalar_loop_body(HVX_Vector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_a, OP_MACRO);                         \
+}                                                                                                                        \
 static inline void OP_NAME##_ua(uint8_t * restrict dst, const uint8_t * restrict src, const ELEM_TYPE val, uint32_t n) { \
-    const HVX_Vector val_vec = SPLAT_MACRO(val); \
-    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf); \
-    assert((uintptr_t) src % 128 == 0); \
-    hvx_scalar_loop_body(HVX_UVector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO); \
-} \
+    const HVX_Vector val_vec = SPLAT_MACRO(val);                                                                         \
+    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf);                                                \
+    assert((uintptr_t) src % 128 == 0);                                                                                  \
+    hvx_scalar_loop_body(HVX_UVector, HVX_Vector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO);                         \
+}                                                                                                                        \
 static inline void OP_NAME##_uu(uint8_t * restrict dst, const uint8_t * restrict src, const ELEM_TYPE val, uint32_t n) { \
-    const HVX_Vector val_vec = SPLAT_MACRO(val); \
-    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf); \
-    hvx_scalar_loop_body(HVX_UVector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO); \
-} \
+    const HVX_Vector val_vec = SPLAT_MACRO(val);                                                                         \
+    const HVX_Vector inf = SPLAT_MACRO((ELEM_TYPE)INFINITY); UNUSED(inf);                                                \
+    hvx_scalar_loop_body(HVX_UVector, HVX_UVector, sizeof(ELEM_TYPE), hvx_vec_store_u, OP_MACRO);                        \
+}                                                                                                                        \
 
 DEFINE_HVX_BINARY_SCALAR_OP_VARIANTS(hvx_add_scalar_f32, HVX_OP_ADD_SCALAR_F32, hvx_vec_splat_f32, float)
 DEFINE_HVX_BINARY_SCALAR_OP_VARIANTS(hvx_sub_scalar_f32, HVX_OP_SUB_SCALAR_F32, hvx_vec_splat_f32, float)
@@ -247,17 +247,17 @@ DEFINE_HVX_BINARY_SCALAR_OP_VARIANTS(hvx_sub_scalar_f16, HVX_OP_SUB_SCALAR_F16, 
 DEFINE_HVX_BINARY_SCALAR_OP_VARIANTS(hvx_mul_scalar_f16, HVX_OP_MUL_SCALAR_F16, hvx_vec_splat_f16, _Float16)
 
 // Dispatcher logic
-#define HVX_BINARY_SCALAR_DISPATCHER(OP_NAME, ELEM_TYPE) \
+#define HVX_BINARY_SCALAR_DISPATCHER(OP_NAME, ELEM_TYPE)                                                                          \
 static inline void OP_NAME(uint8_t * restrict dst, const uint8_t * restrict src, const ELEM_TYPE val, const uint32_t num_elems) { \
-    if (hex_is_aligned((void *) dst, 128) && hex_is_aligned((void *) src, 128)) { \
-        OP_NAME##_aa(dst, src, val, num_elems); \
-    } else if (hex_is_aligned((void *) dst, 128)) { \
-        OP_NAME##_au(dst, src, val, num_elems); \
-    } else if (hex_is_aligned((void *) src, 128)) { \
-        OP_NAME##_ua(dst, src, val, num_elems); \
-    } else { \
-        OP_NAME##_uu(dst, src, val, num_elems); \
-    } \
+    if (hex_is_aligned((void *) dst, 128) && hex_is_aligned((void *) src, 128)) {                                                 \
+        OP_NAME##_aa(dst, src, val, num_elems);                                                                                   \
+    } else if (hex_is_aligned((void *) dst, 128)) {                                                                               \
+        OP_NAME##_au(dst, src, val, num_elems);                                                                                   \
+    } else if (hex_is_aligned((void *) src, 128)) {                                                                               \
+        OP_NAME##_ua(dst, src, val, num_elems);                                                                                   \
+    } else {                                                                                                                      \
+        OP_NAME##_uu(dst, src, val, num_elems);                                                                                   \
+    }                                                                                                                             \
 }
 
 HVX_BINARY_SCALAR_DISPATCHER(hvx_add_scalar_f32, float)
@@ -350,12 +350,12 @@ static inline void hvx_max_scalar_f32(uint8_t * restrict dst, const uint8_t * re
 
 // CLAMP Scalar variants
 
-#define HVX_OP_CLAMP_SCALAR(v) \
-    ({ \
+#define HVX_OP_CLAMP_SCALAR(v)                                           \
+    ({                                                                   \
         HVX_VectorPred pred_cap_right = Q6_Q_vcmp_gt_VsfVsf(v, max_vec); \
         HVX_VectorPred pred_cap_left  = Q6_Q_vcmp_gt_VsfVsf(min_vec, v); \
-        HVX_Vector tmp = Q6_V_vmux_QVV(pred_cap_right, max_vec, v); \
-        Q6_V_vmux_QVV(pred_cap_left, min_vec, tmp); \
+        HVX_Vector tmp = Q6_V_vmux_QVV(pred_cap_right, max_vec, v);      \
+        Q6_V_vmux_QVV(pred_cap_left, min_vec, tmp);                      \
     })
 
 static inline void hvx_clamp_scalar_f32_aa(uint8_t * restrict dst, const uint8_t * restrict src, const float min, const float max, uint32_t n) {

--- a/ggml/src/ggml-hexagon/htp/hvx-div.h
+++ b/ggml/src/ggml-hexagon/htp/hvx-div.h
@@ -219,64 +219,64 @@ static inline HVX_Vector hvx_vec_hybrid_div_f16(HVX_Vector vec1, HVX_Vector vec2
     } while(0)
 
 // Generic macro to define alignment permutations for an op
-#define DEFINE_HVX_DIV_OP_VARIANTS(OP_NAME, OP_LOOP_BODY) \
+#define DEFINE_HVX_DIV_OP_VARIANTS(OP_NAME, OP_LOOP_BODY)                                                                            \
 static inline void OP_NAME##_aaa(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src0 % 128 == 0); \
-    assert((uintptr_t) src1 % 128 == 0); \
-    OP_LOOP_BODY(HVX_Vector, HVX_Vector, HVX_Vector, hvx_vec_store_a); \
-} \
+    assert((uintptr_t) dst % 128 == 0);                                                                                              \
+    assert((uintptr_t) src0 % 128 == 0);                                                                                             \
+    assert((uintptr_t) src1 % 128 == 0);                                                                                             \
+    OP_LOOP_BODY(HVX_Vector, HVX_Vector, HVX_Vector, hvx_vec_store_a);                                                               \
+}                                                                                                                                    \
 static inline void OP_NAME##_aau(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src0 % 128 == 0); \
-    OP_LOOP_BODY(HVX_Vector, HVX_Vector, HVX_UVector, hvx_vec_store_a); \
-} \
+    assert((uintptr_t) dst % 128 == 0);                                                                                              \
+    assert((uintptr_t) src0 % 128 == 0);                                                                                             \
+    OP_LOOP_BODY(HVX_Vector, HVX_Vector, HVX_UVector, hvx_vec_store_a);                                                              \
+}                                                                                                                                    \
 static inline void OP_NAME##_aua(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src1 % 128 == 0); \
-    OP_LOOP_BODY(HVX_Vector, HVX_UVector, HVX_Vector, hvx_vec_store_a); \
-} \
+    assert((uintptr_t) dst % 128 == 0);                                                                                              \
+    assert((uintptr_t) src1 % 128 == 0);                                                                                             \
+    OP_LOOP_BODY(HVX_Vector, HVX_UVector, HVX_Vector, hvx_vec_store_a);                                                              \
+}                                                                                                                                    \
 static inline void OP_NAME##_auu(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    OP_LOOP_BODY(HVX_Vector, HVX_UVector, HVX_UVector, hvx_vec_store_a); \
-} \
+    assert((uintptr_t) dst % 128 == 0);                                                                                              \
+    OP_LOOP_BODY(HVX_Vector, HVX_UVector, HVX_UVector, hvx_vec_store_a);                                                             \
+}                                                                                                                                    \
 static inline void OP_NAME##_uaa(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    assert((uintptr_t) src0 % 128 == 0); \
-    assert((uintptr_t) src1 % 128 == 0); \
-    OP_LOOP_BODY(HVX_UVector, HVX_Vector, HVX_Vector, hvx_vec_store_u); \
-} \
+    assert((uintptr_t) src0 % 128 == 0);                                                                                             \
+    assert((uintptr_t) src1 % 128 == 0);                                                                                             \
+    OP_LOOP_BODY(HVX_UVector, HVX_Vector, HVX_Vector, hvx_vec_store_u);                                                              \
+}                                                                                                                                    \
 static inline void OP_NAME##_uau(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    assert((uintptr_t) src0 % 128 == 0); \
-    OP_LOOP_BODY(HVX_UVector, HVX_Vector, HVX_UVector, hvx_vec_store_u); \
-} \
+    assert((uintptr_t) src0 % 128 == 0);                                                                                             \
+    OP_LOOP_BODY(HVX_UVector, HVX_Vector, HVX_UVector, hvx_vec_store_u);                                                             \
+}                                                                                                                                    \
 static inline void OP_NAME##_uua(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    assert((uintptr_t) src1 % 128 == 0); \
-    OP_LOOP_BODY(HVX_UVector, HVX_UVector, HVX_Vector, hvx_vec_store_u); \
-} \
+    assert((uintptr_t) src1 % 128 == 0);                                                                                             \
+    OP_LOOP_BODY(HVX_UVector, HVX_UVector, HVX_Vector, hvx_vec_store_u);                                                             \
+}                                                                                                                                    \
 static inline void OP_NAME##_uuu(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, uint32_t n) { \
-    OP_LOOP_BODY(HVX_UVector, HVX_UVector, HVX_UVector, hvx_vec_store_u); \
-} \
+    OP_LOOP_BODY(HVX_UVector, HVX_UVector, HVX_UVector, hvx_vec_store_u);                                                            \
+}                                                                                                                                    \
 
 // Dispatcher logic
-#define HVX_DIV_DISPATCHER(OP_NAME) \
+#define HVX_DIV_DISPATCHER(OP_NAME)                                                                                                          \
 static inline void OP_NAME(uint8_t * restrict dst, const uint8_t * restrict src0, const uint8_t * restrict src1, const uint32_t num_elems) { \
-    if (hex_is_aligned((void *) dst, 128)) { \
-        if (hex_is_aligned((void *) src0, 128)) { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aaa(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_aau(dst, src0, src1, num_elems); \
-        } else { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aua(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_auu(dst, src0, src1, num_elems); \
-        } \
-    } else { \
-        if (hex_is_aligned((void *) src0, 128)) { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uaa(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_uau(dst, src0, src1, num_elems); \
-        } else { \
-            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uua(dst, src0, src1, num_elems); \
-            else                                    OP_NAME##_uuu(dst, src0, src1, num_elems); \
-        } \
-    } \
+    if (hex_is_aligned((void *) dst, 128)) {                                                                                                 \
+        if (hex_is_aligned((void *) src0, 128)) {                                                                                            \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aaa(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_aau(dst, src0, src1, num_elems);                                               \
+        } else {                                                                                                                             \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_aua(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_auu(dst, src0, src1, num_elems);                                               \
+        }                                                                                                                                    \
+    } else {                                                                                                                                 \
+        if (hex_is_aligned((void *) src0, 128)) {                                                                                            \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uaa(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_uau(dst, src0, src1, num_elems);                                               \
+        } else {                                                                                                                             \
+            if (hex_is_aligned((void *) src1, 128)) OP_NAME##_uua(dst, src0, src1, num_elems);                                               \
+            else                                    OP_NAME##_uuu(dst, src0, src1, num_elems);                                               \
+        }                                                                                                                                    \
+    }                                                                                                                                        \
 }
 
 DEFINE_HVX_DIV_OP_VARIANTS(hvx_div_f32, hvx_div_f32_loop_body)

--- a/ggml/src/ggml-hexagon/htp/hvx-inverse.h
+++ b/ggml/src/ggml-hexagon/htp/hvx-inverse.h
@@ -169,36 +169,36 @@ static inline HVX_Vector hvx_vec_inverse_f16_guard(HVX_Vector v_sf, HVX_Vector n
     } while(0)
 
 // Generic macro to define alignment permutations for an op
-#define DEFINE_HVX_INV_OP_VARIANTS(OP_NAME, OP_LOOP_BODY) \
+#define DEFINE_HVX_INV_OP_VARIANTS(OP_NAME, OP_LOOP_BODY)                                           \
 static inline void OP_NAME##_aa(uint8_t * restrict dst, const uint8_t * restrict src, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    assert((uintptr_t) src % 128 == 0); \
-    OP_LOOP_BODY(HVX_Vector, HVX_Vector, hvx_vec_store_a); \
-} \
+    assert((uintptr_t) dst % 128 == 0);                                                             \
+    assert((uintptr_t) src % 128 == 0);                                                             \
+    OP_LOOP_BODY(HVX_Vector, HVX_Vector, hvx_vec_store_a);                                          \
+}                                                                                                   \
 static inline void OP_NAME##_au(uint8_t * restrict dst, const uint8_t * restrict src, uint32_t n) { \
-    assert((uintptr_t) dst % 128 == 0); \
-    OP_LOOP_BODY(HVX_Vector, HVX_UVector, hvx_vec_store_a); \
-} \
+    assert((uintptr_t) dst % 128 == 0);                                                             \
+    OP_LOOP_BODY(HVX_Vector, HVX_UVector, hvx_vec_store_a);                                         \
+}                                                                                                   \
 static inline void OP_NAME##_ua(uint8_t * restrict dst, const uint8_t * restrict src, uint32_t n) { \
-    assert((uintptr_t) src % 128 == 0); \
-    OP_LOOP_BODY(HVX_UVector, HVX_Vector, hvx_vec_store_u); \
-} \
+    assert((uintptr_t) src % 128 == 0);                                                             \
+    OP_LOOP_BODY(HVX_UVector, HVX_Vector, hvx_vec_store_u);                                         \
+}                                                                                                   \
 static inline void OP_NAME##_uu(uint8_t * restrict dst, const uint8_t * restrict src, uint32_t n) { \
-    OP_LOOP_BODY(HVX_UVector, HVX_UVector, hvx_vec_store_u); \
-} \
+    OP_LOOP_BODY(HVX_UVector, HVX_UVector, hvx_vec_store_u);                                        \
+}                                                                                                   \
 
 // Dispatcher logic
-#define HVX_INV_DISPATCHER(OP_NAME) \
+#define HVX_INV_DISPATCHER(OP_NAME)                                                                          \
 static inline void OP_NAME(uint8_t * restrict dst, const uint8_t * restrict src, const uint32_t num_elems) { \
-    if (hex_is_aligned((void *) dst, 128) && hex_is_aligned((void *) src, 128)) { \
-        OP_NAME##_aa(dst, src, num_elems); \
-    } else if (hex_is_aligned((void *) dst, 128)) { \
-        OP_NAME##_au(dst, src, num_elems); \
-    } else if (hex_is_aligned((void *) src, 128)) { \
-        OP_NAME##_ua(dst, src, num_elems); \
-    } else { \
-        OP_NAME##_uu(dst, src, num_elems); \
-    } \
+    if (hex_is_aligned((void *) dst, 128) && hex_is_aligned((void *) src, 128)) {                            \
+        OP_NAME##_aa(dst, src, num_elems);                                                                   \
+    } else if (hex_is_aligned((void *) dst, 128)) {                                                          \
+        OP_NAME##_au(dst, src, num_elems);                                                                   \
+    } else if (hex_is_aligned((void *) src, 128)) {                                                          \
+        OP_NAME##_ua(dst, src, num_elems);                                                                   \
+    } else {                                                                                                 \
+        OP_NAME##_uu(dst, src, num_elems);                                                                   \
+    }                                                                                                        \
 }
 
 DEFINE_HVX_INV_OP_VARIANTS(hvx_inverse_f32, hvx_inverse_f32_loop_body)

--- a/ggml/src/ggml-hexagon/htp/hvx-scale.h
+++ b/ggml/src/ggml-hexagon/htp/hvx-scale.h
@@ -68,30 +68,30 @@ static inline void hvx_scale_f32(uint8_t * restrict dst, const uint8_t * restric
     }
 }
 
-#define hvx_scale_offset_f32_loop_body(dst_type, src_type, vec_store)                \
-    do {                                                                             \
-        dst_type * restrict vdst = (dst_type *) dst;                                 \
-        src_type * restrict vsrc = (src_type *) src;                                 \
-                                                                                     \
-        HVX_Vector vs = hvx_vec_splat_f32(scale);                                    \
-        HVX_Vector vo = hvx_vec_splat_f32(offset);                                   \
-                                                                                     \
-        const uint32_t elem_size = sizeof(float);                                    \
-        const uint32_t epv = 128 / elem_size;                                        \
-        const uint32_t nvec = n / epv;                                               \
-        const uint32_t nloe = n % epv;                                               \
-                                                                                     \
-        uint32_t i = 0;                                                              \
-                                                                                     \
-        _Pragma("unroll(4)")                                                         \
-        for (; i < nvec; ++i) {                                                      \
+#define hvx_scale_offset_f32_loop_body(dst_type, src_type, vec_store)                     \
+    do {                                                                                  \
+        dst_type * restrict vdst = (dst_type *) dst;                                      \
+        src_type * restrict vsrc = (src_type *) src;                                      \
+                                                                                          \
+        HVX_Vector vs = hvx_vec_splat_f32(scale);                                         \
+        HVX_Vector vo = hvx_vec_splat_f32(offset);                                        \
+                                                                                          \
+        const uint32_t elem_size = sizeof(float);                                         \
+        const uint32_t epv = 128 / elem_size;                                             \
+        const uint32_t nvec = n / epv;                                                    \
+        const uint32_t nloe = n % epv;                                                    \
+                                                                                          \
+        uint32_t i = 0;                                                                   \
+                                                                                          \
+        _Pragma("unroll(4)")                                                              \
+        for (; i < nvec; ++i) {                                                           \
             HVX_Vector v = Q6_Vqf32_vadd_Vqf32Vsf(Q6_Vqf32_vmpy_VsfVsf(vsrc[i], vs), vo); \
-            vdst[i] = Q6_Vsf_equals_Vqf32(v);                                        \
-        }                                                                            \
-        if (nloe) {                                                                  \
+            vdst[i] = Q6_Vsf_equals_Vqf32(v);                                             \
+        }                                                                                 \
+        if (nloe) {                                                                       \
             HVX_Vector v = Q6_Vqf32_vadd_Vqf32Vsf(Q6_Vqf32_vmpy_VsfVsf(vsrc[i], vs), vo); \
-            vec_store((void *) &vdst[i], nloe * elem_size, Q6_Vsf_equals_Vqf32(v));  \
-        }                                                                            \
+            vec_store((void *) &vdst[i], nloe * elem_size, Q6_Vsf_equals_Vqf32(v));       \
+        }                                                                                 \
     } while(0)
 
 static inline void hvx_scale_offset_f32_aa(uint8_t * restrict dst, const uint8_t * restrict src, const int n, const float scale, const float offset) {

--- a/ggml/src/ggml-hexagon/htp/hvx-sigmoid.h
+++ b/ggml/src/ggml-hexagon/htp/hvx-sigmoid.h
@@ -68,50 +68,50 @@ static inline HVX_Vector hvx_vec_tanh_f32(HVX_Vector x) {
     return Q6_Vsf_equals_Vqf32(res);
 }
 
-#define hvx_sigmoid_loop_body(dst_type, src_type, vec_store)    \
-    do {                                                        \
-        dst_type * restrict vdst = (dst_type *) dst;            \
-        src_type * restrict vsrc = (src_type *) src;            \
-                                                                \
-        const HVX_Vector one     = hvx_vec_splat_f32(1.f);      \
-        const HVX_Vector max_exp = hvx_vec_splat_f32(87.f);     \
-        const HVX_Vector min_exp = hvx_vec_splat_f32(-87.f);    \
-                                                                \
-        const uint32_t epv  = 128 / sizeof(float);              \
-        const uint32_t nvec = n / epv;                          \
-        const uint32_t nloe = n % epv;                          \
-                                                                \
-        uint32_t i = 0;                                         \
-                                                                \
-        _Pragma("unroll(4)")                                    \
-        for (; i < nvec; i++) {                                 \
-             vdst[i] = hvx_vec_fast_sigmoid_f32_guard(vsrc[i], one, max_exp, min_exp); \
-        }                                                       \
-        if (nloe) {                                             \
+#define hvx_sigmoid_loop_body(dst_type, src_type, vec_store)                                  \
+    do {                                                                                      \
+        dst_type * restrict vdst = (dst_type *) dst;                                          \
+        src_type * restrict vsrc = (src_type *) src;                                          \
+                                                                                              \
+        const HVX_Vector one     = hvx_vec_splat_f32(1.f);                                    \
+        const HVX_Vector max_exp = hvx_vec_splat_f32(87.f);                                   \
+        const HVX_Vector min_exp = hvx_vec_splat_f32(-87.f);                                  \
+                                                                                              \
+        const uint32_t epv  = 128 / sizeof(float);                                            \
+        const uint32_t nvec = n / epv;                                                        \
+        const uint32_t nloe = n % epv;                                                        \
+                                                                                              \
+        uint32_t i = 0;                                                                       \
+                                                                                              \
+        _Pragma("unroll(4)")                                                                  \
+        for (; i < nvec; i++) {                                                               \
+             vdst[i] = hvx_vec_fast_sigmoid_f32_guard(vsrc[i], one, max_exp, min_exp);        \
+        }                                                                                     \
+        if (nloe) {                                                                           \
              HVX_Vector tmp = hvx_vec_fast_sigmoid_f32_guard(vsrc[i], one, max_exp, min_exp); \
-             vec_store((void *) &vdst[i], nloe * sizeof(float), tmp); \
-        }                                                       \
+             vec_store((void *) &vdst[i], nloe * sizeof(float), tmp);                         \
+        }                                                                                     \
     } while(0)
 
-#define hvx_tanh_loop_body(dst_type, src_type, vec_store)       \
-    do {                                                        \
-        dst_type * restrict vdst = (dst_type *) dst;            \
-        src_type * restrict vsrc = (src_type *) src;            \
-                                                                \
-        const uint32_t epv  = 128 / sizeof(float);              \
-        const uint32_t nvec = n / epv;                          \
-        const uint32_t nloe = n % epv;                          \
-                                                                \
-        uint32_t i = 0;                                         \
-                                                                \
-        _Pragma("unroll(4)")                                    \
-        for (; i < nvec; i++) {                                 \
-             vdst[i] = hvx_vec_tanh_f32(vsrc[i]);               \
-        }                                                       \
-        if (nloe) {                                             \
-             HVX_Vector tmp = hvx_vec_tanh_f32(vsrc[i]);        \
+#define hvx_tanh_loop_body(dst_type, src_type, vec_store)             \
+    do {                                                              \
+        dst_type * restrict vdst = (dst_type *) dst;                  \
+        src_type * restrict vsrc = (src_type *) src;                  \
+                                                                      \
+        const uint32_t epv  = 128 / sizeof(float);                    \
+        const uint32_t nvec = n / epv;                                \
+        const uint32_t nloe = n % epv;                                \
+                                                                      \
+        uint32_t i = 0;                                               \
+                                                                      \
+        _Pragma("unroll(4)")                                          \
+        for (; i < nvec; i++) {                                       \
+             vdst[i] = hvx_vec_tanh_f32(vsrc[i]);                     \
+        }                                                             \
+        if (nloe) {                                                   \
+             HVX_Vector tmp = hvx_vec_tanh_f32(vsrc[i]);              \
              vec_store((void *) &vdst[i], nloe * sizeof(float), tmp); \
-        }                                                       \
+        }                                                             \
     } while(0)
 
 static inline void hvx_sigmoid_f32_aa(uint8_t * restrict dst, const uint8_t * restrict src, uint32_t n) {

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -3,10 +3,11 @@
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 
 #include <HAP_farf.h>
-#include <HAP_perf.h>
 #include <hexagon_protos.h>
 #include <hexagon_types.h>
 #include <string.h>
+
+#include "hex-common.h"
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
@@ -276,26 +277,50 @@ int op_im2col(struct htp_ops_context * octx) {
 
     uint32_t patch_base, dev_npatches;
     if (octx->mdev_count > 1) {
-        const uint32_t patches_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[1]);
-        uint32_t patches_per_mdev = fastdiv(npatches + octx->mdev_count - 1, &octx->mdev_count_div);
-        patches_per_mdev = ((patches_per_mdev + patches_per_line - 1) / patches_per_line) * patches_per_line;
-        patch_base    = MIN(octx->mdev_idx * patches_per_mdev, npatches);
-        dev_npatches  = MIN(patches_per_mdev, npatches - patch_base);
+        const uint32_t patch_size = dst->nb[1];
+        const uint32_t patches_per_chunk = (patch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(patch_size, HEX_L2_LINE_SIZE)) : 1;
+        const uint32_t total_patch_chunks = npatches / patches_per_chunk;
+        const bool can_split_patches = total_patch_chunks >= octx->mdev_count;
+
+        if (!can_split_patches) {
+            patch_base   = (octx->mdev_idx == 0) ? 0 : npatches;
+            dev_npatches = (octx->mdev_idx == 0) ? npatches : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_patch_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            patch_base = MIN(octx->mdev_idx * chunks_per_mdev * patches_per_chunk, npatches);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                dev_npatches = npatches - patch_base;
+            } else {
+                dev_npatches = MIN(chunks_per_mdev * patches_per_chunk, npatches - patch_base);
+            }
+        }
     } else {
-        patch_base    = 0;
-        dev_npatches  = npatches;
+        patch_base   = 0;
+        dev_npatches = npatches;
     }
 
     uint32_t row_base, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[2]);
-        uint32_t rows_per_mdev = fastdiv(nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        rows_per_mdev = ((rows_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        row_base   = MIN(octx->mdev_idx * rows_per_mdev, nrows);
-        mdev_nrows  = MIN(rows_per_mdev, nrows - row_base);
+        const uint32_t row_size = dst->nb[2];
+        const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
+        const uint32_t total_row_chunks = nrows / rows_per_chunk;
+        const bool can_split_rows = total_row_chunks >= octx->mdev_count;
+
+        if (!can_split_rows) {
+            row_base   = (octx->mdev_idx == 0) ? 0 : nrows;
+            mdev_nrows = (octx->mdev_idx == 0) ? nrows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_row_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            row_base = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, nrows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = nrows - row_base;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, nrows - row_base);
+            }
+        }
     } else {
         row_base   = 0;
-        mdev_nrows  = nrows;
+        mdev_nrows = nrows;
     }
 
     if (dev_npatches == 0 && mdev_nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -21,11 +21,11 @@
 struct htp_im2col_context {
     struct htp_ops_context * octx;
     uint32_t                 patch_base;           // first patch index assigned to this dev
-    uint32_t                 dev_npatches;         // number of patches assigned to this dev
+    uint32_t                 npatches;             // number of patches assigned to this dev
     uint32_t                 npatches_per_thread;  // patches = N*OH*OW (pure-DDR kernel)
 
     uint32_t pe_row_base;              // first N*OH row index assigned to this dev (DMA path)
-    uint32_t dev_nrows_dma;            // number of N*OH rows assigned to this dev (DMA path)
+    uint32_t pe_nrows;                 // number of N*OH rows assigned to this dev (DMA path)
     uint32_t pe_rows_per_thread;       // N*OH rows per worker
     uint32_t pe_src_row_bytes;         // one output row's source: IC*KH*IW*4, rounded 256
     uint32_t pe_dst_row_bytes;         // one output row's dst: OW*patch_stride*2, rounded 256
@@ -76,14 +76,14 @@ static inline void htp_im2col_vtcm_layout_build(struct htp_im2col_vtcm_layout * 
         const uint32_t patch_stride             = IC * KH * KW;                                           \
         const float * restrict src_data         = (const float *) src1->data;                             \
         DST_CTYPE * restrict dst_data           = (DST_CTYPE *) dst->data;                                \
-        const uint32_t dev_patch_end            = ictx->patch_base + ictx->dev_npatches;                  \
+        const uint32_t patch_end                = ictx->patch_base + ictx->npatches;                      \
         const uint32_t patch_start              = ictx->patch_base + ictx->npatches_per_thread * ith;     \
-        const uint32_t patch_end                = MIN(patch_start + ictx->npatches_per_thread, dev_patch_end); \
-        if (patch_start >= patch_end) {                                                                   \
+        const uint32_t patch_stop               = MIN(patch_start + ictx->npatches_per_thread, patch_end); \
+        if (patch_start >= patch_stop) {                                                                   \
             return;                                                                                       \
         }                                                                                                 \
         htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, patch_start);                                   \
-        for (uint32_t p = patch_start; p < patch_end; p++) {                                              \
+        for (uint32_t p = patch_start; p < patch_stop; p++) {                                              \
             const uint32_t iow             = p % OW;                                                      \
             const uint32_t ioh             = (p / OW) % OH;                                               \
             const uint32_t in              = p / (OW * OH);                                               \
@@ -153,10 +153,10 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, hvx
         uint8_t *      dst_base         = ictx->pe_vtcm_dst + ith * ictx->pe_dst_size_per_thread;                    \
         float *        srcb             = (float *) src_base;                                                        \
         DST_CTYPE *    dstb             = (DST_CTYPE *) dst_base;                                                    \
-        const uint32_t mdev_row_end      = ictx->pe_row_base + ictx->dev_nrows_dma;                                  \
+        const uint32_t row_end_max      = ictx->pe_row_base + ictx->pe_nrows;                                       \
         const uint32_t per_thread       = ictx->pe_rows_per_thread;                                                  \
         const uint32_t row_start        = ictx->pe_row_base + per_thread * ith;                                      \
-        const uint32_t row_end          = MIN(row_start + per_thread, mdev_row_end);                                 \
+        const uint32_t row_end          = MIN(row_start + per_thread, row_end_max);                                  \
         if (row_start >= row_end)                                                                                    \
             return;                                                                                                  \
         for (uint32_t r = row_start; r < row_end; r++) {                                                             \
@@ -275,7 +275,8 @@ int op_im2col(struct htp_ops_context * octx) {
     const uint32_t npatches = N * OH * OW;
     const uint32_t nrows    = N * OH;
 
-    uint32_t patch_base, dev_npatches;
+    uint32_t patch_base   = 0;
+    uint32_t dev_npatches = npatches;
     if (octx->mdev_count > 1) {
         const uint32_t patch_size = dst->nb[1];
         const uint32_t patches_per_chunk = (patch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(patch_size, HEX_L2_LINE_SIZE)) : 1;
@@ -294,12 +295,10 @@ int op_im2col(struct htp_ops_context * octx) {
                 dev_npatches = MIN(chunks_per_mdev * patches_per_chunk, npatches - patch_base);
             }
         }
-    } else {
-        patch_base   = 0;
-        dev_npatches = npatches;
     }
 
-    uint32_t row_base, mdev_nrows;
+    uint32_t row_base  = 0;
+    uint32_t dev_nrows = nrows;
     if (octx->mdev_count > 1) {
         const uint32_t row_size = dst->nb[2];
         const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
@@ -307,23 +306,20 @@ int op_im2col(struct htp_ops_context * octx) {
         const bool can_split_rows = total_row_chunks >= octx->mdev_count;
 
         if (!can_split_rows) {
-            row_base   = (octx->mdev_idx == 0) ? 0 : nrows;
-            mdev_nrows = (octx->mdev_idx == 0) ? nrows : 0;
+            row_base  = (octx->mdev_idx == 0) ? 0 : nrows;
+            dev_nrows = (octx->mdev_idx == 0) ? nrows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_row_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
             row_base = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, nrows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = nrows - row_base;
+                dev_nrows = nrows - row_base;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, nrows - row_base);
+                dev_nrows = MIN(chunks_per_mdev * rows_per_chunk, nrows - row_base);
             }
         }
-    } else {
-        row_base   = 0;
-        mdev_nrows = nrows;
     }
 
-    if (dev_npatches == 0 && mdev_nrows == 0) {
+    if (dev_npatches == 0 && dev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -332,17 +328,17 @@ int op_im2col(struct htp_ops_context * octx) {
     struct htp_im2col_context ictx = { 0 };
     ictx.octx                = octx;
     ictx.patch_base          = patch_base;
-    ictx.dev_npatches        = dev_npatches;
+    ictx.npatches            = dev_npatches;
     ictx.npatches_per_thread = (dev_npatches + n_threads - 1) / n_threads;
 
     // Clean non-overlapping patch-embed -> DMA kernel (if it fits VTCM);
     // everything else (padding/dilation/stride edges) -> pure-DDR kernel.
-    if (im2col_use_patchembed_dma(octx) && mdev_nrows > 0) {
-        const uint32_t pth = MIN(octx->n_threads, mdev_nrows);
+    if (im2col_use_patchembed_dma(octx) && dev_nrows > 0) {
+        const uint32_t pth = MIN(octx->n_threads, dev_nrows);
         if (pth > 0 && im2col_patchembed_dma_fits(octx, &ictx, pth)) {
             ictx.pe_row_base        = row_base;
-            ictx.dev_nrows_dma      = mdev_nrows;
-            ictx.pe_rows_per_thread = (mdev_nrows + pth - 1) / pth;
+            ictx.pe_nrows           = dev_nrows;
+            ictx.pe_rows_per_thread = (dev_nrows + pth - 1) / pth;
             if (dst->type == HTP_TYPE_F16) {
                 work_queue_run(octx->ctx->work_queue, im2col_patchembed_dma_thread, &ictx, pth);
             } else {

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -78,12 +78,12 @@ static inline void htp_im2col_vtcm_layout_build(struct htp_im2col_vtcm_layout * 
         DST_CTYPE * restrict dst_data           = (DST_CTYPE *) dst->data;                                \
         const uint32_t patch_end                = ictx->patch_base + ictx->npatches;                      \
         const uint32_t patch_start              = ictx->patch_base + ictx->npatches_per_thread * ith;     \
-        const uint32_t patch_stop               = MIN(patch_start + ictx->npatches_per_thread, patch_end); \
-        if (patch_start >= patch_stop) {                                                                   \
+        const uint32_t patch_stop               = MIN(patch_start + ictx->npatches_per_thread, patch_end);\
+        if (patch_start >= patch_stop) {                                                                  \
             return;                                                                                       \
         }                                                                                                 \
         htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, patch_start);                                   \
-        for (uint32_t p = patch_start; p < patch_stop; p++) {                                              \
+        for (uint32_t p = patch_start; p < patch_stop; p++) {                                             \
             const uint32_t iow             = p % OW;                                                      \
             const uint32_t ioh             = (p / OW) % OH;                                               \
             const uint32_t in              = p / (OW * OH);                                               \
@@ -153,7 +153,7 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, hvx
         uint8_t *      dst_base         = ictx->pe_vtcm_dst + ith * ictx->pe_dst_size_per_thread;                    \
         float *        srcb             = (float *) src_base;                                                        \
         DST_CTYPE *    dstb             = (DST_CTYPE *) dst_base;                                                    \
-        const uint32_t row_end_max      = ictx->pe_row_base + ictx->pe_nrows;                                       \
+        const uint32_t row_end_max      = ictx->pe_row_base + ictx->pe_nrows;                                        \
         const uint32_t per_thread       = ictx->pe_rows_per_thread;                                                  \
         const uint32_t row_start        = ictx->pe_row_base + per_thread * ith;                                      \
         const uint32_t row_end          = MIN(row_start + per_thread, row_end_max);                                  \
@@ -269,76 +269,76 @@ int op_im2col(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t N        = src1->ne[3];
-    const uint32_t OH       = dst->ne[2];
-    const uint32_t OW       = dst->ne[1];
-    const uint32_t npatches = N * OH * OW;
-    const uint32_t nrows    = N * OH;
+    const uint32_t N             = src1->ne[3];
+    const uint32_t OH            = dst->ne[2];
+    const uint32_t OW            = dst->ne[1];
+    const uint32_t total_patches = N * OH * OW;
+    const uint32_t total_rows    = N * OH;
 
-    uint32_t patch_base   = 0;
-    uint32_t dev_npatches = npatches;
+    uint32_t patch_base = 0;
+    uint32_t npatches   = total_patches;
     if (octx->mdev_count > 1) {
         const uint32_t patch_size = dst->nb[1];
         const uint32_t patches_per_chunk = (patch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(patch_size, HEX_L2_LINE_SIZE)) : 1;
-        const uint32_t total_patch_chunks = npatches / patches_per_chunk;
+        const uint32_t total_patch_chunks = total_patches / patches_per_chunk;
         const bool can_split_patches = total_patch_chunks >= octx->mdev_count;
 
         if (!can_split_patches) {
-            patch_base   = (octx->mdev_idx == 0) ? 0 : npatches;
-            dev_npatches = (octx->mdev_idx == 0) ? npatches : 0;
+            patch_base = (octx->mdev_idx == 0) ? 0 : total_patches;
+            npatches   = (octx->mdev_idx == 0) ? total_patches : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_patch_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            patch_base = MIN(octx->mdev_idx * chunks_per_mdev * patches_per_chunk, npatches);
+            patch_base = MIN(octx->mdev_idx * chunks_per_mdev * patches_per_chunk, total_patches);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                dev_npatches = npatches - patch_base;
+                npatches = total_patches - patch_base;
             } else {
-                dev_npatches = MIN(chunks_per_mdev * patches_per_chunk, npatches - patch_base);
+                npatches = MIN(chunks_per_mdev * patches_per_chunk, total_patches - patch_base);
             }
         }
     }
 
-    uint32_t row_base  = 0;
-    uint32_t dev_nrows = nrows;
+    uint32_t row_base = 0;
+    uint32_t nrows    = total_rows;
     if (octx->mdev_count > 1) {
         const uint32_t row_size = dst->nb[2];
         const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
-        const uint32_t total_row_chunks = nrows / rows_per_chunk;
+        const uint32_t total_row_chunks = total_rows / rows_per_chunk;
         const bool can_split_rows = total_row_chunks >= octx->mdev_count;
 
         if (!can_split_rows) {
-            row_base  = (octx->mdev_idx == 0) ? 0 : nrows;
-            dev_nrows = (octx->mdev_idx == 0) ? nrows : 0;
+            row_base = (octx->mdev_idx == 0) ? 0 : total_rows;
+            nrows    = (octx->mdev_idx == 0) ? total_rows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_row_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_base = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, nrows);
+            row_base = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                dev_nrows = nrows - row_base;
+                nrows = total_rows - row_base;
             } else {
-                dev_nrows = MIN(chunks_per_mdev * rows_per_chunk, nrows - row_base);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_base);
             }
         }
     }
 
-    if (dev_npatches == 0 && dev_nrows == 0) {
+    if (npatches == 0 && nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, MAX(dev_npatches, 1));
+    const uint32_t n_threads = MIN(octx->n_threads, MAX(npatches, 1));
 
     struct htp_im2col_context ictx = { 0 };
     ictx.octx                = octx;
     ictx.patch_base          = patch_base;
-    ictx.npatches            = dev_npatches;
-    ictx.npatches_per_thread = (dev_npatches + n_threads - 1) / n_threads;
+    ictx.npatches            = npatches;
+    ictx.npatches_per_thread = (npatches + n_threads - 1) / n_threads;
 
     // Clean non-overlapping patch-embed -> DMA kernel (if it fits VTCM);
     // everything else (padding/dilation/stride edges) -> pure-DDR kernel.
-    if (im2col_use_patchembed_dma(octx) && dev_nrows > 0) {
-        const uint32_t pth = MIN(octx->n_threads, dev_nrows);
+    if (im2col_use_patchembed_dma(octx) && nrows > 0) {
+        const uint32_t pth = MIN(octx->n_threads, nrows);
         if (pth > 0 && im2col_patchembed_dma_fits(octx, &ictx, pth)) {
             ictx.pe_row_base        = row_base;
-            ictx.pe_nrows           = dev_nrows;
-            ictx.pe_rows_per_thread = (dev_nrows + pth - 1) / pth;
+            ictx.pe_nrows           = nrows;
+            ictx.pe_rows_per_thread = (nrows + pth - 1) / pth;
             if (dst->type == HTP_TYPE_F16) {
                 work_queue_run(octx->ctx->work_queue, im2col_patchembed_dma_thread, &ictx, pth);
             } else {
@@ -349,7 +349,7 @@ int op_im2col(struct htp_ops_context * octx) {
         // else: doesn't fit -> fall through to the pure-DDR kernel below.
     }
 
-    if (dev_npatches == 0) {
+    if (npatches == 0) {
         return HTP_STATUS_OK;
     }
 

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -17,6 +17,7 @@
 #include "hex-dma.h"
 #include "hex-profile.h"
 #include "htp-vtcm.h"
+#include "htp-tensor.h"
 
 struct htp_im2col_context {
     struct htp_ops_context * octx;
@@ -280,21 +281,9 @@ int op_im2col(struct htp_ops_context * octx) {
     if (octx->ctx->mdev.count > 1) {
         const uint32_t patch_size = dst->nb[1];
         const uint32_t patches_per_chunk = (patch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(patch_size, HEX_L2_LINE_SIZE)) : 1;
-        const uint32_t total_patch_chunks = total_patches / patches_per_chunk;
-        const bool can_split_patches = total_patch_chunks >= octx->ctx->mdev.count;
-
-        if (!can_split_patches) {
-            patch_base = (octx->ctx->mdev.idx == 0) ? 0 : total_patches;
-            npatches   = (octx->ctx->mdev.idx == 0) ? total_patches : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_patch_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            patch_base = MIN(octx->ctx->mdev.idx * chunks_per_mdev * patches_per_chunk, total_patches);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                npatches = total_patches - patch_base;
-            } else {
-                npatches = MIN(chunks_per_mdev * patches_per_chunk, total_patches - patch_base);
-            }
-        }
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_patches, htp_tensor_mdev_data_aligned(dst) ? patches_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        patch_base = range.start;
+        npatches   = range.count;
     }
 
     uint32_t row_base = 0;
@@ -302,21 +291,9 @@ int op_im2col(struct htp_ops_context * octx) {
     if (octx->ctx->mdev.count > 1) {
         const uint32_t row_size = dst->nb[2];
         const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
-        const uint32_t total_row_chunks = total_rows / rows_per_chunk;
-        const bool can_split_rows = total_row_chunks >= octx->ctx->mdev.count;
-
-        if (!can_split_rows) {
-            row_base = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
-            nrows    = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_row_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_base = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = total_rows - row_base;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_base);
-            }
-        }
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_rows, htp_tensor_mdev_data_aligned(dst) ? rows_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_base = range.start;
+        nrows    = range.count;
     }
 
     if (npatches == 0 && nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -277,19 +277,19 @@ int op_im2col(struct htp_ops_context * octx) {
 
     uint32_t patch_base = 0;
     uint32_t npatches   = total_patches;
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         const uint32_t patch_size = dst->nb[1];
         const uint32_t patches_per_chunk = (patch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(patch_size, HEX_L2_LINE_SIZE)) : 1;
         const uint32_t total_patch_chunks = total_patches / patches_per_chunk;
-        const bool can_split_patches = total_patch_chunks >= octx->mdev_count;
+        const bool can_split_patches = total_patch_chunks >= octx->ctx->mdev.count;
 
         if (!can_split_patches) {
-            patch_base = (octx->mdev_idx == 0) ? 0 : total_patches;
-            npatches   = (octx->mdev_idx == 0) ? total_patches : 0;
+            patch_base = (octx->ctx->mdev.idx == 0) ? 0 : total_patches;
+            npatches   = (octx->ctx->mdev.idx == 0) ? total_patches : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_patch_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            patch_base = MIN(octx->mdev_idx * chunks_per_mdev * patches_per_chunk, total_patches);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_patch_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            patch_base = MIN(octx->ctx->mdev.idx * chunks_per_mdev * patches_per_chunk, total_patches);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 npatches = total_patches - patch_base;
             } else {
                 npatches = MIN(chunks_per_mdev * patches_per_chunk, total_patches - patch_base);
@@ -299,19 +299,19 @@ int op_im2col(struct htp_ops_context * octx) {
 
     uint32_t row_base = 0;
     uint32_t nrows    = total_rows;
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         const uint32_t row_size = dst->nb[2];
         const uint32_t rows_per_chunk = (row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(row_size, HEX_L2_LINE_SIZE)) : 1;
         const uint32_t total_row_chunks = total_rows / rows_per_chunk;
-        const bool can_split_rows = total_row_chunks >= octx->mdev_count;
+        const bool can_split_rows = total_row_chunks >= octx->ctx->mdev.count;
 
         if (!can_split_rows) {
-            row_base = (octx->mdev_idx == 0) ? 0 : total_rows;
-            nrows    = (octx->mdev_idx == 0) ? total_rows : 0;
+            row_base = (octx->ctx->mdev.idx == 0) ? 0 : total_rows;
+            nrows    = (octx->ctx->mdev.idx == 0) ? total_rows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_row_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_base = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_rows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_row_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_base = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_rows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = total_rows - row_base;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, total_rows - row_base);

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -19,11 +19,15 @@
 
 struct htp_im2col_context {
     struct htp_ops_context * octx;
+    uint32_t                 patch_base;           // first patch index assigned to this dev
+    uint32_t                 dev_npatches;         // number of patches assigned to this dev
     uint32_t                 npatches_per_thread;  // patches = N*OH*OW (pure-DDR kernel)
 
-    uint32_t pe_rows_per_thread;                   // N*OH rows per worker
-    uint32_t pe_src_row_bytes;                     // one output row's source: IC*KH*IW*4, rounded 256
-    uint32_t pe_dst_row_bytes;                     // one output row's dst: OW*patch_stride*2, rounded 256
+    uint32_t pe_row_base;              // first N*OH row index assigned to this dev (DMA path)
+    uint32_t dev_nrows_dma;            // number of N*OH rows assigned to this dev (DMA path)
+    uint32_t pe_rows_per_thread;       // N*OH rows per worker
+    uint32_t pe_src_row_bytes;         // one output row's source: IC*KH*IW*4, rounded 256
+    uint32_t pe_dst_row_bytes;         // one output row's dst: OW*patch_stride*2, rounded 256
 
     // Patch-embed DMA path VTCM ping-pong.
     uint8_t * pe_vtcm_src;                         // base of the 2x src buffers region
@@ -58,28 +62,22 @@ static inline void htp_im2col_vtcm_layout_build(struct htp_im2col_vtcm_layout * 
         struct htp_im2col_context * ictx        = (struct htp_im2col_context *) data;                     \
         struct htp_ops_context *    octx        = ictx->octx;                                             \
         struct htp_thread_trace * restrict tr   = &octx->ctx->trace[ith];                                 \
+        const struct htp_tensor * restrict src0 = octx->src[0];                                           \
         const struct htp_tensor * restrict src1 = octx->src[1];                                           \
         const struct htp_tensor * restrict dst  = octx->dst;                                              \
-        const int32_t  s0                       = octx->op_params[0];                                     \
-        const int32_t  s1                       = octx->op_params[1];                                     \
-        const int32_t  p0                       = octx->op_params[2];                                     \
-        const int32_t  p1                       = octx->op_params[3];                                     \
-        const int32_t  d0                       = octx->op_params[4];                                     \
-        const int32_t  d1                       = octx->op_params[5];                                     \
-        const uint32_t N                        = src1->ne[3];                                            \
-        const uint32_t IC                       = src1->ne[2];                                            \
-        const uint32_t IH                       = src1->ne[1];                                            \
-        const uint32_t IW                       = src1->ne[0];                                            \
-        const uint32_t KH                       = octx->src[0]->ne[1];                                    \
-        const uint32_t KW                       = octx->src[0]->ne[0];                                    \
+        const int32_t s0 = octx->op_params[0], s1 = octx->op_params[1];                                   \
+        const int32_t p0 = octx->op_params[2], p1 = octx->op_params[3];                                   \
+        const int32_t d0 = octx->op_params[4], d1 = octx->op_params[5];                                   \
+        const uint32_t N = src1->ne[3], IC = src1->ne[2], IH = src1->ne[1], IW = src1->ne[0];             \
+        const uint32_t KH                       = src0->ne[1], KW = src0->ne[0];                          \
         const uint32_t OH                       = dst->ne[2];                                             \
         const uint32_t OW                       = dst->ne[1];                                             \
         const uint32_t patch_stride             = IC * KH * KW;                                           \
         const float * restrict src_data         = (const float *) src1->data;                             \
         DST_CTYPE * restrict dst_data           = (DST_CTYPE *) dst->data;                                \
-        const uint32_t npatches                 = N * OH * OW;                                            \
-        const uint32_t patch_start              = ictx->npatches_per_thread * ith;                        \
-        const uint32_t patch_end                = MIN(patch_start + ictx->npatches_per_thread, npatches); \
+        const uint32_t dev_patch_end            = ictx->patch_base + ictx->dev_npatches;                  \
+        const uint32_t patch_start              = ictx->patch_base + ictx->npatches_per_thread * ith;     \
+        const uint32_t patch_end                = MIN(patch_start + ictx->npatches_per_thread, dev_patch_end); \
         if (patch_start >= patch_end) {                                                                   \
             return;                                                                                       \
         }                                                                                                 \
@@ -154,12 +152,12 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, hvx
         uint8_t *      dst_base         = ictx->pe_vtcm_dst + ith * ictx->pe_dst_size_per_thread;                    \
         float *        srcb             = (float *) src_base;                                                        \
         DST_CTYPE *    dstb             = (DST_CTYPE *) dst_base;                                                    \
-        const uint32_t nrows            = N * OH;                                                                    \
-        const uint32_t per_thread       = ictx->pe_rows_per_thread;                                                  \
-        const uint32_t row_start        = per_thread * ith;                                                          \
-        const uint32_t row_end          = MIN(row_start + per_thread, nrows);                                        \
-        if (row_start >= row_end)                                                                                    \
-            return;                                                                                                  \
+        const uint32_t dev_row_end      = ictx->pe_row_base + ictx->dev_nrows_dma;                                    \
+        const uint32_t per_thread       = ictx->pe_rows_per_thread;                                                   \
+        const uint32_t row_start        = ictx->pe_row_base + per_thread * ith;                                       \
+        const uint32_t row_end          = MIN(row_start + per_thread, dev_row_end);                                  \
+        if (row_start >= row_end)                                                                                     \
+            return;                                                                                                   \
         for (uint32_t r = row_start; r < row_end; r++) {                                                             \
             const uint32_t in  = r / OH;                                                                             \
             const uint32_t ioh = r % OH;                                                                             \
@@ -266,27 +264,60 @@ int op_im2col(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
-    const uint32_t N         = src1->ne[3];
-    const uint32_t OH        = dst->ne[2];
-    const uint32_t OW        = dst->ne[1];
-    const uint32_t npatches  = N * OH * OW;
-    const uint32_t n_threads = MIN(octx->n_threads, npatches);
-
-    if ((octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) || n_threads == 0) {
+    if (octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) {
         return HTP_STATUS_OK;
     }
 
+    const uint32_t N        = src1->ne[3];
+    const uint32_t OH       = dst->ne[2];
+    const uint32_t OW       = dst->ne[1];
+    const uint32_t npatches = N * OH * OW;
+    const uint32_t nrows    = N * OH;
+
+    uint32_t patch_base, dev_npatches;
+    if (octx->ndev > 1) {
+        const uint32_t patches_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[1]);
+        uint32_t patches_per_dev = (npatches + octx->ndev - 1) / octx->ndev;
+        patches_per_dev = ((patches_per_dev + patches_per_line - 1) / patches_per_line) * patches_per_line;
+        patch_base    = MIN(octx->idev * patches_per_dev, npatches);
+        dev_npatches  = MIN(patches_per_dev, npatches - patch_base);
+    } else {
+        patch_base    = 0;
+        dev_npatches  = npatches;
+    }
+
+    uint32_t row_base, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[2]);
+        uint32_t rows_per_dev = (nrows + octx->ndev - 1) / octx->ndev;
+        rows_per_dev = ((rows_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        row_base   = MIN(octx->idev * rows_per_dev, nrows);
+        dev_nrows  = MIN(rows_per_dev, nrows - row_base);
+    } else {
+        row_base   = 0;
+        dev_nrows  = nrows;
+    }
+
+    if (dev_npatches == 0 && dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(octx->n_threads, MAX(dev_npatches, 1));
+
     struct htp_im2col_context ictx = { 0 };
-    ictx.octx                      = octx;
-    ictx.npatches_per_thread       = (npatches + n_threads - 1) / n_threads;
+    ictx.octx                = octx;
+    ictx.patch_base          = patch_base;
+    ictx.dev_npatches        = dev_npatches;
+    ictx.npatches_per_thread = (dev_npatches + n_threads - 1) / n_threads;
 
     // Clean non-overlapping patch-embed -> DMA kernel (if it fits VTCM);
     // everything else (padding/dilation/stride edges) -> pure-DDR kernel.
-    if (im2col_use_patchembed_dma(octx)) {
-        const uint32_t nrows = N * OH;
-        const uint32_t pth   = MIN(octx->n_threads, nrows);
+    if (im2col_use_patchembed_dma(octx) && dev_nrows > 0) {
+        const uint32_t pth = MIN(octx->n_threads, dev_nrows);
         if (pth > 0 && im2col_patchembed_dma_fits(octx, &ictx, pth)) {
-            ictx.pe_rows_per_thread = (nrows + pth - 1) / pth;
+            ictx.pe_row_base        = row_base;
+            ictx.dev_nrows_dma      = dev_nrows;
+            ictx.pe_rows_per_thread = (dev_nrows + pth - 1) / pth;
             if (dst->type == HTP_TYPE_F16) {
                 work_queue_run(octx->ctx->work_queue, im2col_patchembed_dma_thread, &ictx, pth);
             } else {
@@ -295,6 +326,10 @@ int op_im2col(struct htp_ops_context * octx) {
             return HTP_STATUS_OK;
         }
         // else: doesn't fit -> fall through to the pure-DDR kernel below.
+    }
+
+    if (dev_npatches == 0) {
+        return HTP_STATUS_OK;
     }
 
     if (dst->type == HTP_TYPE_F16) {

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -277,7 +277,7 @@ int op_im2col(struct htp_ops_context * octx) {
     uint32_t patch_base, dev_npatches;
     if (octx->mdev_count > 1) {
         const uint32_t patches_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[1]);
-        uint32_t patches_per_mdev = (npatches + octx->mdev_count - 1) / octx->mdev_count;
+        uint32_t patches_per_mdev = fastdiv(npatches + octx->mdev_count - 1, &octx->mdev_count_div);
         patches_per_mdev = ((patches_per_mdev + patches_per_line - 1) / patches_per_line) * patches_per_line;
         patch_base    = MIN(octx->mdev_idx * patches_per_mdev, npatches);
         dev_npatches  = MIN(patches_per_mdev, npatches - patch_base);
@@ -289,7 +289,7 @@ int op_im2col(struct htp_ops_context * octx) {
     uint32_t row_base, mdev_nrows;
     if (octx->mdev_count > 1) {
         const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[2]);
-        uint32_t rows_per_mdev = (nrows + octx->mdev_count - 1) / octx->mdev_count;
+        uint32_t rows_per_mdev = fastdiv(nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         rows_per_mdev = ((rows_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
         row_base   = MIN(octx->mdev_idx * rows_per_mdev, nrows);
         mdev_nrows  = MIN(rows_per_mdev, nrows - row_base);

--- a/ggml/src/ggml-hexagon/htp/im2col-ops.c
+++ b/ggml/src/ggml-hexagon/htp/im2col-ops.c
@@ -152,12 +152,12 @@ IM2COL_PATCHEMBED_BODY(im2col_patchembed_f32_thread, float, hvx_copy_f32_uu, hvx
         uint8_t *      dst_base         = ictx->pe_vtcm_dst + ith * ictx->pe_dst_size_per_thread;                    \
         float *        srcb             = (float *) src_base;                                                        \
         DST_CTYPE *    dstb             = (DST_CTYPE *) dst_base;                                                    \
-        const uint32_t dev_row_end      = ictx->pe_row_base + ictx->dev_nrows_dma;                                    \
-        const uint32_t per_thread       = ictx->pe_rows_per_thread;                                                   \
-        const uint32_t row_start        = ictx->pe_row_base + per_thread * ith;                                       \
-        const uint32_t row_end          = MIN(row_start + per_thread, dev_row_end);                                  \
-        if (row_start >= row_end)                                                                                     \
-            return;                                                                                                   \
+        const uint32_t mdev_row_end      = ictx->pe_row_base + ictx->dev_nrows_dma;                                  \
+        const uint32_t per_thread       = ictx->pe_rows_per_thread;                                                  \
+        const uint32_t row_start        = ictx->pe_row_base + per_thread * ith;                                      \
+        const uint32_t row_end          = MIN(row_start + per_thread, mdev_row_end);                                 \
+        if (row_start >= row_end)                                                                                    \
+            return;                                                                                                  \
         for (uint32_t r = row_start; r < row_end; r++) {                                                             \
             const uint32_t in  = r / OH;                                                                             \
             const uint32_t ioh = r % OH;                                                                             \
@@ -275,30 +275,30 @@ int op_im2col(struct htp_ops_context * octx) {
     const uint32_t nrows    = N * OH;
 
     uint32_t patch_base, dev_npatches;
-    if (octx->ndev > 1) {
+    if (octx->mdev_count > 1) {
         const uint32_t patches_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[1]);
-        uint32_t patches_per_dev = (npatches + octx->ndev - 1) / octx->ndev;
-        patches_per_dev = ((patches_per_dev + patches_per_line - 1) / patches_per_line) * patches_per_line;
-        patch_base    = MIN(octx->idev * patches_per_dev, npatches);
-        dev_npatches  = MIN(patches_per_dev, npatches - patch_base);
+        uint32_t patches_per_mdev = (npatches + octx->mdev_count - 1) / octx->mdev_count;
+        patches_per_mdev = ((patches_per_mdev + patches_per_line - 1) / patches_per_line) * patches_per_line;
+        patch_base    = MIN(octx->mdev_idx * patches_per_mdev, npatches);
+        dev_npatches  = MIN(patches_per_mdev, npatches - patch_base);
     } else {
         patch_base    = 0;
         dev_npatches  = npatches;
     }
 
-    uint32_t row_base, dev_nrows;
-    if (octx->ndev > 1) {
+    uint32_t row_base, mdev_nrows;
+    if (octx->mdev_count > 1) {
         const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / dst->nb[2]);
-        uint32_t rows_per_dev = (nrows + octx->ndev - 1) / octx->ndev;
-        rows_per_dev = ((rows_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        row_base   = MIN(octx->idev * rows_per_dev, nrows);
-        dev_nrows  = MIN(rows_per_dev, nrows - row_base);
+        uint32_t rows_per_mdev = (nrows + octx->mdev_count - 1) / octx->mdev_count;
+        rows_per_mdev = ((rows_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        row_base   = MIN(octx->mdev_idx * rows_per_mdev, nrows);
+        mdev_nrows  = MIN(rows_per_mdev, nrows - row_base);
     } else {
         row_base   = 0;
-        dev_nrows  = nrows;
+        mdev_nrows  = nrows;
     }
 
-    if (dev_npatches == 0 && dev_nrows == 0) {
+    if (dev_npatches == 0 && mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -312,12 +312,12 @@ int op_im2col(struct htp_ops_context * octx) {
 
     // Clean non-overlapping patch-embed -> DMA kernel (if it fits VTCM);
     // everything else (padding/dilation/stride edges) -> pure-DDR kernel.
-    if (im2col_use_patchembed_dma(octx) && dev_nrows > 0) {
-        const uint32_t pth = MIN(octx->n_threads, dev_nrows);
+    if (im2col_use_patchembed_dma(octx) && mdev_nrows > 0) {
+        const uint32_t pth = MIN(octx->n_threads, mdev_nrows);
         if (pth > 0 && im2col_patchembed_dma_fits(octx, &ictx, pth)) {
             ictx.pe_row_base        = row_base;
-            ictx.dev_nrows_dma      = dev_nrows;
-            ictx.pe_rows_per_thread = (dev_nrows + pth - 1) / pth;
+            ictx.dev_nrows_dma      = mdev_nrows;
+            ictx.pe_rows_per_thread = (mdev_nrows + pth - 1) / pth;
             if (dst->type == HTP_TYPE_F16) {
                 work_queue_run(octx->ctx->work_queue, im2col_patchembed_dma_thread, &ictx, pth);
             } else {

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -738,13 +738,14 @@ static int op_fence(struct htp_ops_context * octx) {
 }
 
 static int op_mdev_setup(struct htp_ops_context * octx) {
-    octx->mdev_idx   = (uint32_t) octx->op_params[0];
-    octx->mdev_count = (uint32_t) octx->op_params[1];
-    if (octx->mdev_count > 1) {
-        octx->mdev_count_div = init_fastdiv_values(octx->mdev_count);
+    struct htp_context * ctx = octx->ctx;
+    ctx->mdev.idx   = (uint16_t) octx->op_params[0];
+    ctx->mdev.count = (uint16_t) octx->op_params[1];
+    if (ctx->mdev.count > 1) {
+        ctx->mdev.count_div = init_fastdiv_values(ctx->mdev.count);
         const struct htp_tensor * sync = octx->src[0];
         assert(sync && sync->data);
-        octx->fence_base = (uint8_t *) sync->data;
+        ctx->mdev.fence_base = (uint8_t *) sync->data;
     }
     return HTP_STATUS_OK;
 }
@@ -999,31 +1000,36 @@ static void prep_tensors(struct htp_context *ctx, struct htp_buf_desc *bufs, str
     }
 }
 
-static int mdev_sync_fence(struct htp_ops_context * octx) {
-    if (octx->mdev_count <= 1) {
+static void mdev_group_init(struct htp_context * ctx, const struct htp_opbatch_req * req) {
+    memset(&ctx->mdev, 0, sizeof(ctx->mdev));
+    ctx->mdev.fence_seq = (uint32_t)((req->seq & 0xfffff) << 12);
+}
+
+static int mdev_group_fence(struct htp_ops_context * octx) {
+    struct htp_context * ctx = octx->ctx;
+    if (ctx->mdev.count <= 1) {
         return HTP_STATUS_OK;
     }
 
-    struct htp_context * ctx = octx->ctx;
-    assert(octx->fence_base != NULL);
+    assert(ctx->mdev.fence_base != NULL);
 
-    const uint32_t seq = ++octx->fence_seq;
+    const uint32_t seq = ++ctx->mdev.fence_seq;
 
     struct htp_thread_trace * tr = &ctx->trace[0];
     htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
 
-    const uint32_t my_mdev_idx = octx->mdev_idx;
-    const uint32_t mdev_count  = octx->mdev_count;
+    const uint32_t mdev_idx   = ctx->mdev.idx;
+    const uint32_t mdev_count = ctx->mdev.count;
 
-    uint8_t * fence_base   = octx->fence_base;
-    atomic_uint * my_fence = (atomic_uint *) (fence_base + my_mdev_idx * HTP_FENCE_SLOT_SIZE);
+    uint8_t * fence_base   = ctx->mdev.fence_base;
+    atomic_uint * my_fence = (atomic_uint *) (fence_base + mdev_idx * HTP_FENCE_SLOT_SIZE);
 
     atomic_store(my_fence, seq);
     asm volatile ("syncht" : : : "memory");
     Q6_dccleaninva_A((void *) my_fence);
 
     for (uint32_t d = 0; d < mdev_count; d++) {
-        if (d == my_mdev_idx) continue;
+        if (d == mdev_idx) continue;
         atomic_uint * peer_fence = (atomic_uint *) (fence_base + d * HTP_FENCE_SLOT_SIZE);
         uint64_t spins = 0;
         while (1) {
@@ -1035,11 +1041,11 @@ static int mdev_sync_fence(struct htp_ops_context * octx) {
             }
             if (++spins == 10000) {
                 FARF(ALWAYS, "ggml-hex: mdev %u waiting for mdev %u : seq 0x%08x (b %u, op %u) my_fence %p (0x%08x) peer_fence %p val 0x%08x (diff %d)\n",
-                     my_mdev_idx, d, seq, seq >> 12, seq & 0xfff, my_fence, atomic_load(my_fence), peer_fence, val, (int32_t)(val - seq));
+                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, my_fence, atomic_load(my_fence), peer_fence, val, (int32_t)(val - seq));
             }
             if (spins > HTP_FENCE_TIMEOUT) {
                 FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u (seq 0x%08x [b %u, op %u], peer_fence %p val 0x%08x)\n",
-                     my_mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, val);
+                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, val);
                 htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
                 return HTP_STATUS_INTERNAL_ERR;
             }
@@ -1098,7 +1104,7 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
             dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
     }
 
-    int fence_status = mdev_sync_fence(octx);
+    int fence_status = mdev_group_fence(octx);
     if (fence_status != HTP_STATUS_OK) {
         return fence_status;
     }
@@ -1175,7 +1181,8 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     octx->n_threads     = ctx->n_threads;
     octx->n_threads_div = ctx->n_threads_div;
     octx->ctx           = ctx;
-    octx->fence_seq = (uint32_t)((req->seq & 0xfffff) << 12);
+
+    mdev_group_init(ctx, req);
 
     work_queue_wakeup(ctx->work_queue);
     if (ctx->hmx_queue) {
@@ -1214,7 +1221,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
     htp_trace_event_stop(&ctx->trace[0], HTP_TRACE_EVT_L2FLUSH, 0);
 
-    int final_sync_status = mdev_sync_fence(octx);
+    int final_sync_status = mdev_group_fence(octx);
     if (final_sync_status != HTP_STATUS_OK && op_status == HTP_STATUS_OK) {
         op_status = final_sync_status;
     }

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -737,14 +737,14 @@ static int op_fence(struct htp_ops_context * octx) {
     return HTP_STATUS_OK;
 }
 
-static int op_mdev_setup(struct htp_ops_context * octx) {
+static int op_mdev_group(struct htp_ops_context * octx) {
     struct htp_context * ctx = octx->ctx;
+    const struct htp_tensor * sync = octx->src[0];
+    assert(sync && sync->data);
     ctx->mdev.idx   = (uint16_t) octx->op_params[0];
-    ctx->mdev.count = (uint16_t) octx->op_params[1];
+    ctx->mdev.count = (uint16_t) sync->ne[1];
     if (ctx->mdev.count > 1) {
         ctx->mdev.count_div = init_fastdiv_values(ctx->mdev.count);
-        const struct htp_tensor * sync = octx->src[0];
-        assert(sync && sync->data);
         ctx->mdev.fence_base = (uint8_t *) sync->data;
     }
     return HTP_STATUS_OK;
@@ -752,8 +752,8 @@ static int op_mdev_setup(struct htp_ops_context * octx) {
 
 static int execute_op(struct htp_ops_context * octx) {
     switch (octx->op) {
-        case HTP_OP_MDEV_SETUP:
-            return op_mdev_setup(octx);
+        case HTP_OP_MDEV_GROUP:
+            return op_mdev_group(octx);
 
         case HTP_OP_FENCE:
             return op_fence(octx);
@@ -828,6 +828,7 @@ static int execute_op(struct htp_ops_context * octx) {
             return op_sum_rows(octx);
 
         case HTP_OP_CPY:
+        case HTP_OP_CPY_FENCE:
             return op_cpy(octx);
 
         case HTP_OP_REPEAT:

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -711,12 +711,21 @@ static inline void profile_stop(uint32_t mode, struct profile_data * d) {
 static int op_fence(struct htp_ops_context * octx) {
     struct htp_context *ctx = octx->ctx;
     struct htp_thread_trace * tr = &ctx->trace[0];
-    const uint32_t seq = (uint32_t) octx->op_params[0];
+    const uint32_t seq  = (uint32_t) octx->op_params[0];
+    const uint32_t mode = (uint32_t) octx->op_params[1];
 
     htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
 
     const struct htp_tensor * sync = octx->src[0];
     atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
+
+    if (mode == 1) {
+        htp_fence_write(sync_fence, seq, HTP_STATUS_OK);
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+        FARF(HIGH, "ggml-hex: sync-signal : fence %p seq %u\n", sync_fence, seq);
+        return HTP_STATUS_OK;
+    }
+
     uint64_t spins = 0;
     while (1) {
         uint32_t sync_seq;
@@ -1100,7 +1109,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
         return;
     }
 
-    FARF(HIGH, "processing opbatch #%u: n-bufs %u n-tensors %u n-ops %u n-traces %u : m-size %u b-size %u t-size %u o-size %u", req->id,
+    FARF(HIGH, "processing opbatch #%llu: n-bufs %u n-tensors %u n-ops %u n-traces %u : m-size %u b-size %u t-size %u o-size %u", (unsigned long long) req->seq,
             n_bufs, n_tens, n_ops, req->n_traces, dbuf->size, b_size, t_size, o_size);
 
     // Setup descriptor pointers
@@ -1186,7 +1195,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
 
     struct htp_opbatch_rsp rsp;
     memset(&rsp, 0, sizeof(rsp));
-    rsp.id           = req->id;
+    rsp.seq          = req->seq;
     rsp.status       = op_status;
     rsp.n_bufs       = n_bufs;
     rsp.n_tensors    = n_tens;
@@ -1194,7 +1203,6 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     rsp.usecs        = batch_prof.usecs;
     rsp.cycles_start = batch_prof.cycles_start;
     rsp.cycles_stop  = batch_prof.cycles_stop;
-    rsp.seq          = req->seq;
 
     if (ctx->profiler == HTP_PROF_TRACE) {
         for (int t = 0; t <= HTP_MAX_NTHREADS; t++) {

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -989,6 +989,8 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_tensor *tens, u
     memcpy(octx->kernel_params, op->kernel_params, sizeof(octx->kernel_params));
     octx->flags = op->flags;
     octx->op    = op->opcode;
+    octx->n_threads     = octx->ctx->n_threads;
+    octx->n_threads_div = octx->ctx->n_threads_div;
 
     FARF(HIGH, "proc-op #%u: opcode %u flags 0x%x", idx, octx->op, octx->flags);
 
@@ -1096,10 +1098,14 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
 
     struct htp_ops_context *octx = &ctx->octx;
     memset(octx, 0, sizeof(*octx));
-    octx->n_threads = ctx->n_threads;
-    octx->ctx       = ctx;
-    octx->mdev_idx   = req->mdev_idx;
-    octx->mdev_count = req->mdev_count;
+    octx->n_threads     = ctx->n_threads;
+    octx->n_threads_div = ctx->n_threads_div;
+    octx->ctx           = ctx;
+    octx->mdev_idx      = req->mdev_idx;
+    octx->mdev_count    = req->mdev_count;
+    if (octx->mdev_count > 1) {
+        octx->mdev_count_div = init_fastdiv_values(octx->mdev_count);
+    }
 
     work_queue_wakeup(ctx->work_queue);
     if (ctx->hmx_queue) {

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -1024,10 +1024,10 @@ static void mdev_group_init(struct htp_context * ctx, const struct htp_opbatch_r
 
 static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs, uint32_t n_bufs,
                        struct htp_tensor * tens, uint32_t idx, struct htp_op_desc * op) {
-    memcpy(octx->op_params, op->params, sizeof(octx->op_params));
+    memcpy(octx->op_params,     op->params, sizeof(octx->op_params));
     memcpy(octx->kernel_params, op->kernel_params, sizeof(octx->kernel_params));
-    octx->flags = op->flags;
-    octx->op    = op->opcode;
+    octx->flags         = op->flags;
+    octx->op            = op->opcode;
     octx->n_threads     = octx->ctx->n_threads;
     octx->n_threads_div = octx->ctx->n_threads_div;
 
@@ -1071,13 +1071,8 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
     htp_mdev_group_barrier(octx);
 
     int status = execute_op(octx);
-    if (status > HTP_STATUS_OK && octx->status == HTP_STATUS_OK) {
-        octx->status = status;
-    }
-    if (octx->status > HTP_STATUS_OK && octx->ctx->mdev.count > 1) {
-        atomic_uint * my_fence = htp_mdev_fence_slot(octx->ctx->mdev.fence_base, octx->ctx->mdev.idx);
-        htp_fence_write(my_fence, octx->ctx->mdev.fence_seq, octx->status);
-    }
+
+    htp_ops_context_set_status(octx, status);
 
     htp_tensor_dirty_all(octx->ctx, octx->dsts, HTP_OP_MAX_OUTPUTS);
 
@@ -1168,9 +1163,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
 
         profile_stop(ctx->profiler, &prof);
 
-        if (op_status > HTP_STATUS_OK && octx->status == HTP_STATUS_OK) {
-            octx->status = op_status;
-        }
+        htp_ops_context_set_status(octx, op_status);
 
         if (ctx->profiler) {
             pds[i].opcode = ops[i].opcode;

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -984,7 +984,52 @@ static void prep_tensors(struct htp_context *ctx, struct htp_buf_desc *bufs, str
     }
 }
 
-static int proc_op_req(struct htp_ops_context * octx, struct htp_tensor *tens, uint32_t idx, struct htp_op_desc * op) {
+static int mdev_sync_fence(struct htp_ops_context * octx, struct htp_buf_desc * bufs, uint32_t n_bufs, uint32_t gen) {
+    if (octx->mdev_count <= 1 || n_bufs == 0 || bufs[0].base == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    struct htp_context * ctx = octx->ctx;
+    struct htp_thread_trace * tr = &ctx->trace[0];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) gen);
+
+    const uint32_t my_mdev_idx = octx->mdev_idx;
+    const uint32_t mdev_count  = octx->mdev_count;
+
+    uint8_t * fence_base   = (uint8_t *) bufs[0].base + bufs[0].size - (mdev_count * HTP_FENCE_SLOT_SIZE);
+    atomic_uint * my_fence = (atomic_uint *) (fence_base + my_mdev_idx * HTP_FENCE_SLOT_SIZE);
+
+    atomic_store(my_fence, gen);
+    asm volatile ("syncht" : : : "memory");
+    Q6_dccleaninva_A((void *) my_fence);
+
+    for (uint32_t d = 0; d < mdev_count; d++) {
+        if (d == my_mdev_idx) continue;
+        atomic_uint * peer_fence = (atomic_uint *) (fence_base + d * HTP_FENCE_SLOT_SIZE);
+        uint64_t spins = 0;
+        while (1) {
+            Q6_dccleaninva_A((void *) peer_fence);
+            uint32_t val = atomic_load(peer_fence);
+            if ((int32_t)(val - gen) >= 0) {
+                break;
+            }
+            if (++spins > HTP_FENCE_TIMEOUT) {
+                FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u (gen %u)\n",
+                     my_mdev_idx, d, gen);
+                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) gen);
+                return HTP_STATUS_INTERNAL_ERR;
+            }
+            hex_pause();
+        }
+    }
+    asm volatile ("syncht" : : : "memory");
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) gen);
+    return HTP_STATUS_OK;
+}
+
+static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs, uint32_t n_bufs,
+                       struct htp_tensor * tens, uint32_t idx, uint32_t gen, struct htp_op_desc * op) {
     memcpy(octx->op_params, op->params, sizeof(octx->op_params));
     memcpy(octx->kernel_params, op->kernel_params, sizeof(octx->kernel_params));
     octx->flags = op->flags;
@@ -1027,6 +1072,11 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_tensor *tens, u
 
         FARF(HIGH, "prep-dst[%u] #%u: data %p size %u : %u:%u:%u:%u", i, dst_idx, (void*) dst->data, dst->size,
             dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
+    }
+
+    int fence_status = mdev_sync_fence(octx, bufs, n_bufs, gen);
+    if (fence_status != HTP_STATUS_OK) {
+        return fence_status;
     }
 
     int status = execute_op(octx);
@@ -1118,7 +1168,8 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
 
         profile_start(ctx->profiler, &prof);
 
-        op_status = proc_op_req(octx, tens, i, &ops[i]);
+        const uint32_t gen = (uint32_t)(req->seq * (n_ops + 2) + i + 1);
+        op_status = proc_op_req(octx, bufs, n_bufs, tens, i, gen, &ops[i]);
 
         profile_stop(ctx->profiler, &prof);
 
@@ -1130,40 +1181,6 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
             for (int j = 0; j < HEX_NUM_PMU_COUNTERS; j++) {
                 pds[i].pmu[j] = prof.pmu_counters[j];
             }
-        }
-
-        // Multi-device FENCE synchronization between ops
-        if (octx->mdev_count > 1 && n_bufs > 0 && bufs[0].base != 0) {
-            const uint32_t gen         = (uint32_t)(req->seq * n_ops + i + 1);
-            const uint32_t my_mdev_idx = octx->mdev_idx;
-            const uint32_t mdev_count  = octx->mdev_count;
-
-            uint8_t * fence_base = (uint8_t *) bufs[0].base + bufs[0].size - (mdev_count * HTP_FENCE_SLOT_SIZE);
-            atomic_uint * my_fence = (atomic_uint *) (fence_base + my_mdev_idx * HTP_FENCE_SLOT_SIZE);
-
-            atomic_store(my_fence, gen);
-            asm volatile ("syncht" : : : "memory");
-            Q6_dccleaninva_A((void *) my_fence);
-
-            for (uint32_t d = 0; d < mdev_count; d++) {
-                if (d == my_mdev_idx) continue;
-                atomic_uint * peer_fence = (atomic_uint *) (fence_base + d * HTP_FENCE_SLOT_SIZE);
-                uint64_t spins = 0;
-                while (1) {
-                    Q6_dccleaninva_A((void *) peer_fence);
-                    uint32_t val = atomic_load(peer_fence);
-                    if ((int32_t)(val - gen) >= 0) {
-                        break;
-                    }
-                    if (++spins > HTP_FENCE_TIMEOUT) {
-                        FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u at op %u (seq %llu gen %u)\n",
-                             my_mdev_idx, d, i, (unsigned long long)req->seq, gen);
-                        break;
-                    }
-                    hex_pause();
-                }
-            }
-            asm volatile ("syncht" : : : "memory");
         }
     }
 
@@ -1177,6 +1194,12 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     htp_trace_event_start(&ctx->trace[0], HTP_TRACE_EVT_L2FLUSH, 0);
     qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
     htp_trace_event_stop(&ctx->trace[0], HTP_TRACE_EVT_L2FLUSH, 0);
+
+    const uint32_t final_gen = (uint32_t)(req->seq * (n_ops + 2) + n_ops + 1);
+    int final_sync_status = mdev_sync_fence(octx, bufs, n_bufs, final_gen);
+    if (final_sync_status != HTP_STATUS_OK && op_status == HTP_STATUS_OK) {
+        op_status = final_sync_status;
+    }
 
     profile_stop(HTP_PROF_BASIC, &batch_prof);
 

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -888,7 +888,7 @@ static int execute_op(struct htp_ops_context * octx) {
     }
 
     FARF(ERROR, "Unknown Op %u", octx->op);
-    return -1;
+    return HTP_STATUS_NO_SUPPORT;
 }
 
 static inline bool reuse_buf(struct htp_context *ctx, uint32_t *m_reuse, struct htp_buf_desc *b) {

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -1013,69 +1013,6 @@ static void mdev_group_init(struct htp_context * ctx, const struct htp_opbatch_r
     ctx->mdev.fence_seq = (uint32_t)((req->seq & 0xfffff) << 12);
 }
 
-static int mdev_group_fence(struct htp_ops_context * octx, int op_status) {
-    struct htp_context * ctx = octx->ctx;
-    if (ctx->mdev.count <= 1) {
-        return op_status;
-    }
-
-    assert(ctx->mdev.fence_base != NULL);
-
-    const uint32_t seq = ++ctx->mdev.fence_seq;
-
-    struct htp_thread_trace * tr = &ctx->trace[0];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-
-    const uint32_t mdev_idx   = ctx->mdev.idx;
-    const uint32_t mdev_count = ctx->mdev.count;
-
-    uint8_t * fence_base   = ctx->mdev.fence_base;
-    atomic_uint * my_fence = htp_mdev_fence(fence_base, mdev_idx);
-    htp_fence_write(my_fence, seq, op_status);
-
-    if (op_status > HTP_STATUS_OK) {
-        htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-        return op_status;
-    }
-
-    for (uint32_t d = 0; d < mdev_count; d++) {
-        if (d == mdev_idx) continue;
-        atomic_uint * peer_fence = htp_mdev_fence(fence_base, d);
-        uint64_t spins = 0;
-        while (1) {
-            uint32_t peer_seq;
-            uint32_t peer_status;
-            htp_fence_read(peer_fence, &peer_seq, &peer_status);
-            if (peer_status > HTP_STATUS_OK) {
-                FARF(ERROR, "ggml-hex: mdev %u peer %u failed with status %u : seq 0x%08x\n",
-                     mdev_idx, d, peer_status, seq);
-                htp_fence_write(my_fence, seq, peer_status);
-                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-                return peer_status;
-            }
-            if ((int32_t)(peer_seq - seq) >= 0) {
-                break;
-            }
-            if (++spins == 10000) {
-                FARF(ALWAYS, "ggml-hex: mdev %u waiting for mdev %u : seq 0x%08x (b %u op %u) my-fence %p peer-fence %p peer-seq 0x%08x (diff %d)\n",
-                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, my_fence, peer_fence, peer_seq, (int32_t)(peer_seq - seq));
-            }
-            if (spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u : seq 0x%08x (b %u op %u) peer-fence %p peer-seq 0x%08x\n",
-                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, peer_seq);
-                htp_fence_write(my_fence, seq, HTP_STATUS_INTERNAL_ERR);
-                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-                return HTP_STATUS_INTERNAL_ERR;
-            }
-            hex_pause();
-        }
-    }
-    asm volatile ("syncht" : : : "memory");
-
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-    return HTP_STATUS_OK;
-}
-
 static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs, uint32_t n_bufs,
                        struct htp_tensor * tens, uint32_t idx, struct htp_op_desc * op) {
     memcpy(octx->op_params, op->params, sizeof(octx->op_params));
@@ -1122,14 +1059,14 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
             dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
     }
 
-    int fence_status = mdev_group_fence(octx, HTP_STATUS_OK);
+    int fence_status = htp_mdev_group_barrier(octx, HTP_STATUS_OK);
     if (fence_status > HTP_STATUS_OK) {
         return fence_status;
     }
 
     int status = execute_op(octx);
     if (status > HTP_STATUS_OK && octx->ctx->mdev.count > 1) {
-        atomic_uint * my_fence = htp_mdev_fence(octx->ctx->mdev.fence_base, octx->ctx->mdev.idx);
+        atomic_uint * my_fence = htp_mdev_fence_slot(octx->ctx->mdev.fence_base, octx->ctx->mdev.idx);
         htp_fence_write(my_fence, octx->ctx->mdev.fence_seq, status);
     }
 
@@ -1243,7 +1180,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
     htp_trace_event_stop(&ctx->trace[0], HTP_TRACE_EVT_L2FLUSH, 0);
 
-    op_status = mdev_group_fence(octx, op_status);
+    op_status = htp_mdev_group_barrier(octx, op_status);
 
     profile_stop(HTP_PROF_BASIC, &batch_prof);
 

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -720,10 +720,10 @@ static int op_fence(struct htp_ops_context * octx) {
     atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
 
     if (mode == 1) {
-        htp_fence_write(sync_fence, seq, HTP_STATUS_OK);
+        htp_fence_write(sync_fence, seq, octx->status);
         htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-        FARF(HIGH, "ggml-hex: sync-signal : fence %p seq %u\n", sync_fence, seq);
-        return HTP_STATUS_OK;
+        FARF(HIGH, "ggml-hex: sync-signal : fence %p seq %u status %d\n", sync_fence, seq, octx->status);
+        return octx->status;
     }
 
     uint64_t spins = 0;
@@ -731,12 +731,12 @@ static int op_fence(struct htp_ops_context * octx) {
         uint32_t sync_seq;
         uint32_t sync_status;
         htp_fence_read(sync_fence, &sync_seq, &sync_status);
-        if (sync_status > HTP_STATUS_OK) {
-            FARF(ERROR, "ggml-hex: sync-wait peer failed with status %u : fence %p seq %u\n", sync_status, sync_fence, seq);
-            htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-            return sync_status;
-        }
         if ((int32_t)(sync_seq - seq) >= 0) {
+            if (sync_status > HTP_STATUS_OK) {
+                FARF(ERROR, "ggml-hex: sync-wait peer failed with status %u : fence %p seq %u\n", sync_status, sync_fence, seq);
+                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+                return sync_status;
+            }
             break;
         }
         if (++spins > HTP_FENCE_TIMEOUT) {
@@ -1068,15 +1068,15 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
             dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
     }
 
-    int fence_status = htp_mdev_group_barrier(octx, HTP_STATUS_OK);
-    if (fence_status > HTP_STATUS_OK) {
-        return fence_status;
-    }
+    htp_mdev_group_barrier(octx);
 
     int status = execute_op(octx);
-    if (status > HTP_STATUS_OK && octx->ctx->mdev.count > 1) {
+    if (status > HTP_STATUS_OK && octx->status == HTP_STATUS_OK) {
+        octx->status = status;
+    }
+    if (octx->status > HTP_STATUS_OK && octx->ctx->mdev.count > 1) {
         atomic_uint * my_fence = htp_mdev_fence_slot(octx->ctx->mdev.fence_base, octx->ctx->mdev.idx);
-        htp_fence_write(my_fence, octx->ctx->mdev.fence_seq, status);
+        htp_fence_write(my_fence, octx->ctx->mdev.fence_seq, octx->status);
     }
 
     htp_tensor_dirty_all(octx->ctx, octx->dsts, HTP_OP_MAX_OUTPUTS);
@@ -1087,7 +1087,7 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
     octx->src3_spad.src = NULL;
     octx->dst_spad.src  = NULL;
 
-    return status;
+    return octx->status;
 }
 
 static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_req * req, const struct dspqueue_buffer * dbuf) {
@@ -1158,7 +1158,8 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     }
 
     int op_status = HTP_STATUS_OK;
-    for (uint32_t i = 0; i < n_ops && op_status == HTP_STATUS_OK; i++) {
+    octx->status  = HTP_STATUS_OK;
+    for (uint32_t i = 0; i < n_ops; i++) {
         struct profile_data prof;
 
         profile_start(ctx->profiler, &prof);
@@ -1166,6 +1167,10 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
         op_status = proc_op_req(octx, bufs, n_bufs, tens, i, &ops[i]);
 
         profile_stop(ctx->profiler, &prof);
+
+        if (op_status > HTP_STATUS_OK && octx->status == HTP_STATUS_OK) {
+            octx->status = op_status;
+        }
 
         if (ctx->profiler) {
             pds[i].opcode = ops[i].opcode;
@@ -1189,14 +1194,14 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
     htp_trace_event_stop(&ctx->trace[0], HTP_TRACE_EVT_L2FLUSH, 0);
 
-    op_status = htp_mdev_group_barrier(octx, op_status);
+    htp_mdev_group_barrier(octx);
 
     profile_stop(HTP_PROF_BASIC, &batch_prof);
 
     struct htp_opbatch_rsp rsp;
     memset(&rsp, 0, sizeof(rsp));
     rsp.seq          = req->seq;
-    rsp.status       = op_status;
+    rsp.status       = octx->status;
     rsp.n_bufs       = n_bufs;
     rsp.n_tensors    = n_tens;
     rsp.n_ops        = n_ops;

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -722,7 +722,7 @@ static int op_fence(struct htp_ops_context * octx) {
     if (mode == 1) {
         htp_fence_write(sync_fence, seq, octx->status);
         htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-        FARF(HIGH, "ggml-hex: sync-signal : fence %p seq %u status %d\n", sync_fence, seq, octx->status);
+        FARF(HIGH, "ggml-hex: sync-signal : fence %p seq 0x%x status %d\n", sync_fence, seq, octx->status);
         return octx->status;
     }
 
@@ -733,14 +733,14 @@ static int op_fence(struct htp_ops_context * octx) {
         htp_fence_read(sync_fence, &sync_seq, &sync_status);
         if ((int32_t)(sync_seq - seq) >= 0) {
             if (sync_status > HTP_STATUS_OK) {
-                FARF(ERROR, "ggml-hex: sync-wait peer failed with status %u : fence %p seq %u\n", sync_status, sync_fence, seq);
+                FARF(ERROR, "ggml-hex: sync-wait peer failed with status %u : fence %p seq 0x%x\n", sync_status, sync_fence, seq);
                 htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
                 return sync_status;
             }
             break;
         }
         if (++spins > HTP_FENCE_TIMEOUT) {
-            FARF(ERROR, "ggml-hex: sync-wait TIMEOUT : fence %p spins %llu seq %u\n", sync_fence, spins, seq);
+            FARF(ERROR, "ggml-hex: sync-wait TIMEOUT : fence %p spins %llu seq 0x%x\n", sync_fence, spins, seq);
             htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
             return HTP_STATUS_INTERNAL_ERR;
         }
@@ -749,7 +749,7 @@ static int op_fence(struct htp_ops_context * octx) {
 
     htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
 
-    FARF(HIGH, "ggml-hex: sync-done : fence %p spins %llu seq %u\n", sync_fence, spins, seq);
+    FARF(HIGH, "ggml-hex: sync-done : fence %p spins %llu seq 0x%x\n", sync_fence, spins, seq);
     return HTP_STATUS_OK;
 }
 

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -984,22 +984,26 @@ static void prep_tensors(struct htp_context *ctx, struct htp_buf_desc *bufs, str
     }
 }
 
-static int mdev_sync_fence(struct htp_ops_context * octx, struct htp_buf_desc * bufs, uint32_t n_bufs, uint32_t gen) {
-    if (octx->mdev_count <= 1 || n_bufs == 0 || bufs[0].base == 0) {
+static int mdev_sync_fence(struct htp_ops_context * octx) {
+    if (octx->mdev_count <= 1) {
         return HTP_STATUS_OK;
     }
 
     struct htp_context * ctx = octx->ctx;
+    assert(ctx->fence_base != NULL);
+
+    const uint32_t seq = ++ctx->fence_seq;
+
     struct htp_thread_trace * tr = &ctx->trace[0];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) gen);
+    htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
 
     const uint32_t my_mdev_idx = octx->mdev_idx;
     const uint32_t mdev_count  = octx->mdev_count;
 
-    uint8_t * fence_base   = (uint8_t *) bufs[0].base + bufs[0].size - (mdev_count * HTP_FENCE_SLOT_SIZE);
+    uint8_t * fence_base   = ctx->fence_base;
     atomic_uint * my_fence = (atomic_uint *) (fence_base + my_mdev_idx * HTP_FENCE_SLOT_SIZE);
 
-    atomic_store(my_fence, gen);
+    atomic_store(my_fence, seq);
     asm volatile ("syncht" : : : "memory");
     Q6_dccleaninva_A((void *) my_fence);
 
@@ -1009,14 +1013,19 @@ static int mdev_sync_fence(struct htp_ops_context * octx, struct htp_buf_desc * 
         uint64_t spins = 0;
         while (1) {
             Q6_dccleaninva_A((void *) peer_fence);
+            asm volatile ("syncht" : : : "memory");
             uint32_t val = atomic_load(peer_fence);
-            if ((int32_t)(val - gen) >= 0) {
+            if ((int32_t)(val - seq) >= 0) {
                 break;
             }
-            if (++spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u (gen %u)\n",
-                     my_mdev_idx, d, gen);
-                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) gen);
+            if (++spins == 10000) {
+                FARF(ALWAYS, "ggml-hex: mdev %u waiting for mdev %u : seq 0x%08x (b %u, op %u) my_fence %p (0x%08x) peer_fence %p val 0x%08x (diff %d)\n",
+                     my_mdev_idx, d, seq, seq >> 12, seq & 0xfff, my_fence, atomic_load(my_fence), peer_fence, val, (int32_t)(val - seq));
+            }
+            if (spins > HTP_FENCE_TIMEOUT) {
+                FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u (seq 0x%08x [b %u, op %u], peer_fence %p val 0x%08x)\n",
+                     my_mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, val);
+                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
                 return HTP_STATUS_INTERNAL_ERR;
             }
             hex_pause();
@@ -1024,12 +1033,12 @@ static int mdev_sync_fence(struct htp_ops_context * octx, struct htp_buf_desc * 
     }
     asm volatile ("syncht" : : : "memory");
 
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) gen);
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
     return HTP_STATUS_OK;
 }
 
 static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs, uint32_t n_bufs,
-                       struct htp_tensor * tens, uint32_t idx, uint32_t gen, struct htp_op_desc * op) {
+                       struct htp_tensor * tens, uint32_t idx, struct htp_op_desc * op) {
     memcpy(octx->op_params, op->params, sizeof(octx->op_params));
     memcpy(octx->kernel_params, op->kernel_params, sizeof(octx->kernel_params));
     octx->flags = op->flags;
@@ -1074,7 +1083,7 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
             dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
     }
 
-    int fence_status = mdev_sync_fence(octx, bufs, n_bufs, gen);
+    int fence_status = mdev_sync_fence(octx);
     if (fence_status != HTP_STATUS_OK) {
         return fence_status;
     }
@@ -1155,6 +1164,12 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     octx->mdev_count    = req->mdev_count;
     if (octx->mdev_count > 1) {
         octx->mdev_count_div = init_fastdiv_values(octx->mdev_count);
+        assert(n_bufs > 0 && bufs[0].base != 0);
+        ctx->fence_base = (uint8_t *) bufs[0].base + bufs[0].size - (octx->mdev_count * HTP_FENCE_SLOT_SIZE);
+        ctx->fence_seq  = (uint32_t)((req->seq & 0xfffff) << 12);
+    } else {
+        ctx->fence_base = NULL;
+        ctx->fence_seq  = 0;
     }
 
     work_queue_wakeup(ctx->work_queue);
@@ -1168,8 +1183,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
 
         profile_start(ctx->profiler, &prof);
 
-        const uint32_t gen = (uint32_t)(req->seq * (n_ops + 2) + i + 1);
-        op_status = proc_op_req(octx, bufs, n_bufs, tens, i, gen, &ops[i]);
+        op_status = proc_op_req(octx, bufs, n_bufs, tens, i, &ops[i]);
 
         profile_stop(ctx->profiler, &prof);
 
@@ -1195,8 +1209,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
     htp_trace_event_stop(&ctx->trace[0], HTP_TRACE_EVT_L2FLUSH, 0);
 
-    const uint32_t final_gen = (uint32_t)(req->seq * (n_ops + 2) + n_ops + 1);
-    int final_sync_status = mdev_sync_fence(octx, bufs, n_bufs, final_gen);
+    int final_sync_status = mdev_sync_fence(octx);
     if (final_sync_status != HTP_STATUS_OK && op_status == HTP_STATUS_OK) {
         op_status = final_sync_status;
     }

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -762,7 +762,6 @@ static int op_fence(struct htp_ops_context * octx) {
 static int op_mdev_group(struct htp_ops_context * octx) {
     struct htp_context * ctx = octx->ctx;
     const struct htp_tensor * sync = octx->src[0];
-    assert(sync && sync->data);
     ctx->mdev.idx   = (uint16_t) octx->op_params[0];
     ctx->mdev.count = (uint16_t) sync->ne[1];
     if (ctx->mdev.count > 1) {

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -1098,6 +1098,8 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     memset(octx, 0, sizeof(*octx));
     octx->n_threads = ctx->n_threads;
     octx->ctx       = ctx;
+    octx->idev      = req->idev;
+    octx->ndev      = req->ndev;
 
     work_queue_wakeup(ctx->work_queue);
     if (ctx->hmx_queue) {
@@ -1122,6 +1124,40 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
             for (int j = 0; j < HEX_NUM_PMU_COUNTERS; j++) {
                 pds[i].pmu[j] = prof.pmu_counters[j];
             }
+        }
+
+        // Multi-device FENCE synchronization between ops
+        if (octx->ndev > 1 && n_bufs > 0 && bufs[0].base != 0) {
+            const uint32_t gen     = (uint32_t)(req->seq * n_ops + i + 1);
+            const uint32_t my_idev = octx->idev;
+            const uint32_t ndev    = octx->ndev;
+
+            uint8_t * fence_base = (uint8_t *) bufs[0].base + bufs[0].size - (ndev * HTP_FENCE_SLOT_SIZE);
+            atomic_uint * my_fence = (atomic_uint *) (fence_base + my_idev * HTP_FENCE_SLOT_SIZE);
+
+            atomic_store(my_fence, gen);
+            asm volatile ("syncht" : : : "memory");
+            Q6_dccleaninva_A((void *) my_fence);
+
+            for (uint32_t d = 0; d < ndev; d++) {
+                if (d == my_idev) continue;
+                atomic_uint * peer_fence = (atomic_uint *) (fence_base + d * HTP_FENCE_SLOT_SIZE);
+                uint64_t spins = 0;
+                while (1) {
+                    Q6_dccleaninva_A((void *) peer_fence);
+                    uint32_t val = atomic_load(peer_fence);
+                    if ((int32_t)(val - gen) >= 0) {
+                        break;
+                    }
+                    if (++spins > HTP_FENCE_TIMEOUT) {
+                        FARF(ERROR, "ggml-hex: dev %u timeout waiting for dev %u at op %u (seq %llu gen %u)\n",
+                             my_idev, d, i, (unsigned long long)req->seq, gen);
+                        break;
+                    }
+                    hex_pause();
+                }
+            }
+            asm volatile ("syncht" : : : "memory");
         }
     }
 

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -1098,8 +1098,8 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     memset(octx, 0, sizeof(*octx));
     octx->n_threads = ctx->n_threads;
     octx->ctx       = ctx;
-    octx->idev      = req->idev;
-    octx->ndev      = req->ndev;
+    octx->mdev_idx   = req->mdev_idx;
+    octx->mdev_count = req->mdev_count;
 
     work_queue_wakeup(ctx->work_queue);
     if (ctx->hmx_queue) {
@@ -1127,20 +1127,20 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
         }
 
         // Multi-device FENCE synchronization between ops
-        if (octx->ndev > 1 && n_bufs > 0 && bufs[0].base != 0) {
-            const uint32_t gen     = (uint32_t)(req->seq * n_ops + i + 1);
-            const uint32_t my_idev = octx->idev;
-            const uint32_t ndev    = octx->ndev;
+        if (octx->mdev_count > 1 && n_bufs > 0 && bufs[0].base != 0) {
+            const uint32_t gen         = (uint32_t)(req->seq * n_ops + i + 1);
+            const uint32_t my_mdev_idx = octx->mdev_idx;
+            const uint32_t mdev_count  = octx->mdev_count;
 
-            uint8_t * fence_base = (uint8_t *) bufs[0].base + bufs[0].size - (ndev * HTP_FENCE_SLOT_SIZE);
-            atomic_uint * my_fence = (atomic_uint *) (fence_base + my_idev * HTP_FENCE_SLOT_SIZE);
+            uint8_t * fence_base = (uint8_t *) bufs[0].base + bufs[0].size - (mdev_count * HTP_FENCE_SLOT_SIZE);
+            atomic_uint * my_fence = (atomic_uint *) (fence_base + my_mdev_idx * HTP_FENCE_SLOT_SIZE);
 
             atomic_store(my_fence, gen);
             asm volatile ("syncht" : : : "memory");
             Q6_dccleaninva_A((void *) my_fence);
 
-            for (uint32_t d = 0; d < ndev; d++) {
-                if (d == my_idev) continue;
+            for (uint32_t d = 0; d < mdev_count; d++) {
+                if (d == my_mdev_idx) continue;
                 atomic_uint * peer_fence = (atomic_uint *) (fence_base + d * HTP_FENCE_SLOT_SIZE);
                 uint64_t spins = 0;
                 while (1) {
@@ -1150,8 +1150,8 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
                         break;
                     }
                     if (++spins > HTP_FENCE_TIMEOUT) {
-                        FARF(ERROR, "ggml-hex: dev %u timeout waiting for dev %u at op %u (seq %llu gen %u)\n",
-                             my_idev, d, i, (unsigned long long)req->seq, gen);
+                        FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u at op %u (seq %llu gen %u)\n",
+                             my_mdev_idx, d, i, (unsigned long long)req->seq, gen);
                         break;
                     }
                     hex_pause();

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -737,8 +737,23 @@ static int op_fence(struct htp_ops_context * octx) {
     return HTP_STATUS_OK;
 }
 
+static int op_mdev_setup(struct htp_ops_context * octx) {
+    octx->mdev_idx   = (uint32_t) octx->op_params[0];
+    octx->mdev_count = (uint32_t) octx->op_params[1];
+    if (octx->mdev_count > 1) {
+        octx->mdev_count_div = init_fastdiv_values(octx->mdev_count);
+        const struct htp_tensor * sync = octx->src[0];
+        assert(sync && sync->data);
+        octx->fence_base = (uint8_t *) sync->data;
+    }
+    return HTP_STATUS_OK;
+}
+
 static int execute_op(struct htp_ops_context * octx) {
     switch (octx->op) {
+        case HTP_OP_MDEV_SETUP:
+            return op_mdev_setup(octx);
+
         case HTP_OP_FENCE:
             return op_fence(octx);
 
@@ -990,9 +1005,9 @@ static int mdev_sync_fence(struct htp_ops_context * octx) {
     }
 
     struct htp_context * ctx = octx->ctx;
-    assert(ctx->fence_base != NULL);
+    assert(octx->fence_base != NULL);
 
-    const uint32_t seq = ++ctx->fence_seq;
+    const uint32_t seq = ++octx->fence_seq;
 
     struct htp_thread_trace * tr = &ctx->trace[0];
     htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
@@ -1000,7 +1015,7 @@ static int mdev_sync_fence(struct htp_ops_context * octx) {
     const uint32_t my_mdev_idx = octx->mdev_idx;
     const uint32_t mdev_count  = octx->mdev_count;
 
-    uint8_t * fence_base   = ctx->fence_base;
+    uint8_t * fence_base   = octx->fence_base;
     atomic_uint * my_fence = (atomic_uint *) (fence_base + my_mdev_idx * HTP_FENCE_SLOT_SIZE);
 
     atomic_store(my_fence, seq);
@@ -1160,17 +1175,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     octx->n_threads     = ctx->n_threads;
     octx->n_threads_div = ctx->n_threads_div;
     octx->ctx           = ctx;
-    octx->mdev_idx      = req->mdev_idx;
-    octx->mdev_count    = req->mdev_count;
-    if (octx->mdev_count > 1) {
-        octx->mdev_count_div = init_fastdiv_values(octx->mdev_count);
-        assert(n_bufs > 0 && bufs[0].base != 0);
-        ctx->fence_base = (uint8_t *) bufs[0].base + bufs[0].size - (octx->mdev_count * HTP_FENCE_SLOT_SIZE);
-        ctx->fence_seq  = (uint32_t)((req->seq & 0xfffff) << 12);
-    } else {
-        ctx->fence_base = NULL;
-        ctx->fence_seq  = 0;
-    }
+    octx->fence_seq = (uint32_t)((req->seq & 0xfffff) << 12);
 
     work_queue_wakeup(ctx->work_queue);
     if (ctx->hmx_queue) {

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -720,12 +720,19 @@ static int op_fence(struct htp_ops_context * octx) {
     atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
 
     if (mode == 1) {
-        htp_fence_write(sync_fence, seq, octx->status);
+        htp_flush_dirty_ranges(ctx);
+
+        htp_mdev_group_barrier(octx);
+
+        if (ctx->mdev.idx == 0) {
+            htp_fence_write(sync_fence, seq, octx->status);
+        }
         htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
         FARF(HIGH, "ggml-hex: sync-signal : fence %p seq 0x%x status %d\n", sync_fence, seq, octx->status);
         return octx->status;
     }
 
+    int status = HTP_STATUS_OK;
     uint64_t spins = 0;
     while (1) {
         uint32_t sync_seq;
@@ -734,15 +741,14 @@ static int op_fence(struct htp_ops_context * octx) {
         if ((int32_t)(sync_seq - seq) >= 0) {
             if (sync_status > HTP_STATUS_OK) {
                 FARF(ERROR, "ggml-hex: sync-wait peer failed with status %u : fence %p seq 0x%x\n", sync_status, sync_fence, seq);
-                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-                return sync_status;
+                status = sync_status;
             }
             break;
         }
         if (++spins > HTP_FENCE_TIMEOUT) {
             FARF(ERROR, "ggml-hex: sync-wait TIMEOUT : fence %p spins %llu seq 0x%x\n", sync_fence, spins, seq);
-            htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
-            return HTP_STATUS_INTERNAL_ERR;
+            status = HTP_STATUS_INTERNAL_ERR;
+            break;
         }
         hex_pause();
     }
@@ -750,7 +756,7 @@ static int op_fence(struct htp_ops_context * octx) {
     htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
 
     FARF(HIGH, "ggml-hex: sync-done : fence %p spins %llu seq 0x%x\n", sync_fence, spins, seq);
-    return HTP_STATUS_OK;
+    return status;
 }
 
 static int op_mdev_group(struct htp_ops_context * octx) {
@@ -1068,13 +1074,13 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
             dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
     }
 
+    htp_tensor_dirty_all(octx->ctx, octx->dsts, HTP_OP_MAX_OUTPUTS);
+
     htp_mdev_group_barrier(octx);
 
     int status = execute_op(octx);
 
     htp_ops_context_set_status(octx, status);
-
-    htp_tensor_dirty_all(octx->ctx, octx->dsts, HTP_OP_MAX_OUTPUTS);
 
     octx->src0_spad.src = NULL;
     octx->src1_spad.src = NULL;

--- a/ggml/src/ggml-hexagon/htp/main.c
+++ b/ggml/src/ggml-hexagon/htp/main.c
@@ -34,6 +34,7 @@
 #include "work-queue.h"
 #include "hex-profile.h"
 #include "allreduce-ops.h"
+#include "htp-fence.h"
 
 #define HMX_QUEUE_CAPACITY     16
 #define HMX_QUEUE_STACK_SIZE   16384
@@ -715,18 +716,24 @@ static int op_fence(struct htp_ops_context * octx) {
     htp_trace_event_start(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
 
     const struct htp_tensor * sync = octx->src[0];
-    atomic_uint * sync_fence = (atomic_uint *) sync->data;
+    atomic_uint * sync_fence = (atomic_uint *) (uintptr_t) sync->data;
     uint64_t spins = 0;
     while (1) {
-        Q6_dccleaninva_A((void *) sync_fence);
-        asm volatile ("syncht" : : : "memory");
-        uint32_t val = atomic_load(&sync_fence[0]);
-        if ((int32_t)(val - seq) >= 0) {
+        uint32_t sync_seq;
+        uint32_t sync_status;
+        htp_fence_read(sync_fence, &sync_seq, &sync_status);
+        if (sync_status > HTP_STATUS_OK) {
+            FARF(ERROR, "ggml-hex: sync-wait peer failed with status %u : fence %p seq %u\n", sync_status, sync_fence, seq);
+            htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+            return sync_status;
+        }
+        if ((int32_t)(sync_seq - seq) >= 0) {
             break;
         }
         if (++spins > HTP_FENCE_TIMEOUT) {
             FARF(ERROR, "ggml-hex: sync-wait TIMEOUT : fence %p spins %llu seq %u\n", sync_fence, spins, seq);
-            break;
+            htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+            return HTP_STATUS_INTERNAL_ERR;
         }
         hex_pause();
     }
@@ -1006,10 +1013,10 @@ static void mdev_group_init(struct htp_context * ctx, const struct htp_opbatch_r
     ctx->mdev.fence_seq = (uint32_t)((req->seq & 0xfffff) << 12);
 }
 
-static int mdev_group_fence(struct htp_ops_context * octx) {
+static int mdev_group_fence(struct htp_ops_context * octx, int op_status) {
     struct htp_context * ctx = octx->ctx;
     if (ctx->mdev.count <= 1) {
-        return HTP_STATUS_OK;
+        return op_status;
     }
 
     assert(ctx->mdev.fence_base != NULL);
@@ -1023,30 +1030,40 @@ static int mdev_group_fence(struct htp_ops_context * octx) {
     const uint32_t mdev_count = ctx->mdev.count;
 
     uint8_t * fence_base   = ctx->mdev.fence_base;
-    atomic_uint * my_fence = (atomic_uint *) (fence_base + mdev_idx * HTP_FENCE_SLOT_SIZE);
+    atomic_uint * my_fence = htp_mdev_fence(fence_base, mdev_idx);
+    htp_fence_write(my_fence, seq, op_status);
 
-    atomic_store(my_fence, seq);
-    asm volatile ("syncht" : : : "memory");
-    Q6_dccleaninva_A((void *) my_fence);
+    if (op_status > HTP_STATUS_OK) {
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+        return op_status;
+    }
 
     for (uint32_t d = 0; d < mdev_count; d++) {
         if (d == mdev_idx) continue;
-        atomic_uint * peer_fence = (atomic_uint *) (fence_base + d * HTP_FENCE_SLOT_SIZE);
+        atomic_uint * peer_fence = htp_mdev_fence(fence_base, d);
         uint64_t spins = 0;
         while (1) {
-            Q6_dccleaninva_A((void *) peer_fence);
-            asm volatile ("syncht" : : : "memory");
-            uint32_t val = atomic_load(peer_fence);
-            if ((int32_t)(val - seq) >= 0) {
+            uint32_t peer_seq;
+            uint32_t peer_status;
+            htp_fence_read(peer_fence, &peer_seq, &peer_status);
+            if (peer_status > HTP_STATUS_OK) {
+                FARF(ERROR, "ggml-hex: mdev %u peer %u failed with status %u : seq 0x%08x\n",
+                     mdev_idx, d, peer_status, seq);
+                htp_fence_write(my_fence, seq, peer_status);
+                htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
+                return peer_status;
+            }
+            if ((int32_t)(peer_seq - seq) >= 0) {
                 break;
             }
             if (++spins == 10000) {
-                FARF(ALWAYS, "ggml-hex: mdev %u waiting for mdev %u : seq 0x%08x (b %u, op %u) my_fence %p (0x%08x) peer_fence %p val 0x%08x (diff %d)\n",
-                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, my_fence, atomic_load(my_fence), peer_fence, val, (int32_t)(val - seq));
+                FARF(ALWAYS, "ggml-hex: mdev %u waiting for mdev %u : seq 0x%08x (b %u op %u) my-fence %p peer-fence %p peer-seq 0x%08x (diff %d)\n",
+                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, my_fence, peer_fence, peer_seq, (int32_t)(peer_seq - seq));
             }
             if (spins > HTP_FENCE_TIMEOUT) {
-                FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u (seq 0x%08x [b %u, op %u], peer_fence %p val 0x%08x)\n",
-                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, val);
+                FARF(ERROR, "ggml-hex: mdev %u timeout waiting for mdev %u : seq 0x%08x (b %u op %u) peer-fence %p peer-seq 0x%08x\n",
+                     mdev_idx, d, seq, seq >> 12, seq & 0xfff, peer_fence, peer_seq);
+                htp_fence_write(my_fence, seq, HTP_STATUS_INTERNAL_ERR);
                 htp_trace_event_stop(tr, HTP_TRACE_EVT_FENCE, (uint16_t) seq);
                 return HTP_STATUS_INTERNAL_ERR;
             }
@@ -1105,12 +1122,16 @@ static int proc_op_req(struct htp_ops_context * octx, struct htp_buf_desc * bufs
             dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3]);
     }
 
-    int fence_status = mdev_group_fence(octx);
-    if (fence_status != HTP_STATUS_OK) {
+    int fence_status = mdev_group_fence(octx, HTP_STATUS_OK);
+    if (fence_status > HTP_STATUS_OK) {
         return fence_status;
     }
 
     int status = execute_op(octx);
+    if (status > HTP_STATUS_OK && octx->ctx->mdev.count > 1) {
+        atomic_uint * my_fence = htp_mdev_fence(octx->ctx->mdev.fence_base, octx->ctx->mdev.idx);
+        htp_fence_write(my_fence, octx->ctx->mdev.fence_seq, status);
+    }
 
     htp_tensor_dirty_all(octx->ctx, octx->dsts, HTP_OP_MAX_OUTPUTS);
 
@@ -1222,10 +1243,7 @@ static void process_opbatch(struct htp_context * ctx, const struct htp_opbatch_r
     qurt_mem_cache_clean((qurt_addr_t) 0, 0, QURT_MEM_CACHE_FLUSH_INVALIDATE_ALL, QURT_MEM_DCACHE);
     htp_trace_event_stop(&ctx->trace[0], HTP_TRACE_EVT_L2FLUSH, 0);
 
-    int final_sync_status = mdev_group_fence(octx);
-    if (final_sync_status != HTP_STATUS_OK && op_status == HTP_STATUS_OK) {
-        op_status = final_sync_status;
-    }
+    op_status = mdev_group_fence(octx, op_status);
 
     profile_stop(HTP_PROF_BASIC, &batch_prof);
 

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -138,6 +138,23 @@ struct htp_mm_context {
     uint32_t vtcm_dst_size_per_thread;
 };
 
+static int htp_mm_init_context(
+    struct htp_ops_context * octx,
+    const struct htp_mm_kernel_params * kparams
+) {
+    if (!htp_ops_context_set_n_threads(octx, (uint32_t) kparams->n_threads)) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+
+    if (kparams->n_hmx) {
+        if (kparams->n_act_threads <= 0 || kparams->n_act_threads > (int32_t) octx->n_threads) {
+            return HTP_STATUS_INVAL_PARAMS;
+        }
+    }
+
+    return HTP_STATUS_OK;
+}
+
 // vdelta control to expand first 32 e8m0 values into 32 uint32 elements
 static const uint8_t __attribute__((aligned(128))) expand_x32_e8m0[128] = {
     0x00, 0x00, 0x00, 0x00, 0x01, 0x04, 0x00, 0x00, 0x02, 0x00, 0x08, 0x08, 0x01, 0x02, 0x00, 0x04, 0x04, 0x00, 0x00,
@@ -1559,7 +1576,7 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
     mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->n_threads_div);
     mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->n_threads_div);
 
-    size_t vtcm_size = kparams->vtcm_size > 0 ? (size_t)kparams->vtcm_size : L.total_bytes;
+    const size_t vtcm_size = L.total_bytes;
 
     FARF(HIGH, "matmul-%s : src0-vtcm-size %zu src1-vtcm-size %zu dst-vtcm-size %zu (%zu)\n", mmctx->type,
          L.src0_bytes, L.src1_bytes, L.dst_bytes, vtcm_size);
@@ -3168,7 +3185,7 @@ static int hmx_mm_f16_f32_batched(struct htp_context *ctx, const hmx_mm_f16_f32_
                             int chunk_dst_cols = params->n - (int)nc;
                             if (chunk_dst_cols > 0) {
                                 transfer_output_chunk_threaded(ctx, output, src2_chunk, vtcm_output, (int) n_rows, (int) n_cols,
-                                                               params->dst_stride, params->src2_stride, chunk_dst_cols, ctx->n_threads);
+                                                               params->dst_stride, params->src2_stride, chunk_dst_cols, n_threads);
                             }
                         }
                     }
@@ -3291,7 +3308,8 @@ static int hmx_mm_id_2d_f32(struct htp_context *ctx,
                                          int cur_a,
                                          int mapping_stride,
                                          int m_start,
-                                         int m_end) {
+                                         int m_end,
+                                         int n_threads) {
     struct htp_thread_trace * tr = &ctx->trace[0];
     htp_trace_event_start(tr, HTP_TRACE_EVT_INIT, 0);
 
@@ -3322,7 +3340,6 @@ static int hmx_mm_id_2d_f32(struct htp_context *ctx,
     const int n_k_tiles = k / HTP_MM_HMX_TILE_N_COLS;
     const struct fastdiv_values n_k_tiles_div = init_fastdiv_values(n_k_tiles);
 
-    const int n_threads = ctx->n_threads;
     const bool is_quant   = (weight_type != HTP_TYPE_F16 && weight_type != HTP_TYPE_F32);
 
     const size_t vec_dot_size = k * sizeof(__fp16);
@@ -3472,7 +3489,7 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
     const float * act_ptr = (const float *) src1->data + m_start * act_stride;
 
     int ret = -1;
-    const int n_threads = MIN(kparams->n_threads, (int) octx->n_threads);
+    const int n_threads = kparams->n_threads;
     if (kparams->kernel_type == HTP_MM_KERNEL_HMX_F16_BATCHED) {
         hmx_mm_f16_f32_batched_params_t batch_params = {
             .dst             = dst_ptr,
@@ -3533,6 +3550,11 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
 int op_matmul(struct htp_ops_context * octx) {
     const struct htp_mm_kernel_params * kparams = (const struct htp_mm_kernel_params *) octx->kernel_params;
 
+    const int status = htp_mm_init_context(octx, kparams);
+    if (status != HTP_STATUS_OK) {
+        return status;
+    }
+
     if (kparams->n_hmx) {
         return hmx_mm_op_matmul(octx, kparams);
     }
@@ -3574,7 +3596,7 @@ static int hmx_mm_op_matmul_id(
                                    nb1, nb2,
                                    (int) src0->nb[1], (int) src0->type,
                                    matrix_rows, cur_a, mmctx->mapping_stride,
-                                   m_start, m_end);
+                                   m_start, m_end, (int) octx->n_threads);
         if (ret != 0) {
             FARF(ERROR, "HMX matmul failed for expert %u, error %d\n", cur_a, ret);
             return HTP_STATUS_NO_SUPPORT;
@@ -3627,7 +3649,7 @@ static int hvx_mm_matmul_id(
     htp_mm_hvx_vtcm_layout_build(&L, kparams->kernel_type, src0->type, ne10, src1_nrows, octx->n_threads,
                                  0, src0_row_size, src1_row_size, 0, kparams->n_prefetch, true, false);
 
-    size_t vtcm_size = kparams->vtcm_size > 0 ? (size_t)kparams->vtcm_size : L.total_bytes;
+    const size_t vtcm_size = L.total_bytes;
 
     FARF(HIGH, "matmul-id-%s : src0-spad-size %zu src1-spad-size %zu src2-spad-size 0 dst-spad-size %zu (%zu)\n", mmctx->type,
          L.src0_bytes, L.src1_bytes, L.dst_bytes, vtcm_size);
@@ -3718,7 +3740,7 @@ static int hmx_mm_op_matmul_id_nx(
                                        dst->nb[1], dst->nb[2],
                                        (int) src_w->nb[1], (int) src_w->type,
                                        matrix_rows, cur_a, mmctx->mapping_stride,
-                                       m_start, m_end);
+                                       m_start, m_end, (int) octx->n_threads);
             if (ret != 0) {
                 FARF(ERROR, "HMX matmul ID NX failed for expert %u weight %u, error %d\n", cur_a, p, ret);
                 return HTP_STATUS_NO_SUPPORT;
@@ -3774,7 +3796,7 @@ static int hvx_mm_matmul_id_nx(
     htp_mm_hvx_vtcm_layout_build(&L, kparams->kernel_type, src0->type, act->ne[0], src1_nrows, octx->n_threads,
                                  0, src0_row_size, src1_row_size, 0, kparams->n_prefetch, true, false);
 
-    size_t vtcm_size = kparams->vtcm_size > 0 ? (size_t)kparams->vtcm_size : L.total_bytes;
+    const size_t vtcm_size = L.total_bytes;
 
     if (octx->ctx->vtcm_size < vtcm_size) {
         FARF(ERROR, "matmul-id-nx: current VTCM reservation %zu is too small, needed %zu\n",
@@ -3887,15 +3909,20 @@ static inline void scan_expert_ids(
 int op_matmul_id(struct htp_ops_context * octx) {
     htp_matmul_tensors_preamble;
 
+    const struct htp_mm_kernel_params * kparams = (const struct htp_mm_kernel_params *) octx->kernel_params;
+    struct htp_mm_context mmctx_struct = {0};
+    struct htp_mm_context * mmctx = &mmctx_struct;
+
+    const int status = htp_mm_init_context(octx, kparams);
+    if (status != HTP_STATUS_OK) {
+        return status;
+    }
+
     struct htp_thread_trace * tr = &octx->ctx->trace[0];
     htp_trace_event_start(tr, HTP_TRACE_EVT_INIT, 0);
 
-    struct htp_mm_context mmctx_struct = {0};
-    struct htp_mm_context * mmctx = &mmctx_struct;
     mmctx->octx = octx;
     mmctx->act = src1;
-
-    const struct htp_mm_kernel_params * kparams = (const struct htp_mm_kernel_params *) octx->kernel_params;
 
     const struct htp_tensor * restrict ids = octx->src[2];
 
@@ -3996,18 +4023,24 @@ int op_matmul_id(struct htp_ops_context * octx) {
 }
 
 int op_matmul_id_nx(struct htp_ops_context * octx) {
+    const struct htp_mm_kernel_params * kparams = (const struct htp_mm_kernel_params *) octx->kernel_params;
+    struct htp_mm_context mmctx_struct = {0};
+    struct htp_mm_context * mmctx = &mmctx_struct;
+
+    const int status = htp_mm_init_context(octx, kparams);
+    if (status != HTP_STATUS_OK) {
+        return status;
+    }
+
     struct htp_thread_trace * tr = &octx->ctx->trace[0];
     htp_trace_event_start(tr, HTP_TRACE_EVT_INIT, 0);
 
-    const struct htp_mm_kernel_params * kparams = (const struct htp_mm_kernel_params *) octx->kernel_params;
+    mmctx->octx = octx;
     const uint32_t n_weights = kparams->n_weights;
     const struct htp_tensor * restrict src0 = octx->src[0];
     const struct htp_tensor * restrict act  = octx->src[n_weights];
     const struct htp_tensor * restrict ids  = octx->src[n_weights + 1];
 
-    struct htp_mm_context mmctx_struct = {0};
-    struct htp_mm_context * mmctx = &mmctx_struct;
-    mmctx->octx = octx;
     mmctx->act = act;
 
     const size_t src0_row_size = src0->nb[1];
@@ -4080,6 +4113,12 @@ int op_matmul_id_nx(struct htp_ops_context * octx) {
 }
 int op_matmul_nx(struct htp_ops_context * octx) {
     const struct htp_mm_kernel_params * kparams = (const struct htp_mm_kernel_params *) octx->kernel_params;
+
+    const int status = htp_mm_init_context(octx, kparams);
+    if (status != HTP_STATUS_OK) {
+        return status;
+    }
+
     if (kparams->n_hmx) {
         return hmx_mm_nx_2d_f32(octx, kparams);
     }
@@ -4146,7 +4185,7 @@ int op_matmul_nx(struct htp_ops_context * octx) {
     htp_mm_hvx_vtcm_layout_build(&L, kparams->kernel_type, src0->type, act->ne[0], src1_nrows, octx->n_threads,
                                  0, src0_row_size, src1_row_size, 0, kparams->n_prefetch, false, true);
 
-    size_t vtcm_size = kparams->vtcm_size > 0 ? (size_t)kparams->vtcm_size : L.total_bytes;
+    const size_t vtcm_size = L.total_bytes;
 
     if (octx->ctx->vtcm_size < vtcm_size) {
         FARF(ERROR, "matmul-nx: current VTCM reservation %zu is too small, needed %zu\n",

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -554,31 +554,31 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t n_k_tiles_w = ne00 / 32;                                                                                         \
         uint32_t tile_row_stride = n_k_tiles_w * tile_size;                                                                       \
                                                                                                                                   \
-        uint32_t dev_start_row = 0;                                                                                                \
-        uint32_t dev_end_row   = ne01;                                                                                              \
+        uint32_t src0_start_row = 0;                                                                                              \
+        uint32_t src0_end_row   = ne01;                                                                                           \
         if (octx->mdev_count > 1) {                                                                                               \
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));                                              \
             const uint32_t total_chunks = ne01 / 32;                                                                              \
             if (!can_split || total_chunks < octx->mdev_count) {                                                                  \
-                dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;                                                                \
-                dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;                                                             \
+                src0_start_row = (octx->mdev_idx == 0) ? 0 : ne01;                                                                \
+                src0_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;                                                             \
             } else {                                                                                                              \
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);             \
-                dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);                                                \
+                src0_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);                                                \
                 if (octx->mdev_idx == octx->mdev_count - 1) {                                                                     \
-                    dev_end_row = ne01;                                                                                          \
+                    src0_end_row = ne01;                                                                                          \
                 } else {                                                                                                          \
-                    dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);                                              \
+                    src0_end_row = MIN(src0_start_row + chunks_per_mdev * 32, ne01);                                              \
                 }                                                                                                                 \
             }                                                                                                                     \
         }                                                                                                                         \
                                                                                                                                   \
-        const uint32_t nrows = dev_end_row - dev_start_row;                                                                       \
+        const uint32_t nrows = src0_end_row - src0_start_row;                                                                     \
         uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);                                          \
         src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);                                                          \
                                                                                                                                   \
-        const uint32_t start_row = dev_start_row + src0_nrows_per_thread * ith;                                                   \
-        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, dev_end_row);                                          \
+        const uint32_t start_row = src0_start_row + src0_nrows_per_thread * ith;                                                  \
+        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, src0_end_row);                                          \
         if (start_row >= end_row) continue;                                                                                       \
                                                                                                                                   \
         uint32_t ct_start = start_row / 32;                                                                                       \
@@ -1165,30 +1165,30 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             if (!src_w || !dst) continue;
 
             const uint32_t ne01 = src_w->ne[1];
-            uint32_t dev_start_row = 0;
-            uint32_t dev_end_row   = ne01;
+            uint32_t start_row = 0;
+            uint32_t end_row   = ne01;
             if (octx->mdev_count > 1) {
                 const uint32_t total_chunks = ne01 / 32;
                 if (total_chunks < octx->mdev_count) {
-                    dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                    dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                    start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                    end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
                 } else {
                     const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                    dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                    start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
                     if (octx->mdev_idx == octx->mdev_count - 1) {
-                        dev_end_row = ne01;
+                        end_row = ne01;
                     } else {
-                        dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);
+                        end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
                     }
                 }
             }
 
-            const uint32_t nrows = dev_end_row - dev_start_row;
+            const uint32_t nrows = end_row - start_row;
             uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = dev_start_row + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, dev_end_row);
+            const uint32_t src0_start_row = start_row + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, end_row);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * restrict src0_row = (const uint8_t *) src_w->data + eid * src_w->nb[2];
@@ -1268,30 +1268,30 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             if (!src_w || !dst) continue;
 
             const uint32_t ne01 = src_w->ne[1];
-            uint32_t dev_start_row = 0;
-            uint32_t dev_end_row   = ne01;
+            uint32_t start_row = 0;
+            uint32_t end_row   = ne01;
             if (octx->mdev_count > 1) {
                 const uint32_t total_chunks = ne01 / 32;
                 if (total_chunks < octx->mdev_count) {
-                    dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                    dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                    start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                    end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
                 } else {
                     const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                    dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                    start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
                     if (octx->mdev_idx == octx->mdev_count - 1) {
-                        dev_end_row = ne01;
+                        end_row = ne01;
                     } else {
-                        dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);
+                        end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
                     }
                 }
             }
 
-            const uint32_t nrows = dev_end_row - dev_start_row;
+            const uint32_t nrows = end_row - start_row;
             uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = dev_start_row + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, dev_end_row);
+            const uint32_t src0_start_row = start_row + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, end_row);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * src0_row = (const uint8_t *) src_w->data + cur_a * src_w->nb[2];
@@ -1670,31 +1670,31 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
 
         const uint32_t ne00 = src_w->ne[0];
         const uint32_t ne01 = src_w->ne[1];
-        uint32_t dev_start_row = 0;
-        uint32_t dev_end_row   = ne01;
+        uint32_t start_row = 0;
+        uint32_t end_row   = ne01;
         if (octx->mdev_count > 1) {
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
             const uint32_t total_chunks = ne01 / 32;
             if (!can_split || total_chunks < octx->mdev_count) {
-                dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
             } else {
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    dev_end_row = ne01;
+                    end_row = ne01;
                 } else {
-                    dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);
+                    end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
                 }
             }
         }
 
-        const uint32_t nrows = dev_end_row - dev_start_row;
+        const uint32_t nrows = end_row - start_row;
         uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);
         src0_nrows_per_thread += (src0_nrows_per_thread & 1);
 
-        const uint32_t src0_start_row  = dev_start_row + src0_nrows_per_thread * ith;
-        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, dev_end_row);
+        const uint32_t src0_start_row  = start_row + src0_nrows_per_thread * ith;
+        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, end_row);
         const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
         if (src0_start_row >= src0_end_row) continue;
 

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -89,8 +89,8 @@ struct htp_mm_context {
 
     // Precomputed values
     uint32_t src0_nrows_per_thread;
-    uint32_t dev_row_start;
-    uint32_t dev_row_end;
+    uint32_t mdev_row_start;
+    uint32_t mdev_row_end;
     uint32_t src0_row_size_padded;
     uint32_t src1_nrows;
 
@@ -254,8 +254,8 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
         ith1 = ith;
     }
 
-    const uint32_t ir0_start = mmctx->dev_row_start + dr0 * ith0;
-    const uint32_t ir0_end   = MIN(ir0_start + dr0, mmctx->dev_row_end);
+    const uint32_t ir0_start = mmctx->mdev_row_start + dr0 * ith0;
+    const uint32_t ir0_end   = MIN(ir0_start + dr0, mmctx->mdev_row_end);
 
     const uint32_t ir1_start = dr1 * ith1;
     const uint32_t ir1_end   = MIN(ir1_start + dr1, nr1);
@@ -314,11 +314,11 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
 static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                        \
+    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;                                                      \
     const uint32_t src1_nrows = ne11 * ne12 * ne13;                                                                               \
                                                                                                                                   \
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                          \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                             \
+    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;                                         \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);                            \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -416,10 +416,10 @@ static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void
 static void hvx_mv_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                        \
+    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;                                                      \
                                                                                                                                   \
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                          \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                             \
+    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;                                         \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);                            \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -551,12 +551,12 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t n_k_tiles_w = ne00 / 32;                                                                                         \
         uint32_t tile_row_stride = n_k_tiles_w * tile_size;                                                                       \
                                                                                                                                   \
-        const uint32_t dev_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                     \
-        uint32_t src0_nrows_per_thread = fastdiv(dev_nrows + nth - 1, &octx->ctx->n_threads_div);                                 \
+        const uint32_t mdev_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;                                                  \
+        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);                                \
         src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);                                                          \
                                                                                                                                   \
-        const uint32_t start_row = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                            \
-        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mmctx->dev_row_end);                                    \
+        const uint32_t start_row = mmctx->mdev_row_start + src0_nrows_per_thread * ith;                                           \
+        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mmctx->mdev_row_end);                                   \
         if (start_row >= end_row) continue;                                                                                       \
                                                                                                                                   \
         uint32_t ct_start = start_row / 32;                                                                                       \
@@ -737,11 +737,11 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
     assert(n_prefetch >= 2 && n_prefetch <= HTP_MM_MAX_PREFETCH && (n_prefetch & (n_prefetch - 1)) == 0);
     const uint32_t prefetch_mask = n_prefetch - 1;
 
-    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;  // src0 rows
+    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;  // src0 rows
     const uint32_t src1_nrows = ne11 * ne12 * ne13;                          // src1 rows
 
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
+    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
     const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
@@ -835,10 +835,10 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
 static void hvx_mv_2d(unsigned int nth, unsigned int ith, void * data) {
     htp_matmul_preamble;
 
-    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
+    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
 
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
+    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
 
@@ -948,10 +948,10 @@ static void hvx_mm_id(unsigned int nth, unsigned int ith, void * data) {
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
 
-    const uint32_t src0_nrows      = mmctx->dev_row_end - mmctx->dev_row_start;  // src0 rows per expert
+    const uint32_t src0_nrows      = mmctx->mdev_row_end - mmctx->mdev_row_start;  // src0 rows per expert
     const uint32_t src1_nrows      = ne11;
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
+    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
 
     hvx_mm_run_quant_task(mmctx, ith);
 
@@ -1038,9 +1038,9 @@ static void hvx_mv_id(unsigned int nth, unsigned int ith, void * data) {
 
     const struct htp_tensor * restrict ids = octx->src[2];
 
-    const uint32_t src0_nrows      = mmctx->dev_row_end - mmctx->dev_row_start;  // src0 rows per expert
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
+    const uint32_t src0_nrows      = mmctx->mdev_row_end - mmctx->mdev_row_start;  // src0 rows per expert
+    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
 
     hvx_mm_run_quant_task(mmctx, ith);
 
@@ -1145,12 +1145,12 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const struct htp_tensor * restrict dst   = octx->dsts[p];
             if (!src_w || !dst) continue;
 
-            const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
+            const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
             uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = mmctx->dev_row_start + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
+            const uint32_t src0_start_row = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * restrict src0_row = (const uint8_t *) src_w->data + eid * src_w->nb[2];
@@ -1229,12 +1229,12 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const struct htp_tensor * restrict dst   = octx->dsts[p];
             if (!src_w || !dst) continue;
 
-            const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
+            const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
             uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = mmctx->dev_row_start + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
+            const uint32_t src0_start_row = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * src0_row = (const uint8_t *) src_w->data + cur_a * src_w->nb[2];
@@ -1328,30 +1328,30 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = ne01 * ne02 * ne03;
     const uint32_t src1_nrows = ne11 * ne12 * ne13;
 
-    uint32_t dev_row_start, dev_row_end;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    uint32_t mdev_row_start, mdev_row_end;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
     } else {
-        dev_row_start = 0;
-        dev_row_end   = src0_nrows;
+        mdev_row_start = 0;
+        mdev_row_end   = src0_nrows;
     }
 
-    if (dev_row_start >= dev_row_end) {
+    if (mdev_row_start >= mdev_row_end) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t dev_nrows = dev_row_end - dev_row_start;
-    mmctx->dev_row_start = dev_row_start;
-    mmctx->dev_row_end   = dev_row_end;
+    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
+    mmctx->mdev_row_start = mdev_row_start;
+    mmctx->mdev_row_end   = mdev_row_end;
 
     bool is_repacked = (src0->type == HTP_TYPE_Q4_0 || src0->type == HTP_TYPE_Q4_1 ||
                         src0->type == HTP_TYPE_Q8_0 || src0->type == HTP_TYPE_IQ4_NL ||
                         src0->type == HTP_TYPE_MXFP4);
 
     // Compute src0_nrows_per_thread
-    mmctx->src0_nrows_per_thread  = fastdiv(dev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    mmctx->src0_nrows_per_thread  = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
     if (is_repacked) {
         mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
     } else {
@@ -1603,12 +1603,12 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
 
         const uint32_t ne00 = src_w->ne[0];
         const uint32_t ne01 = src_w->ne[1];
-        const uint32_t dev_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
-        uint32_t src0_nrows_per_thread = fastdiv(dev_nrows + nth - 1, &octx->ctx->n_threads_div);
+        const uint32_t mdev_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
+        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);
         src0_nrows_per_thread += (src0_nrows_per_thread & 1);
 
-        const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
-        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
+        const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
+        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
         const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
         if (src0_start_row >= src0_end_row) continue;
 
@@ -2735,10 +2735,10 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
 
     int m_start = 0;
     int m_core  = m;
-    if (octx->ndev > 1) {
-        const int rows_per_dev = (m + octx->ndev - 1) / octx->ndev;
-        m_start = MIN((int)(octx->idev * rows_per_dev), m);
-        m_core  = MIN(rows_per_dev, m - m_start);
+    if (octx->mdev_count > 1) {
+        const int rows_per_mdev = (m + octx->mdev_count - 1) / octx->mdev_count;
+        m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m);
+        m_core  = MIN(rows_per_mdev, m - m_start);
     }
 
     if (m_core == 0) {
@@ -3404,10 +3404,10 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
     const int wgt_stride = (int)(src0->nb[1] / sizeof(__fp16));
 
     int m_start, m_dev;
-    if (octx->ndev > 1) {
-        const int rows_per_dev = (m_total + octx->ndev - 1) / octx->ndev;
-        m_start = MIN((int)(octx->idev * rows_per_dev), m_total);
-        m_dev   = MIN(rows_per_dev, m_total - m_start);
+    if (octx->mdev_count > 1) {
+        const int rows_per_mdev = (m_total + octx->mdev_count - 1) / octx->mdev_count;
+        m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_total);
+        m_dev   = MIN(rows_per_mdev, m_total - m_start);
     } else {
         m_start = 0;
         m_dev   = m_total;
@@ -3518,10 +3518,10 @@ static int hmx_mm_op_matmul_id(
 
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
-        if (octx->ndev > 1) {
-            const int rows_per_dev = (m_padded + (int) octx->ndev - 1) / (int) octx->ndev;
-            m_start = MIN((int)(octx->idev * rows_per_dev), m_padded);
-            m_end   = MIN(m_start + rows_per_dev, m_padded);
+        if (octx->mdev_count > 1) {
+            const int rows_per_mdev = (m_padded + (int) octx->mdev_count - 1) / (int) octx->mdev_count;
+            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
+            m_end   = MIN(m_start + rows_per_mdev, m_padded);
         }
         if (m_start >= m_end) continue;
 
@@ -3652,10 +3652,10 @@ static int hmx_mm_op_matmul_id_nx(
 
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
-        if (octx->ndev > 1) {
-            const int rows_per_dev = (m_padded + (int) octx->ndev - 1) / (int) octx->ndev;
-            m_start = MIN((int)(octx->idev * rows_per_dev), m_padded);
-            m_end   = MIN(m_start + rows_per_dev, m_padded);
+        if (octx->mdev_count > 1) {
+            const int rows_per_mdev = (m_padded + (int) octx->mdev_count - 1) / (int) octx->mdev_count;
+            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
+            m_end   = MIN(m_start + rows_per_mdev, m_padded);
         }
         if (m_start >= m_end) continue;
 
@@ -3862,25 +3862,25 @@ int op_matmul_id(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = ne01;  // per expert
     const uint32_t src1_nrows = ne11 * ne12 * ne13;
 
-    uint32_t dev_row_start, dev_row_end;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    uint32_t mdev_row_start, mdev_row_end;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
     } else {
-        dev_row_start = 0;
-        dev_row_end   = src0_nrows;
+        mdev_row_start = 0;
+        mdev_row_end   = src0_nrows;
     }
 
-    if (dev_row_start >= dev_row_end) {
+    if (mdev_row_start >= mdev_row_end) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t dev_nrows = dev_row_end - dev_row_start;
-    mmctx->dev_row_start = dev_row_start;
-    mmctx->dev_row_end   = dev_row_end;
+    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
+    mmctx->mdev_row_start = mdev_row_start;
+    mmctx->mdev_row_end   = mdev_row_end;
 
-    mmctx->src0_nrows_per_thread = fastdiv(dev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
     mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
 
     // row groups
@@ -3969,25 +3969,25 @@ int op_matmul_id_nx(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = src0->ne[1];
     const uint32_t src1_nrows = act->ne[1] * act->ne[2] * act->ne[3];
 
-    uint32_t dev_row_start, dev_row_end;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    uint32_t mdev_row_start, mdev_row_end;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
     } else {
-        dev_row_start = 0;
-        dev_row_end   = src0_nrows;
+        mdev_row_start = 0;
+        mdev_row_end   = src0_nrows;
     }
 
-    if (dev_row_start >= dev_row_end) {
+    if (mdev_row_start >= mdev_row_end) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t dev_nrows = dev_row_end - dev_row_start;
-    mmctx->dev_row_start = dev_row_start;
-    mmctx->dev_row_end   = dev_row_end;
+    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
+    mmctx->mdev_row_start = mdev_row_start;
+    mmctx->mdev_row_end   = mdev_row_end;
 
-    mmctx->src0_nrows_per_thread = fastdiv(dev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
     mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
 
     const int n_ids = ids->ne[0];
@@ -4080,22 +4080,22 @@ int op_matmul_nx(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1];
 
-    uint32_t dev_row_start, dev_row_end;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    uint32_t mdev_row_start, mdev_row_end;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
     } else {
-        dev_row_start = 0;
-        dev_row_end   = src0_nrows;
+        mdev_row_start = 0;
+        mdev_row_end   = src0_nrows;
     }
 
-    if (dev_row_start >= dev_row_end) {
+    if (mdev_row_start >= mdev_row_end) {
         return HTP_STATUS_OK;
     }
 
-    mmctx->dev_row_start = dev_row_start;
-    mmctx->dev_row_end   = dev_row_end;
+    mmctx->mdev_row_start = mdev_row_start;
+    mmctx->mdev_row_end   = mdev_row_end;
 
     const size_t src0_row_size = src0->nb[1];
     const size_t src0_row_size_padded = hex_round_up(src0_row_size, 128);

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -240,16 +240,18 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
     // This is the size of the rest of the dimensions of the result
     const uint32_t nr1 = ne1 * ne2 * ne3;
 
+    const uint32_t mdev_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
+
     // distribute the thread work across the inner or outer loop based on which one is larger
     uint32_t dr0, dr1, ith0, ith1;
     if (nr0 > nr1) {
-        dr0  = fastdiv(nr0 + nth - 1, &octx->ctx->n_threads_div);
+        dr0  = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
         dr1  = nr1;
         ith0 = ith;
         ith1 = 0;
     } else {
-        dr0  = nr0;
-        dr1  = fastdiv(nr1 + nth - 1, &octx->ctx->n_threads_div);
+        dr0  = mdev_nrows;
+        dr1  = fastdiv(nr1 + nth - 1, &octx->n_threads_div);
         ith0 = 0;
         ith1 = ith;
     }
@@ -553,7 +555,7 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
                                                                                                                                   \
         uint32_t mdev_start_row, mdev_end_row;                                                                                \
         if (octx->mdev_count > 1) {                                                                                           \
-            const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;                                  \
+            const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);                        \
             mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);                                                       \
             mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);                                                       \
         } else {                                                                                                              \
@@ -562,7 +564,7 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         }                                                                                                                     \
                                                                                                                               \
         const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;                                                            \
-        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);                            \
+        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);                                \
         src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);                                                          \
                                                                                                                                   \
         const uint32_t start_row = mdev_start_row + src0_nrows_per_thread * ith;                                           \
@@ -1158,7 +1160,7 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const uint32_t ne01 = src_w->ne[1];
             uint32_t mdev_start_row, mdev_end_row;
             if (octx->mdev_count > 1) {
-                const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;
+                const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);
                 mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
                 mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
             } else {
@@ -1167,7 +1169,7 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             }
 
             const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
-            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);
+            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
             const uint32_t src0_start_row = mdev_start_row + src0_nrows_per_thread * ith;
@@ -1253,7 +1255,7 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const uint32_t ne01 = src_w->ne[1];
             uint32_t mdev_start_row, mdev_end_row;
             if (octx->mdev_count > 1) {
-                const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;
+                const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);
                 mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
                 mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
             } else {
@@ -1262,7 +1264,7 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             }
 
             const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
-            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);
+            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
             const uint32_t src0_start_row = mdev_start_row + src0_nrows_per_thread * ith;
@@ -1357,12 +1359,12 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
 
     const struct htp_mm_kernel_params * kparams = (const struct htp_mm_kernel_params *) octx->kernel_params;
 
-    const uint32_t src0_nrows = ne01 * ne02 * ne03;
+    const uint32_t src0_nrows = ne01;
     const uint32_t src1_nrows = ne11 * ne12 * ne13;
 
     uint32_t mdev_row_start, mdev_row_end;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
         mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
     } else {
@@ -1383,7 +1385,7 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
                         src0->type == HTP_TYPE_MXFP4);
 
     // Compute src0_nrows_per_thread
-    mmctx->src0_nrows_per_thread  = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    mmctx->src0_nrows_per_thread  = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->n_threads_div);
     if (is_repacked) {
         mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
     } else {
@@ -1555,11 +1557,11 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
         kparams->kernel_type == HTP_MM_KERNEL_HVX_QUANT_BLOCK) {
         mmctx->vtcm_src1_size_per_thread = L.src1_bytes;
     } else {
-        mmctx->vtcm_src1_size_per_thread = fastdiv(L.src1_bytes, &octx->ctx->n_threads_div);
+        mmctx->vtcm_src1_size_per_thread = fastdiv(L.src1_bytes, &octx->n_threads_div);
     }
 
-    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->ctx->n_threads_div);
-    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->ctx->n_threads_div);
+    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->n_threads_div);
+    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->n_threads_div);
 
     size_t vtcm_size = kparams->vtcm_size > 0 ? (size_t)kparams->vtcm_size : L.total_bytes;
 
@@ -1637,7 +1639,7 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
         const uint32_t ne01 = src_w->ne[1];
         uint32_t mdev_start_row, mdev_end_row;
         if (octx->mdev_count > 1) {
-            const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;
+            const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);
             mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
             mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
         } else {
@@ -1646,7 +1648,7 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
         }
 
         const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
-        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);
+        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
         src0_nrows_per_thread += (src0_nrows_per_thread & 1);
 
         const uint32_t src0_start_row  = mdev_start_row + src0_nrows_per_thread * ith;
@@ -2778,7 +2780,7 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
     int m_start = 0;
     int m_core  = m;
     if (octx->mdev_count > 1) {
-        const int rows_per_mdev = (m + octx->mdev_count - 1) / octx->mdev_count;
+        const int rows_per_mdev = (int) fastdiv(m + octx->mdev_count - 1, &octx->mdev_count_div);
         m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m);
         m_core  = MIN(rows_per_mdev, m - m_start);
     }
@@ -3447,7 +3449,7 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
 
     int m_start, m_dev;
     if (octx->mdev_count > 1) {
-        const int rows_per_mdev = (m_total + octx->mdev_count - 1) / octx->mdev_count;
+        const int rows_per_mdev = (int) fastdiv(m_total + octx->mdev_count - 1, &octx->mdev_count_div);
         m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_total);
         m_dev   = MIN(rows_per_mdev, m_total - m_start);
     } else {
@@ -3561,7 +3563,7 @@ static int hmx_mm_op_matmul_id(
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
         if (octx->mdev_count > 1) {
-            const int rows_per_mdev = (m_padded + (int) octx->mdev_count - 1) / (int) octx->mdev_count;
+            const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
             m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
             m_end   = MIN(m_start + rows_per_mdev, m_padded);
         }
@@ -3659,10 +3661,10 @@ static int hvx_mm_matmul_id(
     mmctx->vtcm_src0_stride = src0_row_size_padded;
     mmctx->vtcm_src1_stride = src1_row_size;
 
-    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->ctx->n_threads_div);
+    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->n_threads_div);
     mmctx->vtcm_src1_size_per_thread = L.src1_bytes;
     mmctx->vtcm_src2_size_per_thread = 0;
-    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->ctx->n_threads_div);
+    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->n_threads_div);
 
     mmctx->n_quant_rows_per_thread = (src1_nrows + n_quant_tasks - 1) / n_quant_tasks;
     mmctx->quant_task_func = quant_task_func;
@@ -3695,7 +3697,7 @@ static int hmx_mm_op_matmul_id_nx(
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
         if (octx->mdev_count > 1) {
-            const int rows_per_mdev = (m_padded + (int) octx->mdev_count - 1) / (int) octx->mdev_count;
+            const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
             m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
             m_end   = MIN(m_start + rows_per_mdev, m_padded);
         }
@@ -3793,9 +3795,9 @@ static int hvx_mm_matmul_id_nx(
     mmctx->vtcm_src0_stride = 0;
     mmctx->vtcm_src1_stride = src1_row_size;
 
-    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->ctx->n_threads_div);
+    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->n_threads_div);
     mmctx->vtcm_src1_size_per_thread = L.src1_bytes;
-    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->ctx->n_threads_div);
+    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->n_threads_div);
 
     mmctx->n_quant_rows_per_thread = (src1_nrows + n_quant_tasks - 1) / n_quant_tasks;
     mmctx->quant_task_func         = quant_task_func;
@@ -3906,7 +3908,7 @@ int op_matmul_id(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_row_end;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
         mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
     } else {
@@ -3922,7 +3924,7 @@ int op_matmul_id(struct htp_ops_context * octx) {
     mmctx->mdev_row_start = mdev_row_start;
     mmctx->mdev_row_end   = mdev_row_end;
 
-    mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->n_threads_div);
     mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
 
     // row groups
@@ -4163,9 +4165,9 @@ int op_matmul_nx(struct htp_ops_context * octx) {
     mmctx->vtcm_src0_stride = is_repacked ? 0 : src0_row_size_padded;
     mmctx->vtcm_src1_stride = src1_row_size;
 
-    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->ctx->n_threads_div);
+    mmctx->vtcm_src0_size_per_thread = fastdiv(L.src0_bytes, &octx->n_threads_div);
     mmctx->vtcm_src1_size_per_thread = L.src1_bytes;
-    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->ctx->n_threads_div);
+    mmctx->vtcm_dst_size_per_thread  = fastdiv(L.dst_bytes, &octx->n_threads_div);
 
     mmctx->n_quant_rows_per_thread = (src1_nrows + n_quant_tasks - 1) / n_quant_tasks;
     mmctx->quant_task_func = quant_task_func;

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -556,16 +556,16 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
                                                                                                                                   \
         uint32_t src0_start_row = 0;                                                                                              \
         uint32_t src0_end_row   = ne01;                                                                                           \
-        if (octx->ctx->mdev.count > 1) {                                                                                               \
+        if (octx->ctx->mdev.count > 1) {                                                                                          \
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));                                              \
             const uint32_t total_chunks = ne01 / 32;                                                                              \
-            if (!can_split || total_chunks < octx->ctx->mdev.count) {                                                                  \
-                src0_start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;                                                                \
-                src0_end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;                                                             \
+            if (!can_split || total_chunks < octx->ctx->mdev.count) {                                                             \
+                src0_start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;                                                           \
+                src0_end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;                                                        \
             } else {                                                                                                              \
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);             \
-                src0_start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);                                                \
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {                                                                     \
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);   \
+                src0_start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);                                           \
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {                                                           \
                     src0_end_row = ne01;                                                                                          \
                 } else {                                                                                                          \
                     src0_end_row = MIN(src0_start_row + chunks_per_mdev * 32, ne01);                                              \

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -89,6 +89,8 @@ struct htp_mm_context {
 
     // Precomputed values
     uint32_t src0_nrows_per_thread;
+    uint32_t dev_row_start;
+    uint32_t dev_row_end;
     uint32_t src0_row_size_padded;
     uint32_t src1_nrows;
 
@@ -252,8 +254,8 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
         ith1 = ith;
     }
 
-    const uint32_t ir0_start = dr0 * ith0;
-    const uint32_t ir0_end   = MIN(ir0_start + dr0, nr0);
+    const uint32_t ir0_start = mmctx->dev_row_start + dr0 * ith0;
+    const uint32_t ir0_end   = MIN(ir0_start + dr0, mmctx->dev_row_end);
 
     const uint32_t ir1_start = dr1 * ith1;
     const uint32_t ir1_end   = MIN(ir1_start + dr1, nr1);
@@ -312,11 +314,11 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
 static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = ne01 * ne02 * ne03;                                                                               \
+    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                      \
     const uint32_t src1_nrows = ne11 * ne12 * ne13;                                                                               \
                                                                                                                                   \
-    const uint32_t src0_start_row  = src0_nrows_per_thread * ith;                                                                 \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);                                     \
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                         \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                            \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -414,10 +416,10 @@ static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void
 static void hvx_mv_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = ne01;                                                                                             \
+    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                      \
                                                                                                                                   \
-    const uint32_t src0_start_row  = src0_nrows_per_thread * ith;                                                                 \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);                                     \
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                         \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                            \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -735,11 +737,11 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
     assert(n_prefetch >= 2 && n_prefetch <= HTP_MM_MAX_PREFETCH && (n_prefetch & (n_prefetch - 1)) == 0);
     const uint32_t prefetch_mask = n_prefetch - 1;
 
-    const uint32_t src0_nrows = ne01 * ne02 * ne03;  // src0 rows
-    const uint32_t src1_nrows = ne11 * ne12 * ne13;  // src1 rows
+    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;  // src0 rows
+    const uint32_t src1_nrows = ne11 * ne12 * ne13;                          // src1 rows
 
-    const uint32_t src0_start_row  = src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
     const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
@@ -833,10 +835,10 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
 static void hvx_mv_2d(unsigned int nth, unsigned int ith, void * data) {
     htp_matmul_preamble;
 
-    const uint32_t src0_nrows = ne01;
+    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
 
-    const uint32_t src0_start_row  = src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
 
@@ -946,10 +948,10 @@ static void hvx_mm_id(unsigned int nth, unsigned int ith, void * data) {
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
 
-    const uint32_t src0_nrows      = ne01;  // src0 rows per expert
+    const uint32_t src0_nrows      = mmctx->dev_row_end - mmctx->dev_row_start;  // src0 rows per expert
     const uint32_t src1_nrows      = ne11;
-    const uint32_t src0_start_row  = src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
 
     hvx_mm_run_quant_task(mmctx, ith);
 
@@ -1036,9 +1038,9 @@ static void hvx_mv_id(unsigned int nth, unsigned int ith, void * data) {
 
     const struct htp_tensor * restrict ids = octx->src[2];
 
-    const uint32_t src0_nrows      = ne01;  // src0 rows per expert
-    const uint32_t src0_start_row  = src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+    const uint32_t src0_nrows      = mmctx->dev_row_end - mmctx->dev_row_start;  // src0 rows per expert
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
 
     hvx_mm_run_quant_task(mmctx, ith);
 
@@ -1143,12 +1145,12 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const struct htp_tensor * restrict dst   = octx->dsts[p];
             if (!src_w || !dst) continue;
 
-            const uint32_t src0_nrows = src_w->ne[1];
+            const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
             uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+            const uint32_t src0_start_row = mmctx->dev_row_start + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * restrict src0_row = (const uint8_t *) src_w->data + eid * src_w->nb[2];
@@ -1227,12 +1229,12 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const struct htp_tensor * restrict dst   = octx->dsts[p];
             if (!src_w || !dst) continue;
 
-            const uint32_t src0_nrows = src_w->ne[1];
+            const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
             uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+            const uint32_t src0_start_row = mmctx->dev_row_start + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * src0_row = (const uint8_t *) src_w->data + cur_a * src_w->nb[2];
@@ -1326,12 +1328,30 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = ne01 * ne02 * ne03;
     const uint32_t src1_nrows = ne11 * ne12 * ne13;
 
+    uint32_t dev_row_start, dev_row_end;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    } else {
+        dev_row_start = 0;
+        dev_row_end   = src0_nrows;
+    }
+
+    if (dev_row_start >= dev_row_end) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t dev_nrows = dev_row_end - dev_row_start;
+    mmctx->dev_row_start = dev_row_start;
+    mmctx->dev_row_end   = dev_row_end;
+
     bool is_repacked = (src0->type == HTP_TYPE_Q4_0 || src0->type == HTP_TYPE_Q4_1 ||
                         src0->type == HTP_TYPE_Q8_0 || src0->type == HTP_TYPE_IQ4_NL ||
                         src0->type == HTP_TYPE_MXFP4);
 
     // Compute src0_nrows_per_thread
-    mmctx->src0_nrows_per_thread  = fastdiv(src0_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    mmctx->src0_nrows_per_thread  = fastdiv(dev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
     if (is_repacked) {
         mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
     } else {
@@ -3368,31 +3388,49 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
     const int act_stride = (int)(src1->nb[1] / sizeof(float));
     const int wgt_stride = (int)(src0->nb[1] / sizeof(__fp16));
 
+    int m_start, m_dev;
+    if (octx->ndev > 1) {
+        const int rows_per_dev = (m_total + octx->ndev - 1) / octx->ndev;
+        m_start = MIN((int)(octx->idev * rows_per_dev), m_total);
+        m_dev   = MIN(rows_per_dev, m_total - m_start);
+    } else {
+        m_start = 0;
+        m_dev   = m_total;
+    }
+
+    if (m_dev == 0) {
+        return HTP_STATUS_OK;
+    }
+
     const float * src2_ptr = NULL;
     uint32_t src2_stride = 0;
     size_t src2_nb2 = 0;
     size_t src2_nb3 = 0;
     if (src2) {
-        src2_ptr = (const float *) src2->data;
         src2_stride = (src2->ne[1] == 1) ? 0 : (uint32_t) (src2->nb[1] / sizeof(float));
+        src2_ptr = (const float *) src2->data + m_start * src2_stride;
         src2_nb2 = (src2->ne[2] == 1) ? 0 : src2->nb[2];
         src2_nb3 = (src2->ne[3] == 1) ? 0 : src2->nb[3];
     }
+
+    const int dst_stride = (int)(dst->nb[1] / sizeof(float));
+    float       * dst_ptr = (float *)       dst->data  + m_start * dst_stride;
+    const float * act_ptr = (const float *) src1->data + m_start * act_stride;
 
     int ret = -1;
     const int n_threads = MIN(kparams->n_threads, (int) octx->n_threads);
     if (kparams->kernel_type == HTP_MM_KERNEL_HMX_F16_BATCHED) {
         hmx_mm_f16_f32_batched_params_t batch_params = {
-            .dst             = (float *) dst->data,
+            .dst             = dst_ptr,
             .src2            = src2_ptr,
-            .activation      = (float *) src1->data,
+            .activation      = act_ptr,
             .weight          = (const __fp16 *) src0->data,
-            .m               = m_total,
+            .m               = m_dev,
             .k               = k,
             .n               = n,
             .act_stride      = act_stride,
             .weight_stride   = wgt_stride,
-            .dst_stride      = (int) (dst->nb[1] / sizeof(float)),
+            .dst_stride      = dst_stride,
             .src2_stride     = src2_stride,
             .ne02            = ne02,
             .ne03            = ne03,
@@ -3420,9 +3458,9 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
                                      kparams->vtcm_size);
     } else {
         ret = hmx_mm_2d_f32(
-            octx->ctx, (float*) dst->data, src2_ptr, (float*) src1->data, (const uint8_t *) src0->data,
-            m_total, k, n, act_stride, (int) src0->nb[1], (int) src0->type, (int) src1->ne[0],
-            (int)(dst->nb[1] / sizeof(float)), src2_stride, (int)dst->ne[0],
+            octx->ctx, dst_ptr, src2_ptr, act_ptr, (const uint8_t *) src0->data,
+            m_dev, k, n, act_stride, (int) src0->nb[1], (int) src0->type, (int) src1->ne[0],
+            dst_stride, src2_stride, (int)dst->ne[0],
             kparams->m_chunk, kparams->n_chunk, kparams->pipeline, n_threads,
             kparams->n_act_threads,
             &kparams->div_n_act_threads,
@@ -3789,7 +3827,25 @@ int op_matmul_id(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = ne01;  // per expert
     const uint32_t src1_nrows = ne11 * ne12 * ne13;
 
-    mmctx->src0_nrows_per_thread = fastdiv(src0_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    uint32_t dev_row_start, dev_row_end;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    } else {
+        dev_row_start = 0;
+        dev_row_end   = src0_nrows;
+    }
+
+    if (dev_row_start >= dev_row_end) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t dev_nrows = dev_row_end - dev_row_start;
+    mmctx->dev_row_start = dev_row_start;
+    mmctx->dev_row_end   = dev_row_end;
+
+    mmctx->src0_nrows_per_thread = fastdiv(dev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
     mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
 
     // row groups
@@ -3878,7 +3934,25 @@ int op_matmul_id_nx(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = src0->ne[1];
     const uint32_t src1_nrows = act->ne[1] * act->ne[2] * act->ne[3];
 
-    mmctx->src0_nrows_per_thread = fastdiv(src0_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
+    uint32_t dev_row_start, dev_row_end;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    } else {
+        dev_row_start = 0;
+        dev_row_end   = src0_nrows;
+    }
+
+    if (dev_row_start >= dev_row_end) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t dev_nrows = dev_row_end - dev_row_start;
+    mmctx->dev_row_start = dev_row_start;
+    mmctx->dev_row_end   = dev_row_end;
+
+    mmctx->src0_nrows_per_thread = fastdiv(dev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
     mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
 
     const int n_ids = ids->ne[0];

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -551,12 +551,22 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t n_k_tiles_w = ne00 / 32;                                                                                         \
         uint32_t tile_row_stride = n_k_tiles_w * tile_size;                                                                       \
                                                                                                                                   \
-        const uint32_t mdev_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;                                                  \
-        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);                                \
+        uint32_t mdev_start_row, mdev_end_row;                                                                                \
+        if (octx->mdev_count > 1) {                                                                                           \
+            const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;                                  \
+            mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);                                                       \
+            mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);                                                       \
+        } else {                                                                                                              \
+            mdev_start_row = 0;                                                                                               \
+            mdev_end_row   = ne01;                                                                                            \
+        }                                                                                                                     \
+                                                                                                                              \
+        const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;                                                            \
+        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);                            \
         src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);                                                          \
                                                                                                                                   \
-        const uint32_t start_row = mmctx->mdev_row_start + src0_nrows_per_thread * ith;                                           \
-        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mmctx->mdev_row_end);                                   \
+        const uint32_t start_row = mdev_start_row + src0_nrows_per_thread * ith;                                           \
+        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mdev_end_row);                                   \
         if (start_row >= end_row) continue;                                                                                       \
                                                                                                                                   \
         uint32_t ct_start = start_row / 32;                                                                                       \
@@ -1145,12 +1155,23 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const struct htp_tensor * restrict dst   = octx->dsts[p];
             if (!src_w || !dst) continue;
 
-            const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
-            uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);
+            const uint32_t ne01 = src_w->ne[1];
+            uint32_t mdev_start_row, mdev_end_row;
+            if (octx->mdev_count > 1) {
+                const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;
+                mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
+                mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
+            } else {
+                mdev_start_row = 0;
+                mdev_end_row   = ne01;
+            }
+
+            const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
+            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
+            const uint32_t src0_start_row = mdev_start_row + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mdev_end_row);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * restrict src0_row = (const uint8_t *) src_w->data + eid * src_w->nb[2];
@@ -1229,12 +1250,23 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const struct htp_tensor * restrict dst   = octx->dsts[p];
             if (!src_w || !dst) continue;
 
-            const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
-            uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);
+            const uint32_t ne01 = src_w->ne[1];
+            uint32_t mdev_start_row, mdev_end_row;
+            if (octx->mdev_count > 1) {
+                const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;
+                mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
+                mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
+            } else {
+                mdev_start_row = 0;
+                mdev_end_row   = ne01;
+            }
+
+            const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
+            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
+            const uint32_t src0_start_row = mdev_start_row + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mdev_end_row);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * src0_row = (const uint8_t *) src_w->data + cur_a * src_w->nb[2];
@@ -1603,12 +1635,22 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
 
         const uint32_t ne00 = src_w->ne[0];
         const uint32_t ne01 = src_w->ne[1];
-        const uint32_t mdev_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
+        uint32_t mdev_start_row, mdev_end_row;
+        if (octx->mdev_count > 1) {
+            const uint32_t rows_per_mdev = (ne01 + octx->mdev_count - 1) / octx->mdev_count;
+            mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
+            mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
+        } else {
+            mdev_start_row = 0;
+            mdev_end_row   = ne01;
+        }
+
+        const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
         uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->ctx->n_threads_div);
         src0_nrows_per_thread += (src0_nrows_per_thread & 1);
 
-        const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
-        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
+        const uint32_t src0_start_row  = mdev_start_row + src0_nrows_per_thread * ith;
+        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mdev_end_row);
         const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
         if (src0_start_row >= src0_end_row) continue;
 
@@ -3966,29 +4008,7 @@ int op_matmul_id_nx(struct htp_ops_context * octx) {
     const size_t src0_row_size = src0->nb[1];
     const size_t src0_row_size_padded = hex_round_up(src0_row_size, 128);
 
-    const uint32_t src0_nrows = src0->ne[1];
     const uint32_t src1_nrows = act->ne[1] * act->ne[2] * act->ne[3];
-
-    uint32_t mdev_row_start, mdev_row_end;
-    if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
-    } else {
-        mdev_row_start = 0;
-        mdev_row_end   = src0_nrows;
-    }
-
-    if (mdev_row_start >= mdev_row_end) {
-        return HTP_STATUS_OK;
-    }
-
-    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
-    mmctx->mdev_row_start = mdev_row_start;
-    mmctx->mdev_row_end   = mdev_row_end;
-
-    mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->ctx->n_threads_div);
-    mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
 
     const int n_ids = ids->ne[0];
     const int n_as  = src0->ne[2];
@@ -4077,25 +4097,6 @@ int op_matmul_nx(struct htp_ops_context * octx) {
     mmctx->act  = act;
 
     const uint32_t src1_nrows = act->ne[1] * act->ne[2] * act->ne[3];
-
-    const uint32_t src0_nrows = src0->ne[1];
-
-    uint32_t mdev_row_start, mdev_row_end;
-    if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
-    } else {
-        mdev_row_start = 0;
-        mdev_row_end   = src0_nrows;
-    }
-
-    if (mdev_row_start >= mdev_row_end) {
-        return HTP_STATUS_OK;
-    }
-
-    mmctx->mdev_row_start = mdev_row_start;
-    mmctx->mdev_row_end   = mdev_row_end;
 
     const size_t src0_row_size = src0->nb[1];
     const size_t src0_row_size_padded = hex_round_up(src0_row_size, 128);

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -556,16 +556,16 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
                                                                                                                                   \
         uint32_t src0_start_row = 0;                                                                                              \
         uint32_t src0_end_row   = ne01;                                                                                           \
-        if (octx->mdev_count > 1) {                                                                                               \
+        if (octx->ctx->mdev.count > 1) {                                                                                               \
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));                                              \
             const uint32_t total_chunks = ne01 / 32;                                                                              \
-            if (!can_split || total_chunks < octx->mdev_count) {                                                                  \
-                src0_start_row = (octx->mdev_idx == 0) ? 0 : ne01;                                                                \
-                src0_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;                                                             \
+            if (!can_split || total_chunks < octx->ctx->mdev.count) {                                                                  \
+                src0_start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;                                                                \
+                src0_end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;                                                             \
             } else {                                                                                                              \
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);             \
-                src0_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);                                                \
-                if (octx->mdev_idx == octx->mdev_count - 1) {                                                                     \
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);             \
+                src0_start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);                                                \
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {                                                                     \
                     src0_end_row = ne01;                                                                                          \
                 } else {                                                                                                          \
                     src0_end_row = MIN(src0_start_row + chunks_per_mdev * 32, ne01);                                              \
@@ -1167,15 +1167,15 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const uint32_t ne01 = src_w->ne[1];
             uint32_t start_row = 0;
             uint32_t end_row   = ne01;
-            if (octx->mdev_count > 1) {
+            if (octx->ctx->mdev.count > 1) {
                 const uint32_t total_chunks = ne01 / 32;
-                if (total_chunks < octx->mdev_count) {
-                    start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                    end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                if (total_chunks < octx->ctx->mdev.count) {
+                    start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;
+                    end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;
                 } else {
-                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                    start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
-                    if (octx->mdev_idx == octx->mdev_count - 1) {
+                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                    start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);
+                    if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                         end_row = ne01;
                     } else {
                         end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
@@ -1270,15 +1270,15 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const uint32_t ne01 = src_w->ne[1];
             uint32_t start_row = 0;
             uint32_t end_row   = ne01;
-            if (octx->mdev_count > 1) {
+            if (octx->ctx->mdev.count > 1) {
                 const uint32_t total_chunks = ne01 / 32;
-                if (total_chunks < octx->mdev_count) {
-                    start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                    end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                if (total_chunks < octx->ctx->mdev.count) {
+                    start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;
+                    end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;
                 } else {
-                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                    start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
-                    if (octx->mdev_idx == octx->mdev_count - 1) {
+                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                    start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);
+                    if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                         end_row = ne01;
                     } else {
                         end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
@@ -1388,16 +1388,16 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
     uint32_t src0_row_start = 0;
     uint32_t src0_row_end   = src0_nrows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
         const uint32_t total_chunks = src0_nrows / 32;
-        if (!can_split || total_chunks < octx->mdev_count) {
-            src0_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            src0_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
+        if (!can_split || total_chunks < octx->ctx->mdev.count) {
+            src0_row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
+            src0_row_end   = (octx->ctx->mdev.idx == 0) ? src0_nrows : src0_nrows;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            src0_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            src0_row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, src0_nrows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 src0_row_end = src0_nrows;
             } else {
                 src0_row_end = MIN(src0_row_start + chunks_per_mdev * 32, src0_nrows);
@@ -1672,16 +1672,16 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
         const uint32_t ne01 = src_w->ne[1];
         uint32_t start_row = 0;
         uint32_t end_row   = ne01;
-        if (octx->mdev_count > 1) {
+        if (octx->ctx->mdev.count > 1) {
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
             const uint32_t total_chunks = ne01 / 32;
-            if (!can_split || total_chunks < octx->mdev_count) {
-                start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+            if (!can_split || total_chunks < octx->ctx->mdev.count) {
+                start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;
+                end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;
             } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     end_row = ne01;
                 } else {
                     end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
@@ -2821,13 +2821,13 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
 
     int m_start = 0;
     int m_rows  = m;
-    if (octx->mdev_count > 1) {
-        if (!htp_tensor_can_row_partition(octx->dsts[0], sizeof(float)) || (uint32_t) m < octx->mdev_count) {
-            m_start = (octx->mdev_idx == 0) ? 0 : m;
-            m_rows  = (octx->mdev_idx == 0) ? m : 0;
+    if (octx->ctx->mdev.count > 1) {
+        if (!htp_tensor_can_row_partition(octx->dsts[0], sizeof(float)) || (uint32_t) m < octx->ctx->mdev.count) {
+            m_start = (octx->ctx->mdev.idx == 0) ? 0 : m;
+            m_rows  = (octx->ctx->mdev.idx == 0) ? m : 0;
         } else {
-            const int rows_per_mdev = (int) fastdiv(m + octx->mdev_count - 1, &octx->mdev_count_div);
-            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m);
+            const int rows_per_mdev = (int) fastdiv(m + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m);
             m_rows  = MIN(rows_per_mdev, m - m_start);
         }
     }
@@ -3496,13 +3496,13 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
 
     int m_start = 0;
     int m_rows  = m_total;
-    if (octx->mdev_count > 1) {
-        if (!htp_tensor_can_row_partition(dst, sizeof(float)) || (uint32_t) m_total < octx->mdev_count) {
-            m_start = (octx->mdev_idx == 0) ? 0 : m_total;
-            m_rows  = (octx->mdev_idx == 0) ? m_total : 0;
+    if (octx->ctx->mdev.count > 1) {
+        if (!htp_tensor_can_row_partition(dst, sizeof(float)) || (uint32_t) m_total < octx->ctx->mdev.count) {
+            m_start = (octx->ctx->mdev.idx == 0) ? 0 : m_total;
+            m_rows  = (octx->ctx->mdev.idx == 0) ? m_total : 0;
         } else {
-            const int rows_per_mdev = (int) fastdiv(m_total + octx->mdev_count - 1, &octx->mdev_count_div);
-            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_total);
+            const int rows_per_mdev = (int) fastdiv(m_total + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m_total);
             m_rows  = MIN(rows_per_mdev, m_total - m_start);
         }
     }
@@ -3612,12 +3612,12 @@ static int hmx_mm_op_matmul_id(
 
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
-        if (octx->mdev_count > 1) {
-            if ((uint32_t) cne1 < octx->mdev_count) {
-                if (octx->mdev_idx > 0) continue;
+        if (octx->ctx->mdev.count > 1) {
+            if ((uint32_t) cne1 < octx->ctx->mdev.count) {
+                if (octx->ctx->mdev.idx > 0) continue;
             } else {
-                const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
-                m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
+                const int rows_per_mdev = (int) fastdiv(m_padded + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m_padded);
                 m_end   = MIN(m_start + rows_per_mdev, m_padded);
             }
         }
@@ -3750,12 +3750,12 @@ static int hmx_mm_op_matmul_id_nx(
 
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
-        if (octx->mdev_count > 1) {
-            if ((uint32_t) cne1 < octx->mdev_count) {
-                if (octx->mdev_idx > 0) continue;
+        if (octx->ctx->mdev.count > 1) {
+            if ((uint32_t) cne1 < octx->ctx->mdev.count) {
+                if (octx->ctx->mdev.idx > 0) continue;
             } else {
-                const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
-                m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
+                const int rows_per_mdev = (int) fastdiv(m_padded + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m_padded);
                 m_end   = MIN(m_start + rows_per_mdev, m_padded);
             }
         }
@@ -4017,15 +4017,15 @@ int op_matmul_id(struct htp_ops_context * octx) {
     } else {
         uint32_t src0_row_start = 0;
         uint32_t src0_row_end   = src0_nrows;
-        if (octx->mdev_count > 1) {
+        if (octx->ctx->mdev.count > 1) {
             const uint32_t total_chunks = src0_nrows / 32;
-            if (total_chunks < octx->mdev_count) {
-                src0_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-                src0_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
+            if (total_chunks < octx->ctx->mdev.count) {
+                src0_row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
+                src0_row_end   = (octx->ctx->mdev.idx == 0) ? src0_nrows : src0_nrows;
             } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                src0_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                src0_row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, src0_nrows);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     src0_row_end = src0_nrows;
                 } else {
                     src0_row_end = MIN(src0_row_start + chunks_per_mdev * 32, src0_nrows);

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -90,8 +90,8 @@ struct htp_mm_context {
 
     // Precomputed values
     uint32_t src0_nrows_per_thread;
-    uint32_t mdev_row_start;
-    uint32_t mdev_row_end;
+    uint32_t src0_row_start;
+    uint32_t src0_row_end;
     uint32_t src0_row_size_padded;
     uint32_t src1_nrows;
 
@@ -241,24 +241,24 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
     // This is the size of the rest of the dimensions of the result
     const uint32_t nr1 = ne1 * ne2 * ne3;
 
-    const uint32_t mdev_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
+    const uint32_t src0_nrows = mmctx->src0_row_end - mmctx->src0_row_start;
 
     // distribute the thread work across the inner or outer loop based on which one is larger
     uint32_t dr0, dr1, ith0, ith1;
     if (nr0 > nr1) {
-        dr0  = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
+        dr0  = fastdiv(src0_nrows + nth - 1, &octx->n_threads_div);
         dr1  = nr1;
         ith0 = ith;
         ith1 = 0;
     } else {
-        dr0  = mdev_nrows;
+        dr0  = src0_nrows;
         dr1  = fastdiv(nr1 + nth - 1, &octx->n_threads_div);
         ith0 = 0;
         ith1 = ith;
     }
 
-    const uint32_t ir0_start = mmctx->mdev_row_start + dr0 * ith0;
-    const uint32_t ir0_end   = MIN(ir0_start + dr0, mmctx->mdev_row_end);
+    const uint32_t ir0_start = mmctx->src0_row_start + dr0 * ith0;
+    const uint32_t ir0_end   = MIN(ir0_start + dr0, mmctx->src0_row_end);
 
     const uint32_t ir1_start = dr1 * ith1;
     const uint32_t ir1_end   = MIN(ir1_start + dr1, nr1);
@@ -317,11 +317,11 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
 static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;                                                      \
+    const uint32_t src0_nrows = mmctx->src0_row_end - mmctx->src0_row_start;                                                      \
     const uint32_t src1_nrows = ne11 * ne12 * ne13;                                                                               \
                                                                                                                                   \
-    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;                                         \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);                            \
+    const uint32_t src0_start_row  = mmctx->src0_row_start + src0_nrows_per_thread * ith;                                         \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->src0_row_end);                            \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -419,10 +419,10 @@ static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void
 static void hvx_mv_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;                                                      \
+    const uint32_t src0_nrows = mmctx->src0_row_end - mmctx->src0_row_start;                                                      \
                                                                                                                                   \
-    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;                                         \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);                            \
+    const uint32_t src0_start_row  = mmctx->src0_row_start + src0_nrows_per_thread * ith;                                         \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->src0_row_end);                            \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -554,33 +554,31 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t n_k_tiles_w = ne00 / 32;                                                                                         \
         uint32_t tile_row_stride = n_k_tiles_w * tile_size;                                                                       \
                                                                                                                                   \
-        uint32_t mdev_start_row, mdev_end_row;                                                                                    \
+        uint32_t dev_start_row = 0;                                                                                                \
+        uint32_t dev_end_row   = ne01;                                                                                              \
         if (octx->mdev_count > 1) {                                                                                               \
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));                                              \
             const uint32_t total_chunks = ne01 / 32;                                                                              \
             if (!can_split || total_chunks < octx->mdev_count) {                                                                  \
-                mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;                                                                \
-                mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;                                                             \
+                dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;                                                                \
+                dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;                                                             \
             } else {                                                                                                              \
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);             \
-                mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);                                                \
+                dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);                                                \
                 if (octx->mdev_idx == octx->mdev_count - 1) {                                                                     \
-                    mdev_end_row = ne01;                                                                                          \
+                    dev_end_row = ne01;                                                                                          \
                 } else {                                                                                                          \
-                    mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);                                              \
+                    dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);                                              \
                 }                                                                                                                 \
             }                                                                                                                     \
-        } else {                                                                                                                  \
-            mdev_start_row = 0;                                                                                                   \
-            mdev_end_row   = ne01;                                                                                                \
         }                                                                                                                         \
                                                                                                                                   \
-        const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;                                                                \
-        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);                                     \
+        const uint32_t nrows = dev_end_row - dev_start_row;                                                                       \
+        uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);                                          \
         src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);                                                          \
                                                                                                                                   \
-        const uint32_t start_row = mdev_start_row + src0_nrows_per_thread * ith;                                                  \
-        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mdev_end_row);                                          \
+        const uint32_t start_row = dev_start_row + src0_nrows_per_thread * ith;                                                   \
+        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, dev_end_row);                                          \
         if (start_row >= end_row) continue;                                                                                       \
                                                                                                                                   \
         uint32_t ct_start = start_row / 32;                                                                                       \
@@ -761,11 +759,11 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
     assert(n_prefetch >= 2 && n_prefetch <= HTP_MM_MAX_PREFETCH && (n_prefetch & (n_prefetch - 1)) == 0);
     const uint32_t prefetch_mask = n_prefetch - 1;
 
-    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;  // src0 rows
+    const uint32_t src0_nrows = mmctx->src0_row_end - mmctx->src0_row_start;  // src0 rows
     const uint32_t src1_nrows = ne11 * ne12 * ne13;                          // src1 rows
 
-    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
+    const uint32_t src0_start_row  = mmctx->src0_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->src0_row_end);
     const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
@@ -859,10 +857,10 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
 static void hvx_mv_2d(unsigned int nth, unsigned int ith, void * data) {
     htp_matmul_preamble;
 
-    const uint32_t src0_nrows = mmctx->mdev_row_end - mmctx->mdev_row_start;
+    const uint32_t src0_nrows = mmctx->src0_row_end - mmctx->src0_row_start;
 
-    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
+    const uint32_t src0_start_row  = mmctx->src0_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->src0_row_end);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
 
@@ -969,13 +967,10 @@ static void hvx_mm_id(unsigned int nth, unsigned int ith, void * data) {
 
     const struct htp_tensor * restrict ids = octx->src[2];
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
-
-    const uint32_t src0_nrows      = mmctx->mdev_row_end - mmctx->mdev_row_start;  // src0 rows per expert
+    const uint32_t src0_nrows      = mmctx->src0_row_end - mmctx->src0_row_start;  // src0 rows per expert
     const uint32_t src1_nrows      = ne11;
-    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
+    const uint32_t src0_start_row  = mmctx->src0_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->src0_row_end);
 
     hvx_mm_run_quant_task(mmctx, ith);
 
@@ -1062,9 +1057,9 @@ static void hvx_mv_id(unsigned int nth, unsigned int ith, void * data) {
 
     const struct htp_tensor * restrict ids = octx->src[2];
 
-    const uint32_t src0_nrows      = mmctx->mdev_row_end - mmctx->mdev_row_start;  // src0 rows per expert
-    const uint32_t src0_start_row  = mmctx->mdev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->mdev_row_end);
+    const uint32_t src0_nrows      = mmctx->src0_row_end - mmctx->src0_row_start;  // src0 rows per expert
+    const uint32_t src0_start_row  = mmctx->src0_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->src0_row_end);
 
     hvx_mm_run_quant_task(mmctx, ith);
 
@@ -1170,32 +1165,30 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             if (!src_w || !dst) continue;
 
             const uint32_t ne01 = src_w->ne[1];
-            uint32_t mdev_start_row, mdev_end_row;
+            uint32_t dev_start_row = 0;
+            uint32_t dev_end_row   = ne01;
             if (octx->mdev_count > 1) {
                 const uint32_t total_chunks = ne01 / 32;
                 if (total_chunks < octx->mdev_count) {
-                    mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                    mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                    dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                    dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
                 } else {
                     const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                    mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                    dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
                     if (octx->mdev_idx == octx->mdev_count - 1) {
-                        mdev_end_row = ne01;
+                        dev_end_row = ne01;
                     } else {
-                        mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);
+                        dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);
                     }
                 }
-            } else {
-                mdev_start_row = 0;
-                mdev_end_row   = ne01;
             }
 
-            const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
-            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
+            const uint32_t nrows = dev_end_row - dev_start_row;
+            uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = mdev_start_row + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mdev_end_row);
+            const uint32_t src0_start_row = dev_start_row + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, dev_end_row);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * restrict src0_row = (const uint8_t *) src_w->data + eid * src_w->nb[2];
@@ -1275,32 +1268,30 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             if (!src_w || !dst) continue;
 
             const uint32_t ne01 = src_w->ne[1];
-            uint32_t mdev_start_row, mdev_end_row;
+            uint32_t dev_start_row = 0;
+            uint32_t dev_end_row   = ne01;
             if (octx->mdev_count > 1) {
                 const uint32_t total_chunks = ne01 / 32;
                 if (total_chunks < octx->mdev_count) {
-                    mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                    mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                    dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                    dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
                 } else {
                     const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                    mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                    dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
                     if (octx->mdev_idx == octx->mdev_count - 1) {
-                        mdev_end_row = ne01;
+                        dev_end_row = ne01;
                     } else {
-                        mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);
+                        dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);
                     }
                 }
-            } else {
-                mdev_start_row = 0;
-                mdev_end_row   = ne01;
             }
 
-            const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
-            uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
+            const uint32_t nrows = dev_end_row - dev_start_row;
+            uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);
             src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);
 
-            const uint32_t src0_start_row = mdev_start_row + src0_nrows_per_thread * ith;
-            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, mdev_end_row);
+            const uint32_t src0_start_row = dev_start_row + src0_nrows_per_thread * ith;
+            const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, dev_end_row);
             if (src0_start_row >= src0_end_row) continue;
 
             const uint8_t * src0_row = (const uint8_t *) src_w->data + cur_a * src_w->nb[2];
@@ -1394,41 +1385,40 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = ne01;
     const uint32_t src1_nrows = ne11 * ne12 * ne13;
 
-    uint32_t mdev_row_start, mdev_row_end;
+    uint32_t src0_row_start = 0;
+    uint32_t src0_row_end   = src0_nrows;
+
     if (octx->mdev_count > 1) {
         const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
         const uint32_t total_chunks = src0_nrows / 32;
         if (!can_split || total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            mdev_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
+            src0_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            src0_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
+            src0_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_row_end = src0_nrows;
+                src0_row_end = src0_nrows;
             } else {
-                mdev_row_end = MIN(mdev_row_start + chunks_per_mdev * 32, src0_nrows);
+                src0_row_end = MIN(src0_row_start + chunks_per_mdev * 32, src0_nrows);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_row_end   = src0_nrows;
     }
 
-    if (mdev_row_start >= mdev_row_end) {
+    if (src0_row_start >= src0_row_end) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
-    mmctx->mdev_row_start = mdev_row_start;
-    mmctx->mdev_row_end   = mdev_row_end;
+    const uint32_t nrows = src0_row_end - src0_row_start;
+    mmctx->src0_row_start = src0_row_start;
+    mmctx->src0_row_end   = src0_row_end;
 
     bool is_repacked = (src0->type == HTP_TYPE_Q4_0 || src0->type == HTP_TYPE_Q4_1 ||
                         src0->type == HTP_TYPE_Q8_0 || src0->type == HTP_TYPE_IQ4_NL ||
                         src0->type == HTP_TYPE_MXFP4);
 
     // Compute src0_nrows_per_thread
-    mmctx->src0_nrows_per_thread  = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->n_threads_div);
+    mmctx->src0_nrows_per_thread  = fastdiv(nrows + octx->n_threads - 1, &octx->n_threads_div);
     if (is_repacked) {
         mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
     } else {
@@ -1680,33 +1670,31 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
 
         const uint32_t ne00 = src_w->ne[0];
         const uint32_t ne01 = src_w->ne[1];
-        uint32_t mdev_start_row, mdev_end_row;
+        uint32_t dev_start_row = 0;
+        uint32_t dev_end_row   = ne01;
         if (octx->mdev_count > 1) {
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
             const uint32_t total_chunks = ne01 / 32;
             if (!can_split || total_chunks < octx->mdev_count) {
-                mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
-                mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                dev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                dev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
             } else {
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                dev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_end_row = ne01;
+                    dev_end_row = ne01;
                 } else {
-                    mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);
+                    dev_end_row = MIN(dev_start_row + chunks_per_mdev * 32, ne01);
                 }
             }
-        } else {
-            mdev_start_row = 0;
-            mdev_end_row   = ne01;
         }
 
-        const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;
-        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);
+        const uint32_t nrows = dev_end_row - dev_start_row;
+        uint32_t src0_nrows_per_thread = fastdiv(nrows + nth - 1, &octx->n_threads_div);
         src0_nrows_per_thread += (src0_nrows_per_thread & 1);
 
-        const uint32_t src0_start_row  = mdev_start_row + src0_nrows_per_thread * ith;
-        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mdev_end_row);
+        const uint32_t src0_start_row  = dev_start_row + src0_nrows_per_thread * ith;
+        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, dev_end_row);
         const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
         if (src0_start_row >= src0_end_row) continue;
 
@@ -2832,28 +2820,28 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
     hmx_init_column_scales(vtcm_scales, Q6_V_vsplat_R(0x3c00));  // scale: 1.0, bias: 0.0 in FP16
 
     int m_start = 0;
-    int m_dev   = m;
+    int m_rows  = m;
     if (octx->mdev_count > 1) {
         if (!htp_tensor_can_row_partition(octx->dsts[0], sizeof(float)) || (uint32_t) m < octx->mdev_count) {
             m_start = (octx->mdev_idx == 0) ? 0 : m;
-            m_dev   = (octx->mdev_idx == 0) ? m : 0;
+            m_rows  = (octx->mdev_idx == 0) ? m : 0;
         } else {
             const int rows_per_mdev = (int) fastdiv(m + octx->mdev_count - 1, &octx->mdev_count_div);
             m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m);
-            m_dev   = MIN(rows_per_mdev, m - m_start);
+            m_rows  = MIN(rows_per_mdev, m - m_start);
         }
     }
 
-    if (m_dev == 0) {
+    if (m_rows == 0) {
         return HTP_STATUS_OK;
     }
 
     FARF(HIGH, "hmx-mm-nx-2d: n_weights %u m %d (%d..%d) k %d wtype %d mc %d nc %d vtcm %zu/%zu",
-         n_weights, m, m_start, m_start + m_dev, k, weight_type, m_chunk_n_rows, n_chunk_n_cols, L.total_bytes, vtcm_budget);
+         n_weights, m, m_start, m_start + m_rows, k, weight_type, m_chunk_n_rows, n_chunk_n_cols, L.total_bytes, vtcm_budget);
 
     htp_trace_event_stop(tr, HTP_TRACE_EVT_INIT, 0);
 
-    const size_t mr_end = (size_t)(m_start + m_dev);
+    const size_t mr_end = (size_t)(m_start + m_rows);
 
     if (pipeline) {
         hmx_matmul_job_t job_slots[2];
@@ -3506,22 +3494,20 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
     const int act_stride = (int)(src1->nb[1] / sizeof(float));
     const int wgt_stride = (int)(src0->nb[1] / sizeof(__fp16));
 
-    int m_start, m_dev;
+    int m_start = 0;
+    int m_rows  = m_total;
     if (octx->mdev_count > 1) {
         if (!htp_tensor_can_row_partition(dst, sizeof(float)) || (uint32_t) m_total < octx->mdev_count) {
             m_start = (octx->mdev_idx == 0) ? 0 : m_total;
-            m_dev   = (octx->mdev_idx == 0) ? m_total : 0;
+            m_rows  = (octx->mdev_idx == 0) ? m_total : 0;
         } else {
             const int rows_per_mdev = (int) fastdiv(m_total + octx->mdev_count - 1, &octx->mdev_count_div);
             m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_total);
-            m_dev   = MIN(rows_per_mdev, m_total - m_start);
+            m_rows  = MIN(rows_per_mdev, m_total - m_start);
         }
-    } else {
-        m_start = 0;
-        m_dev   = m_total;
     }
 
-    if (m_dev == 0) {
+    if (m_rows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -3548,7 +3534,7 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
             .src2            = src2_ptr,
             .activation      = act_ptr,
             .weight          = (const __fp16 *) src0->data,
-            .m               = m_dev,
+            .m               = m_rows,
             .k               = k,
             .n               = n,
             .act_stride      = act_stride,
@@ -3582,7 +3568,7 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
     } else {
         ret = hmx_mm_2d_f32(
             octx->ctx, dst_ptr, src2_ptr, act_ptr, (const uint8_t *) src0->data,
-            m_dev, k, n, act_stride, (int) src0->nb[1], (int) src0->type, (int) src1->ne[0],
+            m_rows, k, n, act_stride, (int) src0->nb[1], (int) src0->type, (int) src1->ne[0],
             dst_stride, src2_stride, (int)dst->ne[0],
             kparams->m_chunk, kparams->n_chunk, kparams->pipeline, n_threads,
             kparams->n_act_threads,
@@ -4029,38 +4015,36 @@ int op_matmul_id(struct htp_ops_context * octx) {
     if (kparams->n_hmx) {
         s = hmx_mm_op_matmul_id(octx, mmctx);
     } else {
-        uint32_t mdev_row_start, mdev_row_end;
+        uint32_t src0_row_start = 0;
+        uint32_t src0_row_end   = src0_nrows;
         if (octx->mdev_count > 1) {
             const uint32_t total_chunks = src0_nrows / 32;
             if (total_chunks < octx->mdev_count) {
-                mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-                mdev_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
+                src0_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+                src0_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
             } else {
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
+                src0_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_row_end = src0_nrows;
+                    src0_row_end = src0_nrows;
                 } else {
-                    mdev_row_end = MIN(mdev_row_start + chunks_per_mdev * 32, src0_nrows);
+                    src0_row_end = MIN(src0_row_start + chunks_per_mdev * 32, src0_nrows);
                 }
             }
-        } else {
-            mdev_row_start = 0;
-            mdev_row_end   = src0_nrows;
         }
 
-        if (mdev_row_start >= mdev_row_end) {
+        if (src0_row_start >= src0_row_end) {
             if (mapping_buf != octx->ctx->ddr_spad_base) {
                 free(mapping_buf);
             }
             return HTP_STATUS_OK;
         }
 
-        const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
-        mmctx->mdev_row_start = mdev_row_start;
-        mmctx->mdev_row_end   = mdev_row_end;
+        const uint32_t nrows = src0_row_end - src0_row_start;
+        mmctx->src0_row_start = src0_row_start;
+        mmctx->src0_row_end   = src0_row_end;
 
-        mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->n_threads_div);
+        mmctx->src0_nrows_per_thread = fastdiv(nrows + octx->n_threads - 1, &octx->n_threads_div);
         mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
 
         if (hvx_mm_init_vec_dot(mmctx, src0->type) == 0) {

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -805,7 +805,7 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
         const uint8_t * ss0 = dma_queue_pop(dma_queue).dst;
 
         htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, ir0);
-        // Process src1 columns in pairs (2×2 tiling)
+        // Process src1 columns in pairs (2x2 tiling)
         uint32_t ir1 = 0;
         for (; ir1 + 1 < src1_nrows; ir1 += 2) {
             const uint8_t * restrict src1_col0 = (const uint8_t *) (src1_data + (ir1+0) * src1_stride);
@@ -815,7 +815,7 @@ static void hvx_mm_2d(unsigned int nth, unsigned int ith, void * data) {
             mmctx->vec_dot_2x2(ne00, &dst_row0[ir0], &dst_row1[ir0], ss0, ss0 + src0_stride, src1_col0, src1_col1);
         }
 
-        // Handle remaining src1 rows (fallback to 2×1)
+        // Handle remaining src1 rows (fallback to 2x1)
         for (; ir1 < src1_nrows; ++ir1) {
             const uint8_t * restrict src1_col = (const uint8_t *) (src1_data + ir1 * src1_stride);
             float * restrict dst_row          = (float *) (dst->data + (ir1 * dst_row_size));

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -21,6 +21,7 @@
 #include "ggml-common.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
+#include "htp-tensor.h"
 #include "matmul-ops.h"
 #include "htp-vtcm.h"
 
@@ -553,22 +554,33 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t n_k_tiles_w = ne00 / 32;                                                                                         \
         uint32_t tile_row_stride = n_k_tiles_w * tile_size;                                                                       \
                                                                                                                                   \
-        uint32_t mdev_start_row, mdev_end_row;                                                                                \
-        if (octx->mdev_count > 1) {                                                                                           \
-            const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);                        \
-            mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);                                                       \
-            mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);                                                       \
-        } else {                                                                                                              \
-            mdev_start_row = 0;                                                                                               \
-            mdev_end_row   = ne01;                                                                                            \
-        }                                                                                                                     \
-                                                                                                                              \
-        const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;                                                            \
-        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);                                \
+        uint32_t mdev_start_row, mdev_end_row;                                                                                    \
+        if (octx->mdev_count > 1) {                                                                                               \
+            const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));                                              \
+            const uint32_t total_chunks = ne01 / 32;                                                                              \
+            if (!can_split || total_chunks < octx->mdev_count) {                                                                  \
+                mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;                                                                \
+                mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;                                                             \
+            } else {                                                                                                              \
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);             \
+                mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);                                                \
+                if (octx->mdev_idx == octx->mdev_count - 1) {                                                                     \
+                    mdev_end_row = ne01;                                                                                          \
+                } else {                                                                                                          \
+                    mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);                                              \
+                }                                                                                                                 \
+            }                                                                                                                     \
+        } else {                                                                                                                  \
+            mdev_start_row = 0;                                                                                                   \
+            mdev_end_row   = ne01;                                                                                                \
+        }                                                                                                                         \
+                                                                                                                                  \
+        const uint32_t mdev_nrows = mdev_end_row - mdev_start_row;                                                                \
+        uint32_t src0_nrows_per_thread = fastdiv(mdev_nrows + nth - 1, &octx->n_threads_div);                                     \
         src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);                                                          \
                                                                                                                                   \
-        const uint32_t start_row = mdev_start_row + src0_nrows_per_thread * ith;                                           \
-        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mdev_end_row);                                   \
+        const uint32_t start_row = mdev_start_row + src0_nrows_per_thread * ith;                                                  \
+        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mdev_end_row);                                          \
         if (start_row >= end_row) continue;                                                                                       \
                                                                                                                                   \
         uint32_t ct_start = start_row / 32;                                                                                       \
@@ -1384,9 +1396,20 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_row_end;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
+        const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
+        const uint32_t total_chunks = src0_nrows / 32;
+        if (!can_split || total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            mdev_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_row_end = src0_nrows;
+            } else {
+                mdev_row_end = MIN(mdev_row_start + chunks_per_mdev * 32, src0_nrows);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_row_end   = src0_nrows;
@@ -1659,9 +1682,20 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
         const uint32_t ne01 = src_w->ne[1];
         uint32_t mdev_start_row, mdev_end_row;
         if (octx->mdev_count > 1) {
-            const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
-            mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
+            const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
+            const uint32_t total_chunks = ne01 / 32;
+            if (!can_split || total_chunks < octx->mdev_count) {
+                mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+            } else {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_end_row = ne01;
+                } else {
+                    mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);
+                }
+            }
         } else {
             mdev_start_row = 0;
             mdev_end_row   = ne01;
@@ -2798,23 +2832,28 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
     hmx_init_column_scales(vtcm_scales, Q6_V_vsplat_R(0x3c00));  // scale: 1.0, bias: 0.0 in FP16
 
     int m_start = 0;
-    int m_core  = m;
+    int m_dev   = m;
     if (octx->mdev_count > 1) {
-        const int rows_per_mdev = (int) fastdiv(m + octx->mdev_count - 1, &octx->mdev_count_div);
-        m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m);
-        m_core  = MIN(rows_per_mdev, m - m_start);
+        if (!htp_tensor_can_row_partition(octx->dsts[0], sizeof(float)) || (uint32_t) m < octx->mdev_count) {
+            m_start = (octx->mdev_idx == 0) ? 0 : m;
+            m_dev   = (octx->mdev_idx == 0) ? m : 0;
+        } else {
+            const int rows_per_mdev = (int) fastdiv(m + octx->mdev_count - 1, &octx->mdev_count_div);
+            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m);
+            m_dev   = MIN(rows_per_mdev, m - m_start);
+        }
     }
 
-    if (m_core == 0) {
+    if (m_dev == 0) {
         return HTP_STATUS_OK;
     }
 
     FARF(HIGH, "hmx-mm-nx-2d: n_weights %u m %d (%d..%d) k %d wtype %d mc %d nc %d vtcm %zu/%zu",
-         n_weights, m, m_start, m_start + m_core, k, weight_type, m_chunk_n_rows, n_chunk_n_cols, L.total_bytes, vtcm_budget);
+         n_weights, m, m_start, m_start + m_dev, k, weight_type, m_chunk_n_rows, n_chunk_n_cols, L.total_bytes, vtcm_budget);
 
     htp_trace_event_stop(tr, HTP_TRACE_EVT_INIT, 0);
 
-    const size_t mr_end = (size_t)(m_start + m_core);
+    const size_t mr_end = (size_t)(m_start + m_dev);
 
     if (pipeline) {
         hmx_matmul_job_t job_slots[2];
@@ -3469,9 +3508,14 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
 
     int m_start, m_dev;
     if (octx->mdev_count > 1) {
-        const int rows_per_mdev = (int) fastdiv(m_total + octx->mdev_count - 1, &octx->mdev_count_div);
-        m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_total);
-        m_dev   = MIN(rows_per_mdev, m_total - m_start);
+        if (!htp_tensor_can_row_partition(dst, sizeof(float)) || (uint32_t) m_total < octx->mdev_count) {
+            m_start = (octx->mdev_idx == 0) ? 0 : m_total;
+            m_dev   = (octx->mdev_idx == 0) ? m_total : 0;
+        } else {
+            const int rows_per_mdev = (int) fastdiv(m_total + octx->mdev_count - 1, &octx->mdev_count_div);
+            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_total);
+            m_dev   = MIN(rows_per_mdev, m_total - m_start);
+        }
     } else {
         m_start = 0;
         m_dev   = m_total;

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -2713,10 +2713,6 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
     const struct htp_tensor * restrict src0 = octx->src[0];
     const struct htp_tensor * restrict act  = octx->src[n_weights];
 
-    if (!src0 || !act) {
-        return HTP_STATUS_INVAL_PARAMS;
-    }
-
     const int weight_type = (int) src0->type;
     const int k           = (int) act->ne[0];
     const int k_valid     = (int) act->ne[0];

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -558,19 +558,9 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t src0_end_row   = ne01;                                                                                           \
         if (octx->ctx->mdev.count > 1) {                                                                                          \
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));                                              \
-            const uint32_t total_chunks = ne01 / 32;                                                                              \
-            if (!can_split || total_chunks < octx->ctx->mdev.count) {                                                             \
-                src0_start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;                                                           \
-                src0_end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;                                                        \
-            } else {                                                                                                              \
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);   \
-                src0_start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);                                           \
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {                                                           \
-                    src0_end_row = ne01;                                                                                          \
-                } else {                                                                                                          \
-                    src0_end_row = MIN(src0_start_row + chunks_per_mdev * 32, ne01);                                              \
-                }                                                                                                                 \
-            }                                                                                                                     \
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(ne01, can_split ? 32 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div); \
+            src0_start_row = range.start;                                                                                         \
+            src0_end_row   = range.start + range.count;                                                                            \
         }                                                                                                                         \
                                                                                                                                   \
         const uint32_t nrows = src0_end_row - src0_start_row;                                                                     \
@@ -1168,19 +1158,10 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             uint32_t start_row = 0;
             uint32_t end_row   = ne01;
             if (octx->ctx->mdev.count > 1) {
-                const uint32_t total_chunks = ne01 / 32;
-                if (total_chunks < octx->ctx->mdev.count) {
-                    start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;
-                    end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;
-                } else {
-                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                    start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);
-                    if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                        end_row = ne01;
-                    } else {
-                        end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
-                    }
-                }
+                const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
+                const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(ne01, can_split ? 32 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+                start_row = range.start;
+                end_row   = range.start + range.count;
             }
 
             const uint32_t nrows = end_row - start_row;
@@ -1271,19 +1252,10 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             uint32_t start_row = 0;
             uint32_t end_row   = ne01;
             if (octx->ctx->mdev.count > 1) {
-                const uint32_t total_chunks = ne01 / 32;
-                if (total_chunks < octx->ctx->mdev.count) {
-                    start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;
-                    end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;
-                } else {
-                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                    start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);
-                    if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                        end_row = ne01;
-                    } else {
-                        end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
-                    }
-                }
+                const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
+                const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(ne01, can_split ? 32 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+                start_row = range.start;
+                end_row   = range.start + range.count;
             }
 
             const uint32_t nrows = end_row - start_row;
@@ -1390,19 +1362,9 @@ static int hvx_mm_matmul(struct htp_ops_context * octx) {
 
     if (octx->ctx->mdev.count > 1) {
         const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
-        const uint32_t total_chunks = src0_nrows / 32;
-        if (!can_split || total_chunks < octx->ctx->mdev.count) {
-            src0_row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
-            src0_row_end   = (octx->ctx->mdev.idx == 0) ? src0_nrows : src0_nrows;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            src0_row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, src0_nrows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                src0_row_end = src0_nrows;
-            } else {
-                src0_row_end = MIN(src0_row_start + chunks_per_mdev * 32, src0_nrows);
-            }
-        }
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(src0_nrows, can_split ? 32 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        src0_row_start = range.start;
+        src0_row_end   = range.start + range.count;
     }
 
     if (src0_row_start >= src0_row_end) {
@@ -1674,19 +1636,9 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
         uint32_t end_row   = ne01;
         if (octx->ctx->mdev.count > 1) {
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
-            const uint32_t total_chunks = ne01 / 32;
-            if (!can_split || total_chunks < octx->ctx->mdev.count) {
-                start_row = (octx->ctx->mdev.idx == 0) ? 0 : ne01;
-                end_row   = (octx->ctx->mdev.idx == 0) ? ne01 : ne01;
-            } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                start_row = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, ne01);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    end_row = ne01;
-                } else {
-                    end_row = MIN(start_row + chunks_per_mdev * 32, ne01);
-                }
-            }
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(ne01, can_split ? 32 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            start_row = range.start;
+            end_row   = range.start + range.count;
         }
 
         const uint32_t nrows = end_row - start_row;
@@ -2822,14 +2774,10 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
     int m_start = 0;
     int m_rows  = m;
     if (octx->ctx->mdev.count > 1) {
-        if (!htp_tensor_can_row_partition(octx->dsts[0], sizeof(float)) || (uint32_t) m < octx->ctx->mdev.count) {
-            m_start = (octx->ctx->mdev.idx == 0) ? 0 : m;
-            m_rows  = (octx->ctx->mdev.idx == 0) ? m : 0;
-        } else {
-            const int rows_per_mdev = (int) fastdiv(m + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m);
-            m_rows  = MIN(rows_per_mdev, m - m_start);
-        }
+        const bool can_split = htp_tensor_can_row_partition(octx->dsts[0], sizeof(float));
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition((uint32_t) m, can_split ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        m_start = (int) range.start;
+        m_rows  = (int) range.count;
     }
 
     if (m_rows == 0) {
@@ -3497,14 +3445,10 @@ static int hmx_mm_op_matmul(struct htp_ops_context * octx, const struct htp_mm_k
     int m_start = 0;
     int m_rows  = m_total;
     if (octx->ctx->mdev.count > 1) {
-        if (!htp_tensor_can_row_partition(dst, sizeof(float)) || (uint32_t) m_total < octx->ctx->mdev.count) {
-            m_start = (octx->ctx->mdev.idx == 0) ? 0 : m_total;
-            m_rows  = (octx->ctx->mdev.idx == 0) ? m_total : 0;
-        } else {
-            const int rows_per_mdev = (int) fastdiv(m_total + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m_total);
-            m_rows  = MIN(rows_per_mdev, m_total - m_start);
-        }
+        const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition((uint32_t) m_total, can_split ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        m_start = (int) range.start;
+        m_rows  = (int) range.count;
     }
 
     if (m_rows == 0) {
@@ -3613,13 +3557,10 @@ static int hmx_mm_op_matmul_id(
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
         if (octx->ctx->mdev.count > 1) {
-            if ((uint32_t) cne1 < octx->ctx->mdev.count) {
-                if (octx->ctx->mdev.idx > 0) continue;
-            } else {
-                const int rows_per_mdev = (int) fastdiv(m_padded + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m_padded);
-                m_end   = MIN(m_start + rows_per_mdev, m_padded);
-            }
+            const bool can_split = htp_tensor_mdev_data_aligned(dst) && (uint32_t) cne1 >= octx->ctx->mdev.count;
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition((uint32_t) m_padded, can_split ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            m_start = (int) range.start;
+            m_end   = (int) (range.start + range.count);
         }
         if (m_start >= m_end) continue;
 
@@ -3751,13 +3692,14 @@ static int hmx_mm_op_matmul_id_nx(
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
         if (octx->ctx->mdev.count > 1) {
-            if ((uint32_t) cne1 < octx->ctx->mdev.count) {
-                if (octx->ctx->mdev.idx > 0) continue;
-            } else {
-                const int rows_per_mdev = (int) fastdiv(m_padded + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                m_start = MIN((int)(octx->ctx->mdev.idx * rows_per_mdev), m_padded);
-                m_end   = MIN(m_start + rows_per_mdev, m_padded);
+            bool can_split = (uint32_t) cne1 >= octx->ctx->mdev.count;
+            for (uint32_t p = 0; p < n_weights && can_split; ++p) {
+                const struct htp_tensor * restrict dst = octx->dsts[p];
+                can_split = !dst || htp_tensor_mdev_data_aligned(dst);
             }
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition((uint32_t) m_padded, can_split ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            m_start = (int) range.start;
+            m_end   = (int) (range.start + range.count);
         }
         if (m_start >= m_end) continue;
 
@@ -4018,19 +3960,10 @@ int op_matmul_id(struct htp_ops_context * octx) {
         uint32_t src0_row_start = 0;
         uint32_t src0_row_end   = src0_nrows;
         if (octx->ctx->mdev.count > 1) {
-            const uint32_t total_chunks = src0_nrows / 32;
-            if (total_chunks < octx->ctx->mdev.count) {
-                src0_row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
-                src0_row_end   = (octx->ctx->mdev.idx == 0) ? src0_nrows : src0_nrows;
-            } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                src0_row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * 32, src0_nrows);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    src0_row_end = src0_nrows;
-                } else {
-                    src0_row_end = MIN(src0_row_start + chunks_per_mdev * 32, src0_nrows);
-                }
-            }
+            const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(src0_nrows, can_split ? 32 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            src0_row_start = range.start;
+            src0_row_end   = range.start + range.count;
         }
 
         if (src0_row_start >= src0_row_end) {

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -1160,9 +1160,19 @@ static void hvx_mv_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const uint32_t ne01 = src_w->ne[1];
             uint32_t mdev_start_row, mdev_end_row;
             if (octx->mdev_count > 1) {
-                const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
-                mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
+                const uint32_t total_chunks = ne01 / 32;
+                if (total_chunks < octx->mdev_count) {
+                    mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                    mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                } else {
+                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                    mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                    if (octx->mdev_idx == octx->mdev_count - 1) {
+                        mdev_end_row = ne01;
+                    } else {
+                        mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);
+                    }
+                }
             } else {
                 mdev_start_row = 0;
                 mdev_end_row   = ne01;
@@ -1255,9 +1265,19 @@ static void hvx_mm_id_nx(unsigned int nth, unsigned int ith, void * data) {
             const uint32_t ne01 = src_w->ne[1];
             uint32_t mdev_start_row, mdev_end_row;
             if (octx->mdev_count > 1) {
-                const uint32_t rows_per_mdev = fastdiv(ne01 + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_start_row = MIN(octx->mdev_idx * rows_per_mdev, ne01);
-                mdev_end_row   = MIN(mdev_start_row + rows_per_mdev, ne01);
+                const uint32_t total_chunks = ne01 / 32;
+                if (total_chunks < octx->mdev_count) {
+                    mdev_start_row = (octx->mdev_idx == 0) ? 0 : ne01;
+                    mdev_end_row   = (octx->mdev_idx == 0) ? ne01 : ne01;
+                } else {
+                    const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                    mdev_start_row = MIN(octx->mdev_idx * chunks_per_mdev * 32, ne01);
+                    if (octx->mdev_idx == octx->mdev_count - 1) {
+                        mdev_end_row = ne01;
+                    } else {
+                        mdev_end_row = MIN(mdev_start_row + chunks_per_mdev * 32, ne01);
+                    }
+                }
             } else {
                 mdev_start_row = 0;
                 mdev_end_row   = ne01;
@@ -3563,9 +3583,13 @@ static int hmx_mm_op_matmul_id(
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
         if (octx->mdev_count > 1) {
-            const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
-            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
-            m_end   = MIN(m_start + rows_per_mdev, m_padded);
+            if ((uint32_t) cne1 < octx->mdev_count) {
+                if (octx->mdev_idx > 0) continue;
+            } else {
+                const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
+                m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
+                m_end   = MIN(m_start + rows_per_mdev, m_padded);
+            }
         }
         if (m_start >= m_end) continue;
 
@@ -3697,9 +3721,13 @@ static int hmx_mm_op_matmul_id_nx(
         const int m_padded = hex_align_up(cne1, 32);
         int m_start = 0, m_end = m_padded;
         if (octx->mdev_count > 1) {
-            const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
-            m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
-            m_end   = MIN(m_start + rows_per_mdev, m_padded);
+            if ((uint32_t) cne1 < octx->mdev_count) {
+                if (octx->mdev_idx > 0) continue;
+            } else {
+                const int rows_per_mdev = (int) fastdiv(m_padded + octx->mdev_count - 1, &octx->mdev_count_div);
+                m_start = MIN((int)(octx->mdev_idx * rows_per_mdev), m_padded);
+                m_end   = MIN(m_start + rows_per_mdev, m_padded);
+            }
         }
         if (m_start >= m_end) continue;
 
@@ -3906,27 +3934,6 @@ int op_matmul_id(struct htp_ops_context * octx) {
     const uint32_t src0_nrows = ne01;  // per expert
     const uint32_t src1_nrows = ne11 * ne12 * ne13;
 
-    uint32_t mdev_row_start, mdev_row_end;
-    if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_row_end   = MIN(mdev_row_start + rows_per_mdev, src0_nrows);
-    } else {
-        mdev_row_start = 0;
-        mdev_row_end   = src0_nrows;
-    }
-
-    if (mdev_row_start >= mdev_row_end) {
-        return HTP_STATUS_OK;
-    }
-
-    const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
-    mmctx->mdev_row_start = mdev_row_start;
-    mmctx->mdev_row_end   = mdev_row_end;
-
-    mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->n_threads_div);
-    mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
-
     // row groups
     const int n_ids = ids->ne[0];  // n_expert_used
     const int n_as  = ne02;        // n_expert
@@ -3978,6 +3985,40 @@ int op_matmul_id(struct htp_ops_context * octx) {
     if (kparams->n_hmx) {
         s = hmx_mm_op_matmul_id(octx, mmctx);
     } else {
+        uint32_t mdev_row_start, mdev_row_end;
+        if (octx->mdev_count > 1) {
+            const uint32_t total_chunks = src0_nrows / 32;
+            if (total_chunks < octx->mdev_count) {
+                mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+                mdev_row_end   = (octx->mdev_idx == 0) ? src0_nrows : src0_nrows;
+            } else {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * 32, src0_nrows);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_row_end = src0_nrows;
+                } else {
+                    mdev_row_end = MIN(mdev_row_start + chunks_per_mdev * 32, src0_nrows);
+                }
+            }
+        } else {
+            mdev_row_start = 0;
+            mdev_row_end   = src0_nrows;
+        }
+
+        if (mdev_row_start >= mdev_row_end) {
+            if (mapping_buf != octx->ctx->ddr_spad_base) {
+                free(mapping_buf);
+            }
+            return HTP_STATUS_OK;
+        }
+
+        const uint32_t mdev_nrows = mdev_row_end - mdev_row_start;
+        mmctx->mdev_row_start = mdev_row_start;
+        mmctx->mdev_row_end   = mdev_row_end;
+
+        mmctx->src0_nrows_per_thread = fastdiv(mdev_nrows + octx->n_threads - 1, &octx->n_threads_div);
+        mmctx->src0_nrows_per_thread = hex_round_up(mmctx->src0_nrows_per_thread, 32);
+
         if (hvx_mm_init_vec_dot(mmctx, src0->type) == 0) {
             s = hvx_mm_matmul_id(octx, mmctx, src1_nrows > 1 ? hvx_mm_id : hvx_mv_id);
         } else {

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -314,11 +314,11 @@ static void hvx_mm_4d(unsigned int nth, unsigned int ith, void * data) {
 static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                      \
+    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                        \
     const uint32_t src1_nrows = ne11 * ne12 * ne13;                                                                               \
                                                                                                                                   \
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                         \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                            \
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                          \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                             \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -416,10 +416,10 @@ static void hvx_mm_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void
 static void hvx_mv_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, void * data) {                                        \
     htp_matmul_preamble;                                                                                                          \
                                                                                                                                   \
-    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                      \
+    const uint32_t src0_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                        \
                                                                                                                                   \
-    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                         \
-    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                            \
+    const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                          \
+    const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);                             \
                                                                                                                                   \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                                        \
                                                                                                                                   \
@@ -551,12 +551,12 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t n_k_tiles_w = ne00 / 32;                                                                                         \
         uint32_t tile_row_stride = n_k_tiles_w * tile_size;                                                                       \
                                                                                                                                   \
-        const uint32_t src0_nrows = ne01 * src_w->ne[2] * src_w->ne[3];                                                           \
-        uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);                                \
+        const uint32_t dev_nrows = mmctx->dev_row_end - mmctx->dev_row_start;                                                     \
+        uint32_t src0_nrows_per_thread = fastdiv(dev_nrows + nth - 1, &octx->ctx->n_threads_div);                                 \
         src0_nrows_per_thread = hex_round_up(src0_nrows_per_thread, 32);                                                          \
                                                                                                                                   \
-        const uint32_t start_row = src0_nrows_per_thread * ith;                                                                   \
-        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, src0_nrows);                                            \
+        const uint32_t start_row = mmctx->dev_row_start + src0_nrows_per_thread * ith;                                            \
+        const uint32_t end_row   = MIN(start_row + src0_nrows_per_thread, mmctx->dev_row_end);                                    \
         if (start_row >= end_row) continue;                                                                                       \
                                                                                                                                   \
         uint32_t ct_start = start_row / 32;                                                                                       \
@@ -1603,13 +1603,12 @@ static void hvx_mm_nx_2d(unsigned int nth, unsigned int ith, void * data) {
 
         const uint32_t ne00 = src_w->ne[0];
         const uint32_t ne01 = src_w->ne[1];
-        const uint32_t src0_nrows = ne01 * src_w->ne[2] * src_w->ne[3];
-
-        uint32_t src0_nrows_per_thread = fastdiv(src0_nrows + nth - 1, &octx->ctx->n_threads_div);
+        const uint32_t dev_nrows = mmctx->dev_row_end - mmctx->dev_row_start;
+        uint32_t src0_nrows_per_thread = fastdiv(dev_nrows + nth - 1, &octx->ctx->n_threads_div);
         src0_nrows_per_thread += (src0_nrows_per_thread & 1);
 
-        const uint32_t src0_start_row  = src0_nrows_per_thread * ith;
-        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+        const uint32_t src0_start_row  = mmctx->dev_row_start + src0_nrows_per_thread * ith;
+        const uint32_t src0_end_row    = MIN(src0_start_row + src0_nrows_per_thread, mmctx->dev_row_end);
         const uint32_t src0_end_row_x2 = src0_start_row + ((src0_end_row - src0_start_row) & ~1U);
         if (src0_start_row >= src0_end_row) continue;
 
@@ -2734,16 +2733,30 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
 
     hmx_init_column_scales(vtcm_scales, Q6_V_vsplat_R(0x3c00));  // scale: 1.0, bias: 0.0 in FP16
 
-    FARF(HIGH, "hmx-mm-nx-2d: n_weights %u m %d k %d wtype %d mc %d nc %d vtcm %zu/%zu",
-         n_weights, m, k, weight_type, m_chunk_n_rows, n_chunk_n_cols, L.total_bytes, vtcm_budget);
+    int m_start = 0;
+    int m_core  = m;
+    if (octx->ndev > 1) {
+        const int rows_per_dev = (m + octx->ndev - 1) / octx->ndev;
+        m_start = MIN((int)(octx->idev * rows_per_dev), m);
+        m_core  = MIN(rows_per_dev, m - m_start);
+    }
+
+    if (m_core == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    FARF(HIGH, "hmx-mm-nx-2d: n_weights %u m %d (%d..%d) k %d wtype %d mc %d nc %d vtcm %zu/%zu",
+         n_weights, m, m_start, m_start + m_core, k, weight_type, m_chunk_n_rows, n_chunk_n_cols, L.total_bytes, vtcm_budget);
 
     htp_trace_event_stop(tr, HTP_TRACE_EVT_INIT, 0);
+
+    const size_t mr_end = (size_t)(m_start + m_core);
 
     if (pipeline) {
         hmx_matmul_job_t job_slots[2];
 
-        for (size_t mr = 0; mr < (size_t) m; mr += m_chunk_n_rows) {
-            const size_t n_rows = hex_smin(m - mr, m_chunk_n_rows);
+        for (size_t mr = (size_t) m_start; mr < mr_end; mr += m_chunk_n_rows) {
+            const size_t n_rows = hex_smin(mr_end - mr, m_chunk_n_rows);
 
             void *vtcm_weight_bufs[2] = { vtcm_scratch0, vtcm_scratch1 };
             void *vtcm_output_bufs[2] = { vtcm_output,   vtcm_scratch2 };
@@ -2842,8 +2855,8 @@ static int hmx_mm_nx_2d_f32(struct htp_ops_context * octx, const struct htp_mm_k
         }
     } else {
         hmx_matmul_job_t job;
-        for (size_t mr = 0; mr < (size_t) m; mr += m_chunk_n_rows) {
-            const size_t n_rows = hex_smin(m - mr, m_chunk_n_rows);
+        for (size_t mr = (size_t) m_start; mr < mr_end; mr += m_chunk_n_rows) {
+            const size_t n_rows = hex_smin(mr_end - mr, m_chunk_n_rows);
 
             struct activation_transfer_params act_params = {
                 .ctx = ctx,
@@ -3236,7 +3249,9 @@ static int hmx_mm_id_2d_f32(struct htp_context *ctx,
                                          int weight_type,
                                          const struct mmid_row_mapping *matrix_rows,
                                          int cur_a,
-                                         int mapping_stride) {
+                                         int mapping_stride,
+                                         int m_start,
+                                         int m_end) {
     struct htp_thread_trace * tr = &ctx->trace[0];
     htp_trace_event_start(tr, HTP_TRACE_EVT_INIT, 0);
 
@@ -3323,8 +3338,8 @@ static int hmx_mm_id_2d_f32(struct htp_context *ctx,
 
     hmx_matmul_job_t job;
 
-    for (size_t mr = 0; mr < (size_t) m_padded; mr += m_chunk_n_rows) {
-        const size_t n_rows = hex_smin(m_padded - mr, m_chunk_n_rows);
+    for (size_t mr = (size_t) m_start; mr < (size_t) m_end; mr += m_chunk_n_rows) {
+        const size_t n_rows = hex_smin((size_t) m_end - mr, m_chunk_n_rows);
         const size_t n_row_tiles = hmx_ceil_div(n_rows, HTP_MM_HMX_TILE_N_ROWS);
 
         transfer_activation_chunk_gathered_threaded(
@@ -3501,6 +3516,15 @@ static int hmx_mm_op_matmul_id(
         const int32_t cne1 = matrix_row_counts[cur_a];
         if (cne1 == 0) continue;
 
+        const int m_padded = hex_align_up(cne1, 32);
+        int m_start = 0, m_end = m_padded;
+        if (octx->ndev > 1) {
+            const int rows_per_dev = (m_padded + (int) octx->ndev - 1) / (int) octx->ndev;
+            m_start = MIN((int)(octx->idev * rows_per_dev), m_padded);
+            m_end   = MIN(m_start + rows_per_dev, m_padded);
+        }
+        if (m_start >= m_end) continue;
+
         int ret = hmx_mm_id_2d_f32(octx->ctx, (float*) dst->data, (float*) src1->data,
                                    (const uint8_t *) src0->data + cur_a * nb02,
                                    cne1, ne00, ne01,
@@ -3509,7 +3533,8 @@ static int hmx_mm_op_matmul_id(
                                    nb11, nb12,
                                    nb1, nb2,
                                    (int) src0->nb[1], (int) src0->type,
-                                   matrix_rows, cur_a, mmctx->mapping_stride);
+                                   matrix_rows, cur_a, mmctx->mapping_stride,
+                                   m_start, m_end);
         if (ret != 0) {
             FARF(ERROR, "HMX matmul failed for expert %u, error %d\n", cur_a, ret);
             return HTP_STATUS_NO_SUPPORT;
@@ -3625,6 +3650,15 @@ static int hmx_mm_op_matmul_id_nx(
         const int32_t cne1 = matrix_row_counts[cur_a];
         if (cne1 == 0) continue;
 
+        const int m_padded = hex_align_up(cne1, 32);
+        int m_start = 0, m_end = m_padded;
+        if (octx->ndev > 1) {
+            const int rows_per_dev = (m_padded + (int) octx->ndev - 1) / (int) octx->ndev;
+            m_start = MIN((int)(octx->idev * rows_per_dev), m_padded);
+            m_end   = MIN(m_start + rows_per_dev, m_padded);
+        }
+        if (m_start >= m_end) continue;
+
         for (uint32_t p = 0; p < n_weights; ++p) {
             const struct htp_tensor * restrict src_w = octx->src[p];
             const struct htp_tensor * restrict dst   = octx->dsts[p];
@@ -3638,7 +3672,8 @@ static int hmx_mm_op_matmul_id_nx(
                                        act->nb[1], act->nb[2],
                                        dst->nb[1], dst->nb[2],
                                        (int) src_w->nb[1], (int) src_w->type,
-                                       matrix_rows, cur_a, mmctx->mapping_stride);
+                                       matrix_rows, cur_a, mmctx->mapping_stride,
+                                       m_start, m_end);
             if (ret != 0) {
                 FARF(ERROR, "HMX matmul ID NX failed for expert %u weight %u, error %d\n", cur_a, p, ret);
                 return HTP_STATUS_NO_SUPPORT;
@@ -4042,6 +4077,25 @@ int op_matmul_nx(struct htp_ops_context * octx) {
     mmctx->act  = act;
 
     const uint32_t src1_nrows = act->ne[1] * act->ne[2] * act->ne[3];
+
+    const uint32_t src0_nrows = src0->ne[1];
+
+    uint32_t dev_row_start, dev_row_end;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_row_end   = MIN(dev_row_start + rows_per_dev, src0_nrows);
+    } else {
+        dev_row_start = 0;
+        dev_row_end   = src0_nrows;
+    }
+
+    if (dev_row_start >= dev_row_end) {
+        return HTP_STATUS_OK;
+    }
+
+    mmctx->dev_row_start = dev_row_start;
+    mmctx->dev_row_end   = dev_row_end;
 
     const size_t src0_row_size = src0->nb[1];
     const size_t src0_row_size_padded = hex_round_up(src0_row_size, 128);

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -558,9 +558,10 @@ static void hvx_mm_nx_2d_repacked_##SUFFIX(unsigned int nth, unsigned int ith, v
         uint32_t src0_end_row   = ne01;                                                                                           \
         if (octx->ctx->mdev.count > 1) {                                                                                          \
             const bool can_split = htp_tensor_can_row_partition(dst, sizeof(float));                                              \
-            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(ne01, can_split ? 32 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div); \
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(ne01, can_split ? 32 : 0,                        \
+                                                         octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div); \
             src0_start_row = range.start;                                                                                         \
-            src0_end_row   = range.start + range.count;                                                                            \
+            src0_end_row   = range.start + range.count;                                                                           \
         }                                                                                                                         \
                                                                                                                                   \
         const uint32_t nrows = src0_end_row - src0_start_row;                                                                     \

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -109,12 +109,12 @@ struct htp_pad_context {
     const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->row_start + pctx->total_dst_rows);
 
 
-#define htp_pad_dma_preamble                                        \
-    const size_t src_row_size         = pctx->src_row_size;         \
-    const size_t src_row_size_aligned = pctx->src_row_size_aligned; \
-    const size_t dst_row_size         = pctx->dst_row_size;         \
-    const size_t dst_row_size_aligned = pctx->dst_row_size_aligned; \
-                                                                    \
+#define htp_pad_dma_preamble                                                                \
+    const size_t src_row_size         = pctx->src_row_size;                                 \
+    const size_t src_row_size_aligned = pctx->src_row_size_aligned;                         \
+    const size_t dst_row_size         = pctx->dst_row_size;                                 \
+    const size_t dst_row_size_aligned = pctx->dst_row_size_aligned;                         \
+                                                                                            \
     uint8_t * src_spad_base = octx->src0_spad.data + ith * octx->src0_spad.size_per_thread; \
     uint8_t * dst_spad_base = octx->dst_spad.data  + ith * octx->dst_spad.size_per_thread;  \
                                                                                             \
@@ -223,7 +223,6 @@ static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void 
     // push dst DMA and prefetch src for the next+1 row.
     // -----------------------------------------------------------------------
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
     for (uint32_t ir = row_start; ir < row_end; ir++) {
         uint8_t * dst_spad_cur = (uint8_t *) dma_queue_pop(dma).src;
@@ -239,6 +238,7 @@ static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void 
                                              lp2, rp2, ne2,
                                              lp3, rp3, ne3);
 
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         if (!interior) {
             hvx_splat_f32_a(dst_spad_cur, 0.0f, ne0);
         } else {
@@ -252,6 +252,7 @@ static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void 
                 hvx_copy_f32_ua(dst_interior, src_spad_cur, ne00);
             }
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         dma_queue_push_vtcm_to_ddr(dma,
             dma_make_ptr(dst_ptr, dst_spad_cur),
@@ -274,8 +275,6 @@ static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void 
                 src_row_size_aligned, src_row_size, next_src_ptr ? 1 : 0);
         }
     }
-
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
     dma_queue_flush(dma);
 
@@ -389,7 +388,6 @@ static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int i
     // aligned HVX ops, push dst DMA and prefetch src for the next+1 row.
     // -----------------------------------------------------------------------
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
-    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
     for (uint32_t ir = row_start; ir < row_end; ir++) {
         uint8_t * dst_spad_cur = (uint8_t *) dma_queue_pop(dma).src;
@@ -399,7 +397,7 @@ static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int i
         pad_decompose_row(ir, ne1, ne2, &i1, &i2, &i3);
         uint8_t * dst_ptr = (uint8_t *) dst->data + i1 * nb1 + i2 * nb2 + i3 * nb3;
 
-
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
         if (lp0 > 0) {
             uint8_t * dst_left       = dst_spad_cur;
             const uint8_t * src_left = src_spad_cur + (size_t)(ne00 - (uint32_t)lp0) * type_size;
@@ -431,6 +429,7 @@ static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int i
                 }
             }
         }
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir);
 
         dma_queue_push_vtcm_to_ddr(dma,
             dma_make_ptr(dst_ptr, dst_spad_cur),
@@ -446,8 +445,6 @@ static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int i
                 src_row_size_aligned, src_row_size, 1);
         }
     }
-
-    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
     dma_queue_flush(dma);
 

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -512,9 +512,7 @@ int op_pad(struct htp_ops_context * octx) {
     // Total VTCM needed: 2 buffers (ping+pong) for src and dst, per thread
     const size_t vtcm_needed = (size_t)n_threads * 2 * (src_row_size_aligned + dst_row_size_aligned);
 
-    const int use_dma = (src0->nb[0] == (uint32_t)type_size) &&
-                        (ne00 >= 512) &&
-                        (octx->ctx->vtcm_base != NULL) &&
+    const int use_dma = (src0->nb[0] == (uint32_t)type_size) && (ne00 >= 512) &&
                         (octx->ctx->vtcm_size >= vtcm_needed);
 
     if (use_dma) {

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -105,7 +105,7 @@ struct htp_pad_context {
                                                                                      \
     const size_t type_size = pctx->type_size;                                        \
                                                                                      \
-    const uint32_t row_start = pctx->row_start + pctx->nrows_per_thread * ith;  \
+    const uint32_t row_start = pctx->row_start + pctx->nrows_per_thread * ith;       \
     const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->row_start + pctx->total_dst_rows);
 
 

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -71,7 +71,7 @@ struct htp_pad_context {
 
     uint32_t nrows_per_thread;
     uint32_t total_dst_rows;
-    uint32_t mdev_row_start;
+    uint32_t row_start;
 
     size_t   type_size;
 
@@ -105,8 +105,8 @@ struct htp_pad_context {
                                                                                      \
     const size_t type_size = pctx->type_size;                                        \
                                                                                      \
-    const uint32_t row_start = pctx->mdev_row_start + pctx->nrows_per_thread * ith;  \
-    const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->mdev_row_start + pctx->total_dst_rows);
+    const uint32_t row_start = pctx->row_start + pctx->nrows_per_thread * ith;  \
+    const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->row_start + pctx->total_dst_rows);
 
 
 #define htp_pad_dma_preamble                                        \
@@ -491,7 +491,9 @@ int op_pad(struct htp_ops_context * octx) {
     const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
     const size_t dst_row_size     = (size_t)ne0 * type_size;
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = total_dst_rows;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
@@ -509,23 +511,20 @@ int op_pad(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
+            nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = total_dst_rows - mdev_row_start;
+                nrows = total_dst_rows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = total_dst_rows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -560,9 +559,9 @@ int op_pad(struct htp_ops_context * octx) {
         .lp1 = lp1, .rp1 = rp1,
         .lp2 = lp2, .rp2 = rp2,
         .lp3 = lp3, .rp3 = rp3,
-        .nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
-        .total_dst_rows   = mdev_nrows,
-        .mdev_row_start    = mdev_row_start,
+        .nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div),
+        .total_dst_rows   = nrows,
+        .row_start        = row_start,
         .type_size        = type_size,
         .src_row_size         = src_row_size,
         .src_row_size_aligned = src_row_size_aligned,

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -493,7 +493,7 @@ int op_pad(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (total_dst_rows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(total_dst_rows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_dst_rows);
         mdev_nrows     = MIN(rows_per_mdev, total_dst_rows - mdev_row_start);
     } else {
@@ -505,7 +505,7 @@ int op_pad(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     const size_t src_row_size         = (size_t)ne00 * type_size;
     const size_t dst_row_size         = (size_t)ne0  * type_size;
@@ -537,7 +537,7 @@ int op_pad(struct htp_ops_context * octx) {
         .lp1 = lp1, .rp1 = rp1,
         .lp2 = lp2, .rp2 = rp2,
         .lp3 = lp3, .rp3 = rp3,
-        .nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+        .nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
         .total_dst_rows   = mdev_nrows,
         .mdev_row_start    = mdev_row_start,
         .type_size        = type_size,

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -12,8 +12,11 @@
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
+#include "hex-common.h"
+#include "hex-profile.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
+#include "htp-tensor.h"
 
 /* Circular wrap: maps any integer x into [0, n) */
 static inline uint32_t wrap_around(int32_t x, uint32_t n) {
@@ -126,8 +129,8 @@ static void pad_job_per_thread_hvx(unsigned int nth, unsigned int ith, void * da
     struct htp_ops_context * octx = pctx->octx;
     htp_pad_preamble;
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
     for (uint32_t dst_row = row_start; dst_row < row_end; dst_row++) {
         uint32_t i1, i2, i3;
@@ -166,14 +169,13 @@ static void pad_job_per_thread_hvx(unsigned int nth, unsigned int ith, void * da
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
-    FARF(HIGH, "pad-hvx %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u usec %u\n",
+    FARF(HIGH, "pad-hvx %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u\n",
          ith, nth,
          src->ne[0], src->ne[1], src->ne[2], src->ne[3],
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         row_start, row_end,
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         row_start, row_end);
 }
 
 // ---------------------------------------------------------------------------
@@ -185,9 +187,6 @@ static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void 
     struct htp_ops_context * octx = pctx->octx;
     htp_pad_preamble;
     htp_pad_dma_preamble;
-
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
 
     // -----------------------------------------------------------------------
     // Priming phase: push 2 pairs of (dummy_dst_DMA, src_DMA) to seed the
@@ -223,6 +222,9 @@ static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void 
     // Main loop: pop completed DMAs, compute in VTCM with aligned HVX ops,
     // push dst DMA and prefetch src for the next+1 row.
     // -----------------------------------------------------------------------
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
+
     for (uint32_t ir = row_start; ir < row_end; ir++) {
         uint8_t * dst_spad_cur = (uint8_t *) dma_queue_pop(dma).src;
         uint8_t * src_spad_cur = (uint8_t *) dma_queue_pop(dma).dst;
@@ -273,16 +275,15 @@ static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void 
         }
     }
 
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
+
     dma_queue_flush(dma);
 
-    t2 = HAP_perf_get_qtimer_count();
-
-    FARF(HIGH, "pad-hvx-dma %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u usec %u\n",
+    FARF(HIGH, "pad-hvx-dma %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u\n",
          ith, nth,
          src->ne[0], src->ne[1], src->ne[2], src->ne[3],
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         row_start, row_end,
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         row_start, row_end);
 }
 
 // ---------------------------------------------------------------------------
@@ -294,8 +295,8 @@ static void pad_job_per_thread_hvx_circular(unsigned int nth, unsigned int ith, 
     struct htp_ops_context * octx = pctx->octx;
     htp_pad_preamble;
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
     for (uint32_t dst_row = row_start; dst_row < row_end; dst_row++) {
         uint32_t i1, i2, i3;
@@ -345,14 +346,13 @@ static void pad_job_per_thread_hvx_circular(unsigned int nth, unsigned int ith, 
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
-    FARF(HIGH, "pad-hvx-circ %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u usec %u\n",
+    FARF(HIGH, "pad-hvx-circ %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u\n",
          ith, nth,
          src->ne[0], src->ne[1], src->ne[2], src->ne[3],
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         row_start, row_end,
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         row_start, row_end);
 }
 
 // ---------------------------------------------------------------------------
@@ -364,9 +364,6 @@ static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int i
     struct htp_ops_context * octx = pctx->octx;
     htp_pad_preamble;
     htp_pad_dma_preamble;
-
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
 
     // -----------------------------------------------------------------------
     // Priming phase: push 2 pairs of (dummy_dst_DMA, src_DMA) to seed the
@@ -391,6 +388,9 @@ static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int i
     // Main loop: pop completed DMAs, assemble circular row in VTCM with
     // aligned HVX ops, push dst DMA and prefetch src for the next+1 row.
     // -----------------------------------------------------------------------
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
+
     for (uint32_t ir = row_start; ir < row_end; ir++) {
         uint8_t * dst_spad_cur = (uint8_t *) dma_queue_pop(dma).src;
         uint8_t * src_spad_cur = (uint8_t *) dma_queue_pop(dma).dst;
@@ -447,16 +447,15 @@ static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int i
         }
     }
 
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
+
     dma_queue_flush(dma);
 
-    t2 = HAP_perf_get_qtimer_count();
-
-    FARF(HIGH, "pad-hvx-circ-dma %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u usec %u\n",
+    FARF(HIGH, "pad-hvx-circ-dma %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u\n",
          ith, nth,
          src->ne[0], src->ne[1], src->ne[2], src->ne[3],
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         row_start, row_end,
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         row_start, row_end);
 }
 
 int op_pad(struct htp_ops_context * octx) {
@@ -490,12 +489,37 @@ int op_pad(struct htp_ops_context * octx) {
     const uint32_t ne00 = src0->ne[0];
 
     const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
+    const size_t dst_row_size     = (size_t)ne0 * type_size;
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(total_dst_rows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_dst_rows);
-        mdev_nrows     = MIN(rows_per_mdev, total_dst_rows - mdev_row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = total_dst_rows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = total_dst_rows;
@@ -508,7 +532,6 @@ int op_pad(struct htp_ops_context * octx) {
     const uint32_t n_threads = octx->n_threads;
 
     const size_t src_row_size         = (size_t)ne00 * type_size;
-    const size_t dst_row_size         = (size_t)ne0  * type_size;
     const size_t src_row_size_aligned = hex_round_up(src_row_size, VLEN);
     const size_t dst_row_size_aligned = hex_round_up(dst_row_size, VLEN);
 
@@ -554,10 +577,10 @@ int op_pad(struct htp_ops_context * octx) {
          dst->ne[0],  dst->ne[1],  dst->ne[2],  dst->ne[3],
          lp0, rp0, lp1, rp1, lp2, rp2, lp3, rp3);
 
-    if      (circular && use_dma) { worker_pool_run_func(octx->ctx->worker_pool, pad_job_per_thread_hvx_circular_dma, &pctx, n_threads); }
-    else if (circular)            { worker_pool_run_func(octx->ctx->worker_pool, pad_job_per_thread_hvx_circular,     &pctx, n_threads); }
-    else if (use_dma)             { worker_pool_run_func(octx->ctx->worker_pool, pad_job_per_thread_hvx_dma,          &pctx, n_threads); }
-    else                          { worker_pool_run_func(octx->ctx->worker_pool, pad_job_per_thread_hvx,              &pctx, n_threads); }
+    if      (circular && use_dma) { work_queue_run(octx->ctx->work_queue, pad_job_per_thread_hvx_circular_dma, &pctx, n_threads); }
+    else if (circular)            { work_queue_run(octx->ctx->work_queue, pad_job_per_thread_hvx_circular,     &pctx, n_threads); }
+    else if (use_dma)             { work_queue_run(octx->ctx->work_queue, pad_job_per_thread_hvx_dma,          &pctx, n_threads); }
+    else                          { work_queue_run(octx->ctx->work_queue, pad_job_per_thread_hvx,              &pctx, n_threads); }
 
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -492,33 +492,11 @@ int op_pad(struct htp_ops_context * octx) {
     uint32_t nrows     = total_dst_rows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_dst_rows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? total_dst_rows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = total_dst_rows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, type_size, (uint32_t) dst_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_dst_rows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {
@@ -580,4 +558,3 @@ int op_pad(struct htp_ops_context * octx) {
 
     return HTP_STATUS_OK;
 }
-

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -68,7 +68,7 @@ struct htp_pad_context {
 
     uint32_t nrows_per_thread;
     uint32_t total_dst_rows;
-    uint32_t dev_row_start;
+    uint32_t mdev_row_start;
 
     size_t   type_size;
 
@@ -79,31 +79,31 @@ struct htp_pad_context {
     size_t   dst_row_size_aligned;
 };
 
-#define htp_pad_preamble                            \
-    const struct htp_tensor * src = octx->src[0];   \
-    const struct htp_tensor * dst = octx->dst;      \
-                                                    \
-    const uint32_t ne00 = src->ne[0];               \
-    const uint32_t nb00 = src->nb[0];               \
-                                                    \
-    const uint32_t ne0 = dst->ne[0];                \
-    const uint32_t ne1 = dst->ne[1];                \
-    const uint32_t ne2 = dst->ne[2];                \
-    const uint32_t ne3 = dst->ne[3];                \
-                                                    \
-    const uint32_t nb1 = dst->nb[1];                \
-    const uint32_t nb2 = dst->nb[2];                \
-    const uint32_t nb3 = dst->nb[3];                \
-                                                    \
-    const int32_t lp0 = pctx->lp0, rp0 = pctx->rp0; \
-    const int32_t lp1 = pctx->lp1, rp1 = pctx->rp1; \
-    const int32_t lp2 = pctx->lp2, rp2 = pctx->rp2; \
-    const int32_t lp3 = pctx->lp3, rp3 = pctx->rp3; \
-                                                    \
-    const size_t type_size = pctx->type_size;       \
-                                                    \
-    const uint32_t row_start = pctx->dev_row_start + pctx->nrows_per_thread * ith;                           \
-    const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->dev_row_start + pctx->total_dst_rows);
+#define htp_pad_preamble                                                             \
+    const struct htp_tensor * src = octx->src[0];                                    \
+    const struct htp_tensor * dst = octx->dst;                                       \
+                                                                                     \
+    const uint32_t ne00 = src->ne[0];                                                \
+    const uint32_t nb00 = src->nb[0];                                                \
+                                                                                     \
+    const uint32_t ne0 = dst->ne[0];                                                 \
+    const uint32_t ne1 = dst->ne[1];                                                 \
+    const uint32_t ne2 = dst->ne[2];                                                 \
+    const uint32_t ne3 = dst->ne[3];                                                 \
+                                                                                     \
+    const uint32_t nb1 = dst->nb[1];                                                 \
+    const uint32_t nb2 = dst->nb[2];                                                 \
+    const uint32_t nb3 = dst->nb[3];                                                 \
+                                                                                     \
+    const int32_t lp0 = pctx->lp0, rp0 = pctx->rp0;                                  \
+    const int32_t lp1 = pctx->lp1, rp1 = pctx->rp1;                                  \
+    const int32_t lp2 = pctx->lp2, rp2 = pctx->rp2;                                  \
+    const int32_t lp3 = pctx->lp3, rp3 = pctx->rp3;                                  \
+                                                                                     \
+    const size_t type_size = pctx->type_size;                                        \
+                                                                                     \
+    const uint32_t row_start = pctx->mdev_row_start + pctx->nrows_per_thread * ith;  \
+    const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->mdev_row_start + pctx->total_dst_rows);
 
 
 #define htp_pad_dma_preamble                                        \
@@ -491,21 +491,21 @@ int op_pad(struct htp_ops_context * octx) {
 
     const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (total_dst_rows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, total_dst_rows);
-        dev_nrows     = MIN(rows_per_dev, total_dst_rows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (total_dst_rows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_dst_rows);
+        mdev_nrows     = MIN(rows_per_mdev, total_dst_rows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = total_dst_rows;
+        mdev_row_start = 0;
+        mdev_nrows     = total_dst_rows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
 
     const size_t src_row_size         = (size_t)ne00 * type_size;
     const size_t dst_row_size         = (size_t)ne0  * type_size;
@@ -537,9 +537,9 @@ int op_pad(struct htp_ops_context * octx) {
         .lp1 = lp1, .rp1 = rp1,
         .lp2 = lp2, .rp2 = rp2,
         .lp3 = lp3, .rp3 = rp3,
-        .nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
-        .total_dst_rows   = dev_nrows,
-        .dev_row_start    = dev_row_start,
+        .nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+        .total_dst_rows   = mdev_nrows,
+        .mdev_row_start    = mdev_row_start,
         .type_size        = type_size,
         .src_row_size         = src_row_size,
         .src_row_size_aligned = src_row_size_aligned,

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -494,7 +494,7 @@ int op_pad(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = total_dst_rows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -510,13 +510,13 @@ int op_pad(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
-            nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_dst_rows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? total_dst_rows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = total_dst_rows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - row_start);

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -179,7 +179,7 @@ static void pad_job_per_thread_hvx(unsigned int nth, unsigned int ith, void * da
 }
 
 // ---------------------------------------------------------------------------
-// HVX + DMA PAD kernel — aligned, double-buffered
+// HVX + DMA PAD kernel - aligned, double-buffered
 // ---------------------------------------------------------------------------
 
 static void pad_job_per_thread_hvx_dma(unsigned int nth, unsigned int ith, void * data) {
@@ -355,7 +355,7 @@ static void pad_job_per_thread_hvx_circular(unsigned int nth, unsigned int ith, 
 }
 
 // ---------------------------------------------------------------------------
-// HVX + DMA circular PAD kernel — aligned, double-buffered
+// HVX + DMA circular PAD kernel - aligned, double-buffered
 // ---------------------------------------------------------------------------
 
 static void pad_job_per_thread_hvx_circular_dma(unsigned int nth, unsigned int ith, void * data) {

--- a/ggml/src/ggml-hexagon/htp/pad-ops.c
+++ b/ggml/src/ggml-hexagon/htp/pad-ops.c
@@ -68,6 +68,7 @@ struct htp_pad_context {
 
     uint32_t nrows_per_thread;
     uint32_t total_dst_rows;
+    uint32_t dev_row_start;
 
     size_t   type_size;
 
@@ -101,8 +102,8 @@ struct htp_pad_context {
                                                     \
     const size_t type_size = pctx->type_size;       \
                                                     \
-    const uint32_t row_start = pctx->nrows_per_thread * ith;                                 \
-    const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->total_dst_rows);
+    const uint32_t row_start = pctx->dev_row_start + pctx->nrows_per_thread * ith;                           \
+    const uint32_t row_end   = MIN(row_start + pctx->nrows_per_thread, pctx->dev_row_start + pctx->total_dst_rows);
 
 
 #define htp_pad_dma_preamble                                        \
@@ -489,7 +490,22 @@ int op_pad(struct htp_ops_context * octx) {
     const uint32_t ne00 = src0->ne[0];
 
     const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
-    const uint32_t n_threads = MIN(octx->n_threads, total_dst_rows > 0 ? total_dst_rows : 1);
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (total_dst_rows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, total_dst_rows);
+        dev_nrows     = MIN(rows_per_dev, total_dst_rows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = total_dst_rows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
 
     const size_t src_row_size         = (size_t)ne00 * type_size;
     const size_t dst_row_size         = (size_t)ne0  * type_size;
@@ -521,8 +537,9 @@ int op_pad(struct htp_ops_context * octx) {
         .lp1 = lp1, .rp1 = rp1,
         .lp2 = lp2, .rp2 = rp2,
         .lp3 = lp3, .rp3 = rp3,
-        .nrows_per_thread = (total_dst_rows + n_threads - 1) / n_threads,
-        .total_dst_rows   = total_dst_rows,
+        .nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
+        .total_dst_rows   = dev_nrows,
+        .dev_row_start    = dev_row_start,
         .type_size        = type_size,
         .src_row_size         = src_row_size,
         .src_row_size_aligned = src_row_size_aligned,

--- a/ggml/src/ggml-hexagon/htp/repeat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/repeat-ops.c
@@ -27,7 +27,7 @@ struct htp_repeat_context {
 
     uint32_t nrows_per_thread;
     uint32_t total_dst_rows;  // ne1 * ne2 * ne3
-    uint32_t mdev_row_start;
+    uint32_t row_start;
 
     size_t   type_size;
 };
@@ -65,8 +65,8 @@ static void repeat_job_per_thread(unsigned int nth, unsigned int ith, void * dat
 
     const size_t row_bytes = ne00 * rctx->type_size;
 
-    const uint32_t row_start = rctx->mdev_row_start + rctx->nrows_per_thread * ith;
-    const uint32_t row_end   = MIN(row_start + rctx->nrows_per_thread, rctx->mdev_row_start + rctx->total_dst_rows);
+    const uint32_t row_start = rctx->row_start + rctx->nrows_per_thread * ith;
+    const uint32_t row_end   = MIN(row_start + rctx->nrows_per_thread, rctx->row_start + rctx->total_dst_rows);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
     htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
@@ -127,19 +127,21 @@ int op_repeat(struct htp_ops_context * octx) {
     }
 
     const uint32_t total_dst_rows  = dst->ne[1] * dst->ne[2] * dst->ne[3];
-    const size_t dst_data_row_size = dst->ne[0] * type_size;
+    const size_t dst_row_size = dst->ne[0] * type_size;
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = total_dst_rows;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
             if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
                 rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_data_row_size &&
+            } else if (dst->nb[1] == dst_row_size &&
                        (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
                        (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
             } else {
                 can_split = false;
             }
@@ -147,23 +149,20 @@ int op_repeat(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
+            nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = total_dst_rows - mdev_row_start;
+                nrows = total_dst_rows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = total_dst_rows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -175,9 +174,9 @@ int op_repeat(struct htp_ops_context * octx) {
         .nr1              = dst->ne[1] / src0->ne[1],
         .nr2              = dst->ne[2] / src0->ne[2],
         .nr3              = dst->ne[3] / src0->ne[3],
-        .nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
-        .total_dst_rows   = mdev_nrows,
-        .mdev_row_start   = mdev_row_start,
+        .nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div),
+        .total_dst_rows   = nrows,
+        .row_start        = row_start,
         .type_size        = type_size,
     };
 

--- a/ggml/src/ggml-hexagon/htp/repeat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/repeat-ops.c
@@ -12,8 +12,10 @@
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
 #include "htp-ctx.h"
+#include "hex-common.h"
+#include "hex-profile.h"
 #include "htp-ops.h"
-#include "htp-ops.h"
+#include "htp-tensor.h"
 
 struct htp_repeat_context {
     struct htp_ops_context * octx;
@@ -66,8 +68,8 @@ static void repeat_job_per_thread(unsigned int nth, unsigned int ith, void * dat
     const uint32_t row_start = rctx->mdev_row_start + rctx->nrows_per_thread * ith;
     const uint32_t row_end   = MIN(row_start + rctx->nrows_per_thread, rctx->mdev_row_start + rctx->total_dst_rows);
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
     for (uint32_t dst_row = row_start; dst_row < row_end; dst_row++) {
         // Decompose flat dst row index into (i1, i2, i3)
@@ -90,12 +92,12 @@ static void repeat_job_per_thread(unsigned int nth, unsigned int ith, void * dat
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, row_start);
 
-    FARF(HIGH, "repeat %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u usec %u\n",
+    FARF(HIGH, "repeat %d/%d: (%ux%ux%ux%u) -> (%ux%ux%ux%u) rows %u:%u\n",
          ith, nth, src->ne[0], src->ne[1], src->ne[2], src->ne[3],
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
-         row_start, row_end, (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         row_start, row_end);
 }
 
 int op_repeat(struct htp_ops_context * octx) {
@@ -124,13 +126,38 @@ int op_repeat(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
+    const uint32_t total_dst_rows  = dst->ne[1] * dst->ne[2] * dst->ne[3];
+    const size_t dst_data_row_size = dst->ne[0] * type_size;
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(total_dst_rows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_dst_rows);
-        mdev_nrows     = MIN(rows_per_mdev, total_dst_rows - mdev_row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_data_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = total_dst_rows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = total_dst_rows;
@@ -159,7 +186,7 @@ int op_repeat(struct htp_ops_context * octx) {
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3],
          rctx.nr0, rctx.nr1, rctx.nr2, rctx.nr3);
 
-    worker_pool_run_func(octx->ctx->worker_pool, repeat_job_per_thread, &rctx, n_threads);
+    work_queue_run(octx->ctx->work_queue, repeat_job_per_thread, &rctx, n_threads);
 
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/repeat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/repeat-ops.c
@@ -128,7 +128,7 @@ int op_repeat(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (total_dst_rows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(total_dst_rows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_dst_rows);
         mdev_nrows     = MIN(rows_per_mdev, total_dst_rows - mdev_row_start);
     } else {
@@ -140,7 +140,7 @@ int op_repeat(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     struct htp_repeat_context rctx = {
         .octx             = octx,
@@ -148,9 +148,9 @@ int op_repeat(struct htp_ops_context * octx) {
         .nr1              = dst->ne[1] / src0->ne[1],
         .nr2              = dst->ne[2] / src0->ne[2],
         .nr3              = dst->ne[3] / src0->ne[3],
-        .nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+        .nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
         .total_dst_rows   = mdev_nrows,
-        .mdev_row_start    = mdev_row_start,
+        .mdev_row_start   = mdev_row_start,
         .type_size        = type_size,
     };
 

--- a/ggml/src/ggml-hexagon/htp/repeat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/repeat-ops.c
@@ -133,33 +133,11 @@ int op_repeat(struct htp_ops_context * octx) {
     uint32_t nrows     = total_dst_rows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_dst_rows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? total_dst_rows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = total_dst_rows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, type_size, (uint32_t) dst_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_dst_rows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/repeat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/repeat-ops.c
@@ -25,7 +25,7 @@ struct htp_repeat_context {
 
     uint32_t nrows_per_thread;
     uint32_t total_dst_rows;  // ne1 * ne2 * ne3
-    uint32_t dev_row_start;
+    uint32_t mdev_row_start;
 
     size_t   type_size;
 };
@@ -63,8 +63,8 @@ static void repeat_job_per_thread(unsigned int nth, unsigned int ith, void * dat
 
     const size_t row_bytes = ne00 * rctx->type_size;
 
-    const uint32_t row_start = rctx->dev_row_start + rctx->nrows_per_thread * ith;
-    const uint32_t row_end   = MIN(row_start + rctx->nrows_per_thread, rctx->dev_row_start + rctx->total_dst_rows);
+    const uint32_t row_start = rctx->mdev_row_start + rctx->nrows_per_thread * ith;
+    const uint32_t row_end   = MIN(row_start + rctx->nrows_per_thread, rctx->mdev_row_start + rctx->total_dst_rows);
 
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
@@ -126,21 +126,21 @@ int op_repeat(struct htp_ops_context * octx) {
 
     const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (total_dst_rows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, total_dst_rows);
-        dev_nrows     = MIN(rows_per_dev, total_dst_rows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (total_dst_rows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, total_dst_rows);
+        mdev_nrows     = MIN(rows_per_mdev, total_dst_rows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = total_dst_rows;
+        mdev_row_start = 0;
+        mdev_nrows     = total_dst_rows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
 
     struct htp_repeat_context rctx = {
         .octx             = octx,
@@ -148,9 +148,9 @@ int op_repeat(struct htp_ops_context * octx) {
         .nr1              = dst->ne[1] / src0->ne[1],
         .nr2              = dst->ne[2] / src0->ne[2],
         .nr3              = dst->ne[3] / src0->ne[3],
-        .nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
-        .total_dst_rows   = dev_nrows,
-        .dev_row_start    = dev_row_start,
+        .nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+        .total_dst_rows   = mdev_nrows,
+        .mdev_row_start    = mdev_row_start,
         .type_size        = type_size,
     };
 

--- a/ggml/src/ggml-hexagon/htp/repeat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/repeat-ops.c
@@ -132,7 +132,7 @@ int op_repeat(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = total_dst_rows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == type_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -148,13 +148,13 @@ int op_repeat(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (total_dst_rows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : total_dst_rows;
-            nrows     = (octx->mdev_idx == 0) ? total_dst_rows : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : total_dst_rows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? total_dst_rows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, total_dst_rows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = total_dst_rows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, total_dst_rows - row_start);

--- a/ggml/src/ggml-hexagon/htp/repeat-ops.c
+++ b/ggml/src/ggml-hexagon/htp/repeat-ops.c
@@ -25,6 +25,7 @@ struct htp_repeat_context {
 
     uint32_t nrows_per_thread;
     uint32_t total_dst_rows;  // ne1 * ne2 * ne3
+    uint32_t dev_row_start;
 
     size_t   type_size;
 };
@@ -62,8 +63,8 @@ static void repeat_job_per_thread(unsigned int nth, unsigned int ith, void * dat
 
     const size_t row_bytes = ne00 * rctx->type_size;
 
-    const uint32_t row_start = rctx->nrows_per_thread * ith;
-    const uint32_t row_end   = MIN(row_start + rctx->nrows_per_thread, rctx->total_dst_rows);
+    const uint32_t row_start = rctx->dev_row_start + rctx->nrows_per_thread * ith;
+    const uint32_t row_end   = MIN(row_start + rctx->nrows_per_thread, rctx->dev_row_start + rctx->total_dst_rows);
 
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
@@ -119,12 +120,27 @@ int op_repeat(struct htp_ops_context * octx) {
             return HTP_STATUS_NO_SUPPORT;
     }
 
-    const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
-    const uint32_t n_threads = MIN(octx->n_threads, total_dst_rows);
-
     if (octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) {
         return HTP_STATUS_OK;
     }
+
+    const uint32_t total_dst_rows = dst->ne[1] * dst->ne[2] * dst->ne[3];
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (total_dst_rows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, total_dst_rows);
+        dev_nrows     = MIN(rows_per_dev, total_dst_rows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = total_dst_rows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
 
     struct htp_repeat_context rctx = {
         .octx             = octx,
@@ -132,8 +148,9 @@ int op_repeat(struct htp_ops_context * octx) {
         .nr1              = dst->ne[1] / src0->ne[1],
         .nr2              = dst->ne[2] / src0->ne[2],
         .nr3              = dst->ne[3] / src0->ne[3],
-        .nrows_per_thread = (total_dst_rows + n_threads - 1) / n_threads,
-        .total_dst_rows   = total_dst_rows,
+        .nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
+        .total_dst_rows   = dev_nrows,
+        .dev_row_start    = dev_row_start,
         .type_size        = type_size,
     };
 

--- a/ggml/src/ggml-hexagon/htp/rope-ops.c
+++ b/ggml/src/ggml-hexagon/htp/rope-ops.c
@@ -80,6 +80,8 @@ struct htp_rope_context {
     size_t dst_row_stride;
     size_t src0_row_size_aligned;
     uint32_t src0_nrows;
+    uint32_t row_start;
+    uint32_t nrows;
 
     struct fastdiv_values div_ne2_ne1;
     struct fastdiv_values div_ne1;
@@ -539,11 +541,11 @@ static void rope_job_f32(unsigned int nth, unsigned int ith, void * data) {
 
     htp_rope_preamble;
 
-    const uint32_t src0_nrows = rctx->src0_nrows;
+    const uint32_t src0_nrows = rctx->nrows;
     const uint32_t src0_nrows_per_thread = rctx->src0_nrows_per_thread;
 
-    const uint32_t src0_start_row = src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+    const uint32_t src0_start_row = rctx->row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, rctx->row_start + src0_nrows);
 
     // no work for this thread
     if (src0_start_row >= src0_end_row) {
@@ -706,8 +708,31 @@ static int execute_op_rope_f32(struct htp_ops_context * octx) {
     }
 
     const struct htp_rope_kernel_params * kparams = (const struct htp_rope_kernel_params *) octx->kernel_params;
-    assert(kparams->n_threads > 0);
+    if (!htp_ops_context_set_n_threads(octx, kparams->n_threads)) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
     assert(octx->ctx->vtcm_size >= kparams->vtcm_size);
+
+    const uint32_t total_rows = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
+
+    uint32_t row_start = 0;
+    uint32_t nrows     = total_rows;
+
+    if (octx->ctx->mdev.count > 1) {
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, sizeof(float), (uint32_t) dst_data_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(
+            total_rows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
+    }
+
+    if (nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = octx->n_threads;
 
     const uint32_t ne0 = dst->ne[0];
     const size_t src0_row_size   = src0->ne[0] * sizeof(float);
@@ -752,15 +777,17 @@ static int execute_op_rope_f32(struct htp_ops_context * octx) {
     rctx.dst_row_stride        = dst_row_stride;
     rctx.src0_row_size_aligned = kparams->src0_row_size_aligned;
 
-    rctx.src0_nrows            = kparams->src0_nrows;
-    rctx.src0_nrows_per_thread = kparams->src0_nrows_per_thread;
+    rctx.src0_nrows            = nrows;
+    rctx.nrows                 = nrows;
+    rctx.row_start             = row_start;
+    rctx.src0_nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
     rctx.div_ne2_ne1           = kparams->div_ne2_ne1;
     rctx.div_ne1               = kparams->div_ne1;
 
     FARF(HIGH, "rope-f32 n-rows %u n-dims %d ne0 %u ext-factor %.6f theta-scale %.6f attn-factor %.6f\n", rctx.src0_nrows, rctx.n_dims, ne0,
          rctx.ext_factor, rctx.theta_scale, rctx.attn_factor);
 
-    work_queue_run(octx->ctx->work_queue, rope_job_f32, &rctx, kparams->n_threads);
+    work_queue_run(octx->ctx->work_queue, rope_job_f32, &rctx, n_threads);
 
     return err;
 }

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -18,6 +18,7 @@
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
 
+#include "hex-common.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
 #include "htp-tensor.h"
@@ -199,14 +200,25 @@ int op_set_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t total_tasks = kparams->total_tasks;
+    const struct htp_tensor * dst = octx->dst;
+    const uint32_t total_tasks    = kparams->total_tasks;
+
     uint32_t mdev_task_start, mdev_tasks;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
-        uint32_t tasks_per_mdev = fastdiv(total_tasks + octx->mdev_count - 1, &octx->mdev_count_div);
-        tasks_per_mdev = ((tasks_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
-        mdev_tasks      = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
+        bool can_split = (dst->nb[1] & 127) == 0 && !htp_tensor_is_permuted(dst);
+        const uint32_t total_chunks = can_split ? total_tasks : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
+            mdev_tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
+        } else {
+            const uint32_t tasks_per_mdev = fastdiv(total_tasks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_tasks = total_tasks - mdev_task_start;
+            } else {
+                mdev_tasks = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
+            }
+        }
     } else {
         mdev_task_start = 0;
         mdev_tasks      = total_tasks;

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -206,16 +206,16 @@ int op_set_rows(struct htp_ops_context * octx) {
     uint32_t task_start = 0;
     uint32_t tasks      = total_tasks;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->nb[1] & 127) == 0 && !htp_tensor_is_permuted(dst);
         const uint32_t total_chunks = can_split ? total_tasks : 0;
-        if (total_chunks < octx->mdev_count) {
-            task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
-            tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            task_start = (octx->ctx->mdev.idx == 0) ? 0 : total_tasks;
+            tasks      = (octx->ctx->mdev.idx == 0) ? total_tasks : 0;
         } else {
-            const uint32_t tasks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t tasks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            task_start = MIN(octx->ctx->mdev.idx * tasks_per_mdev, total_tasks);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 tasks = total_tasks - task_start;
             } else {
                 tasks = MIN(tasks_per_mdev, total_tasks - task_start);

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -58,6 +58,9 @@ struct set_rows_context {
     const struct htp_set_rows_kernel_params * kparams;
     struct htp_set_rows_vtcm_layout vtcm_layout;
     uint8_t * vtcm_base;
+    uint32_t dev_task_start;
+    uint32_t dev_tasks;
+    uint32_t tasks_per_thread;
 };
 
 #define SET_ROWS_THREAD_DMA_FN(TYPE_NAME, IDX_TYPE, COMPUTE_EXPR)                                                \
@@ -67,12 +70,12 @@ static void set_rows_thread_dma_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsig
     const struct htp_set_rows_kernel_params * kparams = srctx->kparams;                                          \
     set_rows_preamble;                                                                                           \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                       \
-    const uint32_t dr  = kparams->tasks_per_thread;                                                              \
-    const uint32_t ir0 = dr * ith;                                                                               \
-    if (ir0 >= kparams->total_tasks) {                                                                           \
+    const uint32_t dr  = srctx->tasks_per_thread;                                                                \
+    const uint32_t ir0 = srctx->dev_task_start + dr * ith;                                                       \
+    if (ir0 >= srctx->dev_task_start + srctx->dev_tasks) {                                                       \
         return;                                                                                                  \
     }                                                                                                            \
-    const uint32_t ir1 = MIN(ir0 + dr, kparams->total_tasks);                                                    \
+    const uint32_t ir1 = MIN(ir0 + dr, srctx->dev_task_start + srctx->dev_tasks);                                \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                 \
     const struct htp_set_rows_vtcm_layout * vtcm_layout = &srctx->vtcm_layout;                                   \
     uint8_t * vtcm_src0 = srctx->vtcm_base + vtcm_layout->off_src0 + ith * vtcm_layout->src0_bytes_per_thread;   \
@@ -192,9 +195,28 @@ int op_set_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_NO_SUPPORT;
     }
 
-    if (octx->src[1]->type != HTP_TYPE_I32 && octx->src[1]->type != HTP_TYPE_I64) {
-        return HTP_STATUS_NO_SUPPORT;
+    if (octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) {
+        return HTP_STATUS_OK;
     }
+
+    const uint32_t total_tasks = kparams->total_tasks;
+    uint32_t dev_task_start, dev_tasks;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
+        uint32_t tasks_per_dev = (total_tasks + octx->ndev - 1) / octx->ndev;
+        tasks_per_dev = ((tasks_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        dev_task_start = MIN(octx->idev * tasks_per_dev, total_tasks);
+        dev_tasks      = MIN(tasks_per_dev, total_tasks - dev_task_start);
+    } else {
+        dev_task_start = 0;
+        dev_tasks      = total_tasks;
+    }
+
+    if (dev_tasks == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(kparams->n_threads, dev_tasks);
 
     // l2fetch the src1 (indices) tensor in the main thread
     hex_l2fetch_block((const void *)octx->src[1]->data, octx->src[1]->ne[3] * octx->src[1]->nb[3]);
@@ -202,8 +224,11 @@ int op_set_rows(struct htp_ops_context * octx) {
     struct set_rows_context srctx;
     srctx.octx = octx;
     srctx.kparams = kparams;
+    srctx.dev_task_start = dev_task_start;
+    srctx.dev_tasks = dev_tasks;
+    srctx.tasks_per_thread = (dev_tasks + n_threads - 1) / n_threads;
 
-    htp_set_rows_vtcm_layout_build(&srctx.vtcm_layout, octx->dst->type, ne00, kparams->n_threads);
+    htp_set_rows_vtcm_layout_build(&srctx.vtcm_layout, octx->dst->type, ne00, n_threads);
     srctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;
 
     work_queue_func_t q_func = NULL;
@@ -216,15 +241,15 @@ int op_set_rows(struct htp_ops_context * octx) {
         default:            return HTP_STATUS_NO_SUPPORT;
     }
 
-    FARF(HIGH, "set-rows: (%ux%ux%ux%u) x (%ux%ux%ux%u) -> (%ux%ux%ux%u) : src0-vtcm-size %zu dst-vtcm-size %zu n_threads %d\n",
+    FARF(HIGH, "set-rows: (%ux%ux%ux%u) x (%ux%ux%ux%u) -> (%ux%ux%ux%u) : src0-vtcm-size %zu dst-vtcm-size %zu n-threads %d\n",
          octx->src[0]->ne[0], octx->src[0]->ne[1], octx->src[0]->ne[2], octx->src[0]->ne[3],
          octx->src[1]->ne[0], octx->src[1]->ne[1], octx->src[1]->ne[2], octx->src[1]->ne[3],
          octx->dst->ne[0], octx->dst->ne[1], octx->dst->ne[2], octx->dst->ne[3],
-         srctx.vtcm_layout.src0_bytes_per_thread * kparams->n_threads,
-         srctx.vtcm_layout.dst_bytes_per_thread  * kparams->n_threads,
-         kparams->n_threads);
+         srctx.vtcm_layout.src0_bytes_per_thread * n_threads,
+         srctx.vtcm_layout.dst_bytes_per_thread  * n_threads,
+         n_threads);
 
-    work_queue_run(octx->ctx->work_queue, q_func, &srctx, kparams->n_threads);
+    work_queue_run(octx->ctx->work_queue, q_func, &srctx, n_threads);
 
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -59,8 +59,8 @@ struct set_rows_context {
     const struct htp_set_rows_kernel_params * kparams;
     struct htp_set_rows_vtcm_layout vtcm_layout;
     uint8_t * vtcm_base;
-    uint32_t mdev_task_start;
-    uint32_t mdev_tasks;
+    uint32_t task_start;
+    uint32_t tasks;
     uint32_t tasks_per_thread;
 };
 
@@ -72,11 +72,11 @@ static void set_rows_thread_dma_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsig
     set_rows_preamble;                                                                                           \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                       \
     const uint32_t dr  = srctx->tasks_per_thread;                                                                \
-    const uint32_t ir0 = srctx->mdev_task_start + dr * ith;                                                      \
-    if (ir0 >= srctx->mdev_task_start + srctx->mdev_tasks) {                                                     \
+    const uint32_t ir0 = srctx->task_start + dr * ith;                                                          \
+    if (ir0 >= srctx->task_start + srctx->tasks) {                                                             \
         return;                                                                                                  \
     }                                                                                                            \
-    const uint32_t ir1 = MIN(ir0 + dr, srctx->mdev_task_start + srctx->mdev_tasks);                              \
+    const uint32_t ir1 = MIN(ir0 + dr, srctx->task_start + srctx->tasks);                              \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                 \
     const struct htp_set_rows_vtcm_layout * vtcm_layout = &srctx->vtcm_layout;                                   \
     uint8_t * vtcm_src0 = srctx->vtcm_base + vtcm_layout->off_src0 + ith * vtcm_layout->src0_bytes_per_thread;   \
@@ -203,28 +203,27 @@ int op_set_rows(struct htp_ops_context * octx) {
     const struct htp_tensor * dst = octx->dst;
     const uint32_t total_tasks    = kparams->total_tasks;
 
-    uint32_t mdev_task_start, mdev_tasks;
+    uint32_t task_start = 0;
+    uint32_t tasks      = total_tasks;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->nb[1] & 127) == 0 && !htp_tensor_is_permuted(dst);
         const uint32_t total_chunks = can_split ? total_tasks : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
-            mdev_tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
+            task_start = (octx->mdev_idx == 0) ? 0 : total_tasks;
+            tasks      = (octx->mdev_idx == 0) ? total_tasks : 0;
         } else {
-            const uint32_t tasks_per_mdev = fastdiv(total_tasks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
+            const uint32_t tasks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_tasks = total_tasks - mdev_task_start;
+                tasks = total_tasks - task_start;
             } else {
-                mdev_tasks = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
+                tasks = MIN(tasks_per_mdev, total_tasks - task_start);
             }
         }
-    } else {
-        mdev_task_start = 0;
-        mdev_tasks      = total_tasks;
     }
 
-    if (mdev_tasks == 0) {
+    if (tasks == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -236,9 +235,9 @@ int op_set_rows(struct htp_ops_context * octx) {
     struct set_rows_context srctx;
     srctx.octx = octx;
     srctx.kparams = kparams;
-    srctx.mdev_task_start = mdev_task_start;
-    srctx.mdev_tasks = mdev_tasks;
-    srctx.tasks_per_thread = fastdiv(mdev_tasks + n_threads - 1, &octx->n_threads_div);
+    srctx.task_start = task_start;
+    srctx.tasks = tasks;
+    srctx.tasks_per_thread = fastdiv(tasks + n_threads - 1, &octx->n_threads_div);
 
     htp_set_rows_vtcm_layout_build(&srctx.vtcm_layout, octx->dst->type, ne00, n_threads);
     srctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -72,11 +72,11 @@ static void set_rows_thread_dma_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsig
     set_rows_preamble;                                                                                           \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                       \
     const uint32_t dr  = srctx->tasks_per_thread;                                                                \
-    const uint32_t ir0 = srctx->task_start + dr * ith;                                                          \
-    if (ir0 >= srctx->task_start + srctx->tasks) {                                                             \
+    const uint32_t ir0 = srctx->task_start + dr * ith;                                                           \
+    if (ir0 >= srctx->task_start + srctx->tasks) {                                                               \
         return;                                                                                                  \
     }                                                                                                            \
-    const uint32_t ir1 = MIN(ir0 + dr, srctx->task_start + srctx->tasks);                              \
+    const uint32_t ir1 = MIN(ir0 + dr, srctx->task_start + srctx->tasks);                                        \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                 \
     const struct htp_set_rows_vtcm_layout * vtcm_layout = &srctx->vtcm_layout;                                   \
     uint8_t * vtcm_src0 = srctx->vtcm_base + vtcm_layout->off_src0 + ith * vtcm_layout->src0_bytes_per_thread;   \

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -217,6 +217,10 @@ int op_set_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
+    if (!htp_ops_context_set_n_threads(octx, (uint32_t) kparams->n_threads)) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+
     const uint32_t n_threads = octx->n_threads;
 
     // l2fetch the src1 (indices) tensor in the main thread

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -58,8 +58,8 @@ struct set_rows_context {
     const struct htp_set_rows_kernel_params * kparams;
     struct htp_set_rows_vtcm_layout vtcm_layout;
     uint8_t * vtcm_base;
-    uint32_t dev_task_start;
-    uint32_t dev_tasks;
+    uint32_t mdev_task_start;
+    uint32_t mdev_tasks;
     uint32_t tasks_per_thread;
 };
 
@@ -71,11 +71,11 @@ static void set_rows_thread_dma_##TYPE_NAME##_##IDX_TYPE(unsigned int nth, unsig
     set_rows_preamble;                                                                                           \
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                       \
     const uint32_t dr  = srctx->tasks_per_thread;                                                                \
-    const uint32_t ir0 = srctx->dev_task_start + dr * ith;                                                       \
-    if (ir0 >= srctx->dev_task_start + srctx->dev_tasks) {                                                       \
+    const uint32_t ir0 = srctx->mdev_task_start + dr * ith;                                                      \
+    if (ir0 >= srctx->mdev_task_start + srctx->mdev_tasks) {                                                     \
         return;                                                                                                  \
     }                                                                                                            \
-    const uint32_t ir1 = MIN(ir0 + dr, srctx->dev_task_start + srctx->dev_tasks);                                \
+    const uint32_t ir1 = MIN(ir0 + dr, srctx->mdev_task_start + srctx->mdev_tasks);                              \
     dma_queue * dma_queue = octx->ctx->dma[ith];                                                                 \
     const struct htp_set_rows_vtcm_layout * vtcm_layout = &srctx->vtcm_layout;                                   \
     uint8_t * vtcm_src0 = srctx->vtcm_base + vtcm_layout->off_src0 + ith * vtcm_layout->src0_bytes_per_thread;   \
@@ -200,23 +200,23 @@ int op_set_rows(struct htp_ops_context * octx) {
     }
 
     const uint32_t total_tasks = kparams->total_tasks;
-    uint32_t dev_task_start, dev_tasks;
-    if (octx->ndev > 1) {
+    uint32_t mdev_task_start, mdev_tasks;
+    if (octx->mdev_count > 1) {
         const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
-        uint32_t tasks_per_dev = (total_tasks + octx->ndev - 1) / octx->ndev;
-        tasks_per_dev = ((tasks_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        dev_task_start = MIN(octx->idev * tasks_per_dev, total_tasks);
-        dev_tasks      = MIN(tasks_per_dev, total_tasks - dev_task_start);
+        uint32_t tasks_per_mdev = (total_tasks + octx->mdev_count - 1) / octx->mdev_count;
+        tasks_per_mdev = ((tasks_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
+        mdev_tasks      = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
     } else {
-        dev_task_start = 0;
-        dev_tasks      = total_tasks;
+        mdev_task_start = 0;
+        mdev_tasks      = total_tasks;
     }
 
-    if (dev_tasks == 0) {
+    if (mdev_tasks == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(kparams->n_threads, dev_tasks);
+    const uint32_t n_threads = MIN(kparams->n_threads, mdev_tasks);
 
     // l2fetch the src1 (indices) tensor in the main thread
     hex_l2fetch_block((const void *)octx->src[1]->data, octx->src[1]->ne[3] * octx->src[1]->nb[3]);
@@ -224,9 +224,9 @@ int op_set_rows(struct htp_ops_context * octx) {
     struct set_rows_context srctx;
     srctx.octx = octx;
     srctx.kparams = kparams;
-    srctx.dev_task_start = dev_task_start;
-    srctx.dev_tasks = dev_tasks;
-    srctx.tasks_per_thread = (dev_tasks + n_threads - 1) / n_threads;
+    srctx.mdev_task_start = mdev_task_start;
+    srctx.mdev_tasks = mdev_tasks;
+    srctx.tasks_per_thread = (mdev_tasks + n_threads - 1) / n_threads;
 
     htp_set_rows_vtcm_layout_build(&srctx.vtcm_layout, octx->dst->type, ne00, n_threads);
     srctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -207,20 +207,10 @@ int op_set_rows(struct htp_ops_context * octx) {
     uint32_t tasks      = total_tasks;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->nb[1] & 127) == 0 && !htp_tensor_is_permuted(dst);
-        const uint32_t total_chunks = can_split ? total_tasks : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            task_start = (octx->ctx->mdev.idx == 0) ? 0 : total_tasks;
-            tasks      = (octx->ctx->mdev.idx == 0) ? total_tasks : 0;
-        } else {
-            const uint32_t tasks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            task_start = MIN(octx->ctx->mdev.idx * tasks_per_mdev, total_tasks);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                tasks = total_tasks - task_start;
-            } else {
-                tasks = MIN(tasks_per_mdev, total_tasks - task_start);
-            }
-        }
+        const bool can_split = htp_tensor_mdev_data_aligned(dst) && (dst->nb[1] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0 && !htp_tensor_is_permuted(dst);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_tasks, can_split ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        task_start = range.start;
+        tasks      = range.count;
     }
 
     if (tasks == 0) {

--- a/ggml/src/ggml-hexagon/htp/set-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/set-rows-ops.c
@@ -203,7 +203,7 @@ int op_set_rows(struct htp_ops_context * octx) {
     uint32_t mdev_task_start, mdev_tasks;
     if (octx->mdev_count > 1) {
         const uint32_t rows_per_line = MAX(1, (uint32_t) 128 / octx->dst->nb[1]);
-        uint32_t tasks_per_mdev = (total_tasks + octx->mdev_count - 1) / octx->mdev_count;
+        uint32_t tasks_per_mdev = fastdiv(total_tasks + octx->mdev_count - 1, &octx->mdev_count_div);
         tasks_per_mdev = ((tasks_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
         mdev_task_start = MIN(octx->mdev_idx * tasks_per_mdev, total_tasks);
         mdev_tasks      = MIN(tasks_per_mdev, total_tasks - mdev_task_start);
@@ -216,7 +216,7 @@ int op_set_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(kparams->n_threads, mdev_tasks);
+    const uint32_t n_threads = octx->n_threads;
 
     // l2fetch the src1 (indices) tensor in the main thread
     hex_l2fetch_block((const void *)octx->src[1]->data, octx->src[1]->ne[3] * octx->src[1]->nb[3]);
@@ -226,7 +226,7 @@ int op_set_rows(struct htp_ops_context * octx) {
     srctx.kparams = kparams;
     srctx.mdev_task_start = mdev_task_start;
     srctx.mdev_tasks = mdev_tasks;
-    srctx.tasks_per_thread = (mdev_tasks + n_threads - 1) / n_threads;
+    srctx.tasks_per_thread = fastdiv(mdev_tasks + n_threads - 1, &octx->n_threads_div);
 
     htp_set_rows_vtcm_layout_build(&srctx.vtcm_layout, octx->dst->type, ne00, n_threads);
     srctx.vtcm_base = (uint8_t *)octx->ctx->vtcm_base;

--- a/ggml/src/ggml-hexagon/htp/softmax-ops.c
+++ b/ggml/src/ggml-hexagon/htp/softmax-ops.c
@@ -69,8 +69,8 @@ struct htp_softmax_context {
     struct fastdiv_values fastdiv_ne13; // For mask broadcasting
 
     uint32_t src0_nrows_per_thread;
-    uint32_t dev_row_start;
-    uint32_t dev_nrows;
+    uint32_t mdev_row_start;
+    uint32_t mdev_nrows;
 };
 
 static void apply_mask(float * restrict wp0,
@@ -225,11 +225,11 @@ static void softmax_job_f32(unsigned int nth, unsigned int ith, void * data) {
 
     htp_softmax_preamble3;
 
-    const uint32_t src0_nrows            = smctx->dev_nrows;
+    const uint32_t src0_nrows            = smctx->mdev_nrows;
     const uint32_t src0_nrows_per_thread = smctx->src0_nrows_per_thread;
 
-    const uint32_t src0_start_row = smctx->dev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, smctx->dev_row_start + src0_nrows);
+    const uint32_t src0_start_row = smctx->mdev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, smctx->mdev_row_start + src0_nrows);
 
     // no work for this thread
     if (src0_start_row >= src0_end_row) {
@@ -345,25 +345,25 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = src0_nrows;
+        mdev_row_start = 0;
+        mdev_nrows     = src0_nrows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
 
-    smctx.src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
-    smctx.dev_row_start         = dev_row_start;
-    smctx.dev_nrows             = dev_nrows;
+    smctx.src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    smctx.mdev_row_start         = mdev_row_start;
+    smctx.mdev_nrows             = mdev_nrows;
 
     const size_t src0_row_size = src0->nb[1];
     const size_t src1_row_size = src0_row_size;

--- a/ggml/src/ggml-hexagon/htp/softmax-ops.c
+++ b/ggml/src/ggml-hexagon/htp/softmax-ops.c
@@ -14,9 +14,11 @@
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
+#include "hex-common.h"
+#include "hex-profile.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
-#include "htp-ops.h"
+#include "htp-tensor.h"
 
 #define htp_softmax_preamble3                     \
     const uint32_t ne00 = src0->ne[0];            \
@@ -236,8 +238,6 @@ static void softmax_job_f32(unsigned int nth, unsigned int ith, void * data) {
         return;
     }
 
-    uint64_t qt = HAP_perf_get_qtimer_count();
-
     int is_aligned = 1;
     int opt_path   = 0;
 
@@ -263,6 +263,9 @@ static void softmax_job_f32(unsigned int nth, unsigned int ith, void * data) {
 
     uint32_t prev_i2 = (uint32_t)-1;
     float slope = 1.0f;
+
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, src0_start_row);
 
     for (uint32_t r = src0_start_row; r < src0_end_row; ++r) {
         uint32_t i1 = fastmodulo(r, ne01, &smctx->fastdiv_ne01);
@@ -325,10 +328,11 @@ static void softmax_job_f32(unsigned int nth, unsigned int ith, void * data) {
         }
     }
 
-    qt = HAP_perf_qtimer_count_to_us(HAP_perf_get_qtimer_count() - qt);
-    FARF(HIGH, "softmax-f32 %d/%d: %ux%ux%ux%u (%u:%u) x %ux%ux%ux%u -> %ux%ux%ux%u : opt %u f16 %u usec %u\n", ith, nth,
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, src0_start_row);
+
+    FARF(HIGH, "softmax-f32 %d/%d: %ux%ux%ux%u (%u:%u) x %ux%ux%ux%u -> %ux%ux%ux%u : opt %u f16 %u\n", ith, nth,
          ne00, ne01, ne02, ne03, src0_start_row, src0_end_row, ne10, ne11, ne12, ne13,
-         ne0, ne1, ne2, ne3, opt_path, smctx->use_f16, (unsigned) qt);
+         ne0, ne1, ne2, ne3, opt_path, smctx->use_f16);
 }
 
 static int execute_op_softmax_f32(struct htp_ops_context * octx) {
@@ -344,12 +348,37 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
     init_softmax_ctx(&smctx, octx);
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_data_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = src0_nrows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = src0_nrows;
@@ -402,9 +431,7 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
     octx->src1_spad.data = octx->src0_spad.data + octx->src0_spad.size; octx->src1_spad.src = NULL;
     octx->dst_spad.data  = octx->src1_spad.data + octx->src1_spad.size; octx->dst_spad.src  = NULL;
 
-    if (octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) return err;
-
-    worker_pool_run_func(octx->ctx->worker_pool, softmax_job_f32, &smctx, n_threads);
+    work_queue_run(octx->ctx->work_queue, softmax_job_f32, &smctx, n_threads);
 
     return err;
 }

--- a/ggml/src/ggml-hexagon/htp/softmax-ops.c
+++ b/ggml/src/ggml-hexagon/htp/softmax-ops.c
@@ -69,6 +69,8 @@ struct htp_softmax_context {
     struct fastdiv_values fastdiv_ne13; // For mask broadcasting
 
     uint32_t src0_nrows_per_thread;
+    uint32_t dev_row_start;
+    uint32_t dev_nrows;
 };
 
 static void apply_mask(float * restrict wp0,
@@ -223,11 +225,11 @@ static void softmax_job_f32(unsigned int nth, unsigned int ith, void * data) {
 
     htp_softmax_preamble3;
 
-    const uint32_t src0_nrows            = ne01 * ne02 * ne03;  // src0 rows
+    const uint32_t src0_nrows            = smctx->dev_nrows;
     const uint32_t src0_nrows_per_thread = smctx->src0_nrows_per_thread;
 
-    const uint32_t src0_start_row = src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);
+    const uint32_t src0_start_row = smctx->dev_row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, smctx->dev_row_start + src0_nrows);
 
     // no work for this thread
     if (src0_start_row >= src0_end_row) {
@@ -342,9 +344,26 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
     init_softmax_ctx(&smctx, octx);
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
-    const uint32_t n_threads  = MIN(octx->n_threads, src0_nrows);
 
-    smctx.src0_nrows_per_thread = (src0_nrows + n_threads - 1) / n_threads;
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = src0_nrows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads  = MIN(octx->n_threads, dev_nrows);
+
+    smctx.src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
+    smctx.dev_row_start         = dev_row_start;
+    smctx.dev_nrows             = dev_nrows;
 
     const size_t src0_row_size = src0->nb[1];
     const size_t src1_row_size = src0_row_size;

--- a/ggml/src/ggml-hexagon/htp/softmax-ops.c
+++ b/ggml/src/ggml-hexagon/htp/softmax-ops.c
@@ -348,7 +348,6 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
     init_softmax_ctx(&smctx, octx);
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
-    const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
     const size_t elem_size = sizeof(float);
     const size_t dst_row_size = dst->nb[1];
 
@@ -356,33 +355,11 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
     uint32_t nrows     = src0_nrows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = src0_nrows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, (uint32_t) elem_size, (uint32_t) dst_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(src0_nrows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/softmax-ops.c
+++ b/ggml/src/ggml-hexagon/htp/softmax-ops.c
@@ -355,7 +355,7 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = src0_nrows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -371,13 +371,13 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = src0_nrows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);

--- a/ggml/src/ggml-hexagon/htp/softmax-ops.c
+++ b/ggml/src/ggml-hexagon/htp/softmax-ops.c
@@ -71,8 +71,8 @@ struct htp_softmax_context {
     struct fastdiv_values fastdiv_ne13; // For mask broadcasting
 
     uint32_t src0_nrows_per_thread;
-    uint32_t mdev_row_start;
-    uint32_t mdev_nrows;
+    uint32_t row_start;
+    uint32_t nrows;
 };
 
 static void apply_mask(float * restrict wp0,
@@ -227,11 +227,11 @@ static void softmax_job_f32(unsigned int nth, unsigned int ith, void * data) {
 
     htp_softmax_preamble3;
 
-    const uint32_t src0_nrows            = smctx->mdev_nrows;
+    const uint32_t src0_nrows            = smctx->nrows;
     const uint32_t src0_nrows_per_thread = smctx->src0_nrows_per_thread;
 
-    const uint32_t src0_start_row = smctx->mdev_row_start + src0_nrows_per_thread * ith;
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, smctx->mdev_row_start + src0_nrows);
+    const uint32_t src0_start_row = smctx->row_start + src0_nrows_per_thread * ith;
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, smctx->row_start + src0_nrows);
 
     // no work for this thread
     if (src0_start_row >= src0_end_row) {
@@ -349,18 +349,22 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
     const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
+    const size_t elem_size = sizeof(float);
+    const size_t dst_row_size = dst->nb[1];
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = src0_nrows;
+
     if (octx->mdev_count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
             if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
                 rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_data_row_size &&
+            } else if (dst->nb[1] == dst_row_size &&
                        (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
                        (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+                rows_per_chunk = (dst_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_row_size, HEX_L2_LINE_SIZE)) : 1;
             } else {
                 can_split = false;
             }
@@ -368,35 +372,31 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = src0_nrows - mdev_row_start;
+                nrows = src0_nrows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = src0_nrows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
     const uint32_t n_threads = octx->n_threads;
 
-    smctx.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
-    smctx.mdev_row_start        = mdev_row_start;
-    smctx.mdev_nrows            = mdev_nrows;
+    smctx.src0_nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
+    smctx.row_start             = row_start;
+    smctx.nrows                 = nrows;
 
     const size_t src0_row_size = src0->nb[1];
     const size_t src1_row_size = src0_row_size;
-    const size_t dst_row_size  = dst->nb[1];
 
     // VTCM scratchpads for all tensors
     // 4 rows per thread, padded to HVX vector size

--- a/ggml/src/ggml-hexagon/htp/softmax-ops.c
+++ b/ggml/src/ggml-hexagon/htp/softmax-ops.c
@@ -347,7 +347,7 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
         mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
@@ -359,11 +359,11 @@ static int execute_op_softmax_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
-    smctx.src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
-    smctx.mdev_row_start         = mdev_row_start;
-    smctx.mdev_nrows             = mdev_nrows;
+    smctx.src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+    smctx.mdev_row_start        = mdev_row_start;
+    smctx.mdev_nrows            = mdev_nrows;
 
     const size_t src0_row_size = src0->nb[1];
     const size_t src1_row_size = src0_row_size;

--- a/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
+++ b/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
@@ -237,19 +237,19 @@ int op_solve_tri(struct htp_ops_context * octx) {
         uint32_t job_start = 0;
         uint32_t njobs     = total_batches;
 
-        if (octx->mdev_count > 1) {
+        if (octx->ctx->mdev.count > 1) {
             const uint32_t batch_size = dst->nb[2];
             const uint32_t batches_per_chunk = (batch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(batch_size, HEX_L2_LINE_SIZE)) : 1;
             const uint32_t total_chunks = total_batches / batches_per_chunk;
-            const bool can_split = total_chunks >= octx->mdev_count;
+            const bool can_split = total_chunks >= octx->ctx->mdev.count;
 
             if (!can_split) {
-                job_start = (octx->mdev_idx == 0) ? 0 : total_batches;
-                njobs     = (octx->mdev_idx == 0) ? total_batches : 0;
+                job_start = (octx->ctx->mdev.idx == 0) ? 0 : total_batches;
+                njobs     = (octx->ctx->mdev.idx == 0) ? total_batches : 0;
             } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                job_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                job_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * batches_per_chunk, total_batches);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     njobs = total_batches - job_start;
                 } else {
                     njobs = MIN(chunks_per_mdev * batches_per_chunk, total_batches - job_start);
@@ -281,15 +281,15 @@ int op_solve_tri(struct htp_ops_context * octx) {
         uint32_t job_start = 0;
         uint32_t njobs     = total_jobs;
 
-        if (octx->mdev_count > 1) {
-            const bool can_split = ((dst->nb[1] & 127) == 0) && (total_jobs >= octx->mdev_count);
+        if (octx->ctx->mdev.count > 1) {
+            const bool can_split = ((dst->nb[1] & 127) == 0) && (total_jobs >= octx->ctx->mdev.count);
             if (!can_split) {
-                job_start = (octx->mdev_idx == 0) ? 0 : total_jobs;
-                njobs     = (octx->mdev_idx == 0) ? total_jobs : 0;
+                job_start = (octx->ctx->mdev.idx == 0) ? 0 : total_jobs;
+                njobs     = (octx->ctx->mdev.idx == 0) ? total_jobs : 0;
             } else {
-                const uint32_t jobs_per_mdev = fastdiv(total_jobs + octx->mdev_count - 1, &octx->mdev_count_div);
-                job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_jobs);
-                if (octx->mdev_idx == octx->mdev_count - 1) {
+                const uint32_t jobs_per_mdev = fastdiv(total_jobs + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+                job_start = MIN(octx->ctx->mdev.idx * jobs_per_mdev, total_jobs);
+                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                     njobs = total_jobs - job_start;
                 } else {
                     njobs = MIN(jobs_per_mdev, total_jobs - job_start);

--- a/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
+++ b/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
@@ -17,7 +17,7 @@ struct htp_solve_tri_context {
     struct htp_ops_context * octx;
     uint32_t                 jobs_per_thread;
     uint32_t                 total_jobs;
-    uint32_t                 mdev_job_start;
+    uint32_t                 job_start;
     uint32_t                 k_chunks;
     uint32_t                 col_block;
 };
@@ -92,8 +92,8 @@ static void solve_tri_batch_thread_f32(unsigned int nth, unsigned int ith, void 
     const uint32_t col_block = VLEN_FP32;
     const uint32_t k_full    = (k / col_block) * col_block;
 
-    const uint32_t start_batch = sctx->mdev_job_start + sctx->jobs_per_thread * ith;
-    const uint32_t end_batch   = MIN(start_batch + sctx->jobs_per_thread, sctx->mdev_job_start + sctx->total_jobs);
+    const uint32_t start_batch = sctx->job_start + sctx->jobs_per_thread * ith;
+    const uint32_t end_batch   = MIN(start_batch + sctx->jobs_per_thread, sctx->job_start + sctx->total_jobs);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
     htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_batch);
@@ -150,8 +150,8 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
 
     const uint32_t ne02 = src0->ne[2];
 
-    const uint32_t start_job = sctx->mdev_job_start + sctx->jobs_per_thread * ith;
-    const uint32_t end_job   = MIN(start_job + sctx->jobs_per_thread, sctx->mdev_job_start + sctx->total_jobs);
+    const uint32_t start_job = sctx->job_start + sctx->jobs_per_thread * ith;
+    const uint32_t end_job   = MIN(start_job + sctx->jobs_per_thread, sctx->job_start + sctx->total_jobs);
 
     struct htp_thread_trace * tr = &octx->ctx->trace[ith];
     htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_job);
@@ -234,7 +234,9 @@ int op_solve_tri(struct htp_ops_context * octx) {
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3], batched);
 
     if (batched) {
-        uint32_t mdev_job_start, mdev_njobs;
+        uint32_t job_start = 0;
+        uint32_t njobs     = total_batches;
+
         if (octx->mdev_count > 1) {
             const uint32_t batch_size = dst->nb[2];
             const uint32_t batches_per_chunk = (batch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(batch_size, HEX_L2_LINE_SIZE)) : 1;
@@ -242,23 +244,20 @@ int op_solve_tri(struct htp_ops_context * octx) {
             const bool can_split = total_chunks >= octx->mdev_count;
 
             if (!can_split) {
-                mdev_job_start = (octx->mdev_idx == 0) ? 0 : total_batches;
-                mdev_njobs     = (octx->mdev_idx == 0) ? total_batches : 0;
+                job_start = (octx->mdev_idx == 0) ? 0 : total_batches;
+                njobs     = (octx->mdev_idx == 0) ? total_batches : 0;
             } else {
                 const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_job_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
+                job_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_njobs = total_batches - mdev_job_start;
+                    njobs = total_batches - job_start;
                 } else {
-                    mdev_njobs = MIN(chunks_per_mdev * batches_per_chunk, total_batches - mdev_job_start);
+                    njobs = MIN(chunks_per_mdev * batches_per_chunk, total_batches - job_start);
                 }
             }
-        } else {
-            mdev_job_start = 0;
-            mdev_njobs     = total_batches;
         }
 
-        if (mdev_njobs == 0) {
+        if (njobs == 0) {
             return HTP_STATUS_OK;
         }
 
@@ -267,9 +266,9 @@ int op_solve_tri(struct htp_ops_context * octx) {
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = fastdiv(mdev_njobs + n_threads - 1, &octx->n_threads_div),
-            .total_jobs      = mdev_njobs,
-            .mdev_job_start  = mdev_job_start,
+            .jobs_per_thread = fastdiv(njobs + n_threads - 1, &octx->n_threads_div),
+            .total_jobs      = njobs,
+            .job_start       = job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };
@@ -279,27 +278,26 @@ int op_solve_tri(struct htp_ops_context * octx) {
         // Chunk-level parallelism
         const uint32_t total_jobs = total_batches * k_chunks;
 
-        uint32_t mdev_job_start, mdev_njobs;
+        uint32_t job_start = 0;
+        uint32_t njobs     = total_jobs;
+
         if (octx->mdev_count > 1) {
             const bool can_split = ((dst->nb[1] & 127) == 0) && (total_jobs >= octx->mdev_count);
             if (!can_split) {
-                mdev_job_start = (octx->mdev_idx == 0) ? 0 : total_jobs;
-                mdev_njobs     = (octx->mdev_idx == 0) ? total_jobs : 0;
+                job_start = (octx->mdev_idx == 0) ? 0 : total_jobs;
+                njobs     = (octx->mdev_idx == 0) ? total_jobs : 0;
             } else {
                 const uint32_t jobs_per_mdev = fastdiv(total_jobs + octx->mdev_count - 1, &octx->mdev_count_div);
-                mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_jobs);
+                job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_jobs);
                 if (octx->mdev_idx == octx->mdev_count - 1) {
-                    mdev_njobs = total_jobs - mdev_job_start;
+                    njobs = total_jobs - job_start;
                 } else {
-                    mdev_njobs = MIN(jobs_per_mdev, total_jobs - mdev_job_start);
+                    njobs = MIN(jobs_per_mdev, total_jobs - job_start);
                 }
             }
-        } else {
-            mdev_job_start = 0;
-            mdev_njobs     = total_jobs;
         }
 
-        if (mdev_njobs == 0) {
+        if (njobs == 0) {
             return HTP_STATUS_OK;
         }
 
@@ -307,9 +305,9 @@ int op_solve_tri(struct htp_ops_context * octx) {
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = fastdiv(mdev_njobs + n_threads - 1, &octx->n_threads_div),
-            .total_jobs      = mdev_njobs,
-            .mdev_job_start  = mdev_job_start,
+            .jobs_per_thread = fastdiv(njobs + n_threads - 1, &octx->n_threads_div),
+            .total_jobs      = njobs,
+            .job_start       = job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };

--- a/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
+++ b/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
@@ -10,6 +10,7 @@
 #include "ggml-common.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
+#include "htp-tensor.h"
 #include "hvx-types.h"
 #include "hvx-utils.h"
 
@@ -240,21 +241,9 @@ int op_solve_tri(struct htp_ops_context * octx) {
         if (octx->ctx->mdev.count > 1) {
             const uint32_t batch_size = dst->nb[2];
             const uint32_t batches_per_chunk = (batch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(batch_size, HEX_L2_LINE_SIZE)) : 1;
-            const uint32_t total_chunks = total_batches / batches_per_chunk;
-            const bool can_split = total_chunks >= octx->ctx->mdev.count;
-
-            if (!can_split) {
-                job_start = (octx->ctx->mdev.idx == 0) ? 0 : total_batches;
-                njobs     = (octx->ctx->mdev.idx == 0) ? total_batches : 0;
-            } else {
-                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                job_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * batches_per_chunk, total_batches);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    njobs = total_batches - job_start;
-                } else {
-                    njobs = MIN(chunks_per_mdev * batches_per_chunk, total_batches - job_start);
-                }
-            }
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_batches, htp_tensor_mdev_data_aligned(dst) ? batches_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            job_start = range.start;
+            njobs     = range.count;
         }
 
         if (njobs == 0) {
@@ -282,19 +271,10 @@ int op_solve_tri(struct htp_ops_context * octx) {
         uint32_t njobs     = total_jobs;
 
         if (octx->ctx->mdev.count > 1) {
-            const bool can_split = ((dst->nb[1] & 127) == 0) && (total_jobs >= octx->ctx->mdev.count);
-            if (!can_split) {
-                job_start = (octx->ctx->mdev.idx == 0) ? 0 : total_jobs;
-                njobs     = (octx->ctx->mdev.idx == 0) ? total_jobs : 0;
-            } else {
-                const uint32_t jobs_per_mdev = fastdiv(total_jobs + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-                job_start = MIN(octx->ctx->mdev.idx * jobs_per_mdev, total_jobs);
-                if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                    njobs = total_jobs - job_start;
-                } else {
-                    njobs = MIN(jobs_per_mdev, total_jobs - job_start);
-                }
-            }
+            const bool can_split = htp_tensor_mdev_data_aligned(dst) && ((dst->nb[1] & (HTP_TENSOR_MDEV_LINE_SIZE - 1)) == 0);
+            const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(total_jobs, can_split ? 1 : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+            job_start = range.start;
+            njobs     = range.count;
         }
 
         if (njobs == 0) {

--- a/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
+++ b/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
@@ -15,7 +15,7 @@ struct htp_solve_tri_context {
     struct htp_ops_context * octx;
     uint32_t                 jobs_per_thread;
     uint32_t                 total_jobs;
-    uint32_t                 dev_job_start;
+    uint32_t                 mdev_job_start;
     uint32_t                 k_chunks;
     uint32_t                 col_block;
 };
@@ -90,8 +90,8 @@ static void solve_tri_batch_thread_f32(unsigned int nth, unsigned int ith, void 
     const uint32_t col_block = VLEN_FP32;
     const uint32_t k_full    = (k / col_block) * col_block;
 
-    const uint32_t start_batch = sctx->dev_job_start + sctx->jobs_per_thread * ith;
-    const uint32_t end_batch   = MIN(start_batch + sctx->jobs_per_thread, sctx->dev_job_start + sctx->total_jobs);
+    const uint32_t start_batch = sctx->mdev_job_start + sctx->jobs_per_thread * ith;
+    const uint32_t end_batch   = MIN(start_batch + sctx->jobs_per_thread, sctx->mdev_job_start + sctx->total_jobs);
 
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
@@ -149,8 +149,8 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
 
     const uint32_t ne02 = src0->ne[2];
 
-    const uint32_t start_job = sctx->dev_job_start + sctx->jobs_per_thread * ith;
-    const uint32_t end_job   = MIN(start_job + sctx->jobs_per_thread, sctx->dev_job_start + sctx->total_jobs);
+    const uint32_t start_job = sctx->mdev_job_start + sctx->jobs_per_thread * ith;
+    const uint32_t end_job   = MIN(start_job + sctx->jobs_per_thread, sctx->mdev_job_start + sctx->total_jobs);
 
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
@@ -234,28 +234,28 @@ int op_solve_tri(struct htp_ops_context * octx) {
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3], batched);
 
     if (batched) {
-        uint32_t dev_job_start, dev_njobs;
-        if (octx->ndev > 1) {
-            const uint32_t jobs_per_dev = (total_batches + octx->ndev - 1) / octx->ndev;
-            dev_job_start = MIN(octx->idev * jobs_per_dev, total_batches);
-            dev_njobs     = MIN(jobs_per_dev, total_batches - dev_job_start);
+        uint32_t mdev_job_start, mdev_njobs;
+        if (octx->mdev_count > 1) {
+            const uint32_t jobs_per_mdev = (total_batches + octx->mdev_count - 1) / octx->mdev_count;
+            mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_batches);
+            mdev_njobs     = MIN(jobs_per_mdev, total_batches - mdev_job_start);
         } else {
-            dev_job_start = 0;
-            dev_njobs     = total_batches;
+            mdev_job_start = 0;
+            mdev_njobs     = total_batches;
         }
 
-        if (dev_njobs == 0) {
+        if (mdev_njobs == 0) {
             return HTP_STATUS_OK;
         }
 
         // Batch-level parallelism
-        const uint32_t n_threads = MIN((uint32_t) octx->n_threads, dev_njobs);
+        const uint32_t n_threads = MIN((uint32_t) octx->n_threads, mdev_njobs);
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = (dev_njobs + n_threads - 1) / n_threads,
-            .total_jobs      = dev_njobs,
-            .dev_job_start   = dev_job_start,
+            .jobs_per_thread = (mdev_njobs + n_threads - 1) / n_threads,
+            .total_jobs      = mdev_njobs,
+            .mdev_job_start   = mdev_job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };
@@ -265,27 +265,27 @@ int op_solve_tri(struct htp_ops_context * octx) {
         // Chunk-level parallelism
         const uint32_t total_jobs = total_batches * k_chunks;
 
-        uint32_t dev_job_start, dev_njobs;
-        if (octx->ndev > 1) {
-            const uint32_t jobs_per_dev = (total_jobs + octx->ndev - 1) / octx->ndev;
-            dev_job_start = MIN(octx->idev * jobs_per_dev, total_jobs);
-            dev_njobs     = MIN(jobs_per_dev, total_jobs - dev_job_start);
+        uint32_t mdev_job_start, mdev_njobs;
+        if (octx->mdev_count > 1) {
+            const uint32_t jobs_per_mdev = (total_jobs + octx->mdev_count - 1) / octx->mdev_count;
+            mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_jobs);
+            mdev_njobs     = MIN(jobs_per_mdev, total_jobs - mdev_job_start);
         } else {
-            dev_job_start = 0;
-            dev_njobs     = total_jobs;
+            mdev_job_start = 0;
+            mdev_njobs     = total_jobs;
         }
 
-        if (dev_njobs == 0) {
+        if (mdev_njobs == 0) {
             return HTP_STATUS_OK;
         }
 
-        const uint32_t n_threads  = MIN((uint32_t) octx->n_threads, dev_njobs);
+        const uint32_t n_threads  = MIN((uint32_t) octx->n_threads, mdev_njobs);
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = (dev_njobs + n_threads - 1) / n_threads,
-            .total_jobs      = dev_njobs,
-            .dev_job_start   = dev_job_start,
+            .jobs_per_thread = (mdev_njobs + n_threads - 1) / n_threads,
+            .total_jobs      = mdev_njobs,
+            .mdev_job_start   = mdev_job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };

--- a/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
+++ b/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
@@ -236,7 +236,7 @@ int op_solve_tri(struct htp_ops_context * octx) {
     if (batched) {
         uint32_t mdev_job_start, mdev_njobs;
         if (octx->mdev_count > 1) {
-            const uint32_t jobs_per_mdev = (total_batches + octx->mdev_count - 1) / octx->mdev_count;
+            const uint32_t jobs_per_mdev = fastdiv(total_batches + octx->mdev_count - 1, &octx->mdev_count_div);
             mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_batches);
             mdev_njobs     = MIN(jobs_per_mdev, total_batches - mdev_job_start);
         } else {
@@ -249,13 +249,13 @@ int op_solve_tri(struct htp_ops_context * octx) {
         }
 
         // Batch-level parallelism
-        const uint32_t n_threads = MIN((uint32_t) octx->n_threads, mdev_njobs);
+        const uint32_t n_threads = octx->n_threads;
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = (mdev_njobs + n_threads - 1) / n_threads,
+            .jobs_per_thread = fastdiv(mdev_njobs + n_threads - 1, &octx->n_threads_div),
             .total_jobs      = mdev_njobs,
-            .mdev_job_start   = mdev_job_start,
+            .mdev_job_start  = mdev_job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };
@@ -267,7 +267,7 @@ int op_solve_tri(struct htp_ops_context * octx) {
 
         uint32_t mdev_job_start, mdev_njobs;
         if (octx->mdev_count > 1) {
-            const uint32_t jobs_per_mdev = (total_jobs + octx->mdev_count - 1) / octx->mdev_count;
+            const uint32_t jobs_per_mdev = fastdiv(total_jobs + octx->mdev_count - 1, &octx->mdev_count_div);
             mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_jobs);
             mdev_njobs     = MIN(jobs_per_mdev, total_jobs - mdev_job_start);
         } else {
@@ -279,13 +279,13 @@ int op_solve_tri(struct htp_ops_context * octx) {
             return HTP_STATUS_OK;
         }
 
-        const uint32_t n_threads  = MIN((uint32_t) octx->n_threads, mdev_njobs);
+        const uint32_t n_threads = octx->n_threads;
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = (mdev_njobs + n_threads - 1) / n_threads,
+            .jobs_per_thread = fastdiv(mdev_njobs + n_threads - 1, &octx->n_threads_div),
             .total_jobs      = mdev_njobs,
-            .mdev_job_start   = mdev_job_start,
+            .mdev_job_start  = mdev_job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };

--- a/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
+++ b/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
@@ -1,8 +1,10 @@
 #pragma clang diagnostic ignored "-Wunused-but-set-variable"
 
 #include <HAP_farf.h>
-#include <HAP_perf.h>
 #include <string.h>
+
+#include "hex-common.h"
+#include "hex-profile.h"
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
@@ -93,8 +95,8 @@ static void solve_tri_batch_thread_f32(unsigned int nth, unsigned int ith, void 
     const uint32_t start_batch = sctx->mdev_job_start + sctx->jobs_per_thread * ith;
     const uint32_t end_batch   = MIN(start_batch + sctx->jobs_per_thread, sctx->mdev_job_start + sctx->total_jobs);
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_batch);
 
     for (uint32_t batch = start_batch; batch < end_batch; ++batch) {
         const uint32_t i03 = batch / ne02;
@@ -128,11 +130,10 @@ static void solve_tri_batch_thread_f32(unsigned int nth, unsigned int ith, void 
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) end_batch);
 
-    FARF(HIGH, "solve-tri-batch %d/%d: A=(%ux%u) B=(%ux%u) batch %u:%u usec %u\n",
-         ith, nth, n, n, k, n, start_batch, end_batch,
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+    FARF(HIGH, "solve-tri-batch %d/%d: A=(%ux%u) B=(%ux%u) batch %u:%u\n",
+         ith, nth, n, n, k, n, start_batch, end_batch);
 }
 
 // Chunk-level thread: each job is one (batch, col_chunk) pair.
@@ -152,8 +153,8 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
     const uint32_t start_job = sctx->mdev_job_start + sctx->jobs_per_thread * ith;
     const uint32_t end_job   = MIN(start_job + sctx->jobs_per_thread, sctx->mdev_job_start + sctx->total_jobs);
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_job);
 
     for (uint32_t job = start_job; job < end_job; ++job) {
         const uint32_t batch = job / sctx->k_chunks;
@@ -186,11 +187,10 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) end_job);
 
-    FARF(HIGH, "solve-tri-chunk %d/%d: A=(%ux%u) B=(%ux%u) jobs %u:%u usec %u\n",
-         ith, nth, n, n, k, n, start_job, end_job,
-         (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+    FARF(HIGH, "solve-tri-chunk %d/%d: A=(%ux%u) B=(%ux%u) jobs %u:%u\n",
+         ith, nth, n, n, k, n, start_job, end_job);
 }
 
 int op_solve_tri(struct htp_ops_context * octx) {
@@ -236,9 +236,23 @@ int op_solve_tri(struct htp_ops_context * octx) {
     if (batched) {
         uint32_t mdev_job_start, mdev_njobs;
         if (octx->mdev_count > 1) {
-            const uint32_t jobs_per_mdev = fastdiv(total_batches + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_batches);
-            mdev_njobs     = MIN(jobs_per_mdev, total_batches - mdev_job_start);
+            const uint32_t batch_size = dst->nb[2];
+            const uint32_t batches_per_chunk = (batch_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(batch_size, HEX_L2_LINE_SIZE)) : 1;
+            const uint32_t total_chunks = total_batches / batches_per_chunk;
+            const bool can_split = total_chunks >= octx->mdev_count;
+
+            if (!can_split) {
+                mdev_job_start = (octx->mdev_idx == 0) ? 0 : total_batches;
+                mdev_njobs     = (octx->mdev_idx == 0) ? total_batches : 0;
+            } else {
+                const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_job_start = MIN(octx->mdev_idx * chunks_per_mdev * batches_per_chunk, total_batches);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_njobs = total_batches - mdev_job_start;
+                } else {
+                    mdev_njobs = MIN(chunks_per_mdev * batches_per_chunk, total_batches - mdev_job_start);
+                }
+            }
         } else {
             mdev_job_start = 0;
             mdev_njobs     = total_batches;
@@ -260,16 +274,26 @@ int op_solve_tri(struct htp_ops_context * octx) {
             .col_block       = col_block,
         };
 
-        worker_pool_run_func(octx->ctx->worker_pool, solve_tri_batch_thread_f32, &sctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, solve_tri_batch_thread_f32, &sctx, n_threads);
     } else {
         // Chunk-level parallelism
         const uint32_t total_jobs = total_batches * k_chunks;
 
         uint32_t mdev_job_start, mdev_njobs;
         if (octx->mdev_count > 1) {
-            const uint32_t jobs_per_mdev = fastdiv(total_jobs + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_jobs);
-            mdev_njobs     = MIN(jobs_per_mdev, total_jobs - mdev_job_start);
+            const bool can_split = ((dst->nb[1] & 127) == 0) && (total_jobs >= octx->mdev_count);
+            if (!can_split) {
+                mdev_job_start = (octx->mdev_idx == 0) ? 0 : total_jobs;
+                mdev_njobs     = (octx->mdev_idx == 0) ? total_jobs : 0;
+            } else {
+                const uint32_t jobs_per_mdev = fastdiv(total_jobs + octx->mdev_count - 1, &octx->mdev_count_div);
+                mdev_job_start = MIN(octx->mdev_idx * jobs_per_mdev, total_jobs);
+                if (octx->mdev_idx == octx->mdev_count - 1) {
+                    mdev_njobs = total_jobs - mdev_job_start;
+                } else {
+                    mdev_njobs = MIN(jobs_per_mdev, total_jobs - mdev_job_start);
+                }
+            }
         } else {
             mdev_job_start = 0;
             mdev_njobs     = total_jobs;
@@ -290,7 +314,7 @@ int op_solve_tri(struct htp_ops_context * octx) {
             .col_block       = col_block,
         };
 
-        worker_pool_run_func(octx->ctx->worker_pool, solve_tri_chunk_thread_f32, &sctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, solve_tri_chunk_thread_f32, &sctx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
+++ b/ggml/src/ggml-hexagon/htp/solve-tri-ops.c
@@ -15,6 +15,7 @@ struct htp_solve_tri_context {
     struct htp_ops_context * octx;
     uint32_t                 jobs_per_thread;
     uint32_t                 total_jobs;
+    uint32_t                 dev_job_start;
     uint32_t                 k_chunks;
     uint32_t                 col_block;
 };
@@ -89,8 +90,8 @@ static void solve_tri_batch_thread_f32(unsigned int nth, unsigned int ith, void 
     const uint32_t col_block = VLEN_FP32;
     const uint32_t k_full    = (k / col_block) * col_block;
 
-    const uint32_t start_batch = sctx->jobs_per_thread * ith;
-    const uint32_t end_batch   = MIN(start_batch + sctx->jobs_per_thread, sctx->total_jobs);
+    const uint32_t start_batch = sctx->dev_job_start + sctx->jobs_per_thread * ith;
+    const uint32_t end_batch   = MIN(start_batch + sctx->jobs_per_thread, sctx->dev_job_start + sctx->total_jobs);
 
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
@@ -148,8 +149,8 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
 
     const uint32_t ne02 = src0->ne[2];
 
-    const uint32_t start_job = sctx->jobs_per_thread * ith;
-    const uint32_t end_job   = MIN(start_job + sctx->jobs_per_thread, sctx->total_jobs);
+    const uint32_t start_job = sctx->dev_job_start + sctx->jobs_per_thread * ith;
+    const uint32_t end_job   = MIN(start_job + sctx->jobs_per_thread, sctx->dev_job_start + sctx->total_jobs);
 
     uint64_t t1, t2;
     t1 = HAP_perf_get_qtimer_count();
@@ -161,16 +162,14 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
         const uint32_t i03 = batch / ne02;
         const uint32_t i02 = batch - i03 * ne02;
 
-        const uint32_t col0 = chunk * sctx->col_block;
-        const uint32_t coln = MIN(sctx->col_block, k - col0);
-
         const float * A_batch =
             (const float *) ((const uint8_t *) (uintptr_t) src0->data + i02 * src0->nb[2] + i03 * src0->nb[3]);
         const float * B_batch =
             (const float *) ((const uint8_t *) (uintptr_t) src1->data + i02 * src1->nb[2] + i03 * src1->nb[3]);
         float * X_batch = (float *) ((uint8_t *) (uintptr_t) dst->data + i02 * dst->nb[2] + i03 * dst->nb[3]);
 
-        const bool use_hvx = (coln >= 8);
+        const uint32_t col0 = chunk * sctx->col_block;
+        const uint32_t coln = MIN(sctx->col_block, k - col0);
 
         for (uint32_t row = 0; row < n; ++row) {
             const float diag     = A_batch[row * n + row];
@@ -179,7 +178,7 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
             const float * A_row = A_batch + row * n;
             const float * B_row = B_batch + row * k;
 
-            if (use_hvx) {
+            if (coln >= 8) {
                 solve_tri_row_hvx(A_row, B_row, X_batch, row, k, col0, coln, inv_diag);
             } else {
                 solve_tri_row_scalar(A_row, B_row, X_batch, row, k, col0, coln, inv_diag);
@@ -189,7 +188,7 @@ static void solve_tri_chunk_thread_f32(unsigned int nth, unsigned int ith, void 
 
     t2 = HAP_perf_get_qtimer_count();
 
-    FARF(HIGH, "solve-tri-chunk %d/%d: A=(%ux%u) B=(%ux%u) job %u:%u usec %u\n",
+    FARF(HIGH, "solve-tri-chunk %d/%d: A=(%ux%u) B=(%ux%u) jobs %u:%u usec %u\n",
          ith, nth, n, n, k, n, start_job, end_job,
          (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
 }
@@ -235,13 +234,28 @@ int op_solve_tri(struct htp_ops_context * octx) {
          dst->ne[0], dst->ne[1], dst->ne[2], dst->ne[3], batched);
 
     if (batched) {
+        uint32_t dev_job_start, dev_njobs;
+        if (octx->ndev > 1) {
+            const uint32_t jobs_per_dev = (total_batches + octx->ndev - 1) / octx->ndev;
+            dev_job_start = MIN(octx->idev * jobs_per_dev, total_batches);
+            dev_njobs     = MIN(jobs_per_dev, total_batches - dev_job_start);
+        } else {
+            dev_job_start = 0;
+            dev_njobs     = total_batches;
+        }
+
+        if (dev_njobs == 0) {
+            return HTP_STATUS_OK;
+        }
+
         // Batch-level parallelism
-        const uint32_t n_threads = MIN((uint32_t) octx->n_threads, total_batches);
+        const uint32_t n_threads = MIN((uint32_t) octx->n_threads, dev_njobs);
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = (total_batches + n_threads - 1) / n_threads,
-            .total_jobs      = total_batches,
+            .jobs_per_thread = (dev_njobs + n_threads - 1) / n_threads,
+            .total_jobs      = dev_njobs,
+            .dev_job_start   = dev_job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };
@@ -250,12 +264,28 @@ int op_solve_tri(struct htp_ops_context * octx) {
     } else {
         // Chunk-level parallelism
         const uint32_t total_jobs = total_batches * k_chunks;
-        const uint32_t n_threads  = MIN((uint32_t) octx->n_threads, MAX(total_jobs, 1));
+
+        uint32_t dev_job_start, dev_njobs;
+        if (octx->ndev > 1) {
+            const uint32_t jobs_per_dev = (total_jobs + octx->ndev - 1) / octx->ndev;
+            dev_job_start = MIN(octx->idev * jobs_per_dev, total_jobs);
+            dev_njobs     = MIN(jobs_per_dev, total_jobs - dev_job_start);
+        } else {
+            dev_job_start = 0;
+            dev_njobs     = total_jobs;
+        }
+
+        if (dev_njobs == 0) {
+            return HTP_STATUS_OK;
+        }
+
+        const uint32_t n_threads  = MIN((uint32_t) octx->n_threads, dev_njobs);
 
         struct htp_solve_tri_context sctx = {
             .octx            = octx,
-            .jobs_per_thread = (total_jobs + n_threads - 1) / n_threads,
-            .total_jobs      = total_jobs,
+            .jobs_per_thread = (dev_njobs + n_threads - 1) / n_threads,
+            .total_jobs      = dev_njobs,
+            .dev_job_start   = dev_job_start,
             .k_chunks        = k_chunks,
             .col_block       = col_block,
         };

--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -363,7 +363,7 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (d_inner + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(d_inner + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, d_inner);
         mdev_nrows     = MIN(rows_per_mdev, d_inner - mdev_row_start);
     } else {
@@ -375,7 +375,7 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     struct htp_ssm_conv_context scctx = { 0 };
     scctx.octx          = octx;
@@ -387,7 +387,8 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
         use_hvx = 1;
     }
 
-    scctx.nrows_per_thread = hex_round_up((mdev_nrows + n_threads - 1) / n_threads, VLEN_FP32);
+    const uint32_t raw_rpt = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+    scctx.nrows_per_thread = hex_round_up(raw_rpt, VLEN_FP32);
 
     const uint32_t d_inner_per_thread = scctx.nrows_per_thread;
     const uint32_t ncs                = src0->ne[0];

--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -63,6 +63,8 @@ struct htp_ssm_conv_context {
     uint32_t nrows_per_thread;
     uint32_t d_inner_tile;
     uint64_t t_start;
+    uint32_t dev_row_start;
+    uint32_t dev_nrows;
 };
 
 #define htp_ssm_conv_preamble                                                   \
@@ -95,8 +97,8 @@ static void ssm_conv_thread_f32_f32(unsigned int nth, unsigned int ith, void *da
 
     // Calculate row range for this thread
     const uint32_t d_inner_per_thread = scctx->nrows_per_thread;
-    const uint32_t d_inner_start = d_inner_per_thread * ith;
-    const uint32_t d_inner_end   = MIN(d_inner_start + d_inner_per_thread, d_inner);
+    const uint32_t d_inner_start = scctx->dev_row_start + d_inner_per_thread * ith;
+    const uint32_t d_inner_end   = MIN(d_inner_start + d_inner_per_thread, scctx->dev_row_start + scctx->dev_nrows);
 
     // No work for this thread
     if (d_inner_start >= d_inner_end) {
@@ -273,8 +275,8 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
     const uint32_t dst_stride_seq    = dst->nb[2]  / sizeof(float);
 
     const uint32_t dr  = scctx->nrows_per_thread;
-    const uint32_t ir0 = dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, d_inner);
+    const uint32_t ir0 = scctx->dev_row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, scctx->dev_row_start + scctx->dev_nrows);
 
     if (ir0 >= ir1) {
         return;
@@ -319,13 +321,14 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
                         HVX_Vector w = *(const HVX_Vector *) (src1_T + j * d_inner_stride + tile_off + cb);
                         acc          = Q6_Vqf32_vadd_Vqf32Vqf32(acc, Q6_Vqf32_vmpy_VsfVsf(x, w));
                     }
-                    HVX_Vector res = Q6_Vsf_equals_Vqf32(acc);
 
-                    float * dst_ptr = dst_data + i3 * dst_stride_seq + t * dst_stride_token + (ir0 + tile_off + cb);
+                    HVX_Vector y = Q6_Vsf_equals_Vqf32(acc);
+
+                    float * dst_ptr = dst_data + (ir0 + tile_off + cb) + t * dst_stride_token + i3 * dst_stride_seq;
                     if (cb_n == C_TILE) {
-                        *(HVX_UVector *) dst_ptr = res;
+                        *(HVX_UVector *) dst_ptr = y;
                     } else {
-                        hvx_vec_store_u(dst_ptr, cb_n * sizeof(float), res);
+                        hvx_vec_store_u(dst_ptr, cb_n * sizeof(float), y);
                     }
                 }
             }
@@ -334,82 +337,101 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
 
     t2 = HAP_perf_get_qtimer_count();
 
-    FARF(HIGH, "ssm-conv-f32-hvx %d/%d: %ux%ux%ux%u (%u:%u) tile=%u * %ux%ux%ux%u -> %ux%ux%ux%u usec %u\n",
-         ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ir0, ir1, d_inner_tile,
+    FARF(HIGH, "ssm-conv-f32-hvx %d/%d: %ux%ux%ux%u (%u:%u) * %ux%ux%ux%u -> %ux%ux%ux%u usec %u\n",
+         ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ir0, ir1,
          src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3], dst->ne[0], dst->ne[1],
          dst->ne[2], dst->ne[3], (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
 }
 
 int op_ssm_conv_f32(struct htp_ops_context * octx) {
-    htp_ssm_conv_tensors_preamble;
+    const struct htp_tensor * src0 = octx->src[0];
+    const struct htp_tensor * src1 = octx->src[1];
+    const struct htp_tensor * dst  = octx->dst;
 
     if (src0->type != HTP_TYPE_F32 || src1->type != HTP_TYPE_F32 || dst->type != HTP_TYPE_F32) {
-        FARF(ERROR, "ssm_conv: only (F32 x F32 -> F32) OPs supported");
         return HTP_STATUS_NO_SUPPORT;
     }
-
-    struct htp_ssm_conv_context scctx = { 0 };
-    scctx.octx = octx;
 
     const uint32_t d_conv  = src1->ne[0];
     const uint32_t d_inner = src0->ne[1];
     const uint32_t n_t     = dst->ne[1];  // tokens per sequence
     const uint32_t n_s     = dst->ne[2];  // number of sequences in the batch
 
-    const uint32_t n_threads = MIN(octx->n_threads, d_inner);
+    if (octx->flags & HTP_OPFLAGS_SKIP_COMPUTE) {
+        return HTP_STATUS_OK;
+    }
 
-    if (!(octx->flags & HTP_OPFLAGS_SKIP_COMPUTE)) {
-        uint32_t use_hvx = 0;
-        if (d_inner >= VLEN_FP32 && n_t >= VLEN_FP32) {
-            use_hvx = 1;
-        }
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (d_inner + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, d_inner);
+        dev_nrows     = MIN(rows_per_dev, d_inner - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = d_inner;
+    }
 
-        scctx.nrows_per_thread = hex_round_up((d_inner + n_threads - 1) / n_threads, VLEN_FP32);
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
 
-        const uint32_t d_inner_per_thread = scctx.nrows_per_thread;
-        const uint32_t ncs                = src0->ne[0];
+    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
 
-        const uint32_t src1_T_size = hex_round_up(d_conv * d_inner_per_thread * sizeof(float), 256);
-        const uint32_t src0_T_max = HTP_SSM_CONV_VTCM_BUDGET > src1_T_size ? HTP_SSM_CONV_VTCM_BUDGET - src1_T_size : 0;
+    struct htp_ssm_conv_context scctx = { 0 };
+    scctx.octx          = octx;
+    scctx.dev_row_start = dev_row_start;
+    scctx.dev_nrows     = dev_nrows;
 
-        uint32_t d_inner_tile = (src0_T_max / sizeof(float)) / ncs;
-        d_inner_tile -= (d_inner_tile % VLEN_FP32);
-        if (d_inner_tile == 0) {
-            FARF(HIGH, "ssm_conv-f32: inner tile rounds to 0 (ncs=%u), falling back to scalar\n", ncs);
+    uint32_t use_hvx = 0;
+    if (dev_nrows >= VLEN_FP32 && n_t >= VLEN_FP32) {
+        use_hvx = 1;
+    }
+
+    scctx.nrows_per_thread = hex_round_up((dev_nrows + n_threads - 1) / n_threads, VLEN_FP32);
+
+    const uint32_t d_inner_per_thread = scctx.nrows_per_thread;
+    const uint32_t ncs                = src0->ne[0];
+
+    const uint32_t src1_T_size = hex_round_up(d_conv * d_inner_per_thread * sizeof(float), 256);
+    const uint32_t src0_T_max = HTP_SSM_CONV_VTCM_BUDGET > src1_T_size ? HTP_SSM_CONV_VTCM_BUDGET - src1_T_size : 0;
+
+    uint32_t d_inner_tile = (src0_T_max / sizeof(float)) / ncs;
+    d_inner_tile -= (d_inner_tile % VLEN_FP32);
+    if (d_inner_tile == 0) {
+        FARF(HIGH, "ssm_conv-f32: inner tile rounds to 0 (ncs=%u), falling back to scalar\n", ncs);
+        use_hvx = 0;
+    } else {
+        scctx.d_inner_tile = d_inner_tile;
+
+        octx->src0_spad.size_per_thread = hex_round_up(d_inner_tile * ncs * sizeof(float), 256);
+        octx->src1_spad.size_per_thread = src1_T_size;
+        octx->dst_spad.size_per_thread  = 0;
+
+        octx->src0_spad.size = octx->src0_spad.size_per_thread * n_threads;
+        octx->src1_spad.size = octx->src1_spad.size_per_thread * n_threads;
+        octx->dst_spad.size  = 0;
+
+        octx->src0_spad.data = octx->ctx->vtcm_base;
+        octx->src1_spad.data = octx->src0_spad.data + octx->src0_spad.size;
+        octx->src0_spad.src  = NULL;
+        octx->src1_spad.src  = NULL;
+
+        const size_t total_spad = octx->src0_spad.size + octx->src1_spad.size;
+        if (total_spad > octx->ctx->vtcm_size) {
+            FARF(HIGH, "ssm_conv-f32: scratchpad %zu exceeds VTCM %zu, falling back to scalar\n",
+                 total_spad, octx->ctx->vtcm_size);
             use_hvx = 0;
-        } else {
-            scctx.d_inner_tile = d_inner_tile;
-
-            octx->src0_spad.size_per_thread = hex_round_up(d_inner_tile * ncs * sizeof(float), 256);
-            octx->src1_spad.size_per_thread = src1_T_size;
-            octx->dst_spad.size_per_thread  = 0;
-
-            octx->src0_spad.size = octx->src0_spad.size_per_thread * n_threads;
-            octx->src1_spad.size = octx->src1_spad.size_per_thread * n_threads;
-            octx->dst_spad.size  = 0;
-
-            octx->src0_spad.data = octx->ctx->vtcm_base;
-            octx->src1_spad.data = octx->src0_spad.data + octx->src0_spad.size;
-            octx->src0_spad.src  = NULL;
-            octx->src1_spad.src  = NULL;
-
-            const size_t total_spad = octx->src0_spad.size + octx->src1_spad.size;
-            if (total_spad > octx->ctx->vtcm_size) {
-                FARF(HIGH, "ssm_conv-f32: scratchpad %zu exceeds VTCM %zu, falling back to scalar\n",
-                     total_spad, octx->ctx->vtcm_size);
-                use_hvx = 0;
-            }
         }
+    }
 
-        FARF(HIGH, "ssm-conv-f32: (%ux%ux%ux%u) x (%ux%ux%ux%u) -> (%ux%ux%ux%u) : use_hvx %d\n", src0->ne[0],
-             src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3], dst->ne[0],
-             dst->ne[1], dst->ne[2], dst->ne[3], use_hvx);
+    FARF(HIGH, "ssm-conv-f32: (%ux%ux%ux%u) x (%ux%ux%ux%u) -> (%ux%ux%ux%u) : use_hvx %d\n", src0->ne[0],
+         src0->ne[1], src0->ne[2], src0->ne[3], src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3], dst->ne[0],
+         dst->ne[1], dst->ne[2], dst->ne[3], use_hvx);
 
-        if (use_hvx) {
-            worker_pool_run_func(octx->ctx->worker_pool, ssm_conv_thread_f32_f32_hvx, &scctx, n_threads);
-        } else {
-            worker_pool_run_func(octx->ctx->worker_pool, ssm_conv_thread_f32_f32, &scctx, n_threads);
-        }
+    if (use_hvx) {
+        worker_pool_run_func(octx->ctx->worker_pool, ssm_conv_thread_f32_f32_hvx, &scctx, n_threads);
+    } else {
+        worker_pool_run_func(octx->ctx->worker_pool, ssm_conv_thread_f32_f32, &scctx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -62,8 +62,8 @@ struct htp_ssm_conv_context {
     uint32_t nrows_per_thread;
     uint32_t d_inner_tile;
     uint64_t t_start;
-    uint32_t mdev_row_start;
-    uint32_t mdev_nrows;
+    uint32_t row_start;
+    uint32_t nrows;
 };
 
 #define htp_ssm_conv_preamble                                                   \
@@ -93,8 +93,8 @@ static void ssm_conv_thread_f32_f32(unsigned int nth, unsigned int ith, void *da
 
     // Calculate row range for this thread
     const uint32_t d_inner_per_thread = scctx->nrows_per_thread;
-    const uint32_t d_inner_start = scctx->mdev_row_start + d_inner_per_thread * ith;
-    const uint32_t d_inner_end   = MIN(d_inner_start + d_inner_per_thread, scctx->mdev_row_start + scctx->mdev_nrows);
+    const uint32_t d_inner_start = scctx->row_start + d_inner_per_thread * ith;
+    const uint32_t d_inner_end   = MIN(d_inner_start + d_inner_per_thread, scctx->row_start + scctx->nrows);
 
     // No work for this thread
     if (d_inner_start >= d_inner_end) {
@@ -271,8 +271,8 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
     const uint32_t dst_stride_seq    = dst->nb[2]  / sizeof(float);
 
     const uint32_t dr  = scctx->nrows_per_thread;
-    const uint32_t ir0 = scctx->mdev_row_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, scctx->mdev_row_start + scctx->mdev_nrows);
+    const uint32_t ir0 = scctx->row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, scctx->row_start + scctx->nrows);
 
     if (ir0 >= ir1) {
         return;
@@ -360,46 +360,45 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = d_inner;
+
     if (octx->mdev_count > 1) {
         const uint32_t elems_per_chunk = VLEN_FP32;
         const uint32_t total_chunks = d_inner / elems_per_chunk;
         const bool can_split = total_chunks >= octx->mdev_count;
 
         if (!can_split) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : d_inner;
-            mdev_nrows     = (octx->mdev_idx == 0) ? d_inner : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : d_inner;
+            nrows     = (octx->mdev_idx == 0) ? d_inner : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, d_inner);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, d_inner);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = d_inner - mdev_row_start;
+                nrows = d_inner - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * elems_per_chunk, d_inner - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * elems_per_chunk, d_inner - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = d_inner;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
     const uint32_t n_threads = octx->n_threads;
 
     struct htp_ssm_conv_context scctx = { 0 };
-    scctx.octx          = octx;
-    scctx.mdev_row_start = mdev_row_start;
-    scctx.mdev_nrows     = mdev_nrows;
+    scctx.octx      = octx;
+    scctx.row_start = row_start;
+    scctx.nrows     = nrows;
 
     uint32_t use_hvx = 0;
-    if (mdev_nrows >= VLEN_FP32 && n_t >= VLEN_FP32) {
+    if (nrows >= VLEN_FP32 && n_t >= VLEN_FP32) {
         use_hvx = 1;
     }
 
-    const uint32_t raw_rpt = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+    const uint32_t raw_rpt = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
     scctx.nrows_per_thread = hex_round_up(raw_rpt, VLEN_FP32);
 
     const uint32_t d_inner_per_thread = scctx.nrows_per_thread;

--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -17,6 +17,7 @@
 #include "hex-dma.h"
 #include "hex-profile.h"
 #include "htp-ops.h"
+#include "htp-tensor.h"
 #include "hvx-utils.h"
 
 #define htp_ssm_conv_tensors_preamble                           \
@@ -365,21 +366,9 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
 
     if (octx->ctx->mdev.count > 1) {
         const uint32_t elems_per_chunk = VLEN_FP32;
-        const uint32_t total_chunks = d_inner / elems_per_chunk;
-        const bool can_split = total_chunks >= octx->ctx->mdev.count;
-
-        if (!can_split) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : d_inner;
-            nrows     = (octx->ctx->mdev.idx == 0) ? d_inner : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * elems_per_chunk, d_inner);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = d_inner - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * elems_per_chunk, d_inner - row_start);
-            }
-        }
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(d_inner, htp_tensor_mdev_data_aligned(dst) ? elems_per_chunk : 0, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -363,18 +363,18 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = d_inner;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         const uint32_t elems_per_chunk = VLEN_FP32;
         const uint32_t total_chunks = d_inner / elems_per_chunk;
-        const bool can_split = total_chunks >= octx->mdev_count;
+        const bool can_split = total_chunks >= octx->ctx->mdev.count;
 
         if (!can_split) {
-            row_start = (octx->mdev_idx == 0) ? 0 : d_inner;
-            nrows     = (octx->mdev_idx == 0) ? d_inner : 0;
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : d_inner;
+            nrows     = (octx->ctx->mdev.idx == 0) ? d_inner : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, d_inner);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * elems_per_chunk, d_inner);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = d_inner - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * elems_per_chunk, d_inner - row_start);

--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -63,8 +63,8 @@ struct htp_ssm_conv_context {
     uint32_t nrows_per_thread;
     uint32_t d_inner_tile;
     uint64_t t_start;
-    uint32_t dev_row_start;
-    uint32_t dev_nrows;
+    uint32_t mdev_row_start;
+    uint32_t mdev_nrows;
 };
 
 #define htp_ssm_conv_preamble                                                   \
@@ -97,8 +97,8 @@ static void ssm_conv_thread_f32_f32(unsigned int nth, unsigned int ith, void *da
 
     // Calculate row range for this thread
     const uint32_t d_inner_per_thread = scctx->nrows_per_thread;
-    const uint32_t d_inner_start = scctx->dev_row_start + d_inner_per_thread * ith;
-    const uint32_t d_inner_end   = MIN(d_inner_start + d_inner_per_thread, scctx->dev_row_start + scctx->dev_nrows);
+    const uint32_t d_inner_start = scctx->mdev_row_start + d_inner_per_thread * ith;
+    const uint32_t d_inner_end   = MIN(d_inner_start + d_inner_per_thread, scctx->mdev_row_start + scctx->mdev_nrows);
 
     // No work for this thread
     if (d_inner_start >= d_inner_end) {
@@ -275,8 +275,8 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
     const uint32_t dst_stride_seq    = dst->nb[2]  / sizeof(float);
 
     const uint32_t dr  = scctx->nrows_per_thread;
-    const uint32_t ir0 = scctx->dev_row_start + dr * ith;
-    const uint32_t ir1 = MIN(ir0 + dr, scctx->dev_row_start + scctx->dev_nrows);
+    const uint32_t ir0 = scctx->mdev_row_start + dr * ith;
+    const uint32_t ir1 = MIN(ir0 + dr, scctx->mdev_row_start + scctx->mdev_nrows);
 
     if (ir0 >= ir1) {
         return;
@@ -361,33 +361,33 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (d_inner + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, d_inner);
-        dev_nrows     = MIN(rows_per_dev, d_inner - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (d_inner + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, d_inner);
+        mdev_nrows     = MIN(rows_per_mdev, d_inner - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = d_inner;
+        mdev_row_start = 0;
+        mdev_nrows     = d_inner;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
+    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
 
     struct htp_ssm_conv_context scctx = { 0 };
     scctx.octx          = octx;
-    scctx.dev_row_start = dev_row_start;
-    scctx.dev_nrows     = dev_nrows;
+    scctx.mdev_row_start = mdev_row_start;
+    scctx.mdev_nrows     = mdev_nrows;
 
     uint32_t use_hvx = 0;
-    if (dev_nrows >= VLEN_FP32 && n_t >= VLEN_FP32) {
+    if (mdev_nrows >= VLEN_FP32 && n_t >= VLEN_FP32) {
         use_hvx = 1;
     }
 
-    scctx.nrows_per_thread = hex_round_up((dev_nrows + n_threads - 1) / n_threads, VLEN_FP32);
+    scctx.nrows_per_thread = hex_round_up((mdev_nrows + n_threads - 1) / n_threads, VLEN_FP32);
 
     const uint32_t d_inner_per_thread = scctx.nrows_per_thread;
     const uint32_t ncs                = src0->ne[0];

--- a/ggml/src/ggml-hexagon/htp/ssm-conv.c
+++ b/ggml/src/ggml-hexagon/htp/ssm-conv.c
@@ -4,7 +4,6 @@
 
 #include <HAP_farf.h>
 #include <HAP_mem.h>
-#include <HAP_perf.h>
 #include <HAP_ps.h>
 #include <hexagon_protos.h>
 #include <hexagon_types.h>
@@ -16,7 +15,7 @@
 #include "ggml-common.h"
 #include "htp-ctx.h"
 #include "hex-dma.h"
-#include "htp-ops.h"
+#include "hex-profile.h"
 #include "htp-ops.h"
 #include "hvx-utils.h"
 
@@ -77,9 +76,6 @@ struct htp_ssm_conv_context {
 static void ssm_conv_thread_f32_f32(unsigned int nth, unsigned int ith, void *data) {
     htp_ssm_conv_preamble;
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
-
     const uint32_t d_conv  = src1->ne[0];
     const uint32_t d_inner = src0->ne[1];
     const uint32_t n_t     = dst->ne[1];
@@ -105,6 +101,9 @@ static void ssm_conv_thread_f32_f32(unsigned int nth, unsigned int ith, void *da
         return;
     }
 
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) d_inner_start);
+
     for (uint32_t i3 = 0; i3 < n_s; ++i3) {
         for (uint32_t i2 = 0; i2 < n_t; ++i2) {
             for (uint32_t i1 = d_inner_start; i1 < d_inner_end; ++i1) {
@@ -123,12 +122,12 @@ static void ssm_conv_thread_f32_f32(unsigned int nth, unsigned int ith, void *da
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) d_inner_end);
 
-    FARF(HIGH, "ssm-conv-f32 %d/%d: %ux%ux%ux%u (%u:%u) * %ux%ux%ux%u -> %ux%ux%ux%u usec %u\n",
+    FARF(HIGH, "ssm-conv-f32 %d/%d: %ux%ux%ux%u (%u:%u) * %ux%ux%ux%u -> %ux%ux%ux%u\n",
          ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], d_inner_start, d_inner_end,
          src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3], dst->ne[0], dst->ne[1],
-         dst->ne[2], dst->ne[3], (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         dst->ne[2], dst->ne[3]);
 }
 
 
@@ -259,9 +258,6 @@ static inline void transpose_src0_block(const float * src0_block,
 static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void *data) {
     htp_ssm_conv_preamble;
 
-    uint64_t t1, t2;
-    t1 = HAP_perf_get_qtimer_count();
-
     const uint32_t d_conv  = src1->ne[0];
     const uint32_t d_inner = src0->ne[1];
     const uint32_t n_t     = dst->ne[1];
@@ -281,6 +277,9 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
     if (ir0 >= ir1) {
         return;
     }
+
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir0);
 
     const uint32_t d_inner_per_thread = ir1 - ir0;
     const uint32_t d_inner_stride     = scctx->nrows_per_thread;
@@ -335,12 +334,12 @@ static void ssm_conv_thread_f32_f32_hvx(unsigned int nth, unsigned int ith, void
         }
     }
 
-    t2 = HAP_perf_get_qtimer_count();
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) ir1);
 
-    FARF(HIGH, "ssm-conv-f32-hvx %d/%d: %ux%ux%ux%u (%u:%u) * %ux%ux%ux%u -> %ux%ux%ux%u usec %u\n",
+    FARF(HIGH, "ssm-conv-f32-hvx %d/%d: %ux%ux%ux%u (%u:%u) * %ux%ux%ux%u -> %ux%ux%ux%u\n",
          ith, nth, src0->ne[0], src0->ne[1], src0->ne[2], src0->ne[3], ir0, ir1,
          src1->ne[0], src1->ne[1], src1->ne[2], src1->ne[3], dst->ne[0], dst->ne[1],
-         dst->ne[2], dst->ne[3], (unsigned) HAP_perf_qtimer_count_to_us(t2 - t1));
+         dst->ne[2], dst->ne[3]);
 }
 
 int op_ssm_conv_f32(struct htp_ops_context * octx) {
@@ -363,9 +362,22 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(d_inner + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, d_inner);
-        mdev_nrows     = MIN(rows_per_mdev, d_inner - mdev_row_start);
+        const uint32_t elems_per_chunk = VLEN_FP32;
+        const uint32_t total_chunks = d_inner / elems_per_chunk;
+        const bool can_split = total_chunks >= octx->mdev_count;
+
+        if (!can_split) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : d_inner;
+            mdev_nrows     = (octx->mdev_idx == 0) ? d_inner : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * elems_per_chunk, d_inner);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = d_inner - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * elems_per_chunk, d_inner - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = d_inner;
@@ -430,9 +442,9 @@ int op_ssm_conv_f32(struct htp_ops_context * octx) {
          dst->ne[1], dst->ne[2], dst->ne[3], use_hvx);
 
     if (use_hvx) {
-        worker_pool_run_func(octx->ctx->worker_pool, ssm_conv_thread_f32_f32_hvx, &scctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, ssm_conv_thread_f32_f32_hvx, &scctx, n_threads);
     } else {
-        worker_pool_run_func(octx->ctx->worker_pool, ssm_conv_thread_f32_f32, &scctx, n_threads);
+        work_queue_run(octx->ctx->work_queue, ssm_conv_thread_f32_f32, &scctx, n_threads);
     }
 
     return HTP_STATUS_OK;

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -103,8 +103,31 @@ int op_sum_rows(struct htp_ops_context * octx) {
     }
 
     const uint32_t src0_nrows = ne01 * ne02 * ne03;
-    const uint32_t n_threads = MIN(octx->n_threads, src0_nrows);
-    const uint32_t rows_per_thread = (src0_nrows + n_threads - 1) / n_threads;
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        /*
+            This op may write to a very small number of rows. If multiple devices split
+            up the rows, they may race to write to the same cache line, leading to
+            incorrect output. So, this op needs a minimum check before it gets split for
+            multi-device uses.
+        */
+        const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / nb1);
+        uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        rows_per_dev = ((rows_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = src0_nrows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
+    const uint32_t rows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
 
     bool opt_path = false;
     if ((0 == hex_is_aligned((void *) src0->data, VLEN)) && !(nb01 & (VLEN - 1))) {
@@ -112,13 +135,13 @@ int op_sum_rows(struct htp_ops_context * octx) {
     }
 
     struct sum_rows_context smctx = {
-        .src_data        = (const uint8_t *) src0->data,
-        .dst_data        = (uint8_t *) dst->data,
+        .src_data        = (const uint8_t *) src0->data + dev_row_start * nb01,
+        .dst_data        = (uint8_t *) dst->data + dev_row_start * nb1,
         .ne00            = ne00,
         .src_stride      = nb01,
         .dst_stride      = nb1,
         .rows_per_thread = rows_per_thread,
-        .total_rows      = src0_nrows,
+        .total_rows      = dev_nrows,
         .opt_path        = opt_path,
     };
 

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -113,7 +113,9 @@ int op_sum_rows(struct htp_ops_context * octx) {
     const uint32_t src0_nrows      = ne01 * ne02 * ne03;
     const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = src0_nrows;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
@@ -131,28 +133,25 @@ int op_sum_rows(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = src0_nrows - mdev_row_start;
+                nrows = src0_nrows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = src0_nrows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
     const uint32_t n_threads = octx->n_threads;
-    const uint32_t rows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
+    const uint32_t rows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div);
 
     bool opt_path = false;
     if ((0 == hex_is_aligned((void *) src0->data, VLEN)) && !(nb01 & (VLEN - 1))) {
@@ -161,13 +160,13 @@ int op_sum_rows(struct htp_ops_context * octx) {
 
     struct sum_rows_context smctx = {
         .octx            = octx,
-        .src_data        = (const uint8_t *) src0->data + mdev_row_start * nb01,
-        .dst_data        = (uint8_t *) dst->data + mdev_row_start * nb1,
+        .src_data        = (const uint8_t *) src0->data + row_start * nb01,
+        .dst_data        = (uint8_t *) dst->data + row_start * nb1,
         .ne00            = ne00,
         .src_stride      = nb01,
         .dst_stride      = nb1,
         .rows_per_thread = rows_per_thread,
-        .total_rows      = mdev_nrows,
+        .total_rows      = nrows,
         .opt_path        = opt_path,
     };
 

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -104,8 +104,8 @@ int op_sum_rows(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = ne01 * ne02 * ne03;
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
         /*
             This op may write to a very small number of rows. If multiple devices split
             up the rows, they may race to write to the same cache line, leading to
@@ -113,21 +113,21 @@ int op_sum_rows(struct htp_ops_context * octx) {
             multi-device uses.
         */
         const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / nb1);
-        uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        rows_per_dev = ((rows_per_dev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+        uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        rows_per_mdev = ((rows_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = src0_nrows;
+        mdev_row_start = 0;
+        mdev_nrows     = src0_nrows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, dev_nrows);
-    const uint32_t rows_per_thread = (dev_nrows + n_threads - 1) / n_threads;
+    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
+    const uint32_t rows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
 
     bool opt_path = false;
     if ((0 == hex_is_aligned((void *) src0->data, VLEN)) && !(nb01 & (VLEN - 1))) {
@@ -135,13 +135,13 @@ int op_sum_rows(struct htp_ops_context * octx) {
     }
 
     struct sum_rows_context smctx = {
-        .src_data        = (const uint8_t *) src0->data + dev_row_start * nb01,
-        .dst_data        = (uint8_t *) dst->data + dev_row_start * nb1,
+        .src_data        = (const uint8_t *) src0->data + mdev_row_start * nb01,
+        .dst_data        = (uint8_t *) dst->data + mdev_row_start * nb1,
         .ne00            = ne00,
         .src_stride      = nb01,
         .dst_stride      = nb1,
         .rows_per_thread = rows_per_thread,
-        .total_rows      = dev_nrows,
+        .total_rows      = mdev_nrows,
         .opt_path        = opt_path,
     };
 

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -116,7 +116,7 @@ int op_sum_rows(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = src0_nrows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -132,13 +132,13 @@ int op_sum_rows(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = src0_nrows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -113,7 +113,7 @@ int op_sum_rows(struct htp_ops_context * octx) {
             multi-device uses.
         */
         const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / nb1);
-        uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         rows_per_mdev = ((rows_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
         mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
@@ -126,8 +126,8 @@ int op_sum_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads = MIN(octx->n_threads, mdev_nrows);
-    const uint32_t rows_per_thread = (mdev_nrows + n_threads - 1) / n_threads;
+    const uint32_t n_threads = octx->n_threads;
+    const uint32_t rows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div);
 
     bool opt_path = false;
     if ((0 == hex_is_aligned((void *) src0->data, VLEN)) && !(nb01 & (VLEN - 1))) {

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -23,25 +23,25 @@
     const struct htp_tensor *src0 = octx->src[0]; \
     const struct htp_tensor *dst  = octx->dst;    \
                                                   \
-    const uint32_t ne00 = src0->ne[0];     \
-    const uint32_t ne01 = src0->ne[1];     \
-    const uint32_t ne02 = src0->ne[2];     \
-    const uint32_t ne03 = src0->ne[3];     \
-                                           \
-    const uint32_t nb00 = src0->nb[0];     \
-    const uint32_t nb01 = src0->nb[1];     \
-    const uint32_t nb02 = src0->nb[2];     \
-    const uint32_t nb03 = src0->nb[3];     \
-                                           \
-    const uint32_t  ne0 = dst->ne[0];      \
-    const uint32_t  ne1 = dst->ne[1];      \
-    const uint32_t  ne2 = dst->ne[2];      \
-    const uint32_t  ne3 = dst->ne[3];      \
-                                           \
-    const uint32_t  nb0 = dst->nb[0];      \
-    const uint32_t  nb1 = dst->nb[1];      \
-    const uint32_t  nb2 = dst->nb[2];      \
-    const uint32_t  nb3 = dst->nb[3];      \
+    const uint32_t ne00 = src0->ne[0];            \
+    const uint32_t ne01 = src0->ne[1];            \
+    const uint32_t ne02 = src0->ne[2];            \
+    const uint32_t ne03 = src0->ne[3];            \
+                                                  \
+    const uint32_t nb00 = src0->nb[0];            \
+    const uint32_t nb01 = src0->nb[1];            \
+    const uint32_t nb02 = src0->nb[2];            \
+    const uint32_t nb03 = src0->nb[3];            \
+                                                  \
+    const uint32_t  ne0 = dst->ne[0];             \
+    const uint32_t  ne1 = dst->ne[1];             \
+    const uint32_t  ne2 = dst->ne[2];             \
+    const uint32_t  ne3 = dst->ne[3];             \
+                                                  \
+    const uint32_t  nb0 = dst->nb[0];             \
+    const uint32_t  nb1 = dst->nb[1];             \
+    const uint32_t  nb2 = dst->nb[2];             \
+    const uint32_t  nb3 = dst->nb[3];             \
 
 struct sum_rows_context {
     struct htp_ops_context * octx;

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -117,33 +117,11 @@ int op_sum_rows(struct htp_ops_context * octx) {
     uint32_t nrows     = src0_nrows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_data_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = src0_nrows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, sizeof(float), (uint32_t) dst_data_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(src0_nrows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
+++ b/ggml/src/ggml-hexagon/htp/sum-rows-ops.c
@@ -13,9 +13,11 @@
 
 #define GGML_COMMON_DECL_C
 #include "ggml-common.h"
+#include "hex-common.h"
+#include "hex-profile.h"
 #include "htp-ctx.h"
 #include "htp-ops.h"
-#include "htp-ops.h"
+#include "htp-tensor.h"
 
 #define sum_rows_preamble                         \
     const struct htp_tensor *src0 = octx->src[0]; \
@@ -42,6 +44,7 @@
     const uint32_t  nb3 = dst->nb[3];      \
 
 struct sum_rows_context {
+    struct htp_ops_context * octx;
     const uint8_t * src_data;
     uint8_t       * dst_data;
     uint32_t        ne00;
@@ -76,6 +79,9 @@ static void sum_rows_thread_f32(unsigned int nth, unsigned int ith, void *data) 
     // Calculate actual number of rows for this thread
     const uint32_t n_rows = end_row - start_row;
 
+    struct htp_thread_trace * tr = &smctx->octx->ctx->trace[ith];
+    htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
+
     for (uint32_t ir = 0; ir < n_rows; ir++) {
         const float * restrict src_local = src_th + (ir * (src_stride / sizeof(float)));
 
@@ -89,6 +95,8 @@ static void sum_rows_thread_f32(unsigned int nth, unsigned int ith, void *data) 
             dst_th[ir] = hvx_reduce_sum_f32((const uint8_t *) src_local, ne00);
         }
     }
+
+    htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, (uint16_t) start_row);
 }
 
 int op_sum_rows(struct htp_ops_context * octx) {
@@ -102,21 +110,38 @@ int op_sum_rows(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t src0_nrows = ne01 * ne02 * ne03;
+    const uint32_t src0_nrows      = ne01 * ne02 * ne03;
+    const size_t dst_data_row_size = dst->ne[0] * sizeof(float);
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        /*
-            This op may write to a very small number of rows. If multiple devices split
-            up the rows, they may race to write to the same cache line, leading to
-            incorrect output. So, this op needs a minimum check before it gets split for
-            multi-device uses.
-        */
-        const uint32_t rows_per_line = MAX(1, (uint32_t) HEX_L2_LINE_SIZE / nb1);
-        uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        rows_per_mdev = ((rows_per_mdev + rows_per_line - 1) / rows_per_line) * rows_per_line;
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == sizeof(float)) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_data_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = src0_nrows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = src0_nrows;
@@ -135,6 +160,7 @@ int op_sum_rows(struct htp_ops_context * octx) {
     }
 
     struct sum_rows_context smctx = {
+        .octx            = octx,
         .src_data        = (const uint8_t *) src0->data + mdev_row_start * nb01,
         .dst_data        = (uint8_t *) dst->data + mdev_row_start * nb1,
         .ne00            = ne00,
@@ -145,7 +171,7 @@ int op_sum_rows(struct htp_ops_context * octx) {
         .opt_path        = opt_path,
     };
 
-    worker_pool_run_func(octx->ctx->worker_pool, sum_rows_thread_f32, &smctx, n_threads);
+    work_queue_run(octx->ctx->work_queue, sum_rows_thread_f32, &smctx, n_threads);
 
     return HTP_STATUS_OK;
 }

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -1150,12 +1150,39 @@ static int execute_op_unary(struct htp_ops_context * octx) {
     const struct htp_unary_kernel_params * kparams = (const struct htp_unary_kernel_params *) octx->kernel_params;
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
+    const size_t elem_size = is_f16 ? sizeof(_Float16) : sizeof(float);
+    const size_t src0_data_row_size = src0->ne[0] * elem_size;
+    const size_t dst_data_row_size  = dst->ne[0]  * elem_size;
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
-        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
-        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
+        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
+        uint32_t rows_per_chunk = 1;
+        if (can_split) {
+            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
+                rows_per_chunk = 1;
+            } else if (dst->nb[1] == dst_data_row_size &&
+                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
+                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
+                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
+            } else {
+                can_split = false;
+            }
+        }
+
+        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
+        if (total_chunks < octx->mdev_count) {
+            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        } else {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
+            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->mdev_idx == octx->mdev_count - 1) {
+                mdev_nrows = src0_nrows - mdev_row_start;
+            } else {
+                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+            }
+        }
     } else {
         mdev_row_start = 0;
         mdev_nrows     = src0_nrows;
@@ -1166,11 +1193,6 @@ static int execute_op_unary(struct htp_ops_context * octx) {
     }
 
     const uint32_t n_threads = octx->n_threads;
-
-    const size_t elem_size = is_f16 ? sizeof(_Float16) : sizeof(float);
-
-    const size_t src0_data_row_size = src0->ne[0] * elem_size;
-    const size_t dst_data_row_size  = dst->ne[0]  * elem_size;
 
     const size_t src0_row_size_aligned = kparams->src0_row_size_aligned;
     const size_t dst_row_size_aligned  = kparams->dst_row_size_aligned;
@@ -1306,7 +1328,7 @@ static int execute_op_unary(struct htp_ops_context * octx) {
         }
 
         if (task_func) {
-            worker_pool_run_func(octx->ctx->worker_pool, task_func, &uctx, n_threads);
+            work_queue_run(octx->ctx->work_queue, task_func, &uctx, n_threads);
         } else {
             FARF(ERROR, "execute_op_unary: task function is NULL for op %d\n", octx->op);
             err = HTP_STATUS_NO_SUPPORT;

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -662,8 +662,8 @@ static void unary_task_##SUFFIX##_##NAME(unsigned int nth, unsigned int ith, voi
     const size_t dst_row_size_aligned  = uctx->dst_row_size_aligned;                                                \
                                                                                                                     \
     const uint32_t src0_nrows = uctx->src0_nrows;                                                                   \
-    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                    \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);        \
+    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                  \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);      \
                                                                                                                     \
     if (src0_start_row >= src0_end_row) {                                                                           \
         return;                                                                                                     \
@@ -770,7 +770,7 @@ static void unary_task_##SUFFIX##_##NAME(unsigned int nth, unsigned int ith, voi
         if (next_ir < src0_end_row) {                                                                               \
             const uint32_t next_block_size = unary_block_size(next_ir, src0_end_row, BLOCK, block_src0_contig,      \
                                                               block_dst_contig, ne01, div_ne01);                    \
-            const uint32_t pref_ir = next_ir + next_block_size;                                                       \
+            const uint32_t pref_ir = next_ir + next_block_size;                                                     \
             if (pref_ir < src0_end_row) {                                                                           \
                 const uint32_t pref_block_size = unary_block_size(pref_ir, src0_end_row, BLOCK, block_src0_contig,  \
                                                                   block_dst_contig, ne01, div_ne01);                \

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -497,7 +497,7 @@ static void tri_f32(const float * restrict src,
         }
         if (boundary > ne0) boundary = ne0;
 
-        // Full HVX vectors — each starts at a 128-byte aligned offset
+        // Full HVX vectors - each starts at a 128-byte aligned offset
         for (uint32_t i = 0; i < nvec; i++) {
             const uint32_t vec_start = i * VLEN_FP32;
             const uint32_t vec_end   = vec_start + VLEN_FP32;
@@ -564,7 +564,7 @@ static void softplus_f32(const float * restrict src,
 
         for (uint32_t i = 0; i < ne0; i++) {
             float x = src_f[i];
-            // For x > 20: softplus(x) ≈ x (avoids exp overflow)
+            // For x > 20: softplus(x) ~ x (avoids exp overflow)
             dst_f[i] = (x > 20.0f) ? x : logf(1.0f + expf(x));
         }
     }

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -1149,6 +1149,10 @@ static int execute_op_unary(struct htp_ops_context * octx) {
 
     const struct htp_unary_kernel_params * kparams = (const struct htp_unary_kernel_params *) octx->kernel_params;
 
+    if (!htp_ops_context_set_n_threads(octx, kparams->n_threads)) {
+        return HTP_STATUS_INVAL_PARAMS;
+    }
+
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
     const size_t elem_size = is_f16 ? sizeof(_Float16) : sizeof(float);
     const size_t src0_data_row_size = src0->ne[0] * elem_size;

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -1157,7 +1157,7 @@ static int execute_op_unary(struct htp_ops_context * octx) {
     uint32_t row_start = 0;
     uint32_t nrows     = src0_nrows;
 
-    if (octx->mdev_count > 1) {
+    if (octx->ctx->mdev.count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
         if (can_split) {
@@ -1173,13 +1173,13 @@ static int execute_op_unary(struct htp_ops_context * octx) {
         }
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->mdev_count) {
-            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+        if (total_chunks < octx->ctx->mdev.count) {
+            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
         } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->mdev_idx == octx->mdev_count - 1) {
+            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
+            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
                 nrows = src0_nrows - row_start;
             } else {
                 nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -1158,33 +1158,11 @@ static int execute_op_unary(struct htp_ops_context * octx) {
     uint32_t nrows     = src0_nrows;
 
     if (octx->ctx->mdev.count > 1) {
-        bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
-        uint32_t rows_per_chunk = 1;
-        if (can_split) {
-            if (dst->ne[1] > 1 && (dst->nb[1] & 127) == 0) {
-                rows_per_chunk = 1;
-            } else if (dst->nb[1] == dst_data_row_size &&
-                       (dst->ne[2] <= 1 || dst->nb[2] == dst->nb[1] * dst->ne[1]) &&
-                       (dst->ne[3] <= 1 || dst->nb[3] == dst->nb[2] * dst->ne[2])) {
-                rows_per_chunk = (dst_data_row_size > 0) ? (HEX_L2_LINE_SIZE / hex_gcd_u32(dst_data_row_size, HEX_L2_LINE_SIZE)) : 1;
-            } else {
-                can_split = false;
-            }
-        }
-
-        const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
-        if (total_chunks < octx->ctx->mdev.count) {
-            row_start = (octx->ctx->mdev.idx == 0) ? 0 : src0_nrows;
-            nrows     = (octx->ctx->mdev.idx == 0) ? src0_nrows : 0;
-        } else {
-            const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->ctx->mdev.count - 1, &octx->ctx->mdev.count_div);
-            row_start = MIN(octx->ctx->mdev.idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
-            if (octx->ctx->mdev.idx == octx->ctx->mdev.count - 1) {
-                nrows = src0_nrows - row_start;
-            } else {
-                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
-            }
-        }
+        uint32_t rows_per_chunk = 0;
+        htp_tensor_mdev_rows_per_chunk(dst, (uint32_t) elem_size, (uint32_t) dst_data_row_size, &rows_per_chunk);
+        const struct htp_tensor_mdev_range range = htp_tensor_mdev_partition(src0_nrows, rows_per_chunk, octx->ctx->mdev.idx, octx->ctx->mdev.count, &octx->ctx->mdev.count_div);
+        row_start = range.start;
+        nrows     = range.count;
     }
 
     if (nrows == 0) {

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -1153,7 +1153,7 @@ static int execute_op_unary(struct htp_ops_context * octx) {
 
     uint32_t mdev_row_start, mdev_nrows;
     if (octx->mdev_count > 1) {
-        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        const uint32_t rows_per_mdev = fastdiv(src0_nrows + octx->mdev_count - 1, &octx->mdev_count_div);
         mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
         mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
@@ -1165,7 +1165,7 @@ static int execute_op_unary(struct htp_ops_context * octx) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(kparams->n_threads, mdev_nrows);
+    const uint32_t n_threads = octx->n_threads;
 
     const size_t elem_size = is_f16 ? sizeof(_Float16) : sizeof(float);
 
@@ -1209,7 +1209,7 @@ static int execute_op_unary(struct htp_ops_context * octx) {
         struct htp_unary_context uctx = {
             .octx                  = octx,
             .kparams               = kparams,
-            .src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+            .src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
             .src0_nrows            = mdev_nrows,
             .mdev_row_start         = mdev_row_start,
 

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -46,6 +46,7 @@ struct htp_unary_context {
     uint32_t                  block;
     uint32_t                  src0_nrows;
     uint32_t                  src0_nrows_per_thread;
+    uint32_t                  dev_row_start;
     uint32_t                  nc;
     uint32_t                  col_tile;             // tiled mode
     bool                      broadcast_weight;
@@ -661,8 +662,8 @@ static void unary_task_##SUFFIX##_##NAME(unsigned int nth, unsigned int ith, voi
     const size_t dst_row_size_aligned  = uctx->dst_row_size_aligned;                                                \
                                                                                                                     \
     const uint32_t src0_nrows = uctx->src0_nrows;                                                                   \
-    const uint32_t src0_start_row = src0_nrows_per_thread * ith;                                                    \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, src0_nrows);                        \
+    const uint32_t src0_start_row = uctx->dev_row_start + src0_nrows_per_thread * ith;                             \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->dev_row_start + src0_nrows); \
                                                                                                                     \
     if (src0_start_row >= src0_end_row) {                                                                           \
         return;                                                                                                     \
@@ -843,12 +844,14 @@ static void unary_task_f32_tiled_##NAME(unsigned int nth, unsigned int ith, void
                                                                                                                     \
     htp_unary_preamble;                                                                                             \
                                                                                                                     \
+    uint32_t     src0_nrows_per_thread = uctx->src0_nrows_per_thread;                                               \
+                                                                                                                    \
     int32_t *      op_params = octx->op_params;                                                                     \
     const uint32_t col_tile  = uctx->col_tile;                                                                      \
                                                                                                                     \
-    const uint32_t src0_nrows     = uctx->src0_nrows;                                                               \
-    const uint32_t src0_start_row = uctx->src0_nrows_per_thread * ith;                                              \
-    const uint32_t src0_end_row   = MIN(src0_start_row + uctx->src0_nrows_per_thread, src0_nrows);                  \
+    const uint32_t src0_nrows = uctx->src0_nrows;                                                                   \
+    const uint32_t src0_start_row = uctx->dev_row_start + src0_nrows_per_thread * ith;                             \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->dev_row_start + src0_nrows); \
                                                                                                                     \
     if (src0_start_row >= src0_end_row) {                                                                           \
         return;                                                                                                     \
@@ -1147,7 +1150,22 @@ static int execute_op_unary(struct htp_ops_context * octx) {
     const struct htp_unary_kernel_params * kparams = (const struct htp_unary_kernel_params *) octx->kernel_params;
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
-    const uint32_t n_threads  = kparams->n_threads;
+
+    uint32_t dev_row_start, dev_nrows;
+    if (octx->ndev > 1) {
+        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
+        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
+        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    } else {
+        dev_row_start = 0;
+        dev_nrows     = src0_nrows;
+    }
+
+    if (dev_nrows == 0) {
+        return HTP_STATUS_OK;
+    }
+
+    const uint32_t n_threads  = MIN(kparams->n_threads, dev_nrows);
 
     const size_t elem_size = is_f16 ? sizeof(_Float16) : sizeof(float);
 
@@ -1191,8 +1209,9 @@ static int execute_op_unary(struct htp_ops_context * octx) {
         struct htp_unary_context uctx = {
             .octx                  = octx,
             .kparams               = kparams,
-            .src0_nrows_per_thread = (src0_nrows + n_threads - 1) / n_threads,
-            .src0_nrows            = src0_nrows,
+            .src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
+            .src0_nrows            = dev_nrows,
+            .dev_row_start         = dev_row_start,
 
             .data_src0             = (const uint8_t *)src0->data,
             .data_src1             = (octx->op == HTP_OP_RMS_NORM_MUL) ? (const uint8_t *)src1->data : NULL,

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -46,7 +46,7 @@ struct htp_unary_context {
     uint32_t                  block;
     uint32_t                  src0_nrows;
     uint32_t                  src0_nrows_per_thread;
-    uint32_t                  mdev_row_start;
+    uint32_t                  row_start;
     uint32_t                  nc;
     uint32_t                  col_tile;             // tiled mode
     bool                      broadcast_weight;
@@ -662,8 +662,8 @@ static void unary_task_##SUFFIX##_##NAME(unsigned int nth, unsigned int ith, voi
     const size_t dst_row_size_aligned  = uctx->dst_row_size_aligned;                                                \
                                                                                                                     \
     const uint32_t src0_nrows = uctx->src0_nrows;                                                                   \
-    const uint32_t src0_start_row = uctx->mdev_row_start + src0_nrows_per_thread * ith;                               \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->mdev_row_start + src0_nrows);   \
+    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                     \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);         \
                                                                                                                     \
     if (src0_start_row >= src0_end_row) {                                                                           \
         return;                                                                                                     \
@@ -850,8 +850,8 @@ static void unary_task_f32_tiled_##NAME(unsigned int nth, unsigned int ith, void
     const uint32_t col_tile  = uctx->col_tile;                                                                        \
                                                                                                                       \
     const uint32_t src0_nrows = uctx->src0_nrows;                                                                     \
-    const uint32_t src0_start_row = uctx->mdev_row_start + src0_nrows_per_thread * ith;                               \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->mdev_row_start + src0_nrows);   \
+    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                     \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);         \
                                                                                                                       \
     if (src0_start_row >= src0_end_row) {                                                                             \
         return;                                                                                                       \
@@ -1154,7 +1154,9 @@ static int execute_op_unary(struct htp_ops_context * octx) {
     const size_t src0_data_row_size = src0->ne[0] * elem_size;
     const size_t dst_data_row_size  = dst->ne[0]  * elem_size;
 
-    uint32_t mdev_row_start, mdev_nrows;
+    uint32_t row_start = 0;
+    uint32_t nrows     = src0_nrows;
+
     if (octx->mdev_count > 1) {
         bool can_split = (dst->ne[0] == 1 || dst->nb[0] == elem_size) && !htp_tensor_is_permuted(dst);
         uint32_t rows_per_chunk = 1;
@@ -1172,23 +1174,20 @@ static int execute_op_unary(struct htp_ops_context * octx) {
 
         const uint32_t total_chunks = can_split ? (src0_nrows / rows_per_chunk) : 0;
         if (total_chunks < octx->mdev_count) {
-            mdev_row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
-            mdev_nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
+            row_start = (octx->mdev_idx == 0) ? 0 : src0_nrows;
+            nrows     = (octx->mdev_idx == 0) ? src0_nrows : 0;
         } else {
             const uint32_t chunks_per_mdev = fastdiv(total_chunks + octx->mdev_count - 1, &octx->mdev_count_div);
-            mdev_row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
+            row_start = MIN(octx->mdev_idx * chunks_per_mdev * rows_per_chunk, src0_nrows);
             if (octx->mdev_idx == octx->mdev_count - 1) {
-                mdev_nrows = src0_nrows - mdev_row_start;
+                nrows = src0_nrows - row_start;
             } else {
-                mdev_nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - mdev_row_start);
+                nrows = MIN(chunks_per_mdev * rows_per_chunk, src0_nrows - row_start);
             }
         }
-    } else {
-        mdev_row_start = 0;
-        mdev_nrows     = src0_nrows;
     }
 
-    if (mdev_nrows == 0) {
+    if (nrows == 0) {
         return HTP_STATUS_OK;
     }
 
@@ -1231,9 +1230,9 @@ static int execute_op_unary(struct htp_ops_context * octx) {
         struct htp_unary_context uctx = {
             .octx                  = octx,
             .kparams               = kparams,
-            .src0_nrows_per_thread = fastdiv(mdev_nrows + n_threads - 1, &octx->n_threads_div),
-            .src0_nrows            = mdev_nrows,
-            .mdev_row_start         = mdev_row_start,
+            .src0_nrows_per_thread = fastdiv(nrows + n_threads - 1, &octx->n_threads_div),
+            .src0_nrows            = nrows,
+            .row_start             = row_start,
 
             .data_src0             = (const uint8_t *)src0->data,
             .data_src1             = (octx->op == HTP_OP_RMS_NORM_MUL) ? (const uint8_t *)src1->data : NULL,

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -46,7 +46,7 @@ struct htp_unary_context {
     uint32_t                  block;
     uint32_t                  src0_nrows;
     uint32_t                  src0_nrows_per_thread;
-    uint32_t                  dev_row_start;
+    uint32_t                  mdev_row_start;
     uint32_t                  nc;
     uint32_t                  col_tile;             // tiled mode
     bool                      broadcast_weight;
@@ -662,8 +662,8 @@ static void unary_task_##SUFFIX##_##NAME(unsigned int nth, unsigned int ith, voi
     const size_t dst_row_size_aligned  = uctx->dst_row_size_aligned;                                                \
                                                                                                                     \
     const uint32_t src0_nrows = uctx->src0_nrows;                                                                   \
-    const uint32_t src0_start_row = uctx->dev_row_start + src0_nrows_per_thread * ith;                             \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->dev_row_start + src0_nrows); \
+    const uint32_t src0_start_row = uctx->mdev_row_start + src0_nrows_per_thread * ith;                               \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->mdev_row_start + src0_nrows);   \
                                                                                                                     \
     if (src0_start_row >= src0_end_row) {                                                                           \
         return;                                                                                                     \
@@ -834,126 +834,126 @@ DEFINE_UNARY_TASK_IMPL(unary_abs, _Float16, f16, false, false, abs_f16(src0_vtcm
 DEFINE_UNARY_TASK_IMPL(unary_log, _Float16, f16, false, false, log_f16(src0_vtcm, dst_vtcm, block_size, uctx))
 
 // Apply a pointwise unary op to one column tile that is already in VTCM.
-#define DEFINE_UNARY_TILED_TASK(NAME, IS_TRI, CORE_TILE_EXPR)                                                       \
-static void unary_task_f32_tiled_##NAME(unsigned int nth, unsigned int ith, void * data) {                          \
-    const struct htp_unary_context * uctx = (const struct htp_unary_context *) data;                                \
-    struct htp_ops_context * octx = uctx->octx;                                                                     \
-    const struct htp_tensor * src = octx->src[0];                                                                   \
-    const struct htp_tensor * dst = octx->dst;                                                                      \
-    struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                          \
-                                                                                                                    \
-    htp_unary_preamble;                                                                                             \
-                                                                                                                    \
-    uint32_t     src0_nrows_per_thread = uctx->src0_nrows_per_thread;                                               \
-                                                                                                                    \
-    int32_t *      op_params = octx->op_params;                                                                     \
-    const uint32_t col_tile  = uctx->col_tile;                                                                      \
-                                                                                                                    \
-    const uint32_t src0_nrows = uctx->src0_nrows;                                                                   \
-    const uint32_t src0_start_row = uctx->dev_row_start + src0_nrows_per_thread * ith;                             \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->dev_row_start + src0_nrows); \
-                                                                                                                    \
-    if (src0_start_row >= src0_end_row) {                                                                           \
-        return;                                                                                                     \
-    }                                                                                                               \
-                                                                                                                    \
-    const uint8_t * restrict data_src = uctx->data_src0;                                                            \
-    uint8_t * restrict       data_dst = uctx->data_dst;                                                             \
-                                                                                                                    \
-    uint8_t * src0_vtcm_data = uctx->vtcm_src0 + (ith * uctx->vtcm_src0_size_per_thread);                           \
-    uint8_t * dst_vtcm_data  = uctx->vtcm_dst + (ith * uctx->vtcm_dst_size_per_thread);                             \
-                                                                                                                    \
-    const size_t src0_half = uctx->src0_vtcm_half_size;                                                             \
-    const size_t dst_half  = uctx->dst_vtcm_half_size;                                                              \
-                                                                                                                    \
-    dma_queue * dmaq = octx->ctx->dma[ith];                                                                         \
-                                                                                                                    \
-    const struct fastdiv_values * div_ne01  = &uctx->kparams->div_ne01;                                             \
-    const struct fastdiv_values * div_ne02  = &uctx->kparams->div_ne02;                                             \
-    const struct fastdiv_values * div_ne012 = &uctx->kparams->div_ne012;                                            \
-    const struct fastdiv_values * div_tpr   = &uctx->kparams->div_tpr;                                              \
-                                                                                                                    \
-    const uint32_t tiles_per_row = (ne0 + col_tile - 1) / col_tile;                                                 \
-    const int32_t  tri_ttype     = (IS_TRI) ? op_params[0] : 0;                                                     \
-                                                                                                                    \
-    const bool src0_contig = (nb02 == (size_t)ne01 * nb01) &&                                                       \
-                             (nb03 == (size_t)ne02 * nb02);                                                         \
-    const bool dst_contig  = (nb2  == (size_t)ne1  * nb1)  &&                                                       \
-                             (nb3  == (size_t)ne2  * nb2);                                                          \
-                                                                                                                    \
-    const uint32_t total_tiles = (src0_end_row - src0_start_row) * tiles_per_row;                                   \
-                                                                                                                    \
-    for (uint32_t t = 0, vtcm_idx = 0; t < total_tiles && vtcm_idx < 2; t++, vtcm_idx++) {                          \
-        const uint32_t row  = src0_start_row + t / tiles_per_row;                                                   \
-        const uint32_t col  = (t % tiles_per_row) * col_tile;                                                       \
-        const uint32_t tw   = MIN(col_tile, ne0 - col);                                                             \
-        const size_t   tb   = (size_t) tw * sizeof(float);                                                          \
-        const size_t   soff = (src0_contig ? (row * nb01) :                                                         \
-                               unary_row_offset(row, ne01, ne02, div_ne01, div_ne02, div_ne012, nb01, nb02, nb03)) +\
-                               (size_t) col * sizeof(float);                                                        \
-                                                                                                                    \
-        dma_queue_push(dmaq, dma_make_ptr(data_dst, dst_vtcm_data + (vtcm_idx * dst_half)), 0, 0, 0, 0);            \
-        dma_queue_push(dmaq, dma_make_ptr(src0_vtcm_data + (vtcm_idx * src0_half), data_src + soff), tb, tb, tb, 1);\
-    }                                                                                                               \
-                                                                                                                    \
-    uint32_t row = src0_start_row;                                                                                  \
-    uint32_t col = 0;                                                                                               \
-    uint32_t tile_in_row = 0;                                                                                       \
-    uint32_t i01 = fastmodulo(row, ne01, div_ne01);                                                                 \
-                                                                                                                    \
-    uint32_t prow = src0_start_row + fastdiv(2, div_tpr);                                                           \
-    uint32_t pcol = fastmodulo(2, tiles_per_row, div_tpr) * col_tile;                                               \
-    uint32_t ptile_in_row = fastmodulo(2, tiles_per_row, div_tpr);                                                  \
-                                                                                                                    \
-    for (uint32_t t = 0; t < total_tiles; t++) {                                                                    \
-        uint8_t * dst_vtcm = (uint8_t *) dma_queue_pop(dmaq).src;                                                   \
-        uint8_t * src_vtcm = (uint8_t *) dma_queue_pop(dmaq).dst;                                                   \
-                                                                                                                    \
-        const uint32_t tw  = MIN(col_tile, ne0 - col);                                                              \
-                                                                                                                    \
-        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, t);                                                       \
-        CORE_TILE_EXPR;                                                                                             \
-        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, t);                                                        \
-                                                                                                                    \
-        const size_t doff = (dst_contig ? (row * nb1) :                                                             \
-                             unary_row_offset(row, ne1, ne2, div_ne01, div_ne02, div_ne012, nb1, nb2, nb3)) +       \
-                             (size_t) col * sizeof(float);                                                          \
-        const size_t tb   = (size_t) tw * sizeof(float);                                                            \
-        dma_queue_push(dmaq, dma_make_ptr(data_dst + doff, dst_vtcm), tb, tb, tb, 1);                               \
-                                                                                                                    \
-        const uint32_t pt = t + 2;                                                                                  \
-        if (pt < total_tiles) {                                                                                     \
-            const uint32_t ptw  = MIN(col_tile, ne0 - pcol);                                                        \
-            const size_t   ptb  = (size_t) ptw * sizeof(float);                                                     \
-            const size_t   psoff = (src0_contig ? (prow * nb01) :                                                   \
-                                    unary_row_offset(prow, ne01, ne02, div_ne01, div_ne02, div_ne012, nb01, nb02,   \
-                                                     nb03)) +                                                       \
-                                   (size_t) pcol * sizeof(float);                                                   \
-            dma_queue_push(dmaq, dma_make_ptr(src_vtcm, data_src + psoff), ptb, ptb, ptb, 1);                       \
-        }                                                                                                           \
-                                                                                                                    \
-        tile_in_row++;                                                                                              \
-        col += col_tile;                                                                                            \
-        if (tile_in_row == tiles_per_row) {                                                                         \
-            tile_in_row = 0;                                                                                        \
-            col = 0;                                                                                                \
-            row++;                                                                                                  \
-            i01++;                                                                                                  \
-            if (i01 == ne01) {                                                                                      \
-                i01 = 0;                                                                                            \
-            }                                                                                                       \
-        }                                                                                                           \
-                                                                                                                    \
-        ptile_in_row++;                                                                                             \
-        pcol += col_tile;                                                                                           \
-        if (ptile_in_row == tiles_per_row) {                                                                        \
-            ptile_in_row = 0;                                                                                       \
-            pcol = 0;                                                                                               \
-            prow++;                                                                                                 \
-        }                                                                                                           \
-    }                                                                                                               \
-                                                                                                                    \
-    dma_queue_flush(dmaq);                                                                                          \
+#define DEFINE_UNARY_TILED_TASK(NAME, IS_TRI, CORE_TILE_EXPR)                                                         \
+static void unary_task_f32_tiled_##NAME(unsigned int nth, unsigned int ith, void * data) {                            \
+    const struct htp_unary_context * uctx = (const struct htp_unary_context *) data;                                  \
+    struct htp_ops_context * octx = uctx->octx;                                                                       \
+    const struct htp_tensor * src = octx->src[0];                                                                     \
+    const struct htp_tensor * dst = octx->dst;                                                                        \
+    struct htp_thread_trace * tr = &octx->ctx->trace[ith];                                                            \
+                                                                                                                      \
+    htp_unary_preamble;                                                                                               \
+                                                                                                                      \
+    uint32_t     src0_nrows_per_thread = uctx->src0_nrows_per_thread;                                                 \
+                                                                                                                      \
+    int32_t *      op_params = octx->op_params;                                                                       \
+    const uint32_t col_tile  = uctx->col_tile;                                                                        \
+                                                                                                                      \
+    const uint32_t src0_nrows = uctx->src0_nrows;                                                                     \
+    const uint32_t src0_start_row = uctx->mdev_row_start + src0_nrows_per_thread * ith;                               \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->mdev_row_start + src0_nrows);   \
+                                                                                                                      \
+    if (src0_start_row >= src0_end_row) {                                                                             \
+        return;                                                                                                       \
+    }                                                                                                                 \
+                                                                                                                      \
+    const uint8_t * restrict data_src = uctx->data_src0;                                                              \
+    uint8_t * restrict       data_dst = uctx->data_dst;                                                               \
+                                                                                                                      \
+    uint8_t * src0_vtcm_data = uctx->vtcm_src0 + (ith * uctx->vtcm_src0_size_per_thread);                             \
+    uint8_t * dst_vtcm_data  = uctx->vtcm_dst + (ith * uctx->vtcm_dst_size_per_thread);                               \
+                                                                                                                      \
+    const size_t src0_half = uctx->src0_vtcm_half_size;                                                               \
+    const size_t dst_half  = uctx->dst_vtcm_half_size;                                                                \
+                                                                                                                      \
+    dma_queue * dmaq = octx->ctx->dma[ith];                                                                           \
+                                                                                                                      \
+    const struct fastdiv_values * div_ne01  = &uctx->kparams->div_ne01;                                               \
+    const struct fastdiv_values * div_ne02  = &uctx->kparams->div_ne02;                                               \
+    const struct fastdiv_values * div_ne012 = &uctx->kparams->div_ne012;                                              \
+    const struct fastdiv_values * div_tpr   = &uctx->kparams->div_tpr;                                                \
+                                                                                                                      \
+    const uint32_t tiles_per_row = (ne0 + col_tile - 1) / col_tile;                                                   \
+    const int32_t  tri_ttype     = (IS_TRI) ? op_params[0] : 0;                                                       \
+                                                                                                                      \
+    const bool src0_contig = (nb02 == (size_t)ne01 * nb01) &&                                                         \
+                             (nb03 == (size_t)ne02 * nb02);                                                           \
+    const bool dst_contig  = (nb2  == (size_t)ne1  * nb1)  &&                                                         \
+                             (nb3  == (size_t)ne2  * nb2);                                                            \
+                                                                                                                      \
+    const uint32_t total_tiles = (src0_end_row - src0_start_row) * tiles_per_row;                                     \
+                                                                                                                      \
+    for (uint32_t t = 0, vtcm_idx = 0; t < total_tiles && vtcm_idx < 2; t++, vtcm_idx++) {                            \
+        const uint32_t row  = src0_start_row + t / tiles_per_row;                                                     \
+        const uint32_t col  = (t % tiles_per_row) * col_tile;                                                         \
+        const uint32_t tw   = MIN(col_tile, ne0 - col);                                                               \
+        const size_t   tb   = (size_t) tw * sizeof(float);                                                            \
+        const size_t   soff = (src0_contig ? (row * nb01) :                                                           \
+                               unary_row_offset(row, ne01, ne02, div_ne01, div_ne02, div_ne012, nb01, nb02, nb03)) +  \
+                               (size_t) col * sizeof(float);                                                          \
+                                                                                                                      \
+        dma_queue_push(dmaq, dma_make_ptr(data_dst, dst_vtcm_data + (vtcm_idx * dst_half)), 0, 0, 0, 0);              \
+        dma_queue_push(dmaq, dma_make_ptr(src0_vtcm_data + (vtcm_idx * src0_half), data_src + soff), tb, tb, tb, 1);  \
+    }                                                                                                                 \
+                                                                                                                      \
+    uint32_t row = src0_start_row;                                                                                    \
+    uint32_t col = 0;                                                                                                 \
+    uint32_t tile_in_row = 0;                                                                                         \
+    uint32_t i01 = fastmodulo(row, ne01, div_ne01);                                                                   \
+                                                                                                                      \
+    uint32_t prow = src0_start_row + fastdiv(2, div_tpr);                                                             \
+    uint32_t pcol = fastmodulo(2, tiles_per_row, div_tpr) * col_tile;                                                 \
+    uint32_t ptile_in_row = fastmodulo(2, tiles_per_row, div_tpr);                                                    \
+                                                                                                                      \
+    for (uint32_t t = 0; t < total_tiles; t++) {                                                                      \
+        uint8_t * dst_vtcm = (uint8_t *) dma_queue_pop(dmaq).src;                                                     \
+        uint8_t * src_vtcm = (uint8_t *) dma_queue_pop(dmaq).dst;                                                     \
+                                                                                                                      \
+        const uint32_t tw  = MIN(col_tile, ne0 - col);                                                                \
+                                                                                                                      \
+        htp_trace_event_start(tr, HTP_TRACE_EVT_HVX_COMP, t);                                                         \
+        CORE_TILE_EXPR;                                                                                               \
+        htp_trace_event_stop(tr, HTP_TRACE_EVT_HVX_COMP, t);                                                          \
+                                                                                                                      \
+        const size_t doff = (dst_contig ? (row * nb1) :                                                               \
+                             unary_row_offset(row, ne1, ne2, div_ne01, div_ne02, div_ne012, nb1, nb2, nb3)) +         \
+                             (size_t) col * sizeof(float);                                                            \
+        const size_t tb   = (size_t) tw * sizeof(float);                                                              \
+        dma_queue_push(dmaq, dma_make_ptr(data_dst + doff, dst_vtcm), tb, tb, tb, 1);                                 \
+                                                                                                                      \
+        const uint32_t pt = t + 2;                                                                                    \
+        if (pt < total_tiles) {                                                                                       \
+            const uint32_t ptw  = MIN(col_tile, ne0 - pcol);                                                          \
+            const size_t   ptb  = (size_t) ptw * sizeof(float);                                                       \
+            const size_t   psoff = (src0_contig ? (prow * nb01) :                                                     \
+                                    unary_row_offset(prow, ne01, ne02, div_ne01, div_ne02, div_ne012, nb01, nb02,     \
+                                                     nb03)) +                                                         \
+                                   (size_t) pcol * sizeof(float);                                                     \
+            dma_queue_push(dmaq, dma_make_ptr(src_vtcm, data_src + psoff), ptb, ptb, ptb, 1);                         \
+        }                                                                                                             \
+                                                                                                                      \
+        tile_in_row++;                                                                                                \
+        col += col_tile;                                                                                              \
+        if (tile_in_row == tiles_per_row) {                                                                           \
+            tile_in_row = 0;                                                                                          \
+            col = 0;                                                                                                  \
+            row++;                                                                                                    \
+            i01++;                                                                                                    \
+            if (i01 == ne01) {                                                                                        \
+                i01 = 0;                                                                                              \
+            }                                                                                                         \
+        }                                                                                                             \
+                                                                                                                      \
+        ptile_in_row++;                                                                                               \
+        pcol += col_tile;                                                                                             \
+        if (ptile_in_row == tiles_per_row) {                                                                          \
+            ptile_in_row = 0;                                                                                         \
+            pcol = 0;                                                                                                 \
+            prow++;                                                                                                   \
+        }                                                                                                             \
+    }                                                                                                                 \
+                                                                                                                      \
+    dma_queue_flush(dmaq);                                                                                            \
 }
 
 static inline void tile_scale_f32(uint8_t * dst_vtcm, const uint8_t * src_vtcm, uint32_t tw, const int32_t * op_params) {
@@ -1151,21 +1151,21 @@ static int execute_op_unary(struct htp_ops_context * octx) {
 
     const uint32_t src0_nrows = src0->ne[1] * src0->ne[2] * src0->ne[3];
 
-    uint32_t dev_row_start, dev_nrows;
-    if (octx->ndev > 1) {
-        const uint32_t rows_per_dev = (src0_nrows + octx->ndev - 1) / octx->ndev;
-        dev_row_start = MIN(octx->idev * rows_per_dev, src0_nrows);
-        dev_nrows     = MIN(rows_per_dev, src0_nrows - dev_row_start);
+    uint32_t mdev_row_start, mdev_nrows;
+    if (octx->mdev_count > 1) {
+        const uint32_t rows_per_mdev = (src0_nrows + octx->mdev_count - 1) / octx->mdev_count;
+        mdev_row_start = MIN(octx->mdev_idx * rows_per_mdev, src0_nrows);
+        mdev_nrows     = MIN(rows_per_mdev, src0_nrows - mdev_row_start);
     } else {
-        dev_row_start = 0;
-        dev_nrows     = src0_nrows;
+        mdev_row_start = 0;
+        mdev_nrows     = src0_nrows;
     }
 
-    if (dev_nrows == 0) {
+    if (mdev_nrows == 0) {
         return HTP_STATUS_OK;
     }
 
-    const uint32_t n_threads  = MIN(kparams->n_threads, dev_nrows);
+    const uint32_t n_threads  = MIN(kparams->n_threads, mdev_nrows);
 
     const size_t elem_size = is_f16 ? sizeof(_Float16) : sizeof(float);
 
@@ -1209,9 +1209,9 @@ static int execute_op_unary(struct htp_ops_context * octx) {
         struct htp_unary_context uctx = {
             .octx                  = octx,
             .kparams               = kparams,
-            .src0_nrows_per_thread = (dev_nrows + n_threads - 1) / n_threads,
-            .src0_nrows            = dev_nrows,
-            .dev_row_start         = dev_row_start,
+            .src0_nrows_per_thread = (mdev_nrows + n_threads - 1) / n_threads,
+            .src0_nrows            = mdev_nrows,
+            .mdev_row_start         = mdev_row_start,
 
             .data_src0             = (const uint8_t *)src0->data,
             .data_src1             = (octx->op == HTP_OP_RMS_NORM_MUL) ? (const uint8_t *)src1->data : NULL,

--- a/ggml/src/ggml-hexagon/htp/unary-ops.c
+++ b/ggml/src/ggml-hexagon/htp/unary-ops.c
@@ -662,8 +662,8 @@ static void unary_task_##SUFFIX##_##NAME(unsigned int nth, unsigned int ith, voi
     const size_t dst_row_size_aligned  = uctx->dst_row_size_aligned;                                                \
                                                                                                                     \
     const uint32_t src0_nrows = uctx->src0_nrows;                                                                   \
-    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                     \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);         \
+    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                    \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);        \
                                                                                                                     \
     if (src0_start_row >= src0_end_row) {                                                                           \
         return;                                                                                                     \
@@ -770,7 +770,7 @@ static void unary_task_##SUFFIX##_##NAME(unsigned int nth, unsigned int ith, voi
         if (next_ir < src0_end_row) {                                                                               \
             const uint32_t next_block_size = unary_block_size(next_ir, src0_end_row, BLOCK, block_src0_contig,      \
                                                               block_dst_contig, ne01, div_ne01);                    \
-            const uint32_t pref_ir = next_ir + next_block_size;                                                     \
+            const uint32_t pref_ir = next_ir + next_block_size;                                                       \
             if (pref_ir < src0_end_row) {                                                                           \
                 const uint32_t pref_block_size = unary_block_size(pref_ir, src0_end_row, BLOCK, block_src0_contig,  \
                                                                   block_dst_contig, ne01, div_ne01);                \
@@ -850,8 +850,8 @@ static void unary_task_f32_tiled_##NAME(unsigned int nth, unsigned int ith, void
     const uint32_t col_tile  = uctx->col_tile;                                                                        \
                                                                                                                       \
     const uint32_t src0_nrows = uctx->src0_nrows;                                                                     \
-    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                     \
-    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);         \
+    const uint32_t src0_start_row = uctx->row_start + src0_nrows_per_thread * ith;                                    \
+    const uint32_t src0_end_row   = MIN(src0_start_row + src0_nrows_per_thread, uctx->row_start + src0_nrows);        \
                                                                                                                       \
     if (src0_start_row >= src0_end_row) {                                                                             \
         return;                                                                                                       \

--- a/scripts/snapdragon/ggml-hexagon-align-macros.py
+++ b/scripts/snapdragon/ggml-hexagon-align-macros.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+align-macros.py - Inspect and align trailing backslashes in multiline C/C++ macros.
+
+Usage:
+    align-macros.py [paths...]                 # Check and report misaligned macros
+    align-macros.py --diff [paths...]          # Show unified diff of fixes
+    align-macros.py --fix [paths...]           # Fix misaligned macros in-place
+    align-macros.py --fix --mode majority ...  # Align to the dominant column
+    align-macros.py --fix --pad 2 ...          # Align to (max_content_len + pad)
+
+Safety rules:
+    - Macros that are ALREADY aligned are NEVER touched (unless --all is given).
+    - Whitespace after trailing backslashes is flagged and cleaned.
+"""
+
+import argparse
+import difflib
+import os
+import re
+import sys
+from collections import Counter
+from typing import List, Optional, Tuple, NamedTuple
+
+
+class MacroLine(NamedTuple):
+    line_num: int       # 1-indexed
+    raw: str            # Original line including newline
+    content: str        # Line content before trailing backslash (stripped of trailing whitespace)
+    bs_col: Optional[int]  # 1-indexed column of backslash, or None if last line has no backslash
+    trailing_ws: bool   # True if whitespace existed after the backslash
+
+
+class MacroDef(NamedTuple):
+    name: str
+    filepath: str
+    start_line: int
+    end_line: int
+    lines: List[MacroLine]
+
+
+def parse_macros(filepath: str) -> List[MacroDef]:
+    """Extract all multiline macros from a C/C++ source file."""
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except Exception as e:
+        print(f"Error reading {filepath}: {e}", file=sys.stderr)
+        return []
+
+    macros: List[MacroDef] = []
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        line = lines[i]
+        m = re.match(r"^\s*#\s*define\s+([A-Za-z_][A-Za-z0-9_]*)", line)
+        if m:
+            macro_name = m.group(1)
+            macro_start = i + 1
+            macro_lines: List[MacroLine] = []
+            cur = i
+
+            while cur < n:
+                l_raw = lines[cur]
+                l_rstrip = l_raw.rstrip("\r\n")
+
+                # Check if line has a trailing backslash
+                # Note: handle possible accidental spaces after backslash
+                match_bs = re.search(r"\\([ \t]*)$", l_rstrip)
+                if match_bs:
+                    has_trailing_ws = len(match_bs.group(1)) > 0
+                    bs_index = match_bs.start()
+                    content = l_rstrip[:bs_index].rstrip()
+                    # 1-indexed column of the backslash
+                    bs_col = bs_index + 1
+                    macro_lines.append(MacroLine(
+                        line_num=cur + 1,
+                        raw=l_raw,
+                        content=content,
+                        bs_col=bs_col,
+                        trailing_ws=has_trailing_ws
+                    ))
+                    cur += 1
+                else:
+                    # Line does not end with backslash
+                    if cur == i:
+                        # Single-line macro, not multiline
+                        break
+                    else:
+                        # Final line of a multiline macro
+                        macro_lines.append(MacroLine(
+                            line_num=cur + 1,
+                            raw=l_raw,
+                            content=l_rstrip.rstrip(),
+                            bs_col=None,
+                            trailing_ws=False
+                        ))
+                        break
+
+            # Only record if it is a multiline macro (has at least one continuation line)
+            continuation_lines = [ml for ml in macro_lines if ml.bs_col is not None]
+            if continuation_lines:
+                macro_end = macro_lines[-1].line_num
+                macros.append(MacroDef(
+                    name=macro_name,
+                    filepath=filepath,
+                    start_line=macro_start,
+                    end_line=macro_end,
+                    lines=macro_lines
+                ))
+            i = cur
+        i += 1
+
+    return macros
+
+
+def is_macro_aligned(macro: MacroDef) -> bool:
+    """A macro is aligned if all continuation lines have backslashes at the same column."""
+    bs_cols = [ml.bs_col for ml in macro.lines if ml.bs_col is not None]
+    if not bs_cols:
+        return True
+    has_trailing_ws = any(ml.trailing_ws for ml in macro.lines)
+    return len(set(bs_cols)) == 1 and not has_trailing_ws
+
+
+def compute_target_column(macro: MacroDef, mode: str, pad: int, target_col: Optional[int]) -> int:
+    """Determine the column where backslashes should be aligned."""
+    max_content_len = max(len(ml.content) for ml in macro.lines)
+    min_needed = max_content_len + pad
+
+    if target_col is not None:
+        return max(target_col, min_needed)
+
+    bs_cols = [ml.bs_col for ml in macro.lines if ml.bs_col is not None]
+    if not bs_cols:
+        return min_needed
+
+    if mode == "min":
+        return min_needed
+    elif mode == "max":
+        return max(max(bs_cols), min_needed)
+    elif mode == "majority":
+        counts = Counter(bs_cols)
+        # Sort by frequency descending, then by column descending
+        majority_col = sorted(counts.items(), key=lambda x: (-x[1], -x[0]))[0][0]
+        return max(majority_col, min_needed)
+    else:
+        return min_needed
+
+
+def realign_macro_lines(macro: MacroDef, target_col: int) -> List[str]:
+    """Format macro lines with backslashes aligned at target_col."""
+    new_lines: List[str] = []
+    for ml in macro.lines:
+        nl = "\r\n" if ml.raw.endswith("\r\n") else "\n"
+        if ml.bs_col is None:
+            # Last line without backslash
+            new_lines.append(ml.raw)
+        else:
+            if not ml.content:
+                spaces = " " * (target_col - 1)
+                new_lines.append(f"{spaces}\\{nl}")
+            else:
+                spaces_needed = max(1, target_col - len(ml.content) - 1)
+                new_lines.append(f"{ml.content}{' ' * spaces_needed}\\{nl}")
+    return new_lines
+
+
+def process_file(filepath: str, args: argparse.Namespace) -> Tuple[int, int, Optional[str]]:
+    macros = parse_macros(filepath)
+    if not macros:
+        return 0, 0, None
+
+    with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+        file_lines = f.readlines()
+
+    misaligned_count = 0
+    modified = False
+    new_file_lines = list(file_lines)
+
+    for macro in macros:
+        aligned = is_macro_aligned(macro)
+        if not aligned or args.all:
+            if not aligned:
+                misaligned_count += 1
+
+            bs_cols = [ml.bs_col for ml in macro.lines if ml.bs_col is not None]
+            max_content = max(len(ml.content) for ml in macro.lines)
+            col_counts = Counter(bs_cols)
+
+            if not args.quiet:
+                print(f"{filepath}:{macro.start_line}-{macro.end_line} [{macro.name}]")
+                print(f"  Max content width: {max_content}, Min needed column (+{args.pad}): {max_content + args.pad}")
+                print(f"  Current backslash columns: {dict(sorted(col_counts.items()))}")
+                trailing_ws_lines = [ml.line_num for ml in macro.lines if ml.trailing_ws]
+                if trailing_ws_lines:
+                    print(f"  Warning: Trailing whitespace after backslash on line(s): {trailing_ws_lines}")
+
+            target_col = compute_target_column(macro, args.mode, args.pad, args.target_col)
+            if not args.quiet:
+                print(f"  -> Target alignment column: {target_col}")
+
+            realigned = realign_macro_lines(macro, target_col)
+
+            start_idx = macro.start_line - 1
+            end_idx = start_idx + len(macro.lines)
+            if new_file_lines[start_idx:end_idx] != realigned:
+                new_file_lines[start_idx:end_idx] = realigned
+                modified = True
+
+    diff_text = None
+    if modified:
+        diff = difflib.unified_diff(
+            file_lines,
+            new_file_lines,
+            fromfile=f"a/{filepath}",
+            tofile=f"b/{filepath}",
+            lineterm=""
+        )
+        diff_text = "\n".join(diff)
+
+        if args.fix:
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.writelines(new_file_lines)
+            if not args.quiet:
+                print(f"  [FIXED] Updated {filepath}")
+
+    return len(macros), misaligned_count, diff_text
+
+
+def find_source_files(paths: List[str]) -> List[str]:
+    extensions = {".c", ".cpp", ".cc", ".cxx", ".h", ".hpp", ".inl"}
+    result: List[str] = []
+    for p in paths:
+        if os.path.isfile(p):
+            result.append(p)
+        elif os.path.isdir(p):
+            for root, _, files in os.walk(p):
+                for file in sorted(files):
+                    _, ext = os.path.splitext(file)
+                    if ext.lower() in extensions:
+                        result.append(os.path.join(root, file))
+    return sorted(result)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Inspect and align backslashes in multiline C/C++ macros."
+    )
+    parser.add_argument("paths", nargs="*", default=["."], help="Files or directories to scan (default: current dir)")
+    parser.add_argument("--fix", action="store_true", help="Fix misaligned macros in-place")
+    parser.add_argument("--diff", action="store_true", help="Display unified diff of suggested fixes")
+    parser.add_argument("--check", action="store_true", help="Exit with code 1 if misaligned macros exist")
+    parser.add_argument("--mode", choices=["min", "max", "majority"], default="min",
+                        help="Alignment mode: 'min' (max_len + pad), 'max' (max existing col), 'majority' (dominant col)")
+    parser.add_argument("--pad", type=int, default=2, help="Spaces between longest line and backslash (default: 2)")
+    parser.add_argument("--target-col", type=int, default=None, help="Force alignment to an exact column")
+    parser.add_argument("--all", action="store_true", help="Realign all macros even if already aligned (default: only misaligned)")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Only output errors and diffs/summary")
+
+    args = parser.parse_args()
+
+    files = find_source_files(args.paths)
+    if not files:
+        print("No C/C++ source files found.", file=sys.stderr)
+        sys.exit(0)
+
+    total_macros = 0
+    total_misaligned = 0
+    diffs: List[str] = []
+
+    for filepath in files:
+        num_macros, num_misaligned, diff_text = process_file(filepath, args)
+        total_macros += num_macros
+        total_misaligned += num_misaligned
+        if diff_text:
+            diffs.append(diff_text)
+
+    if args.diff and diffs:
+        print("\n--- Proposed Changes ---\n")
+        for d in diffs:
+            print(d)
+
+    print(f"\nSummary: scanned {len(files)} files, {total_macros} multiline macros, {total_misaligned} misaligned.")
+
+    if args.check and total_misaligned > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/snapdragon/ggml-hexagon-align-macros.py
+++ b/scripts/snapdragon/ggml-hexagon-align-macros.py
@@ -16,11 +16,14 @@ Safety rules:
 
 import argparse
 import difflib
+import logging
 import os
 import re
 import sys
 from collections import Counter
 from typing import List, Optional, Tuple, NamedTuple
+
+logger = logging.getLogger("ggml-hexagon-align-macros")
 
 
 class MacroLine(NamedTuple):
@@ -45,7 +48,7 @@ def parse_macros(filepath: str) -> List[MacroDef]:
         with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             lines = f.readlines()
     except Exception as e:
-        print(f"Error reading {filepath}: {e}", file=sys.stderr)
+        logger.error(f"Error reading {filepath}: {e}")
         return []
 
     macros: List[MacroDef] = []
@@ -190,16 +193,16 @@ def process_file(filepath: str, args: argparse.Namespace) -> Tuple[int, int, Opt
             col_counts = Counter(bs_cols)
 
             if not args.quiet:
-                print(f"{filepath}:{macro.start_line}-{macro.end_line} [{macro.name}]")
-                print(f"  Max content width: {max_content}, Min needed column (+{args.pad}): {max_content + args.pad}")
-                print(f"  Current backslash columns: {dict(sorted(col_counts.items()))}")
+                logger.info(f"{filepath}:{macro.start_line}-{macro.end_line} [{macro.name}]")
+                logger.info(f"  Max content width: {max_content}, Min needed column (+{args.pad}): {max_content + args.pad}")
+                logger.info(f"  Current backslash columns: {dict(sorted(col_counts.items()))}")
                 trailing_ws_lines = [ml.line_num for ml in macro.lines if ml.trailing_ws]
                 if trailing_ws_lines:
-                    print(f"  Warning: Trailing whitespace after backslash on line(s): {trailing_ws_lines}")
+                    logger.warning(f"  Warning: Trailing whitespace after backslash on line(s): {trailing_ws_lines}")
 
             target_col = compute_target_column(macro, args.mode, args.pad, args.target_col)
             if not args.quiet:
-                print(f"  -> Target alignment column: {target_col}")
+                logger.info(f"  -> Target alignment column: {target_col}")
 
             realigned = realign_macro_lines(macro, target_col)
 
@@ -224,7 +227,7 @@ def process_file(filepath: str, args: argparse.Namespace) -> Tuple[int, int, Opt
             with open(filepath, "w", encoding="utf-8") as f:
                 f.writelines(new_file_lines)
             if not args.quiet:
-                print(f"  [FIXED] Updated {filepath}")
+                logger.info(f"  [FIXED] Updated {filepath}")
 
     return len(macros), misaligned_count, diff_text
 
@@ -245,6 +248,7 @@ def find_source_files(paths: List[str]) -> List[str]:
 
 
 def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
     parser = argparse.ArgumentParser(
         description="Inspect and align backslashes in multiline C/C++ macros."
     )
@@ -263,7 +267,7 @@ def main():
 
     files = find_source_files(args.paths)
     if not files:
-        print("No C/C++ source files found.", file=sys.stderr)
+        logger.error("No C/C++ source files found.")
         sys.exit(0)
 
     total_macros = 0
@@ -278,11 +282,11 @@ def main():
             diffs.append(diff_text)
 
     if args.diff and diffs:
-        print("\n--- Proposed Changes ---\n")
+        logger.info("\n--- Proposed Changes ---\n")
         for d in diffs:
-            print(d)
+            logger.info(d)
 
-    print(f"\nSummary: scanned {len(files)} files, {total_macros} multiline macros, {total_misaligned} misaligned.")
+    logger.info(f"\nSummary: scanned {len(files)} files, {total_macros} multiline macros, {total_misaligned} misaligned.")
 
     if args.check and total_misaligned > 0:
         sys.exit(1)

--- a/scripts/snapdragon/run.py
+++ b/scripts/snapdragon/run.py
@@ -316,6 +316,22 @@ def main():
                 device_val = os.environ["DEVICE"]
             else:
                 device_val = "HTP0"
+
+            # In row-split mode, llama.cpp only needs the main device passed to --device;
+            # the backend manages all devices via GGML_HEXAGON_DEVICES.
+            is_row_split = False
+            for i, arg in enumerate(cmd_args):
+                if arg in ("--split-mode", "-sm") and i + 1 < len(cmd_args):
+                    if cmd_args[i + 1].lower() == "row":
+                        is_row_split = True
+                elif arg.startswith("--split-mode=") and arg.split("=", 1)[1].lower() == "row":
+                    is_row_split = True
+                elif arg.startswith("-sm=") and arg.split("=", 1)[1].lower() == "row":
+                    is_row_split = True
+
+            if is_row_split and device_val:
+                device_val = device_val.split(",")[0]
+
             if device_val:
                 cmd_args += ["--device", device_val]
 

--- a/scripts/snapdragon/run.py
+++ b/scripts/snapdragon/run.py
@@ -317,20 +317,28 @@ def main():
             else:
                 device_val = "HTP0"
 
-            # In row-split mode, llama.cpp only needs the main device passed to --device;
-            # the backend manages all devices via GGML_HEXAGON_DEVICES.
-            is_row_split = False
-            for i, arg in enumerate(cmd_args):
-                if arg in ("--split-mode", "-sm") and i + 1 < len(cmd_args):
-                    if cmd_args[i + 1].lower() == "row":
-                        is_row_split = True
-                elif arg.startswith("--split-mode=") and arg.split("=", 1)[1].lower() == "row":
-                    is_row_split = True
-                elif arg.startswith("-sm=") and arg.split("=", 1)[1].lower() == "row":
-                    is_row_split = True
-
-            if is_row_split and device_val:
-                device_val = device_val.split(",")[0]
+            # If bracket syntax is used in device_val (e.g. HTP0[0-1:0],HTP1[0-1:1]), extract device names for --device
+            if "[" in device_val:
+                names = []
+                depth = 0
+                curr = []
+                for ch in device_val:
+                    if ch == '[':
+                        depth += 1
+                    elif ch == ']':
+                        if depth > 0:
+                            depth -= 1
+                    elif ch == ',' and depth == 0:
+                        part = "".join(curr).strip()
+                        if part:
+                            names.append(part.split("[")[0].strip())
+                        curr = []
+                    elif depth == 0:
+                        curr.append(ch)
+                part = "".join(curr).strip()
+                if part:
+                    names.append(part.split("[")[0].strip())
+                device_val = ",".join(names)
 
             if device_val:
                 cmd_args += ["--device", device_val]

--- a/scripts/snapdragon/run.py
+++ b/scripts/snapdragon/run.py
@@ -14,6 +14,42 @@ import logging
 logger = logging.getLogger("run")
 
 
+MANAGED_ENV_NAMES = (
+    "GGML_HEXAGON_DEVICES",
+    "GGML_HEXAGON_VERBOSE",
+    "GGML_HEXAGON_PROFILE",
+    "GGML_HEXAGON_NHVX",
+    "GGML_HEXAGON_NHMX",
+    "GGML_HEXAGON_HOSTBUF",
+    "GGML_HEXAGON_OPBATCH",
+    "GGML_HEXAGON_OPQUEUE",
+    "GGML_HEXAGON_OPPOLL",
+    "GGML_HEXAGON_OPFILTER",
+    "GGML_HEXAGON_OPFUSION",
+    "GGML_HEXAGON_VMEM",
+    "GGML_HEXAGON_MBUF",
+    "GGML_HEXAGON_MM_SELECT",
+    "GGML_HEXAGON_FA_SELECT",
+    "GGML_HEXAGON_AR_SELECT",
+    "GGML_HEXAGON_ETM",
+    "GGML_HEXAGON_ARCH",
+    "GGML_HEXAGON_OPTRACE",
+    "GGML_OPENCL_PLATFORM",
+    "GGML_OPENCL_DEVICE",
+    "GGML_OPENCL_OPFILTER",
+    "GGML_OPENCL_KERNEL_CACHE_DIR",
+    "GGML_OPENCL_KERNEL_CACHE_DEBUG",
+    "GGML_OPENCL_FA_TUNE",
+    "GGML_OPENCL_DISABLE_FUSION",
+    "GGML_OPENCL_ADRENO_XMEM_GEMM",
+    "GGML_OPENCL_ADRENO_USE_LARGE_BUFFER",
+    "GGML_SCHED_DEBUG",
+    "MTMD_BACKEND_DEVICE",
+    "D",
+    "DEVICE",
+)
+
+
 def parse_target(target_str):
     if not target_str:
         return None, None
@@ -36,6 +72,57 @@ def shlex_join(args_list):
         return shlex.join(args_list)
     import pipes
     return " ".join(pipes.quote(x) for x in args_list)
+
+
+def split_device_list(devices):
+    parts = []
+    curr = []
+    bracket_depth = 0
+
+    for ch in devices:
+        if ch == '[':
+            bracket_depth += 1
+            curr.append(ch)
+        elif ch == ']':
+            if bracket_depth > 0:
+                bracket_depth -= 1
+            curr.append(ch)
+        elif ch == ',' and bracket_depth == 0:
+            part = "".join(curr).strip()
+            if part:
+                parts.append(part)
+            curr = []
+        else:
+            curr.append(ch)
+
+    part = "".join(curr).strip()
+    if part:
+        parts.append(part)
+
+    return parts
+
+
+def device_arg_from_devices(devices):
+    if devices.isdigit():
+        n = int(devices)
+        return ",".join(f"HTP{i}" for i in range(n))
+
+    names = []
+    for part in split_device_list(devices):
+        if "[" in part:
+            part = part.split("[", 1)[0].strip()
+        if part:
+            names.append(part)
+
+    return ",".join(names)
+
+
+def normalize_cmd_device_args(cmd_args):
+    for i, arg in enumerate(cmd_args):
+        if arg == "--device" and i + 1 < len(cmd_args):
+            cmd_args[i + 1] = device_arg_from_devices(cmd_args[i + 1])
+        elif arg.startswith("--device="):
+            cmd_args[i] = "--device=" + device_arg_from_devices(arg.split("=", 1)[1])
 
 
 def main():
@@ -142,8 +229,6 @@ def main():
     def set_env(env_name, opt_val):
         if opt_val is not None:
             env_vars[env_name] = str(opt_val)
-        elif env_name in os.environ:
-            env_vars[env_name] = os.environ[env_name]
 
     # Resolve and filter devices (HTP vs OpenCL)
     device_in_cmd = None
@@ -166,7 +251,7 @@ def main():
         hex_devices = devices_val
         cl_device = ""
     else:
-        parts = [p.strip() for p in devices_val.split(",")]
+        parts = split_device_list(devices_val)
         # Any device containing "htp" is Hexagon, rest is OpenCL
         hex_parts = [p for p in parts if "htp" in p.lower()]
         cl_parts = [
@@ -181,15 +266,13 @@ def main():
     # Set Hexagon devices
     if hex_devices:
         env_vars["GGML_HEXAGON_DEVICES"] = hex_devices
-    elif "GGML_HEXAGON_DEVICES" in os.environ:
-        env_vars["GGML_HEXAGON_DEVICES"] = os.environ["GGML_HEXAGON_DEVICES"]
+
+    normalize_cmd_device_args(cmd_args)
 
     # Set OpenCL device (unless overridden by --cl-device)
     final_cl_device = args.cl_device if args.cl_device is not None else cl_device
     if final_cl_device:
         env_vars["GGML_OPENCL_DEVICE"] = final_cl_device
-    elif "GGML_OPENCL_DEVICE" in os.environ:
-        env_vars["GGML_OPENCL_DEVICE"] = os.environ["GGML_OPENCL_DEVICE"]
 
     # Map shared & backend-specific parameters with correct overrides
 
@@ -206,8 +289,6 @@ def main():
 
     if args.cl_fa_tune or args.profile is not None:
         env_vars["GGML_OPENCL_FA_TUNE"] = "1"
-    elif "GGML_OPENCL_FA_TUNE" in os.environ:
-        env_vars["GGML_OPENCL_FA_TUNE"] = os.environ["GGML_OPENCL_FA_TUNE"]
 
     # Other Hexagon environment variables
     set_env("GGML_HEXAGON_NHVX", args.hex_nhvx)
@@ -235,18 +316,12 @@ def main():
 
     if args.cl_disable_fusion:
         env_vars["GGML_OPENCL_DISABLE_FUSION"] = "1"
-    elif "GGML_OPENCL_DISABLE_FUSION" in os.environ:
-        env_vars["GGML_OPENCL_DISABLE_FUSION"] = os.environ["GGML_OPENCL_DISABLE_FUSION"]
 
     if args.cl_adreno_xmem:
         env_vars["GGML_OPENCL_ADRENO_XMEM_GEMM"] = "1"
-    elif "GGML_OPENCL_ADRENO_XMEM_GEMM" in os.environ:
-        env_vars["GGML_OPENCL_ADRENO_XMEM_GEMM"] = os.environ["GGML_OPENCL_ADRENO_XMEM_GEMM"]
 
     if args.cl_adreno_large_buffer:
         env_vars["GGML_OPENCL_ADRENO_USE_LARGE_BUFFER"] = "1"
-    elif "GGML_OPENCL_ADRENO_USE_LARGE_BUFFER" in os.environ:
-        env_vars["GGML_OPENCL_ADRENO_USE_LARGE_BUFFER"] = os.environ["GGML_OPENCL_ADRENO_USE_LARGE_BUFFER"]
 
     if args.sched_debug:
         env_vars["GGML_SCHED_DEBUG"] = "2"
@@ -288,15 +363,7 @@ def main():
         has_b = any(arg == "-b" for arg in cmd_args)
         if not has_b:
             if args.devices:
-                if args.devices.isdigit():
-                    n = int(args.devices)
-                    device_val = ",".join(f"HTP{i}" for i in range(n))
-                else:
-                    device_val = args.devices
-            elif "D" in os.environ:
-                device_val = os.environ["D"]
-            elif "DEVICE" in os.environ:
-                device_val = os.environ["DEVICE"]
+                device_val = device_arg_from_devices(args.devices)
             else:
                 device_val = "HTP0"
             if device_val:
@@ -305,40 +372,9 @@ def main():
         has_device = any(arg.startswith("--device") for arg in cmd_args)
         if not has_device:
             if args.devices:
-                if args.devices.isdigit():
-                    n = int(args.devices)
-                    device_val = ",".join(f"HTP{i}" for i in range(n))
-                else:
-                    device_val = args.devices
-            elif "D" in os.environ:
-                device_val = os.environ["D"]
-            elif "DEVICE" in os.environ:
-                device_val = os.environ["DEVICE"]
+                device_val = device_arg_from_devices(args.devices)
             else:
                 device_val = "HTP0"
-
-            # If bracket syntax is used in device_val (e.g. HTP0[0-1:0],HTP1[0-1:1]), extract device names for --device
-            if "[" in device_val:
-                names = []
-                depth = 0
-                curr = []
-                for ch in device_val:
-                    if ch == '[':
-                        depth += 1
-                    elif ch == ']':
-                        if depth > 0:
-                            depth -= 1
-                    elif ch == ',' and depth == 0:
-                        part = "".join(curr).strip()
-                        if part:
-                            names.append(part.split("[")[0].strip())
-                        curr = []
-                    elif depth == 0:
-                        curr.append(ch)
-                part = "".join(curr).strip()
-                if part:
-                    names.append(part.split("[")[0].strip())
-                device_val = ",".join(names)
 
             if device_val:
                 cmd_args += ["--device", device_val]
@@ -439,6 +475,8 @@ def main():
         else:
             local_env["LD_LIBRARY_PATH"] = lib_dir + os.path.pathsep + local_env.get("LD_LIBRARY_PATH", "")
 
+        for k in MANAGED_ENV_NAMES:
+            local_env.pop(k, None)
         for k, v in env_vars.items():
             local_env[k] = v
 


### PR DESCRIPTION
## Overview

This PR adds support for `--split-mode row` where the model tensors are split between multiple-NPUs.
The work is heavily based on the original  multi-core implementation by **Alex Lu @alexlu-qc.** 

We already supported `--split-mode tensor` and `--split-mode layer` and this update adds the third method of parallel model execution where the Hexagon backend does all the work splitting internally. `row-split` mode has some advantages over `tensor-split` because it does not require `ALLREDUCE` operations but it also has some downside because all weights need to be shared. So the peformance benefits depend on the model.

The PR further improves support for async backend apis `event_record`, `event_wait` and enables proper `pipepline-parallel` model with `layer-split`. 

Unfortunately, the internal multi-device split affects every kernel (only a few lines of common code but still every kernel needs to know how to partition work). Hence lots of changes but they are all very specific and focused on the main feature.

Some of the changes were also required to address various bugs/issues that got in the way of supporting this mode.
I also include updates to the user guide to cover the new use-cases and the developer guide to add some new guidelines and rules for adding/updating ops/kernels.

## Additional information

Here are some examples how to run all three modes on IQ9 EVK (dual-NPU device).

### Layer Split 

```
./scripts/snapdragon/run.py --target ubuntu:192.168.1.87 --devices HTP0:0,HTP1:0 -- LLAMA_GRAPH_REUSE_DISABLE=1 bin/llama-completion -m Qwen3-4B-Q4_0.gguf --jinja -st -f sample_prompt_1024.txt -n 64 --split-mode layer -ngl 99 --batch-size 2048 --ubatch-size 256
...
0.11.189.594 I common_perf_print: prompt eval time =    1622.79 ms /   740 tokens (    2.19 ms per token,   456.00 tokens per second)
0.11.189.597 I common_perf_print:        eval time =    5795.33 ms /    63 runs   (   91.99 ms per token,    10.87 tokens per second)
```

_Note the need to disable `graph-reuse` for pipeline parallel mode to kick in (not hexagon specific)_

### Tensor Split

```
./scripts/snapdragon/run.py --target ubuntu:maxk@192.168.1.87 --devices HTP0:0,HTP1:0 -- bin/llama-completion -m Qwen3-4B-Q4_0.gguf --jinja -st -f ../sample_prompt_1024.txt --ctx-size 4096 -n 64 --split-mode tensor
...
0.08.511.846 I common_perf_print: prompt eval time =     972.87 ms /   740 tokens (    1.31 ms per token,   760.64 tokens per second)
0.08.511.848 I common_perf_print:        eval time =    4418.10 ms /    63 runs   (   70.13 ms per token,    14.26 tokens per second)

```

### Row Split

```
/scripts/snapdragon/run.py --target ubuntu:maxk@192.168.1.87 --devices 'HTP0[0-1:0]' -- bin/llama-completion -m ../gguf/Qwen3-4B-Q4_0.gguf --jinja -st -f ../sample_prompt_1024.txt --ctx-size 4096 -n 64 --split-mode row
...
0.08.768.227 I common_perf_print: prompt eval time =     871.08 ms /   740 tokens (    1.18 ms per token,   849.53 tokens per second)
0.08.768.229 I common_perf_print:        eval time =    4450.81 ms /    63 runs   (   70.65 ms per token,    14.15 tokens per second)
```

Please see the updated user and developer guides for additional info (`GGML_HEXAGON_DEVICES` syntax, etc)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, lots of help from Antigravity on refactoring, bug hunting, and scripts updates.