### PR TITLE
cuda: enable GGML_CUDA_FA_ALL_QUANTS by default

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -203,7 +203,7 @@ option(GGML_CUDA_FORCE_CUBLAS               "ggml: always use cuBLAS instead of 
 option(GGML_CUDA_NO_PEER_COPY               "ggml: do not use peer to peer copies"            OFF)
 option(GGML_CUDA_NO_VMM                     "ggml: do not try to use CUDA VMM"                OFF)
 option(GGML_CUDA_FA                         "ggml: compile ggml FlashAttention CUDA kernels"  ON)
-option(GGML_CUDA_FA_ALL_QUANTS              "ggml: compile all quants for FlashAttention"     OFF)
+option(GGML_CUDA_FA_ALL_QUANTS              "ggml: compile all quants for FlashAttention"     ON)
 option(GGML_CUDA_GRAPHS                     "ggml: use CUDA graphs (llama.cpp only)"          ${GGML_CUDA_GRAPHS_DEFAULT})
 option(GGML_CUDA_NCCL                       "ggml: use NVIDIA Collective Comm. Library"       ON)
 set   (GGML_CUDA_COMPRESSION_MODE "size" CACHE STRING


### PR DESCRIPTION
## Overview

Stock builds only compile the FA-vec kernel instances for f16, q4_0, q8_0 and bf16 KV. Any other KV quant (q4_1, q5_0, q5_1, ...) silently falls back to the generic dequant path, which on my RTX 3090 drops prefill from ~1147 t/s to ~34 t/s with flash attention on, and nothing in the logs hints at what is going on.

This flips the default of GGML_CUDA_FA_ALL_QUANTS to ON. It just compiles the remaining template instances, no new code. People who want the old behavior can pass -DGGML_CUDA_FA_ALL_QUANTS=OFF.

## Additional information

Fixes #27109 (silent prefill collapse with 4-bit KV cache). Related: #26285, #27140, #28633.

Measured on 1x RTX 3090, Qwen3.8-27B, K=q4_1 / V=q8_0, 130K ctx, llama_bench with shuffled real-corpus prompts (seed=42, 2-run avg):

| Context | PP t/s (default build) | PP t/s (this PR) |
|--------:|-----------------------:|-----------------:|
| ~20K    | ~34                    | 1094             |
| ~65K    | ~34                    | 852              |
| ~120K   | ~34                    | 659              |

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - tests were done with the help of AI
