### PR TITLE
json-schema-to-grammar : report incomplete-conversion warnings only once

### DIFF
--- a/common/json-schema-to-grammar.cpp
+++ b/common/json-schema-to-grammar.cpp
@@ -4,7 +4,9 @@
 #include <algorithm>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <regex>
+#include <set>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -1093,7 +1095,22 @@ public:
             throw std::invalid_argument("JSON schema conversion failed:\n" + string_join(_errors, "\n"));
         }
         if (!_warnings.empty()) {
-            fprintf(stderr, "WARNING: JSON schema conversion was incomplete: %s\n", string_join(_warnings, "; ").c_str());
+            // The grammar is (re)built on every request in llama-server, so
+            // report each distinct warning once and stay quiet afterwards.
+            static std::mutex warned_mtx;
+            static std::set<std::string> warned;
+            std::vector<std::string> fresh;
+            {
+                std::lock_guard<std::mutex> lock(warned_mtx);
+                for (const auto & warning : _warnings) {
+                    if (warned.insert(warning).second) {
+                        fresh.push_back(warning);
+                    }
+                }
+            }
+            if (!fresh.empty()) {
+                fprintf(stderr, "WARNING: JSON schema conversion was incomplete: %s\n", string_join(fresh, "; ").c_str());
+            }
         }
     }
 


### PR DESCRIPTION
In llama-server the tool-call grammar is (re)built on every request (common/chat.cpp build_chat_peg_parser -> build_grammar), so a tool schema containing a regex pattern with no grammar equivalent (e.g. a lookahead, as in some agentic clients' tool definitions) logs a "WARNING: JSON schema conversion was incomplete" line on every request.

Report each distinct warning only once per process; repeats are suppressed. Behavior is unchanged otherwise - the affected fields still fall back to "any string".

## Overview

### Problem
llama-server logs one

```
WARNING: JSON schema conversion was incomplete: pattern … is not supported (unsupported group syntax), accepting any string
```

line **per request** whenever a tool schema contains a regex pattern with no
grammar equivalent (lookaheads `(?!…)` / `(?=…)` / `(?<!…)`, named groups, …).
Such patterns appear in real agentic clients' tool definitions (path-segment
validation regexes), so a server serving one such client spams the log once
per turn — in a short session: 74 warning lines for 78 tasks.

### Why it repeats

The tool-call grammar is (re)built on every request
(`common/chat.cpp` → `build_chat_peg_parser` → `build_grammar()`), and each
`build_grammar()` call creates a fresh `common_schema_converter`.
`check_errors()` therefore re-emits the same warning on every request.

### Fix

Report each distinct warning once per process: `check_errors()` now keeps a
process-wide set of already-emitted warning strings (guarded by a mutex).
First occurrence still prints the usual WARNING line; repeats are suppressed.

No behavior change: the affected fields still fall back to "any string", and
the full diagnostic (with the offending pattern) is in the log from the first
occurrence.

A follow-up could cache the compiled grammar keyed on the tool schema to
avoid the per-request rebuild altogether; that is a much larger change and is
out of scope here.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — Claude Code was used to investigate the warning and draft the patch. I reviewed the change and verified it locally before submitting (unit test + functional before/after comparison).  