### PR TITLE
clip : disable flash attention for D=72 on HIP to avoid aperture violation

### DIFF
--- a/tools/mtmd/clip.cpp
+++ b/tools/mtmd/clip.cpp
@@ -770,7 +770,15 @@ ggml_tensor * clip_graph::build_attn(
 
     ggml_tensor * cur;
 
-    if (flash_attn_type == CLIP_FLASH_ATTN_TYPE_ENABLED) {
+    // HIP tile FA kernel crashes for D=72 with large sequences (issue #28608)
+    bool use_flash_attn = (flash_attn_type == CLIP_FLASH_ATTN_TYPE_ENABLED);
+#ifdef GGML_USE_HIP
+    if (d_head == 72) {
+        use_flash_attn = false;
+    }
+#endif
+
+    if (use_flash_attn) {
         ggml_tensor * v = ggml_permute(ctx0, v_cur, 0, 2, 1, 3);
 
         k = ggml_cast(ctx0, k, GGML_TYPE_F16);


### PR DESCRIPTION
This fixes a crash in the HIP flash-attention kernel when the CLIP vision
encoder uses a head dimension of 72.

I was able to reproduce it on 2x RX 7900 XTX with ROCm 7.14.1. Larger
images eventually cause:

`HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION`

The problem seems to be specific to the HIP D=72 flash-attention path, so
this change disables that path for D=72 and uses the existing matmul
attention implementation instead.

I tested this with Qwen3.8 (256k context) and Gemma4 (32k context), using
images from 320px through 2560px. The images that previously crashed now
process correctly.

NVIDIA and other head dimensions are left unchanged.
Fixes #28608

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, runtime tests