### PR TITLE
HIP: tune MMVQ batch thresholds on RDNA3.5

### DIFF
--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -365,6 +365,33 @@ bool ggml_cuda_should_use_mmvq(enum ggml_type type, int cc, int64_t ne11) {
                 return ne11 <= MMVQ_MAX_BATCH_SIZE;
         }
     }
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+        switch (type) {
+            case GGML_TYPE_Q4_K:
+            case GGML_TYPE_Q5_K:
+                return ne11 <= 2;
+            case GGML_TYPE_Q3_K:
+            case GGML_TYPE_Q6_K:
+                return ne11 <= 3;
+            case GGML_TYPE_Q8_0:
+            case GGML_TYPE_Q2_K:
+                return ne11 <= 4;
+            case GGML_TYPE_Q4_1:
+            case GGML_TYPE_Q5_1:
+            case GGML_TYPE_MXFP4:
+            case GGML_TYPE_IQ4_NL:
+            case GGML_TYPE_IQ3_XXS:
+                return ne11 <= 5;
+            case GGML_TYPE_Q4_0:
+            case GGML_TYPE_Q5_0:
+            case GGML_TYPE_IQ3_S:
+            case GGML_TYPE_IQ4_XS:
+            case GGML_TYPE_IQ1_S:
+                return ne11 <= 6;
+            default:
+                return ne11 <= MMVQ_MAX_BATCH_SIZE;
+        }
+    }
     if (GGML_CUDA_CC_IS_CDNA(cc)) {
         if (GGML_CUDA_CC_IS_CDNA1(cc)) {
             switch (type) {


### PR DESCRIPTION
## Overview

`ggml_cuda_should_use_mmvq` had no per-type tuning for RDNA3.5 and fell through
to a flat `ne11 <= MMVQ_MAX_BATCH_SIZE` (8). This PR adds a table for it which
gives a performance boost for batched generation.

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

I introduced a temporary env var override which allowed me to sweep ne11 1-16 with
`test-backend-ops perf -o MUL_MAT`.

### Results

| threshold | types |
|---|---|
| `ne11 <= 2` | Q4_K, Q5_K |
| `ne11 <= 3` | Q3_K, Q6_K |
| `ne11 <= 4` | Q8_0, Q2_K |
| `ne11 <= 5` | Q4_1, Q5_1, MXFP4, IQ4_NL, IQ3_XXS |
| `ne11 <= 6` | Q4_0, Q5_0, IQ3_S, IQ4_XS, IQ1_S |
| default (8) | IQ2_XXS, IQ2_XS, IQ2_S, Q1_0, Q2_0, NVFP4 |

### End-to-end (Strix Halo / gfx1151, Qwen3.8-27B-UD-IQ4_XS, `llama-batched-bench`, S_TG)

| npl | gain |
|---:|---:|
| 1 | -0.8% (identical to master, null control) |
| 4 | **+6.4% +/- 2.0** |
| 6 | **+10.2% +/- 1.9** |
| 8 | **+20.5% +/- 1.9** |


`test-backend-ops -o MUL_MAT`: 1288/1288.


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Claude Opus helped me write the sweep script and implement the PR.