### PR TITLE
llama-bench : add --override-kv

### DIFF
--- a/tools/llama-bench/README.md
+++ b/tools/llama-bench/README.md
@@ -75,6 +75,8 @@ test parameters:
   -ot --override-tensor <tensor name pattern>=<buffer type>;...
                                             (default: disabled)
   -nopo, --no-op-offload <0|1>              (default: 0)
+  --override-kv <key>=<type>:<value>        override model metadata by key; types int, float, bool, str
+                                            (default: none; can be given multiple times)
   --no-host <0|1>                           (default: 0)
 
 Multiple values can be given for each parameter by separating them with ','

--- a/tools/llama-bench/llama-bench.cpp
+++ b/tools/llama-bench/llama-bench.cpp
@@ -366,6 +366,7 @@ struct cmd_params {
     std::vector<bool>                no_host;
     std::vector<size_t>              fit_params_target;
     std::vector<uint32_t>            fit_params_min_ctx;
+    std::vector<llama_model_kv_override> kv_overrides;
     ggml_numa_strategy               numa;
     int                              reps;
     ggml_sched_priority              prio;
@@ -411,6 +412,7 @@ static const cmd_params cmd_params_defaults = {
     /* no_host              */ { false },
     /* fit_params_target    */ { 0 },
     /* fit_params_min_ctx   */ { 0 },
+    /* kv_overrides         */ {},
     /* numa                 */ GGML_NUMA_STRATEGY_DISABLED,
     /* reps                 */ 5,
     /* prio                 */ GGML_SCHED_PRIO_NORMAL,
@@ -483,6 +485,8 @@ static void print_usage(int /* argc */, char ** argv) {
     printf("  -ot --override-tensor <tensor name pattern>=<buffer type>;...\n");
     printf("                                                    (default: disabled)\n");
     printf("  -nopo, --no-op-offload <0|1>                      (default: 0)\n");
+    printf("  --override-kv <key>=<type>:<value>                 override model metadata by key; types int, float, bool, str\n");
+    printf("                                                    (default: none; can be given multiple times)\n");
     printf("  --no-host <0|1>                                   (default: %s)\n", join(cmd_params_defaults.no_host, ",").c_str());
     printf("\n");
     printf(
@@ -928,6 +932,16 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
                 }
                 auto p = string_split<bool>(argv[i], split_delim);
                 params.embeddings.insert(params.embeddings.end(), p.begin(), p.end());
+            } else if (arg == "--override-kv") {
+                if (++i >= argc) {
+                    invalid_param = true;
+                    break;
+                }
+                if (!string_parse_kv_override(argv[i], params.kv_overrides)) {
+                    fprintf(stderr, "error: invalid override-kv value: '%s'\n", argv[i]);
+                    invalid_param = true;
+                    break;
+                }
             } else if (arg == "-nopo" || arg == "--no-op-offload") {
                 if (++i >= argc) {
                     invalid_param = true;
@@ -1200,6 +1214,10 @@ static cmd_params parse_cmd_params(int argc, char ** argv) {
     if (params.tensor_buft_overrides.empty()) {
         params.tensor_buft_overrides = cmd_params_defaults.tensor_buft_overrides;
     }
+    if (!params.kv_overrides.empty()) {
+        params.kv_overrides.emplace_back();
+        params.kv_overrides.back().key[0] = 0;
+    }
     if (params.embeddings.empty()) {
         params.embeddings = cmd_params_defaults.embeddings;
     }
@@ -1255,6 +1273,7 @@ struct cmd_params_instance {
     std::vector<ggml_backend_dev_t> devices;
     std::vector<float> tensor_split;
     std::vector<llama_model_tensor_buft_override> tensor_buft_overrides;
+    const std::vector<llama_model_kv_override> * kv_overrides;
     bool               embeddings;
     bool               no_op_offload;
     bool               no_host;
@@ -1273,6 +1292,9 @@ struct cmd_params_instance {
         mparams.lazy_mode     = lazy_mode;
         mparams.main_gpu      = main_gpu;
         mparams.tensor_split  = tensor_split.data();
+        if (kv_overrides && !kv_overrides->empty()) {
+            mparams.kv_overrides = kv_overrides->data();
+        }
         mparams.no_host       = no_host;
 
         if (n_cpu_moe <= 0) {
@@ -1400,6 +1422,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,
                 /* .tensor_buft_overrides = */ ot,
+                /* .kv_overrides          = */ &params.kv_overrides,
                 /* .embeddings            = */ embd,
                 /* .no_op_offload         = */ nopo,
                 /* .no_host               = */ noh,
@@ -1437,6 +1460,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,
                 /* .tensor_buft_overrides = */ ot,
+                /* .kv_overrides          = */ &params.kv_overrides,
                 /* .embeddings            = */ embd,
                 /* .no_op_offload         = */ nopo,
                 /* .no_host               = */ noh,
@@ -1474,6 +1498,7 @@ static std::vector<cmd_params_instance> get_cmd_params_instances(const cmd_param
                 /* .devices               = */ devs,
                 /* .tensor_split          = */ ts,
                 /* .tensor_buft_overrides = */ ot,
+                /* .kv_overrides          = */ &params.kv_overrides,
                 /* .embeddings            = */ embd,
                 /* .no_op_offload         = */ nopo,
                 /* .no_host               = */ noh,


### PR DESCRIPTION
## Overview

Adds `--override-kv KEY=TYPE:VALUE` to `llama-bench`, the same metadata override `llama-server`, `llama-cli` and the other `common`-based tools accept. Parsed with the existing `string_parse_kv_override()`, kept as one list applied to every model load (not a sweep dimension, like `--numa`), passed through `llama_model_params.kv_overrides`. 25 lines plus the README entry.

Why the existing mechanism does not suffice: benchmarking a metadata knob today means driving `llama-server` and reading `timings` instead of `llama-bench`'s pp/tg table with its depth sweeps, repetitions and markdown/JSON output. The case that raised it is `qwen4exp.attention.indexer.top_k` (Qwen3.8-Flash-Next's sparse-attention selection width), which is a prefill lever that grows with depth (+8 % at 29k, +25 % at 120k prompt tokens for 1024 vs 2048 on Vulkan); any GGUF metadata the loader reads at model init is in the same position.

Closes #28546.

## Additional information

Smoke on this branch (master e71b805 + the change), Strix Halo gfx1151 / RADV, Qwen3.8-Flash-Next UD-Q4_K_XL:

```
llama-bench -m ... -ngl 999 -fa 1 -p 64 -n 16 -r 1 -v --override-kv qwen4exp.attention.indexer.top_k=int:1024
validate_override: Using metadata override (  int) 'qwen4exp.attention.indexer.top_k' = 1024
| qwen4exp A3B Q4_K - Medium | 103.68 GiB | 176.94 B | Vulkan | 999 | 1 | pp64 | 91.80 ± 0.00 |
| qwen4exp A3B Q4_K - Medium | 103.68 GiB | 176.94 B | Vulkan | 999 | 1 | tg16 | 22.20 ± 0.00 |
```

An invalid value (`--override-kv foo`) is rejected with `error: invalid override-kv value`, as in `llama-server`.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. AI was used to draft the change and to run and reduce the smoke; I reviewed the changes and ran the tests, and I am responsible for them.
