### PR TITLE
llama : use int32_t for llama_sampler_chain_n return type

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -1357,7 +1357,7 @@ extern "C" {
     LLAMA_API struct llama_sampler * llama_sampler_chain_get(      struct llama_sampler * chain, int32_t i);
 
     // the total number of samplers in the chain
-    LLAMA_API int                    llama_sampler_chain_n  (const struct llama_sampler * chain);
+    LLAMA_API int32_t                llama_sampler_chain_n  (const struct llama_sampler * chain);
 
     // after removing a sampler, the chain will no longer own it, and it will not be freed when the chain is freed
     LLAMA_API struct llama_sampler * llama_sampler_chain_remove(   struct llama_sampler * chain, int32_t i);

--- a/src/llama-sampler.cpp
+++ b/src/llama-sampler.cpp
@@ -1006,7 +1006,7 @@ struct llama_sampler * llama_sampler_chain_remove(struct llama_sampler * chain, 
     return result;
 }
 
-int llama_sampler_chain_n(const struct llama_sampler * chain) {
+int32_t llama_sampler_chain_n(const struct llama_sampler * chain) {
     const auto * p = (const llama_sampler_chain *) chain->ctx;
 
     return p->samplers.size();


### PR DESCRIPTION
## Overview

`llama_sampler_chain_n()` returns a bare `int`, while the sibling accessors in the same API group (`llama_sampler_chain_get`, `llama_sampler_chain_remove`) already use `int32_t`.

This PR changes the return type to `int32_t` for consistency, as discussed in #4574.

`int` is 32-bit on all platforms currently supported by llama.cpp, so there is no ABI or behavior change — the three in-repo call sites compile without modification or new warnings.

## Additional information

Contributes to #4574 (the issue asks for small incremental changes only).

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — the code change was implemented with AI assistance and manually reviewed and tested by me.