### PR TITLE
jinja: treat a null left operand of in as a plain lookup

### DIFF
--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -167,6 +167,12 @@ value binary_expression::execute_impl(context & ctx) {
         }
         throw std::runtime_error("Cannot perform operation " + op.value + " on undefined values");
     } else if (is_val<value_none>(left_val) || is_val<value_none>(right_val)) {
+        if (!is_val<value_none>(right_val) && (op.value == "in" || op.value == "not in")) {
+            // case: none in {'low': 1}
+            // A null left operand is looked up like any other value.
+            bool member = test_is_in();
+            return mk_val<value_bool>(op.value == "in" ? member : !member);
+        }
         if (op.value == "+" || op.value == "~") {
             value res = mk_val<value_undefined>();
             if (workaround_concat_null_with_str(res)) {

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -374,6 +374,24 @@ static void test_expressions(testing & t) {
         "42"
     );
 
+    test_template(t, "none in object",
+        "{{ x in {'low': 1, 'high': 2} }}",
+        {{"x", nullptr}},
+        "False"
+    );
+
+    test_template(t, "none not in object",
+        "{{ x not in {'low': 1, 'high': 2} }}",
+        {{"x", nullptr}},
+        "True"
+    );
+
+    test_template(t, "none in array",
+        "{{ x in [1, none, 3] }}",
+        {{"x", nullptr}},
+        "True"
+    );
+
     test_template(t, "dot notation",
         "{{ user.name }}",
         {{"user", {{"name", "Bob"}}}},


### PR DESCRIPTION
## Overview

A template that defaults an optional variable to none and then tests its membership in a map fails with "Cannot perform operation on null values", where Jinja evaluates the membership test normally and returns false. For example:

    {%- set reasoning_effort = reasoning_effort | default(none) -%}
    {%- if reasoning_effort in reasoning_effort_map -%}

The branch right above already handles the same operators for undefined operands, so this aligns the null case with it and reuses the existing membership helper.

The three cases added to test_expressions cover `in` and `not in` against an object, and `in` against an array holding a null. They also run under test-jinja-py, which compares the output against Python's Jinja2.

## Additional information

### Testing

Tested the test :) without the patch, test-jinja fails on exactly the three new cases and nothing else (3 of 20 assertions in expressions); with it, everything passes, including test-jinja-py which checks the output against Python's Jinja2.

Also probed the neighbouring cases to make sure nothing else was missing from that branch, and they already behave like Jinja2:

none == none -> True
none == 1 -> False
none != 1 -> True
none is none -> True

So in and not in were the only ones falling through to the error.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
