### PR TITLE
vulkan: fix three null-pointer crashes on pre-1.2 devices reporting VK 1.2 features

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -6973,6 +6973,19 @@ static vk_device ggml_vk_get_device(size_t idx) {
         device->buffer_device_address = vk12_features.bufferDeviceAddress;
         device->vulkan_memory_model = vk12_features.vulkanMemoryModel;
 
+        // Feature bit is core-1.2, but the proc address still needs the KHR extension
+        // enabled on a pre-1.2 device (some drivers report the feature without listing the
+        // extension name) -- otherwise the later call resolves to a null function pointer.
+        if (device->buffer_device_address && device->properties.apiVersion < VK_API_VERSION_1_2) {
+            device_extensions.push_back("VK_KHR_buffer_device_address");
+        }
+
+        // Same pre-1.2 gap as above, for timeline semaphores (used unconditionally, not
+        // behind a capability check).
+        if (vk12_features.timelineSemaphore && device->properties.apiVersion < VK_API_VERSION_1_2) {
+            device_extensions.push_back("VK_KHR_timeline_semaphore");
+        }
+
         if (device->subgroup_size_control) {
             device->subgroup_min_size = subgroup_size_control_props.minSubgroupSize;
             device->subgroup_max_size = subgroup_size_control_props.maxSubgroupSize;
@@ -7099,7 +7112,10 @@ static vk_device ggml_vk_get_device(size_t idx) {
             throw std::runtime_error("Unsupported device");
         }
 
-        device_extensions.push_back("VK_KHR_16bit_storage");
+        // Core since 1.1; some drivers stop listing it as an extension past that point.
+        if (device->properties.apiVersion < VK_API_VERSION_1_1) {
+            device_extensions.push_back("VK_KHR_16bit_storage");
+        }
 
 #ifdef GGML_VULKAN_VALIDATE
         device_extensions.push_back("VK_KHR_shader_non_semantic_info");
@@ -7222,6 +7238,10 @@ static vk_device ggml_vk_get_device(size_t idx) {
             .setPEnabledExtensionNames(device_extensions);
         device_create_info.setPNext(&device_features2);
         device->device = device->physical_device.createDevice(device_create_info);
+
+        // Only ever init()'d against the instance; some ICDs don't resolve device-level
+        // extension functions through the instance-level trampoline alone.
+        VULKAN_HPP_DEFAULT_DISPATCHER.init(device->device);
 
         if (device->device_fault) {
             device->pfn_vkGetDeviceFaultInfoEXT = (PFN_vkGetDeviceFaultInfoEXT)


### PR DESCRIPTION
On drivers whose real `VkPhysicalDeviceProperties.apiVersion` is < 1.2 but that still populate `VkPhysicalDeviceVulkan12Features` (observed live on a Samsung Galaxy S21 FE, Mali-G78, Android 16), three promoted-to-1.2 code paths in `ggml-vulkan.cpp` resolved to null function pointers and crashed with SIGSEGV (fault addr `0x0`) the moment they were actually called:

1. `VK_KHR_16bit_storage` was requested as an explicit device extension unconditionally, even once its functionality is core (Vulkan 1.1+) and some drivers correctly stop advertising it as a discrete extension name — this produced `VK_ERROR_EXTENSION_NOT_PRESENT` at device-creation time. Fix: only request it below `VK_API_VERSION_1_1`.
2. `device->buffer_device_address` is set purely from the `VK_KHR_buffer_device_address` / Vulkan-1.2 feature bit, but the corresponding extension was never added to `device_extensions` — so on a sub-1.2 device, `vkGetDeviceProcAddr("vkGetBufferDeviceAddress")` legitimately returns null, and the very first `ggml_vk_create_buffer()` call crashes.
3. Same gap for `VK_KHR_timeline_semaphore`, used unconditionally by this backend's own synchronization (`ggml_backend_vk_device_event_synchronize`). Crashed slightly later, during the first real tensor upload.
4. `VULKAN_HPP_DEFAULT_DISPATCHER` was only ever `init()`'d against the `VkInstance`, never the `VkDevice` created afterward — so every device-level (and device-extension) function was resolved through the generic instance-level `vkGetInstanceProcAddr` trampoline instead of the concrete device's `vkGetDeviceProcAddr`. That trampoline is not guaranteed to resolve every function on every ICD; adding the missing `VULKAN_HPP_DEFAULT_DISPATCHER.init(device->device)` call is what the Vulkan-Hpp docs recommend after device creation, and is what actually made (2) and (3) resolve correctly once their extensions were requested.

## Verification

Verified end-to-end on-device: a real GGUF model (Qwen3.5 0.8B) now loads with `-ngl 99` and serves real `/v1/chat/completions` through this backend on the Galaxy S21 FE, where it previously crashed unconditionally at model load (and, per prior investigation, even at `-ngl 0` — `ggml-vulkan`'s mere presence took the working CPU-only path down with it).

Each of the four fixes was isolated by bisecting the crash one symbolized backtrace at a time (unstripped build + `llvm-symbolizer`) — each fix moved the crash further into model load until it succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)