### PR TITLE
ggml-cuda: add first-node extents to the CUDA graph cache key

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -1262,6 +1262,40 @@ struct ggml_tensor_extra_gpu {
 #define USE_CUDA_GRAPH
 #endif
 
+// Coarse graph identity + execution-variant discriminator.
+//
+// Graph cache entries are keyed by (first node pointer, leading extents of
+// that node).  Workloads whose graphs recur with a small set of mutually
+// incompatible shapes - e.g. speculative-decode catch-up vs draft steps, or
+// MoE micro-batches of 1..4 tokens - each get their own cache entry instead
+// of churning a single shared property/warmup history.  Differences that this key does not capture (dtype, layout, op params, ...) keep going through the unchanged property check in ggml_cuda_graph_update_required(), including its uid fast path.  This change only splits previously shared entries - it never merges previously separate ones - so replay decisions are made exactly as before.
+struct ggml_cuda_graph_key {
+    const void * first_node_ptr;
+    int64_t      ne[GGML_MAX_DIMS];
+
+    bool operator==(const ggml_cuda_graph_key & other) const {
+        if (first_node_ptr != other.first_node_ptr) {
+            return false;
+        }
+        for (int i = 0; i < GGML_MAX_DIMS; ++i) {
+            if (ne[i] != other.ne[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+struct ggml_cuda_graph_key_hash {
+    size_t operator()(const ggml_cuda_graph_key & k) const {
+        size_t h = (size_t)(uintptr_t) k.first_node_ptr;
+        for (int i = 0; i < GGML_MAX_DIMS; ++i) {
+            h ^= (size_t) k.ne[i] + 0x9e3779b97f4a7c15ull + (h << 6) + (h >> 2);
+        }
+        return h;
+    }
+};
+
 struct ggml_cuda_graph {
 #ifdef USE_CUDA_GRAPH
     ~ggml_cuda_graph() {
@@ -1459,13 +1493,14 @@ struct ggml_backend_cuda_context {
     int curr_stream_no = 0;
 
 #ifdef USE_CUDA_GRAPH
-    // Map from first_node_ptr to cuda_graph - allows multiple graphs per context
+    // Map from graph key (first node + leading extents) to cuda_graph - allows
+    // multiple graphs per context
     // when the computation is split across CPU/GPU (e.g., with --n-cpu-moe)
-    std::unordered_map<const void *, std::unique_ptr<ggml_cuda_graph>> cuda_graphs;
+    std::unordered_map<ggml_cuda_graph_key, std::unique_ptr<ggml_cuda_graph>, ggml_cuda_graph_key_hash> cuda_graphs;
 
     int64_t last_graph_eviction_sweep = 0;
 
-    ggml_cuda_graph * cuda_graph(const void * first_node_ptr) {
+    ggml_cuda_graph * cuda_graph(const ggml_cuda_graph_key & graph_key) {
         const int64_t time_now = ggml_time_us();
 
         // sweep every 5s, evicting cuda graphs unused for >=10s
@@ -1480,9 +1515,9 @@ struct ggml_backend_cuda_context {
             }
         }
 
-        auto it = cuda_graphs.find(first_node_ptr);
+        auto it = cuda_graphs.find(graph_key);
         if (it == cuda_graphs.end()) {
-            it = cuda_graphs.emplace(first_node_ptr, std::make_unique<ggml_cuda_graph>()).first;
+            it = cuda_graphs.emplace(graph_key, std::make_unique<ggml_cuda_graph>()).first;
         }
         it->second->last_used_time = time_now;
         return it->second.get();

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2580,14 +2580,17 @@ static bool ggml_cuda_graph_check_compability(ggml_cgraph * cgraph) {
     return use_cuda_graph;
 }
 
-static const void * ggml_cuda_graph_get_key(ggml_cgraph * cgraph) {
-    return cgraph->nodes[0];
+static ggml_cuda_graph_key ggml_cuda_graph_get_key(ggml_cgraph * cgraph) {
+    ggml_cuda_graph_key key;
+    key.first_node_ptr = cgraph->nodes[0];
+    memcpy(key.ne, cgraph->nodes[0]->ne, sizeof(key.ne));
+    return key;
 }
 
 static bool ggml_cuda_graph_update_required(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph * cgraph) {
     bool res = false;
 
-    const void * graph_key = ggml_cuda_graph_get_key(cgraph);
+    const ggml_cuda_graph_key graph_key = ggml_cuda_graph_get_key(cgraph);
     ggml_cuda_graph * graph = cuda_ctx->cuda_graph(graph_key);
 
     if (cgraph->uid != 0 &&
@@ -2626,7 +2629,7 @@ static bool ggml_cuda_graph_update_required(ggml_backend_cuda_context * cuda_ctx
     return res;
 }
 
-static void ggml_cuda_graph_update_executable(ggml_backend_cuda_context * cuda_ctx, const void * graph_key) {
+static void ggml_cuda_graph_update_executable(ggml_backend_cuda_context * cuda_ctx, const ggml_cuda_graph_key & graph_key) {
     ggml_cuda_graph * graph = cuda_ctx->cuda_graph(graph_key);
 
 #if CUDART_VERSION >= 12000
@@ -4174,7 +4177,7 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
     return 0;
 }
 
-static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph * cgraph, const bool use_cuda_graph, const bool cuda_graph_update_required, const void * graph_key) {
+static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph * cgraph, const bool use_cuda_graph, const bool cuda_graph_update_required, const ggml_cuda_graph_key & graph_key) {
     bool graph_evaluated_or_captured = false;
 
     // flag used to determine whether it is an integrated_gpu
@@ -4393,7 +4396,7 @@ static void ggml_cuda_graph_evaluate_and_capture(ggml_backend_cuda_context * cud
 }
 
 #ifdef USE_CUDA_GRAPH
-static bool ggml_cuda_graph_set_enabled(ggml_backend_cuda_context * cuda_ctx, const void * graph_key) {
+static bool ggml_cuda_graph_set_enabled(ggml_backend_cuda_context * cuda_ctx, const ggml_cuda_graph_key & graph_key) {
     ggml_cuda_graph * graph = cuda_ctx->cuda_graph(graph_key);
 
     if (graph->graph == nullptr) {
@@ -4416,7 +4419,7 @@ static enum ggml_status ggml_backend_cuda_graph_compute(ggml_backend_t backend, 
 
     bool use_cuda_graph             = false;
     bool cuda_graph_update_required = false;
-    const void * graph_key = nullptr;
+    ggml_cuda_graph_key graph_key{};
 
 #ifdef USE_CUDA_GRAPH
     graph_key = ggml_cuda_graph_get_key(cgraph);
@@ -4519,7 +4522,7 @@ static void ggml_backend_cuda_graph_optimize(ggml_backend_t backend, ggml_cgraph
     }
 
 #ifdef USE_CUDA_GRAPH
-    const void * graph_key = ggml_cuda_graph_get_key(cgraph);
+    const ggml_cuda_graph_key graph_key = ggml_cuda_graph_get_key(cgraph);
     const bool use_cuda_graph = ggml_cuda_graph_set_enabled(cuda_ctx, graph_key);
 #else
     const bool use_cuda_graph = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -307,6 +307,7 @@ if (NOT LLAMA_SANITIZE_ADDRESS AND NOT GGML_SCHED_NO_REALLOC)
   llama_build_and_test(test-opt.cpp)
 endif()
 llama_build_and_test(test-backend-ops.cpp)
+llama_build_and_test(test-cuda-graph-cache.cpp)
 
 # the tensor API kernels come from a separate metallib - check they produce correct results
 # ref: https://github.com/ggml-org/llama.cpp/issues/27473

--- a/tests/test-cuda-graph-cache.cpp
+++ b/tests/test-cuda-graph-cache.cpp
@@ -1,0 +1,270 @@
+// Regression test for the CUDA graph cache key partitioning.
+//
+// Two execution variants of one MUL_MAT_ID graph share the same first-node pointer but differ in the first node's extents (micro-batch ne[2] 1 <-> 4).  Under the bare first-node-pointer key both variants land in one cache entry, and the periodically stable workload below emits one "CUDA graph warmup reset" per pair switch.  With the key partitioned by first-node extents the same workload replays without any reset.
+//
+// The test counts the backend's own diagnostics through ggml_log_set().  Op-level numeric correctness is covered by test-backend-ops.  Skips when no CUDA device is registered.
+
+#include "ggml.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+
+#include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#ifdef _WIN32
+#include <malloc.h> // using malloc.h with MSC/MINGW
+#endif
+#include <map>
+#include <utility>
+#include <vector>
+
+static constexpr int N_EMBD = 256;
+static constexpr int N_EXP = 8;
+static constexpr int N_LAYER = 8;
+static constexpr int WARM = 8;
+static constexpr int ALTERNATE = 100;
+static constexpr size_t META_SIZE = 32ull << 20;
+
+static int g_failures = 0;
+static std::atomic<long> g_resets{0};
+static std::atomic<long> g_completes{0};
+
+static void log_cb(enum ggml_log_level level, const char * text, void * /*user*/) {
+    if (strstr(text, "CUDA graph warmup reset")) {
+        g_resets.fetch_add(1);
+    } else if (strstr(text, "CUDA graph warmup complete")) {
+        g_completes.fetch_add(1);
+    }
+    if (level == GGML_LOG_LEVEL_ERROR || level == GGML_LOG_LEVEL_WARN) {
+        fprintf(stderr, "ggml: %s", text);
+    }
+}
+
+// portable 64-byte aligned allocation (MSVC has no aligned_alloc)
+static void * meta_alloc(size_t size) {
+#ifdef _WIN32
+    return _aligned_malloc(size, 64);
+#else
+    return aligned_alloc(64, size);
+#endif
+}
+
+static void meta_free(void * p) {
+#ifdef _WIN32
+    _aligned_free(p);
+#else
+    free(p);
+#endif
+}
+
+#define CHECK(cond, ...)                                       \
+    do {                                                       \
+        if (!(cond)) {                                         \
+            printf("  FAIL: %s (line %d): ", #cond, __LINE__); \
+            printf(__VA_ARGS__);                               \
+            printf("\n");                                      \
+            g_failures++;                                      \
+        }                                                      \
+    } while (0)
+
+// one gallocr per shape keeps the graph plan stable across calls.  All
+// externally supplied tensors are flagged as inputs (ggml_set_input), so the
+// allocator reserves their storage before the main allocation pass and no
+// parameter can be aliased away by another leaf of the same call.  Every
+// parameter is still re-uploaded on every call: the harness never assumes
+// that leaf content persists across a compute.
+struct harness {
+    ggml_backend_t backend = nullptr;
+    std::map<int, ggml_gallocr_t> galloc;
+    void * meta = nullptr;
+    std::vector<std::vector<uint8_t>> wq;
+
+    bool init(ggml_backend_dev_t dev) {
+        const size_t n = (size_t) N_EMBD * N_EMBD * N_EXP;
+        std::vector<float> f(n);
+        wq.resize(N_LAYER);
+        for (int l = 0; l < N_LAYER; ++l) {
+            for (size_t i = 0; i < n; ++i) {
+                f[i] = (float)((i * 40503u + (uint32_t)(l * 2246822519u + 7)) % 4000u) / 2000.0f - 1.0f;
+            }
+            wq[l].resize(ggml_row_size(GGML_TYPE_Q8_0, N_EMBD) * N_EMBD * N_EXP);
+            ggml_quantize_chunk(GGML_TYPE_Q8_0, f.data(), wq[l].data(), 0, n / N_EMBD, N_EMBD, nullptr);
+        }
+        backend = ggml_backend_dev_init(dev, nullptr);
+        meta = meta_alloc(META_SIZE);
+        return backend != nullptr && meta != nullptr;
+    }
+
+    void fill_f32(ggml_tensor * t, uint32_t seed) {
+        const size_t n = ggml_nbytes(t) / sizeof(float);
+        std::vector<float> buf(n);
+        for (size_t i = 0; i < n; ++i) {
+            buf[i] = (float)((i * 2654435761u + seed) % 2000u) / 1000.0f - 1.0f;
+        }
+        ggml_backend_tensor_set(t, buf.data(), 0, ggml_nbytes(t));
+    }
+
+    void run_call(int bs, const void ** first_node, int64_t * first_node_ne) {
+        ggml_init_params ip = {};
+        ip.mem_size   = META_SIZE;
+        ip.mem_buffer = meta;
+        ip.no_alloc   = true;
+        ggml_context * ctx = ggml_init(ip);
+
+        ggml_tensor * x   = ggml_new_tensor_3d(ctx, GGML_TYPE_F32, N_EMBD, 1, bs);
+        ggml_tensor * ids = ggml_new_tensor_2d(ctx, GGML_TYPE_I32, 1, bs);
+        ggml_set_input(x);
+        ggml_set_input(ids);
+        std::vector<std::pair<ggml_tensor *, int>> params;
+        ggml_tensor * cur = x;
+        for (int l = 0; l < N_LAYER; ++l) {
+            ggml_tensor * w = ggml_new_tensor_3d(ctx, GGML_TYPE_Q8_0, N_EMBD, N_EMBD, N_EXP);
+            ggml_set_input(w);
+            cur = ggml_mul_mat_id(ctx, w, cur, ids);
+            params.emplace_back(w, 1000 + l);
+            ggml_tensor * s = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, N_EMBD);
+            ggml_tensor * b = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, N_EMBD);
+            ggml_set_input(s);
+            ggml_set_input(b);
+            cur = ggml_mul(ctx, cur, s);
+            cur = ggml_add(ctx, cur, b);
+            params.emplace_back(s, 2000 + l);
+            params.emplace_back(b, 3000 + l);
+        }
+        ggml_cgraph * cgraph = ggml_new_graph_custom(ctx, 1024, false);
+        ggml_build_forward_expand(cgraph, cur);
+
+        if (!galloc.count(bs)) {
+            galloc[bs] = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend));
+        }
+        if (!ggml_gallocr_reserve(galloc[bs], cgraph) || !ggml_gallocr_alloc_graph(galloc[bs], cgraph)) {
+            fprintf(stderr, "galloc failed\n");
+            exit(1);
+        }
+
+        // re-upload every input on every call
+        fill_f32(x, 12345);
+        for (auto & [t, code] : params) {
+            if (t->type == GGML_TYPE_Q8_0) {
+                ggml_backend_tensor_set(t, wq[code - 1000].data(), 0, ggml_nbytes(t));
+            } else {
+                fill_f32(t, (uint32_t)(code * 2654435761u + 11));
+            }
+        }
+        {
+            std::vector<int32_t> idbuf(bs);
+            for (int i = 0; i < bs; ++i) {
+                idbuf[i] = (int)((i * 3 + 1) % N_EXP);
+            }
+            ggml_backend_tensor_set(ids, idbuf.data(), 0, ggml_nbytes(ids));
+        }
+
+        if (ggml_backend_graph_compute(backend, cgraph) != GGML_STATUS_SUCCESS) {
+            fprintf(stderr, "graph compute failed\n");
+            exit(1);
+        }
+        if (first_node) {
+            // the first operation node of the graph is the coarse cache key
+            ggml_tensor * n0 = ggml_graph_node(cgraph, 0);
+            *first_node = n0;
+            if (first_node_ne) {
+                memcpy(first_node_ne, n0->ne, sizeof(int64_t) * GGML_MAX_DIMS);
+            }
+        }
+        ggml_free(ctx);
+    }
+
+    void cleanup() {
+        for (auto & kv : galloc) {
+            ggml_gallocr_free(kv.second);
+        }
+        galloc.clear();
+        if (backend) {
+            ggml_backend_free(backend);
+        }
+        meta_free(meta);
+    }
+};
+
+int main() {
+    setvbuf(stdout, nullptr, _IOLBF, 0);
+    ggml_time_init();
+    ggml_log_set(log_cb, nullptr);
+    ggml_backend_load_all();
+
+    // find an explicitly CUDA-registered device; do not assume that the first GPU backend is CUDA
+    ggml_backend_dev_t dev = nullptr;
+    for (size_t r = 0; r < ggml_backend_reg_count() && !dev; ++r) {
+        ggml_backend_reg_t reg = ggml_backend_reg_get(r);
+        if (strcmp(ggml_backend_reg_name(reg), "CUDA") != 0) {
+            continue;
+        }
+        if (ggml_backend_reg_dev_count(reg) > 0) {
+            dev = ggml_backend_reg_dev_get(reg, 0);
+        }
+    }
+    if (!dev) {
+        printf("test-cuda-graph-cache: SKIP (no CUDA device registered)\n");
+        return 0;
+    }
+
+    harness R;
+    if (!R.init(dev)) {
+        fprintf(stderr, "harness init failed\n");
+        return 1;
+    }
+
+    const void * key_s1 = nullptr;
+    const void * key_s4 = nullptr;
+    int64_t ne_s1[GGML_MAX_DIMS] = {0};
+    int64_t ne_s4[GGML_MAX_DIMS] = {0};
+
+    R.run_call(1, nullptr, nullptr); // absorbs one-time lazy init
+
+    // warm each variant on its own: each must demonstrate on its own that it converges to replay, and each warm phase must produce at least one warmup-complete diagnostic (positive control for the log surface)
+    printf("warming S1 and S4 (%d calls each)\n", WARM);
+    for (int i = 0; i < WARM; ++i) {
+        R.run_call(1, &key_s1, ne_s1);
+    }
+    const long completes_s1 = g_completes.load();
+    for (int i = 0; i < WARM; ++i) {
+        R.run_call(4, &key_s4, ne_s4);
+    }
+    const long completes_s4 = g_completes.load();
+    printf("warmup complete events: %ld after S1, %ld after S4\n", completes_s1, completes_s4);
+
+    // preconditions for this test to be meaningful: the two variants really do collide on the old (pointer-only) key, and the new discriminator really does separate them
+    CHECK(key_s1 != nullptr, "no first-node pointer captured for S1");
+    CHECK(key_s4 != nullptr, "no first-node pointer captured for S4");
+    CHECK(key_s1 == key_s4, "S1 and S4 first-node pointers differ (%p vs %p): the variants no longer share a cache key and this test cannot reproduce the bug", key_s1, key_s4);
+    CHECK(memcmp(ne_s1, ne_s4, sizeof(ne_s1)) != 0, "S1 and S4 first-node extents are identical: the partitioned key would not separate the variants");
+    CHECK(ne_s1[2] == 1 && ne_s4[2] == 4, "expected micro-batch ne[2] 1 <-> 4 (got %lld vs %lld)", (long long) ne_s1[2], (long long) ne_s4[2]);
+
+    if (completes_s1 < 1 || completes_s4 < completes_s1 + 1) {
+        printf("test-cuda-graph-cache: SKIP (missing warmup-complete events per variant; cannot judge reset behavior)\n");
+        R.cleanup();
+        return g_failures == 0 ? 0 : 1;
+    }
+
+    // regression window: pairs give each variant enough consecutive calls to complete warmup on its own, so under the unpartitioned key every pair switch resets the shared entry - while partitioned entries replay the whole window without a single reset
+    const long resets0 = g_resets.load();
+    printf("alternating S1,S1,S4,S4 x%d\n", ALTERNATE);
+    for (int i = 0; i < ALTERNATE; ++i) {
+        R.run_call(1, nullptr, nullptr);
+        R.run_call(1, nullptr, nullptr);
+        R.run_call(4, nullptr, nullptr);
+        R.run_call(4, nullptr, nullptr);
+    }
+    const long resets = g_resets.load() - resets0;
+    printf("warmup resets inside the window: %ld (over %d pair switches)\n", resets, ALTERNATE);
+    CHECK(resets == 0, "alternating variants sharing one cache key must not reset the shared warmup state (resets=%ld)", resets);
+
+    R.cleanup();
+    if (g_failures == 0) {
+        printf("test-cuda-graph-cache: PASS\n");
+    } else {
+        printf("test-cuda-graph-cache: FAIL\n");
+    }
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Problem

Variants that alternate under a single CUDA graph cache key keep invalidating the shared warmup state, so speculative decoding on this workload drifts toward direct evaluation. 
## Changes

- Graph cache key: `first_node_ptr` -> `(first_node_ptr, first node ne[])`.
- `ggml_cuda_graph_get_key()` returns the full key; call sites follow.
- Eviction scan untouched.

## Why safe

The change is a partition refinement: P0(A) != P0(B) => P1(A) != P1(B). Domains that were already separate are never merged - the only effect is that variants which previously shared one domain are split apart. Differences the key still does not cover (dtype, layout, op-params) keep reaching the validator with exactly the upstream behavior.

## Tests

New file `tests/test-cuda-graph-cache.cpp`. Fail-before: on master `9cf3bf25` the window shows 200 resets -> FAIL. Pass-after: 0 resets -> PASS. The test observes an existing diagnostic event, adds no production API, and skips at runtime without a CUDA device. Per AGENTS.md requirements for new `tests/*` files, maintainer decides placement (folding it into existing facilities is acceptable).

`test-backend-ops`: CUDA suite plus an explicit `-b CPU` suite both OK (satisfies the two-backend requirement).

## Verification / Reproducers

- MMID reproducer (model-less) on `9cf3bf25`: unpatched 63/62 plus alternating-phase collapse -> patched 2/0.
- Real workload (Qwen2.5-1.5B + 0.5B draft-simple, `4d917609`): spec gen median 173.5 -> 205.3 t/s; 1024-token paired 154.25 vs 155.90 t/s.
- Both reproducers are in #28652.
## Additional information

Detailed analysis, history and reproducers in #28652.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. 
How it was used:
Root-cause investigation: A/B experiments and log analysis were assisted by AI (gpt 5.6 and glm-5.3-flash) under my direction.
Patch and regression test: AI drafted them against a design I approved; I verified fail-before / pass-after (200 vs 0 resets) on my own hardware before submitting.
Mechanical work: build scripts, log trimming.
My own work: chose the approach, ran all verification end to end, reviewed the diff line by line.
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
