### PR TITLE
chat : keep DSML markup out of DeepSeek V3.2 string tool arguments

### DIFF
--- a/common/parsers/deepseek.cpp
+++ b/common/parsers/deepseek.cpp
@@ -170,7 +170,10 @@ common_chat_params common_chat_params_init_deepseek_v3_2(const common_chat_templ
                         p.tool_arg_open(p.literal(PARAM_START + " name=\"") + p.tool_arg_name(p.literal(param_name)) +
                                         p.literal("\" string=\"" + std::string(is_string ? "true" : "false") + "\">")) +
                         (is_string ?
-                             p.tool_arg_string_value(p.until(PARAM_END)) :
+                             // A string value ends at the exact closing tag. Stop early on any
+                             // DSML-looking markup so stray or nested tags fail the parse (and are
+                             // excluded by the grammar) instead of being swallowed into the value.
+                             p.tool_arg_string_value(p.until_one_of({ PARAM_END, "<｜", "</｜" })) :
                              p.tool_arg_json_value(p.schema(p.json(), "tool-" + name + "-arg-" + param_name + "-schema",
                                                             param_schema, false))) +
                         p.tool_arg_close(p.literal(PARAM_END)));

--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -4127,6 +4127,55 @@ static void test_template_output_peg_parsers(bool detailed_debug) {
             .expect_reasoning("I'm thinking")
             .expect_content("Hello, world!\nWhat's up?")
             .run();
+
+        // String parameter values may contain plain angle brackets ...
+        tst.test(
+               "<｜DSML｜function_calls>\n"
+               "<｜DSML｜invoke name=\"get_time\">\n"
+               "<｜DSML｜parameter name=\"city\" string=\"true\">Tokyo <east> & Osaka</｜DSML｜parameter>\n"
+               "</｜DSML｜invoke>\n"
+               "</｜DSML｜function_calls>")
+            .enable_thinking(false)
+            .reasoning_format(COMMON_REASONING_FORMAT_DEEPSEEK)
+            .tools({ get_time_tool })
+            .expect_tool_calls({
+                { "get_time", R"({"city": "Tokyo <east> & Osaka"})", {} },
+            })
+            .run();
+
+        // ... but DSML-looking markup inside a string value must not be swallowed
+        // into the value: the grammar rejects it, so constrained sampling cannot
+        // produce a stray or nested tag inside an argument.
+        {
+            auto tmpls = read_templates("models/templates/deepseek-ai-DeepSeek-V3.2.jinja");
+            common_chat_templates_inputs inputs;
+            inputs.messages        = { message_user };
+            inputs.tools           = { get_time_tool };
+            inputs.enable_thinking = false;
+            auto params = common_chat_templates_apply(tmpls.get(), inputs);
+            // match_string() consumes grammar state, so build a fresh grammar per check.
+            auto accepts = [&](const std::string & text) {
+                auto grammar = build_grammar(params.grammar);
+                if (!grammar) {
+                    throw std::runtime_error("Failed to build DeepSeek V3.2 tool grammar");
+                }
+                return match_string(text, grammar.get());
+            };
+            const std::string clean_call =
+                "<｜DSML｜function_calls>\n"
+                "<｜DSML｜invoke name=\"get_time\">\n"
+                "<｜DSML｜parameter name=\"city\" string=\"true\">Tokyo</｜DSML｜parameter>\n"
+                "</｜DSML｜invoke>\n"
+                "</｜DSML｜function_calls>";
+            const std::string markup_in_value =
+                "<｜DSML｜function_calls>\n"
+                "<｜DSML｜invoke name=\"get_time\">\n"
+                "<｜DSML｜parameter name=\"city\" string=\"true\">Tokyo<｜DSML｜parameter name=\"x\" string=\"true\">y</｜DSML｜parameter>\n"
+                "</｜DSML｜invoke>\n"
+                "</｜DSML｜function_calls>";
+            assert_equals(true,  accepts(clean_call));
+            assert_equals(false, accepts(markup_in_value));
+        }
     }
 
     // DeepSeek V4 tests - same DSML markup as V3.2, but the tool call block is named


### PR DESCRIPTION
## Overview

I ran into this on 6 September while testing DeepSeek V4 Flash 0731 (Unsloth UD-IQ3_XXS) locally on an AMD Strix Halo system. llama.cpp handles its tool format through the DeepSeek V3.2 DSML parser.

During one of the tool loops, the model misspelled a closing parameter marker. Instead of treating that as malformed DSML, the parser swallowed it as part of the string argument. The model then kept generating until it eventually hit the token ceiling.

Tracing that back led to the DeepSeek V3.2 tool-call parser in `common/parsers/deepseek.cpp`.

At the moment, string parameter values are parsed using a bare `until(PARAM_END)`. Because of that, the value can consume anything up to the next valid closing parameter tag — including text that itself looks like malformed or unexpected DSML markup.

The same PEG is also used to build the sampling grammar, so constrained generation can technically produce stray or nested `<｜DSML｜...>` markup inside a string value and still have it accepted by the grammar.

This change tightens that behaviour.

A string value now stops when it encounters either:

* the actual closing parameter tag, or
* anything that looks like DSML markup: `<｜` or `</｜`.

Normal angle brackets are still perfectly valid inside string values, so content such as `<east> & Osaka` continues to work as expected.

I added two regression tests in `tests/test-chat.cpp`:

* A parser test with `<east> & Osaka` inside a string parameter to make sure ordinary angle-bracket content is preserved literally.
* A grammar test that builds the DeepSeek V3.2 tool grammar, confirms that a clean tool call is accepted, and confirms that a call containing a nested `<｜DSML｜parameter ...>` inside the argument value is rejected.

The rejection test fails against current master and passes with this change.

The full `test-chat` suite also passes.

## Additional information

The original failure I saw was not a nested parameter tag. DeepSeek V4 Flash misspelled a closing parameter marker, the parser treated that malformed DSML as part of the argument string, and generation continued until the token limit.

The nested-tag case in the regression test is a simpler deterministic way of exercising the same parser bug: DSML-looking markup should never be allowed to disappear into an ordinary string parameter.


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. The original fix and the two regression tests were produced with the assistance of Codex Sol. I reviewed the generated changes, verified that they address the issue I reproduced locally, ran the relevant test suite, and take responsibility for the submitted change.