### PR TITLE
CUDA: use radix-select TOP_K in the CUB fallback for wide rows

### DIFF
--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -1,6 +1,8 @@
 #include "argsort.cuh"
 #include "top-k.cuh"
 
+#include <cstdlib>
+
 #ifdef GGML_CUDA_USE_CUB
 #    include <cub/cub.cuh>
 #    if (CCCL_MAJOR_VERSION >= 3 && CCCL_MINOR_VERSION >= 2)
@@ -48,7 +50,8 @@ static int next_power_of_2(int x) {
 
 #endif                            // CUB_TOP_K_AVAILABLE
 
-#if !defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP)
+// radix-select top-k: used by HIP for wide rows and by CUB builds without DeviceTopK (CCCL < 3.2)
+#if !defined(CUB_TOP_K_AVAILABLE) && (defined(GGML_CUDA_USE_CUB) || defined(GGML_USE_HIP))
 
 static __device__ __forceinline__ uint32_t top_k_float_to_ordered(float value) {
     const uint32_t bits = __float_as_uint(value);
@@ -208,7 +211,7 @@ static void top_k_radix_cuda(
             src, dst, states, ncols, k, blocks_per_row);
 }
 
-#endif // !defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP)
+#endif // !defined(CUB_TOP_K_AVAILABLE) && (defined(GGML_CUDA_USE_CUB) || defined(GGML_USE_HIP))
 
 void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0   = dst->src[0];
@@ -233,6 +236,15 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
         top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
     }
 #elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+    // No DeviceTopK in this CCCL. Sorting every key of every row and copying the first k is expensive for wide rows,
+    // so use the radix-select top-k for rows of at least 8192 columns. The threshold is conservative: on an RTX 3090
+    // the segmented sort was still faster at 4096 columns and the radix-select faster from 8192 columns on.
+    // GGML_CUDA_TOPK_ARGSORT=1 forces the argsort path (for A/B comparisons within one binary).
+    static const bool force_argsort = getenv("GGML_CUDA_TOPK_ARGSORT") != nullptr && atoi(getenv("GGML_CUDA_TOPK_ARGSORT")) != 0;
+    if (!force_argsort && ncols >= 8192) {
+        top_k_radix_cuda(pool, src0_d, dst_d, ncols, nrows, k, stream);
+        return;
+    }
     // Fall back to argsort + copy
     const int    ncols_pad      = next_power_of_2(ncols);
     const size_t shared_mem     = ncols_pad * sizeof(int);


### PR DESCRIPTION
## Overview

When CUB has no DeviceTopK (every CCCL older than 3.2), ggml_cuda_op_top_k falls back to sorting every key of every row with a segmented radix sort and copying the first k. For wide rows the cost of the sort is large, the qwen4exp QSA indexer runs TOP_K over 4 rows x n_kv columns with k = 2051,and at 131k context that sort costs 5.1 ms per generated token which is about a third of the GPU time per token.

This PR makes the existing radix-select kernel (Until now this has been HIP-only) available to CUB builds without DeviceTopK and uses it in that fallback for rows of >= 8192 columns. The threshold was measured, it wasn't estimated or guessed. On an RTX 3090 (CUDA 12.0, CUB 2.0.1), the segmented sort was still faster at 4096 columns and the radix-select was faster from 8192 on. Builds that have CCCL >= 3.2 keep using DeviceTopK. HIP, MUSA and no-CUB builds are unchanged by this. GGML_CUDA_TOPK_ARGSORT=1 forces the old path so both can be compared within one binary.

## Additional information

Correctness: test-backend-ops -o TOP_K passes 525/525 on both paths (268 cases at >= 8192 columns, up to 524,299 columns, k up to 9,999, 112 with ties).

**Kernel only timings (test-backend-ops perf, TOP_K with k = 16, CUDA graphs off, GPU shared with a running server):** on all 46 test shapes with rows of 8192 columns or more, radix-select beats the segmented sort by about 1.42x at worst and 2.25x in the median and up to 11x for 16-row batches. On 4096-column rows, the sort was still faster (24.1 us vs 38.9 us for radix-select), so the switch happens at 8192 columns rather than the 1024 proposed in the earlier unmerged #28366.

**End to end (Qwen3.8-Flash-Next Q4_K_XL, 131k context, MTP draft, same binary, kill-switch A/B, two windows run in both orders):** Nsight Systems traces show the top-k kernels dropping from 5.1 to 0.25 ms per generated token. Decode on cached 128-token continuations increased from 30.3 to 34.9 t/s, +13 to +18% on every one of six position-paired runs, and a fresh 128-token request after the prefill gained +10% as well (one pair). Prefill was unchanged as expected considering the sort does not run there. A separate production-sampling quality screen (480 requests at ~37k and ~119k context, three seeds, argsort path as the control) found no consistent quality regression and 9 to 12% higher decode throughput at ~119k on every seed.

**Some caveats:**
- Tie behaviour differs. The segmented sort always kept the lower index so its output was repeatable. Radix-select, like CUB's DeviceTopK keeps whichever of the exactly tied values it reaches first so the selected set can differ between runs when ties occur. Any tied choice is a valid top-k result and test-backend-ops accepts it. This is the same behaviour #28497 describes for DeviceTopK.
- The 4096/8192 crossover was measured at k = 16 without CUDA graphs on one GPU model. Other k and other GPUs may cross elsewhere. The threshold of 8192 is conservative for the 3090.
- Not measured: MUSA and no-CUB builds (unchanged by this PR), other k at the boundary, an idle GPU.

This was measured on 2x RTX 3090 (sm_86), driver 595.84, CUDA 12.0.140, CUB 2.0.1, where CUB_TOP_K_AVAILABLE is undefined and this fallback is the active path.

Related earlier work: #28366 proposed the same dispatch with a 1024-column threshold and no measurements. It was closed unmerged.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. The code change was written by an AI assistant (Claude) under my direction and reviewed by me. All builds, tests, profiles and quality measurements were run by me on my own hardware. This description and the commit message are my own words.