### PR TITLE
nemotron: fix MTPv2 draft head loading for Nemotron 3 Super

### DIFF
--- a/src/models/nemotron-h-moe.cpp
+++ b/src/models/nemotron-h-moe.cpp
@@ -97,11 +97,18 @@ llama_model_nemotron_h_moe::graph_mtp::graph_mtp(const llama_model & model, cons
     cb(cur, "mtp_attn_post_norm", il);
 
     {
+        ggml_tensor * inp_emb    = cur;
+        ggml_tensor * inp_latent = cur;
+        if (layer.ffn_latent_down) {
+            inp_latent = ggml_mul_mat(ctx0, layer.ffn_latent_down, cur);
+            cb(inp_latent, "mtp_ffn_latent_down", il);
+        }
+
         ggml_tensor * router_logits = build_lora_mm(layer.ffn_gate_inp, cur);
         cb(router_logits, "mtp_ffn_moe_logits", il);
 
         ggml_tensor * moe_out =
-            build_moe_ffn(cur,
+            build_moe_ffn(inp_latent,
                 layer.ffn_gate_inp,
                 layer.ffn_up_exps,
                 nullptr, // no gate
@@ -118,7 +125,12 @@ llama_model_nemotron_h_moe::graph_mtp::graph_mtp(const llama_model & model, cons
                 layer.ffn_down_exps_s);
         cb(moe_out, "mtp_ffn_moe_out", il);
 
-        ggml_tensor * ffn_shexp = build_ffn(cur,
+        if (layer.ffn_latent_up) {
+            moe_out = ggml_mul_mat(ctx0, layer.ffn_latent_up, moe_out);
+            cb(moe_out, "mtp_ffn_latent_up", il);
+        }
+
+        ggml_tensor * ffn_shexp = build_ffn(inp_emb,
                 layer.ffn_up_shexp,   NULL, layer.ffn_up_shexp_s,
                 NULL,                 NULL, NULL,
                 layer.ffn_down_shexp, NULL, layer.ffn_down_shexp_s,

--- a/src/models/nemotron-h.cpp
+++ b/src/models/nemotron-h.cpp
@@ -164,6 +164,8 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader & ml) {
         layer.attn_post_norm  = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM,  "weight", i), {n_embd}, mtp_flags);
         layer.ffn_gate_inp    = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,    "weight", i), {n_embd, n_expert}, mtp_flags);
         layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias",   i), {n_expert}, mtp_flags);
+        layer.ffn_latent_down = create_tensor(tn(LLM_TENSOR_FFN_LATENT_DOWN, "weight", i), {n_embd, moe_n_embd}, mtp_flags | TENSOR_NOT_REQUIRED);
+        layer.ffn_latent_up   = create_tensor(tn(LLM_TENSOR_FFN_LATENT_UP,   "weight", i), {moe_n_embd, n_embd}, mtp_flags | TENSOR_NOT_REQUIRED);
         layer.ffn_down_exps   = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS,   "weight", i), {n_ff_exp,   moe_n_embd, n_expert}, mtp_flags);
         layer.ffn_up_exps     = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,     "weight", i), {moe_n_embd, n_ff_exp,   n_expert}, mtp_flags);
         layer.ffn_down_shexp  = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP,  "weight", i), {n_ff_shexp, n_embd}, mtp_flags);


### PR DESCRIPTION
## Overview

I ran into this while testing NVIDIA's official MTPv2 draft head for Nemotron 3 Super.

On current llama.cpp, the draft head cannot be loaded. When loading the draft file, llama.cpp only creates 19 of its 21 tensors. The two missing tensors are the latent input and output projections used by Nemotron 3 Super's MoE layers.

The main model already handles these projections correctly.

Nemotron 3 Super performs its MoE computation in a 1,024-wide latent space rather than directly on the 4,096-wide hidden state. Before the router and experts, the hidden state is projected down into that latent representation. After the experts, it is projected back to the full hidden size.

The MTP draft head contains a copy of one of these layers, but the draft-head path currently skips both projections. As a result, the official MTPv2 head cannot be represented correctly and fails to load.

This change adds the two optional latent projection tensors to the draft block and applies them in the same places as the existing main-model graph:

project from the hidden state into the latent space before the router and experts;
project the MoE result back to the full hidden size afterwards.

The implementation intentionally mirrors the existing Nemotron 3 Super path rather than introducing new behavior.

Results

With current master, NVIDIA's official MTPv2 draft head does not load.

With this change, the same head loads correctly and speculative decoding works.

Across six prompts:

draft-token acceptance ranged from 56% to 97%;
decoding was 7% to 52% faster than the equivalent no-draft run;
a representative prompt improved by approximately 35%.

An earlier test of the same head on a patched engine showed approximately 22% improvement, so the results are consistent with that behavior.

Three of the six responses were byte-identical to their corresponding no-draft runs.

Two runs diverged at an early near-tie token. Both resulting answers were correct; this is the same kind of small decoding variation I have also observed when comparing ROCm and Vulkan execution. I am mentioning it here explicitly rather than treating speculative decoding as byte-identical in every run.

Peak memory usage was approximately 94 GB, leaving around 27 GiB available on the test system.

## Additional information

NVIDIA's repository contains the MTP head rather than a complete standalone draft GGUF. For testing, I converted the head using llama.cpp's own convert_hf_to_gguf.py and added the three shared tensors required by the draft model — token embedding, output norm, and output — from a Nemotron 3 Super sidecar built from the same target model.

The change itself is small: the draft block now loads and uses the same latent input/output projections that llama.cpp already uses for the corresponding layer in the main Nemotron 3 Super graph.

The MTP head itself came from NVIDIA's official repository; the GGUF used for validation was assembled as described above.


## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - OpenAI Codex was used to produce the original fix. Claude Code was used during the later rebase onto current master and for the validation work described in this PR. I reviewed the resulting changes, verified the implementation against the existing Nemotron 3 Super graph, tested it locally with the converted NVIDIA MTPv2 draft head, reviewed the outputs and performance data, and take responsibility for the submitted change.