### PR TITLE
model: fix all granite family parameter counts

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -947,7 +947,7 @@ const char * llm_type_name(llm_type type) {
         case LLM_TYPE_26B_A4B:       return "26B.A4B";
         case LLM_TYPE_30B_A3B:       return "30B.A3B";
         case LLM_TYPE_31B_A3_5B:     return "31B.A3.5B";
-        case LLM_TYPE_32B_9B:        return "32B.A9B";
+        case LLM_TYPE_32B_A9B:        return "32B.A9B";
         case LLM_TYPE_35B_A3B:       return "35B.A3B";
         case LLM_TYPE_48B_A3B:       return "48B.A3B";
         case LLM_TYPE_75B_A9B:       return "75B.A9B";

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -936,6 +936,7 @@ const char * llm_type_name(llm_type type) {
         case LLM_TYPE_17B_128E:      return "17Bx128E (Maverick)";
         case LLM_TYPE_A13B:          return "A13B";
         case LLM_TYPE_1B_A400M:      return "1B.A400M";
+        case LLM_TYPE_3B_A800M:      return "3B.A800M";
         case LLM_TYPE_7B_A1B:        return "7B.A1B";
         case LLM_TYPE_8B_A1B:        return "8B.A1B";
         case LLM_TYPE_7_9B_A1_3B:    return "7.9B.A1.3B";
@@ -946,6 +947,7 @@ const char * llm_type_name(llm_type type) {
         case LLM_TYPE_26B_A4B:       return "26B.A4B";
         case LLM_TYPE_30B_A3B:       return "30B.A3B";
         case LLM_TYPE_31B_A3_5B:     return "31B.A3.5B";
+        case LLM_TYPE_32B_9B:        return "32B.A9B";
         case LLM_TYPE_35B_A3B:       return "35B.A3B";
         case LLM_TYPE_48B_A3B:       return "48B.A3B";
         case LLM_TYPE_75B_A9B:       return "75B.A9B";

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -947,7 +947,7 @@ const char * llm_type_name(llm_type type) {
         case LLM_TYPE_26B_A4B:       return "26B.A4B";
         case LLM_TYPE_30B_A3B:       return "30B.A3B";
         case LLM_TYPE_31B_A3_5B:     return "31B.A3.5B";
-        case LLM_TYPE_32B_A9B:        return "32B.A9B";
+        case LLM_TYPE_32B_A9B:       return "32B.A9B";
         case LLM_TYPE_35B_A3B:       return "35B.A3B";
         case LLM_TYPE_48B_A3B:       return "48B.A3B";
         case LLM_TYPE_75B_A9B:       return "75B.A9B";

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -128,7 +128,7 @@ enum llm_type {
     LLM_TYPE_26B_A4B, // Gemma4
     LLM_TYPE_30B_A3B,
     LLM_TYPE_31B_A3_5B,
-    LLM_TYPE_32B_9B,  // Granite4 Hybrid
+    LLM_TYPE_32B_A9B,  // Granite4 Hybrid
     LLM_TYPE_35B_A3B, // Qwen3.5
     LLM_TYPE_48B_A3B, // Kimi Linear
     LLM_TYPE_75B_A9B, // Nemotron 3 Puzzle

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -128,7 +128,7 @@ enum llm_type {
     LLM_TYPE_26B_A4B, // Gemma4
     LLM_TYPE_30B_A3B,
     LLM_TYPE_31B_A3_5B,
-    LLM_TYPE_32B_A9B,  // Granite4 Hybrid
+    LLM_TYPE_32B_A9B, // Granite4 Hybrid
     LLM_TYPE_35B_A3B, // Qwen3.5
     LLM_TYPE_48B_A3B, // Kimi Linear
     LLM_TYPE_75B_A9B, // Nemotron 3 Puzzle

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -117,6 +117,7 @@ enum llm_type {
     LLM_TYPE_17B_128E, // llama4 Maverick
     LLM_TYPE_A13B,
     LLM_TYPE_1B_A400M, // Granite3 MoE
+    LLM_TYPE_3B_A800M, // Granite3 MoE
     LLM_TYPE_7B_A1B,
     LLM_TYPE_8B_A1B, // lfm2moe
     LLM_TYPE_7_9B_A1_3B, // Ling-3.0-tiny
@@ -127,6 +128,7 @@ enum llm_type {
     LLM_TYPE_26B_A4B, // Gemma4
     LLM_TYPE_30B_A3B,
     LLM_TYPE_31B_A3_5B,
+    LLM_TYPE_32B_9B,  // Granite4 Hybrid
     LLM_TYPE_35B_A3B, // Qwen3.5
     LLM_TYPE_48B_A3B, // Kimi Linear
     LLM_TYPE_75B_A9B, // Nemotron 3 Puzzle

--- a/src/models/granite-hybrid.cpp
+++ b/src/models/granite-hybrid.cpp
@@ -1,4 +1,3 @@
-#include "llama-model.h"
 #include "models.h"
 
 void llama_model_granite_hybrid::load_arch_hparams(llama_model_loader & ml) {
@@ -31,7 +30,7 @@ void llama_model_granite_hybrid::load_arch_hparams(llama_model_loader & ml) {
         case 768: type = LLM_TYPE_350M; break;
         case 1536: type = (hparams.n_ff() == 512 ? LLM_TYPE_7B_A1B : LLM_TYPE_1B); break;
         case 2048: case 2560: type = LLM_TYPE_3B; break;
-        case 4096: type = LLM_TYPE_32B_9B; break;
+        case 4096: type = LLM_TYPE_32B_A9B; break;
         default: type = LLM_TYPE_UNKNOWN;
     }
 

--- a/src/models/granite-hybrid.cpp
+++ b/src/models/granite-hybrid.cpp
@@ -1,3 +1,4 @@
+#include "llama-model.h"
 #include "models.h"
 
 void llama_model_granite_hybrid::load_arch_hparams(llama_model_loader & ml) {
@@ -30,7 +31,7 @@ void llama_model_granite_hybrid::load_arch_hparams(llama_model_loader & ml) {
         case 768: type = LLM_TYPE_350M; break;
         case 1536: type = (hparams.n_ff() == 512 ? LLM_TYPE_7B_A1B : LLM_TYPE_1B); break;
         case 2048: case 2560: type = LLM_TYPE_3B; break;
-        case 4096: type = LLM_TYPE_32B; break;
+        case 4096: type = LLM_TYPE_32B_9B; break;
         default: type = LLM_TYPE_UNKNOWN;
     }
 

--- a/src/models/granite-moe.cpp
+++ b/src/models/granite-moe.cpp
@@ -9,7 +9,7 @@ void llama_model_granite_moe::load_arch_hparams(llama_model_loader & ml) {
 
     switch (hparams.n_layer()) {
         case 24: type = LLM_TYPE_1B_A400M; break;
-        case 32: type = LLM_TYPE_3B; break;
+        case 32: type = LLM_TYPE_3B_A800M; break;
         case 40: type = LLM_TYPE_3B; break;
         // Add additional layer/vocab/etc checks here for other model sizes
         default: type = LLM_TYPE_UNKNOWN;

--- a/src/models/granite-moe.cpp
+++ b/src/models/granite-moe.cpp
@@ -10,7 +10,6 @@ void llama_model_granite_moe::load_arch_hparams(llama_model_loader & ml) {
     switch (hparams.n_layer()) {
         case 24: type = LLM_TYPE_1B_A400M; break;
         case 32: type = LLM_TYPE_3B_A800M; break;
-        case 40: type = LLM_TYPE_3B; break;
         // Add additional layer/vocab/etc checks here for other model sizes
         default: type = LLM_TYPE_UNKNOWN;
     }

--- a/src/models/granite.cpp
+++ b/src/models/granite.cpp
@@ -1,3 +1,4 @@
+#include "llama-model.h"
 #include "models.h"
 
 #include <sstream>
@@ -38,7 +39,16 @@ void llama_model_granite::load_arch_hparams(llama_model_loader & ml) {
 
     switch (hparams.n_layer()) {
         case 32: type = LLM_TYPE_3B; break;
-        case 40: type = LLM_TYPE_3B; break;
+        case 40: {
+            switch (hparams.n_embd) {
+                case 2048: type = LLM_TYPE_2B; break;
+                case 2560: type = LLM_TYPE_3B; break;
+                case 4096: type = LLM_TYPE_8B; break;
+                default: type = LLM_TYPE_UNKNOWN; break;
+            }
+            break;
+        }
+        case 64: type = LLM_TYPE_30B; break;
         // Add additional layer/vocab/etc checks here for other model sizes
         default: type = LLM_TYPE_UNKNOWN;
     }

--- a/src/models/granite.cpp
+++ b/src/models/granite.cpp
@@ -43,7 +43,7 @@ void llama_model_granite::load_arch_hparams(llama_model_loader & ml) {
                 case 2048: type = LLM_TYPE_2B; break;
                 case 2560: type = LLM_TYPE_3B; break;
                 case 4096: type = LLM_TYPE_8B; break;
-                default: type = LLM_TYPE_UNKNOWN; break;
+                default: type = LLM_TYPE_UNKNOWN;
             }
             break;
         }

--- a/src/models/granite.cpp
+++ b/src/models/granite.cpp
@@ -1,4 +1,3 @@
-#include "llama-model.h"
 #include "models.h"
 
 #include <sstream>


### PR DESCRIPTION
## Overview

cont: #28632

After #28632, I realised that quite a lot of our Granite family parameter counts are either inaccurate (2B model reported as 3B), missing, or using dense model naming schemes when the model is MoE or hybrid.

This PR fixes _all_ Granite family parameter counts reported in `llama-bench`.

## Additional information

| -hf <model>                                             | Original                           | Updated                             |
|---------------------------------------------------------|------------------------------------|-------------------------------------|
| bartowski/granite-3.0-2b-instruct-GGUF:Q2_K             | granite 2B Q2_K - Medium           | No changes                          |
| bartowski/granite-3.0-8b-instruct-GGUF:Q2_K             | granite 8B Q2_K - Medium           | No changes                          |
| bartowski/granite-3.0-1b-a400m-instruct-GGUF:Q3_K_S     | granitemoe 1B.A400M Q3_K - Small   | No changes                          |
| bartowski/granite-3.0-3b-a800m-instruct-GGUF:Q2_K       | granitemoe 3B Q2_K - Medium        | granitemoe 3B.A800M Q2_K - Medium   |
| bartowski/granite-3.1-2b-instruct-GGUF:Q2_K             | granite 2B Q2_K - Medium           | No changes                          |
| bartowski/granite-3.1-8b-instruct-GGUF:Q2_K             | granite 8B Q2_K - Medium           | No changes                          |
| bartowski/granite-3.1-1b-a400m-instruct-GGUF:Q2_K       | granitemoe 1B.A400M Q2_K - Medium  | No changes                          |
| bartowski/granite-3.1-3b-a800m-instruct-GGUF:Q2_K       | granitemoe 3B Q2_K - Medium        | granitemoe 3B.A800M Q2_K - Medium   |
| bartowski/ibm-granite_granite-3.2-2b-instruct-GGUF:Q2_K | granite 2B Q2_K - Medium           | No changes                          |
| bartowski/ibm-granite_granite-3.2-8b-instruct-GGUF:Q2_K | granite 8B Q2_K - Medium           | No changes                          |
| ibm-granite/granite-3.3-2b-instruct-GGUF:Q2_K           | granite 2B Q2_K - Medium           | No changes                          |
| ibm-granite/granite-3.3-8b-instruct-GGUF:Q2_K           | granite 8B Q2_K - Medium           | No changes                          |
| ibm-granite/granite-4.0-micro-GGUF:Q2_K                 | granite 3B Q2_K - Medium           | No changes                          |
| ibm-granite/granite-4.0-h-micro-GGUF:Q2_K               | granitehybrid 3B Q2_K - Medium     | No changes                          |
| ibm-granite/granite-4.0-h-tiny-GGUF:Q2_K                | granitehybrid 7B.A1B Q2_K - Medium | No changes                          |
| ibm-granite/granite-4.0-h-small-GGUF:Q2_K               | granitehybrid 32B Q2_K - Medium    | granitehybrid 32B.A9B Q2_K - Medium |
| unsloth/granite-4.0-h-350m-GGUF:Q3_K_S                  | granitehybrid 350M Q3_K - Small    | No changes                          |
| unsloth/granite-4.0-h-1b-GGUF:Q2_K                      | granitehybrid 1B Q2_K - Medium     | No changes                          |
| ibm-granite/granite-4.1-3b-GGUF:Q2_K                    | granite 2B Q2_K - Medium           | granite 3B Q2_K - Medium            |
| ibm-granite/granite-4.1-8b-GGUF:Q2_K                    | granite 8B Q2_K - Medium           | No changes                          |
| ibm-granite/granite-4.1-30b-GGUF:Q2_K                   | granite ?B Q2_K - Medium           | granite 30B Q2_K - Medium           |
| ibm-granite/granite-4.2-3b-GGUF:Q2_K                    | granite 2B Q2_K - Medium           | granite 3B Q2_K - Medium            |
| ibm-granite/granite-4.2-8b-GGUF:Q2_K                    | granite 8B Q2_K - Medium           | No changes                          |
| ibm-granite/granite-4.2-30b-GGUF:Q2_K                   | granite ?B Q2_K - Medium           | granite 30B Q2_K - Medium           |

cc: @gabe-l-hart

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: No, painstakingly checked every model 🙃

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
