### PR TITLE
webui: stop re-probing disabled /tools endpoint on every message

### DIFF
--- a/tools/ui/src/lib/hooks/use-tools-panel.svelte.ts
+++ b/tools/ui/src/lib/hooks/use-tools-panel.svelte.ts
@@ -47,7 +47,7 @@ export function useToolsPanel(): UseToolsPanelReturn {
 
 		if (toolsStore.toolGroups.length > 0) return null;
 
-		// Tools endpoint is unreachable (404) — server started without --tools
+		// Tools endpoint unreachable (403) — server started without tools
 		if (toolsStore.isToolsEndpointUnreachable) {
 			return `To enable Server Tools you need to run llama-server with ${CLI_FLAGS.TOOLS} all or ${CLI_FLAGS.TOOLS} <name> flag. To see MCP Tools you need to add / enable MCP Server(s).`;
 		}

--- a/tools/ui/src/lib/stores/agentic/index.svelte.ts
+++ b/tools/ui/src/lib/stores/agentic/index.svelte.ts
@@ -315,8 +315,14 @@ class AgenticStore {
 		// Clear any pending permissions/continue requests for this conversation when starting a new flow
 		this.gates.clear(conversationId);
 
-		// Ensure server tools are fetched before checking if agentic is enabled
-		if (toolsStore.serverTools.length === 0 && !toolsStore.loading) {
+		// Ensure server tools are fetched before checking if agentic is enabled.
+		// A disabled /tools endpoint stays disabled for the life of the server,
+		// so the tools panel is the only place that probes it again.
+		if (
+			toolsStore.serverTools.length === 0 &&
+			!toolsStore.loading &&
+			!toolsStore.isToolsEndpointUnreachable
+		) {
 			await toolsStore.fetchServerTools();
 		}
 

--- a/tools/ui/src/lib/stores/tools.svelte.ts
+++ b/tools/ui/src/lib/stores/tools.svelte.ts
@@ -32,7 +32,7 @@ import { mcpStore } from '$lib/stores/mcp/index.svelte';
 import { modelsStore } from '$lib/stores/models/index.svelte';
 import { settingsStore } from '$lib/stores/settings/index.svelte';
 import type { OpenAIToolDefinition, ToolEntry, ToolGroup } from '$lib/types';
-import { buildSandboxToolDefinition } from '$lib/utils';
+import { ApiError, buildSandboxToolDefinition } from '$lib/utils';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 
 /** Stable selection identity for a tool, shared by the disabled set and the permission store */
@@ -246,13 +246,10 @@ class ToolsStore {
 				toolInfos.filter((info) => info.uses_cwd).map((info) => info.tool)
 			);
 		} catch (err) {
-			const errorMessage = err instanceof Error ? err.message : String(err);
-
-			this._error = errorMessage;
+			this._error = err instanceof Error ? err.message : String(err);
 
 			// 403 from /tools means the server was started without --tools
-			// TODO: check status code instead of relying on message
-			if (errorMessage.includes('this feature is disabled')) {
+			if (err instanceof ApiError && err.status === 403) {
 				this._toolsEndpointUnreachable = true;
 				console.info('[ToolsStore] Server tools are disabled on the server');
 			} else {


### PR DESCRIPTION
## Overview

Fixes #28299.

When llama-server is started without tools, the web UI sends a `GET /tools` before every chat message. Each request returns 403 ("this feature is disabled"), and on exposed servers these repeated failed requests get the client banned by fail2ban.

Root cause: `runAgenticFlow` guards its refetch on `serverTools.length === 0 && !loading`. When the endpoint is disabled, that condition never becomes false, so the UI retries before every message. The store already tracks the disabled state (`isToolsEndpointUnreachable`) but the guard never consulted it.

Changes:
- `agentic/index.svelte.ts`: add `!toolsStore.isToolsEndpointUnreachable` to the refetch guard
- `tools.svelte.ts`: detect the disabled endpoint via the error status (403) instead of string-matching the error message, resolving the existing TODO

The tools panel keeps probing on open so the UI recovers without a page reload once the server is restarted with tools enabled.

## Additional information

Verified end to end against a local llama-server without `--tools` (serving the built UI), with `fetch` instrumented in the page:

- before: every chat message produced one `GET /tools` (403)
- after: chat generations produce zero `/tools` requests; opening the tools panel probes once (user-driven, the recovery path)

`svelte-check` reports 0 errors/0 warnings, eslint+prettier clean, and the unit test suite passes (649/649).

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — light usage (AI-assisted code analysis and formatting). I understand the changes fully and verified them locally end-to-end.