### PR TITLE
Increase tolerance for Add fusion tests

### DIFF
--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -3336,6 +3336,14 @@ struct test_bin_bcast : public test_case {
         return op == ggml_div;
     }
 
+    double max_nmse_err() override {
+        if (op == ggml_add && type == GGML_TYPE_F16 && nf > 1) {
+            // Fused ADDs can keep FP32 intermediates while the CPU rounds each ADD to FP16.
+            return 1e-6;
+        }
+        return test_case::max_nmse_err();
+    }
+
     double max_maa_err() override {
         return op == ggml_add ? 1e-4 : 1e-3;
     }


### PR DESCRIPTION
## Overview

This PR raises the NMSE tolerance from `1e-7` to `1e-6` only for FP16 ADD chains with `nf > 1`.

This accommodates the rounding difference between fused FP32 accumulation and the CPU's per-ADD FP16 rounding, exposed by recently added tests (PR https://github.com/ggml-org/llama.cpp/pull/27610). CUDA kernels and other test tolerances remain unchanged.


## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, paired with Codex.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
