### PR TITLE
cmake : warn when GGML_NATIVE on MSVC leaves AVX-512 extensions unset

### DIFF
--- a/ggml/src/ggml-cpu/CMakeLists.txt
+++ b/ggml/src/ggml-cpu/CMakeLists.txt
@@ -277,6 +277,24 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
                         list(APPEND ARCH_FLAGS -mavx512bf16)
                     endif()
                 endif()
+
+                # FindSIMD.cmake (included above for GGML_NATIVE) only detects the
+                # base AVX-512 flag; it never sets the extension options, and MSVC
+                # does not define their macros on its own. A "native" build on a
+                # VNNI-capable CPU therefore silently drops the __AVX512VNNI__ paths
+                # in ggml-cpu (arch/x86/quants.c, llamafile/sgemm.cpp, amx/), and
+                # ggml_cpu_has_avx512_vnni() reports 0 for a CPU that has VNNI.
+                if (GGML_NATIVE AND NOT GGML_AVX512_VNNI)
+                    message(WARNING
+                        "GGML_NATIVE enabled AVX-512 for MSVC, but the AVX-512 extension "
+                        "macros are not set: MSVC does not define them and FindSIMD.cmake "
+                        "detects only the base AVX-512 flag. The __AVX512VNNI__ code paths "
+                        "in ggml-cpu are therefore not compiled, and "
+                        "ggml_cpu_has_avx512_vnni() will report 0 even on a CPU that "
+                        "supports VNNI. If this CPU supports AVX512-VNNI (Zen 4, Sapphire "
+                        "Rapids and later), reconfigure with -DGGML_AVX512_VNNI=ON "
+                        "-DGGML_AVX512_VBMI=ON -DGGML_AVX512_BF16=ON.")
+                endif()
                 if (GGML_AMX_TILE)
                     list(APPEND ARCH_DEFINITIONS __AMX_TILE__ GGML_AMX_TILE)
                 endif()


### PR DESCRIPTION
## Overview

On MSVC, `-DGGML_NATIVE=ON` produces a build that compiles out the
`__AVX512VNNI__` code paths on a VNNI-capable CPU, and then reports that CPU as
having no VNNI. This PR adds a configure-time warning. It only warns — no
compiled behaviour changes.

`ggml/src/ggml-cpu/cmake/FindSIMD.cmake`, included from the MSVC branch when
`GGML_NATIVE` is set, detects only the base flag:

```cmake
check_sse("AVX512" " ;/arch:AVX512")
if (NOT ${AVX512_FOUND})
    set(GGML_AVX512 OFF)
else()
    set(GGML_AVX512 ON)
endif()
```

It never sets `GGML_AVX512_VBMI` / `_VNNI` / `_BF16`, which are the options
`ggml/src/ggml-cpu/CMakeLists.txt` uses to append the extension macros to
`ARCH_DEFINITIONS` — precisely because, as the comment there says, "MSVC has no
compile-time flags enabling specific AVX512 extensions, neither it defines the
macros corresponding to the extensions".

What is lost on a native MSVC build on Zen 4 / Sapphire Rapids:

- `arch/x86/quants.c` — `mul_sum_us8_pairs_float()` falls back from
  `_mm256_dpbusd_epi32` to the longer sequence
- `llamafile/sgemm.cpp` — same in `updot()`
- the `amx/` paths are gated on it as well
- `ggml_cpu_has_avx512_vnni()` is a compile-time `#if`, so it returns 0 and
  `system_info` reports `AVX512_VNNI = 0` for a CPU that has VNNI

GCC and Clang are unaffected: `-march=native` defines the macros from the CPU.

There is no error and no warning today, and `CMakeCache.txt` is misleading: it
shows `GGML_AVX512:BOOL=OFF` while `/arch:AVX512` is in the compile flags,
because `FindSIMD.cmake` sets a directory variable rather than the cache entry.

## Additional information

Reproduction on Ryzen 9 7950X, Windows, MSVC 19.41, Ninja, at 22397c3, counting
occurrences in the generated `build.ninja`:

| | `-DGGML_NATIVE=ON` | with the extension flags |
|---|---:|---:|
| `__AVX512VNNI__` | 0 | 16 |
| `__AVX512VBMI__` | 0 | 16 |
| `__AVX512BF16__` | 0 | 16 |
| `/arch:AVX512` | 16 | 16 |
| `CMakeCache.txt` | `GGML_AVX512:BOOL=OFF` | `ON` |

The warning condition deliberately requires `GGML_NATIVE`: passing
`-DGGML_AVX512=ON` without VNNI is an explicit choice, whereas asking for
"native" implies matching the host CPU.

Verified both ways on that machine:

- `-DGGML_NATIVE=ON` alone → `CMake Warning at ggml/src/ggml-cpu/CMakeLists.txt:288`
- adding `-DGGML_AVX512=ON -DGGML_AVX512_VBMI=ON -DGGML_AVX512_VNNI=ON -DGGML_AVX512_BF16=ON`
  → no such warning

Both complete `Generating done`.

The same mechanism exists in `ikawrakow/ik_llama.cpp`, where the equivalent
warning was merged as ikawrakow/ik_llama.cpp#2429; the `FindSIMD.cmake` files in
the two projects are byte-identical.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — the CMake change and this description were drafted
  with AI assistance (Claude Code). The reproduction was run on my own hardware
  (Ryzen 9 7950X, Windows, MSVC 19.41) and reviewed by me. I am responsible for
  every line submitted.
