### PR TITLE
server : fix response_format json_schema when schema is not nested in the json_schema wrapper

### DIFF
--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -1313,7 +1313,7 @@ Given a ChatML-formatted json description in `messages`, it returns the predicte
 
 See [OpenAI Chat Completions API documentation](https://platform.openai.com/docs/api-reference/chat). llama.cpp `/completion`-specific features such as `mirostat` are also supported.
 
-The `response_format` parameter supports both plain JSON output (e.g. `{"type": "json_object"}`) and schema-constrained JSON (e.g. `{"type": "json_object", "schema": {"type": "string", "minLength": 10, "maxLength": 100}}` or `{"type": "json_schema", "schema": {"properties": { "name": { "title": "Name",  "type": "string" }, "date": { "title": "Date",  "type": "string" }, "participants": { "items": {"type: "string" }, "title": "Participants",  "type": "string" } } } }`), similar to other OpenAI-inspired API providers.
+The `response_format` parameter supports both plain JSON output (e.g. `{"type": "json_object"}`) and schema-constrained JSON (e.g. `{"type": "json_object", "schema": {"type": "string", "minLength": 10, "maxLength": 100}}` or `{"type": "json_schema", "schema": {"properties": { "name": { "title": "Name",  "type": "string" }, "date": { "title": "Date",  "type": "string" }, "participants": { "items": {"type: "string" }, "title": "Participants",  "type": "string" } } } }`), similar to other OpenAI-inspired API providers. The OpenAI wrapper form `{"type": "json_schema", "json_schema": {"name": ..., "strict": ..., "schema": {...}}}` is also accepted.
 
 `chat_template_kwargs`: Allows sending additional parameters to the json templating system. For example: `{"enable_thinking": false}`
 

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1174,10 +1174,15 @@ json oaicompat_chat_params_parse(
                 json_schema = json_value(response_format, "schema", json::object());
             }
         } else if (response_type == "json_schema") {
+            // OpenAI-style wrapper: {"type": "json_schema", "json_schema": {"name": ..., "schema": {...}}}
             auto schema_wrapper = json_value(response_format, "json_schema", json::object());
             json_schema = json_value(schema_wrapper, "schema", json::object());
+            // also accept the schema directly under response_format
+            if (json_schema.empty() && response_format.contains("schema")) {
+                json_schema = response_format.at("schema");
+            }
         } else if (!response_type.empty() && response_type != "text") {
-            throw std::invalid_argument("response_format type must be one of \"text\" or \"json_object\", but got: " + response_type);
+            throw std::invalid_argument("response_format type must be one of \"text\", \"json_object\" or \"json_schema\", but got: " + response_type);
         }
     }
 

--- a/tools/server/tests/unit/test_chat_completion.py
+++ b/tools/server/tests/unit/test_chat_completion.py
@@ -238,6 +238,7 @@ def test_apply_chat_template():
     ({"type": "json_object", "schema": {"const": "42"}}, 6, "\"42\""),
     ({"type": "json_object", "schema": {"items": [{"type": "integer"}]}}, 10, "[ -3000 ]"),
     ({"type": "json_schema", "json_schema": {"schema": {"const": "foooooo"}}}, 10, "\"foooooo\""),
+    ({"type": "json_schema", "schema": {"const": "foooooo"}}, 10, "\"foooooo\""),
     ({"type": "json_object"}, 10, "(\\{|John)+"),
     ({"type": "sound"}, 0, None),
     # invalid response format (expected to fail)


### PR DESCRIPTION
## Overview

`response_format` with `type: "json_schema"` only picked up the schema when it was nested inside `json_schema.schema` (the OpenAI wrapper form). If the schema was passed directly as `response_format.schema` — the form the server README documents — it was silently replaced with an empty schema, so generation ran unconstrained.

This accepts the top-level form as a fallback (nested wrapper still takes precedence when both are present), mentions `json_schema` in the invalid-type error message, documents the wrapper form in the README, and adds a test case.

I reproduced this against master with a tiny test model: before the patch the top-level form returned free-form text, after the patch the output follows the schema. `json_object` and the nested wrapper form behave exactly as before (byte-identical at temperature 0).

Fixes #10732

## Additional information

- [x] I have read and agree with the contributing guidelines
- AI usage disclosure: YES — the code change was implemented with AI assistance and manually reviewed and tested by me.
