### PR TITLE
metal: fix tuning include path in subprojects

### DIFF
--- a/tools/tuning/CMakeLists.txt
+++ b/tools/tuning/CMakeLists.txt
@@ -3,7 +3,7 @@ set(TARGET ggml-metal-tuning)
 add_executable(${TARGET} main.cpp bench.cpp fa-vec.cpp)
 target_link_libraries(${TARGET} PRIVATE ggml ${CMAKE_THREAD_LIBS_INIT})
 target_compile_features(${TARGET} PRIVATE cxx_std_17)
-target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/ggml/src/ggml-metal)
+target_include_directories(${TARGET} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../ggml/src/ggml-metal)
 
 if(LLAMA_TOOLS_INSTALL)
     install(TARGETS ${TARGET} RUNTIME)


### PR DESCRIPTION
## Overview

Fixes #28114.

Resolve the Metal tuning include directory relative to its own CMakeLists.txt. When llama.cpp is included through FetchContent, CMAKE_SOURCE_DIR points to the consuming project and ggml-metal-tuning fails to find ggml-metal-tuning.h.

## Validation

- Reproduced the missing-header build failure with a minimal FetchContent consumer before the change.
- Built and linked ggml-metal-tuning successfully in the same consumer after the change.
- Built and linked ggml-metal-tuning in a standalone Metal build.
- Passed applicable pre-commit-hooks v4.6.0 checks (trailing whitespace, final newline, file size) and git diff --check.

## Requirements

The change is limited to the include path in tools/tuning/CMakeLists.txt. No runtime code changes.
