### PR TITLE
convert : note MiniCPM5-2B shares the MiniCPM5-1B tokenizer

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1844,7 +1844,7 @@ class TextModel(ModelBase):
             # ref: https://huggingface.co/lewtun/talkie-1930-13b-it-hf
             res = "talkie"
         if chkhsh == "36f3066e97b7f3994b379aaacde306c1444c6ae84e81a5ae3cd2b7ed3b8c42d4":
-            # ref: https://huggingface.co/openbmb/MiniCPM5-1B
+            # ref: https://huggingface.co/openbmb/MiniCPM5-1B and https://huggingface.co/openbmb/MiniCPM5-2B (identical tokenizer)
             res = "minicpm5"
         if chkhsh == "f241072145675bf8322086f115aebad05e9f869557a238bf2150a2a417d1bf60":
             # ref: https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2

--- a/convert_hf_to_gguf_update.py
+++ b/convert_hf_to_gguf_update.py
@@ -158,6 +158,7 @@ models = [
     {"name": "f2llmv2",          "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/codefuse-ai/F2LLM-v2-4B", },
     {"name": "sarvam-moe",       "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/sarvamai/sarvam-30b", },
     {"name": "talkie",           "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/lewtun/talkie-1930-13b-it-hf", },
+    # MiniCPM5-2B ships a byte-identical tokenizer.json, so it maps to this same chkhsh - do not add a second entry for it
     {"name": "minicpm5",         "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/openbmb/MiniCPM5-1B"},
     {"name": "granite-embed-multi-97m", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/ibm-granite/granite-embedding-97m-multilingual-r2", },
     {"name": "granite-embed-multi-311m", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/ibm-granite/granite-embedding-311m-multilingual-r2", },


### PR DESCRIPTION
Follow-up to #23384 (MiniCPM5-1B), now that
[openbmb/MiniCPM5-2B](https://huggingface.co/openbmb/MiniCPM5-2B) and
[openbmb/MiniCPM5-2B-GGUF](https://huggingface.co/openbmb/MiniCPM5-2B-GGUF)
are public.

**Comment-only change — no behaviour change.**

MiniCPM5-2B ships a **byte-identical** `tokenizer.json` to 1B
(md5 `ee55db96827d21929c7c5db2092596a8`), so running the
`convert_hf_to_gguf_update.py` recipe against it reproduces the hash that is
already in the table:

```
36f3066e97b7f3994b379aaacde306c1444c6ae84e81a5ae3cd2b7ed3b8c42d4   (187 tokens on CHK_TXT)
```

Verified against four copies of the file — HF 1B, HF 2B, and two local
checkpoints — all identical.

So 2B already converts correctly today and needs no code change. This commit
only records *why*, because the obvious move for the next person adding 2B is
to append a second entry, and that would be a silent regression:

- entries in `get_vocab_base_pre()` are sequential `if` statements, not
  `elif`, so a second entry carrying the same hash placed later wins for
  **both** models — see the existing `mpt`/`olmo` and `bert-bge`/`jina-v2-en`
  pairs, where the later entry already shadows the earlier one;
- renaming the pre type away from `minicpm5` would break every GGUF already
  published with `tokenizer.ggml.pre = "minicpm5"`, including openbmb's own
  1B and 2B releases.

The note is deliberately kept on one line: `get_existing_models()` in
`convert_hf_to_gguf_update.py` matches the `if chkhsh == ...` / `res = ...`
pair with a regex that tolerates only a single line between them, so splitting
the comment across two lines breaks regeneration. Confirmed by trying it.

The chat template for 2B is a separate matter and is in its own PR.
