### PR TITLE
CUDA: fuse dense Q4_K Gate/Up projections and SwiGLU for prefill

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -381,7 +381,6 @@ static bool ggml_cuda_is_aligned(const ggml_tensor * tensor, const size_t alignm
            tensor->nb[3] % alignment == 0;
 }
 
-// If the tensor is a temporary compute buffer, clear any potential padding past ggml_nbytes().
 static void ggml_cuda_clear_padding(const ggml_tensor * tensor, cudaStream_t stream) {
     if (ggml_backend_buffer_get_usage(tensor->buffer) != GGML_BACKEND_BUFFER_USAGE_COMPUTE) {
         return;

--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -381,6 +381,20 @@ static bool ggml_cuda_is_aligned(const ggml_tensor * tensor, const size_t alignm
            tensor->nb[3] % alignment == 0;
 }
 
+// If the tensor is a temporary compute buffer, clear any potential padding past ggml_nbytes().
+static void ggml_cuda_clear_padding(const ggml_tensor * tensor, cudaStream_t stream) {
+    if (ggml_backend_buffer_get_usage(tensor->buffer) != GGML_BACKEND_BUFFER_USAGE_COMPUTE) {
+        return;
+    }
+    const size_t size_data  = ggml_nbytes(tensor);
+    const size_t size_alloc = ggml_backend_buffer_get_alloc_size(tensor->buffer, tensor);
+    if (size_alloc > size_data) {
+        GGML_ASSERT(ggml_is_contiguously_allocated(tensor));
+        GGML_ASSERT(!tensor->view_src);
+        CUDA_CHECK(cudaMemsetAsync((char *) tensor->data + size_data, 0, size_alloc - size_data, stream));
+    }
+}
+
 static constexpr __device__ int ggml_cuda_get_physical_warp_size() {
 #if defined(GGML_USE_HIP) && (defined(__GFX9__) || defined(__GFX8__))
     return 64;

--- a/ggml/src/ggml-cuda/cp-async.cuh
+++ b/ggml/src/ggml-cuda/cp-async.cuh
@@ -1,3 +1,5 @@
+#pragma once
+
 // Simplified API for asynchronous data loading.
 
 #include "common.cuh"

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1833,7 +1833,6 @@ static bool ggml_cuda_mul_mat_q_gate_up_swiglu_matches(
 
     const int cc        = ggml_cuda_info().devices[device].cc;
     const int warp_size = ggml_cuda_info().devices[device].warp_size;
-    // Only replace matrix multiplications that ggml_cuda_mul_mat would have sent to MMQ.
     if (!GGML_CUDA_CC_IS_NVIDIA(cc) || !turing_mma_available(cc) || !cp_async_available(cc) ||
             ggml_cuda_should_use_mmvf(GGML_TYPE_Q4_K, cc, x_up->ne, x_up->nb, y->ne[1]) ||
             ggml_cuda_should_use_mmf(GGML_TYPE_Q4_K, cc, warp_size, x_up->ne, x_up->nb, y->ne[1], false) ||

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1783,14 +1783,17 @@ static bool ggml_cuda_should_fuse_mul_mat_vec_f(const ggml_tensor * tensor) {
     return use_mul_mat_vec_f;
 }
 
+static bool ggml_cuda_mul_mat_bad_padding_clear(const ggml_tensor * src0) {
+    return ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE &&
+        ggml_nbytes(src0) != ggml_backend_buffer_get_alloc_size(src0->buffer, src0) && src0->view_src;
+}
+
 static bool ggml_cuda_should_fuse_mul_mat_vec_q(const ggml_tensor * tensor) {
     ggml_tensor *       src0 = tensor->src[0];
     ggml_tensor *       src1 = tensor->src[1];
     const ggml_tensor * dst  = tensor;
 
-    const bool bad_padding_clear = ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE &&
-                                   ggml_nbytes(src0) != ggml_backend_buffer_get_alloc_size(src0->buffer, src0) &&
-                                   src0->view_src;
+    const bool bad_padding_clear = ggml_cuda_mul_mat_bad_padding_clear(src0);
 
     bool use_mul_mat_vec_q = ggml_is_quantized(src0->type) && !bad_padding_clear && src1->type == GGML_TYPE_F32 &&
                              dst->type == GGML_TYPE_F32 && src1->ne[1] <= MMVQ_MAX_BATCH_SIZE;
@@ -1812,6 +1815,47 @@ static bool ggml_cuda_should_fuse_mul_mat_vec_q(const ggml_tensor * tensor) {
     return use_mul_mat_vec_q;
 }
 
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+static bool ggml_cuda_should_fuse_mul_mat_q_gate_up_swiglu(
+        const ggml_tensor * up, const ggml_tensor * gate, const ggml_tensor * glu) {
+    const ggml_tensor * x_up   = up->src[0];
+    const ggml_tensor * x_gate = gate->src[0];
+    const ggml_tensor * y      = up->src[1];
+
+    if (up->op != GGML_OP_MUL_MAT || x_up->type != GGML_TYPE_Q4_K || y->type != GGML_TYPE_F32 || y->ne[1] <= 1 ||
+            ggml_get_glu_op(glu) != GGML_GLU_OP_SWIGLU || glu->type != GGML_TYPE_F32 ||
+            ggml_get_op_params_i32(up, 1) != GGML_HINT_NONE || ggml_get_op_params_i32(gate, 1) != GGML_HINT_NONE) {
+        return false;
+    }
+
+    if (!ggml_cuda_should_fuse_mul_mat(up, gate, glu)) {
+        return false;
+    }
+
+    if (ggml_cuda_mul_mat_bad_padding_clear(x_up) || ggml_cuda_mul_mat_bad_padding_clear(x_gate)) {
+        return false;
+    }
+
+    // The fused tile loader uses 16 byte vector loads.
+    if (!ggml_cuda_is_aligned(x_up, 16) || !ggml_cuda_is_aligned(x_gate, 16)) {
+        return false;
+    }
+
+    const int device    = ggml_cuda_get_device();
+    const int cc        = ggml_cuda_info().devices[device].cc;
+    const int warp_size = ggml_cuda_info().devices[device].warp_size;
+    // Only replace matrix multiplications that ggml_cuda_mul_mat would have sent to MMQ.
+    if (!GGML_CUDA_CC_IS_NVIDIA(cc) || !turing_mma_available(cc) || !cp_async_available(cc) ||
+            ggml_cuda_should_use_mmvf(GGML_TYPE_Q4_K, cc, x_up->ne, x_up->nb, y->ne[1]) ||
+            ggml_cuda_should_use_mmf(GGML_TYPE_Q4_K, cc, warp_size, x_up->ne, x_up->nb, y->ne[1], false) ||
+            ggml_cuda_should_use_mmvq(GGML_TYPE_Q4_K, cc, y->ne[1])) {
+        return false;
+    }
+
+    return ggml_cuda_should_use_mmq(GGML_TYPE_Q4_K, cc, y->ne[1], 0);
+}
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+
 static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
     GGML_TENSOR_BINARY_OP_LOCALS
 
@@ -1823,9 +1867,7 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
     // If src0 is a temporary compute buffer it may have some padding that needs to be cleared for mul_mat_vec_q or mul_mat_q.
     // But if src0 is also a view of another tensor then this cannot be done safely because it may overwrite valid tensor data.
     // Therefore, in such cases use cuBLAS.
-    const bool bad_padding_clear = ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE
-        && ggml_nbytes(src0) != ggml_backend_buffer_get_alloc_size(src0->buffer, src0) && src0->view_src;
-    if (bad_padding_clear || src1->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32) {
+    if (ggml_cuda_mul_mat_bad_padding_clear(src0) || src1->type != GGML_TYPE_F32 || dst->type != GGML_TYPE_F32) {
         ggml_cuda_mul_mat_cublas(ctx, src0, src1, dst);
         return;
     }
@@ -3965,6 +4007,13 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                 fused_node_count  = 3;
                 break;
             }
+
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+            if (ggml_cuda_should_fuse_mul_mat_q_gate_up_swiglu(up, gate, glu)) {
+                ggml_cuda_mul_mat_q_gate_up_swiglu(*cuda_ctx, up->src[0], gate->src[0], up->src[1], glu);
+                return 2;
+            }
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
         }
     }
 

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -1816,11 +1816,10 @@ static bool ggml_cuda_should_fuse_mul_mat_vec_q(const ggml_tensor * tensor) {
 }
 
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-static bool ggml_cuda_should_fuse_mul_mat_q_gate_up_swiglu(
-        const ggml_tensor * up, const ggml_tensor * gate, const ggml_tensor * glu) {
-    const ggml_tensor * x_up   = up->src[0];
-    const ggml_tensor * x_gate = gate->src[0];
-    const ggml_tensor * y      = up->src[1];
+static bool ggml_cuda_mul_mat_q_gate_up_swiglu_matches(
+        const ggml_tensor * up, const ggml_tensor * gate, const ggml_tensor * glu, const int device) {
+    const ggml_tensor * x_up = up->src[0];
+    const ggml_tensor * y    = up->src[1];
 
     if (up->op != GGML_OP_MUL_MAT || x_up->type != GGML_TYPE_Q4_K || y->type != GGML_TYPE_F32 || y->ne[1] <= 1 ||
             ggml_get_glu_op(glu) != GGML_GLU_OP_SWIGLU || glu->type != GGML_TYPE_F32 ||
@@ -1832,16 +1831,6 @@ static bool ggml_cuda_should_fuse_mul_mat_q_gate_up_swiglu(
         return false;
     }
 
-    if (ggml_cuda_mul_mat_bad_padding_clear(x_up) || ggml_cuda_mul_mat_bad_padding_clear(x_gate)) {
-        return false;
-    }
-
-    // The fused tile loader uses 16 byte vector loads.
-    if (!ggml_cuda_is_aligned(x_up, 16) || !ggml_cuda_is_aligned(x_gate, 16)) {
-        return false;
-    }
-
-    const int device    = ggml_cuda_get_device();
     const int cc        = ggml_cuda_info().devices[device].cc;
     const int warp_size = ggml_cuda_info().devices[device].warp_size;
     // Only replace matrix multiplications that ggml_cuda_mul_mat would have sent to MMQ.
@@ -1853,6 +1842,21 @@ static bool ggml_cuda_should_fuse_mul_mat_q_gate_up_swiglu(
     }
 
     return ggml_cuda_should_use_mmq(GGML_TYPE_Q4_K, cc, y->ne[1], 0);
+}
+
+static bool ggml_cuda_should_fuse_mul_mat_q_gate_up_swiglu(
+        const ggml_tensor * up, const ggml_tensor * gate, const ggml_tensor * glu) {
+    if (!ggml_cuda_mul_mat_q_gate_up_swiglu_matches(up, gate, glu, ggml_cuda_get_device())) {
+        return false;
+    }
+
+    const ggml_tensor * x_up   = up->src[0];
+    const ggml_tensor * x_gate = gate->src[0];
+    if (ggml_cuda_mul_mat_bad_padding_clear(x_up) || ggml_cuda_mul_mat_bad_padding_clear(x_gate)) {
+        return false;
+    }
+
+    return ggml_cuda_is_aligned(x_up, 16) && ggml_cuda_is_aligned(x_gate, 16);
 }
 #endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
@@ -4544,10 +4548,24 @@ static void ggml_backend_cuda_event_wait(ggml_backend_t backend, ggml_backend_ev
 
 static void ggml_backend_cuda_graph_optimize(ggml_backend_t backend, ggml_cgraph * cgraph, ggml_backend_graph_optimize_params * params) {
     ggml_backend_cuda_context * cuda_ctx = (ggml_backend_cuda_context *) backend->context;
+    ggml_cuda_set_device(cuda_ctx->device);
 
     static const bool disable_fusion = getenv("GGML_CUDA_DISABLE_FUSION") != nullptr && std::atoi(getenv("GGML_CUDA_DISABLE_FUSION"));
     if (!disable_fusion) {
         for (int i = 0; i < cgraph->n_nodes; ++i) {
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+            if (i + 2 < cgraph->n_nodes && cgraph->nodes[i + 2]->op == GGML_OP_GLU) {
+                ggml_tensor * glu  = cgraph->nodes[i + 2];
+                ggml_tensor * gate = cgraph->nodes[i];
+                ggml_tensor * up   = cgraph->nodes[i + 1];
+                if (glu->src[0] == gate && glu->src[1] == up &&
+                        ggml_cuda_mul_mat_q_gate_up_swiglu_matches(up, gate, glu, cuda_ctx->device)) {
+                    params->add_alloc_dep(params->user_data, up->src[1], glu);
+                    i += 2;
+                    continue;
+                }
+            }
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
             if (cgraph->nodes[i]->op != GGML_OP_MUL) {
                 continue;
             }
@@ -4591,8 +4609,6 @@ static void ggml_backend_cuda_graph_optimize(ggml_backend_t backend, ggml_cgraph
     if (!use_cuda_graph) {
         return;
     }
-
-    ggml_cuda_set_device(cuda_ctx->device);
 
     // number of out-degrees for a particular node
     std::unordered_map<const ggml_tensor *, int> fan_out;

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -144,7 +144,6 @@ static void ggml_cuda_mul_mat_q_impl(
     const size_t y_values_per_block = use_native_fp4 ? QK_FP4_MMQ            : QK8_1_MMQ;
 
     if (!ids) {
-        // The fused path needs the Q8_1 tail sized for its largest J.
         int64_t J_padding = ggml_cuda_mmq_get_J_max(src0->type, fallback, cc, ne11);
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
         if (gate) {

--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -6,6 +6,14 @@
 #include <cstdint>
 
 static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+    if (args.x_gate) {
+        GGML_ASSERT(args.type_x == GGML_TYPE_Q4_K);
+        mul_mat_q_gate_up_swiglu_case<GGML_TYPE_Q4_K>(ctx, args, stream);
+        return;
+    }
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+
     switch (args.type_x) {
         case GGML_TYPE_Q1_0:
             mul_mat_q_case<GGML_TYPE_Q1_0>(ctx, args, stream);
@@ -82,11 +90,20 @@ static void ggml_cuda_mul_mat_q_switch_type(ggml_backend_cuda_context & ctx, con
     }
 }
 
-void ggml_cuda_mul_mat_q(
-        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst) {
+// gate != nullptr selects the fused dense Q4_K gate+up+SwiGLU kernel: src0 is the up weight, dst the SwiGLU output.
+static void ggml_cuda_mul_mat_q_impl(
+        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1,
+        const ggml_tensor * ids, ggml_tensor * dst, const ggml_tensor * gate) {
     GGML_ASSERT(        src1->type == GGML_TYPE_F32);
     GGML_ASSERT(        dst->type  == GGML_TYPE_F32);
     GGML_ASSERT(!ids || ids->type  == GGML_TYPE_I32); // Optional, used for batched GGML_MUL_MAT_ID.
+
+    if (gate) {
+        GGML_ASSERT(ids == nullptr);
+        GGML_ASSERT(src0->type == GGML_TYPE_Q4_K && gate->type == GGML_TYPE_Q4_K);
+        GGML_ASSERT(ggml_are_same_shape(src0, gate));
+        GGML_ASSERT(ggml_are_same_stride(src0, gate));
+    }
 
     GGML_TENSOR_BINARY_OP_LOCALS;
 
@@ -106,15 +123,9 @@ void ggml_cuda_mul_mat_q(
     const float * src1_d = (const float *) src1->data;
     float       *  dst_d = (float       *)  dst->data;
 
-    // If src0 is a temporary compute buffer, clear any potential padding.
-    if (ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE) {
-        const size_t size_data  = ggml_nbytes(src0);
-        const size_t size_alloc = ggml_backend_buffer_get_alloc_size(src0->buffer, src0);
-        if (size_alloc > size_data) {
-            GGML_ASSERT(ggml_is_contiguously_allocated(src0));
-            GGML_ASSERT(!src0->view_src);
-            CUDA_CHECK(cudaMemsetAsync((char *) src0->data + size_data, 0, size_alloc - size_data, stream));
-        }
+    ggml_cuda_clear_padding(src0, stream);
+    if (gate) {
+        ggml_cuda_clear_padding(gate, stream);
     }
 
     const int64_t ne10_padded = GGML_PAD(ne10, MATRIX_ROW_PADDING);
@@ -133,8 +144,15 @@ void ggml_cuda_mul_mat_q(
     const size_t y_values_per_block = use_native_fp4 ? QK_FP4_MMQ            : QK8_1_MMQ;
 
     if (!ids) {
+        // The fused path needs the Q8_1 tail sized for its largest J.
+        int64_t J_padding = ggml_cuda_mmq_get_J_max(src0->type, fallback, cc, ne11);
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+        if (gate) {
+            J_padding = GGML_CUDA_MMQ_GATE_UP_SWIGLU_J_MAX;
+        }
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
         const size_t nbytes_src1_q8_1 = ne13*ne12 * ne11*ne10_padded * y_block_size/y_values_per_block +
-            ggml_cuda_mmq_get_J_max(src0->type, fallback, cc, ne11) * sizeof(block_q8_1_mmq);
+            J_padding * sizeof(block_q8_1_mmq);
         ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), nbytes_src1_q8_1);
         ggml_cuda_pool_alloc<float> src1_scale(ctx.pool());
         if (src0->type == GGML_TYPE_NVFP4 && use_native_fp4) {
@@ -165,13 +183,14 @@ void ggml_cuda_mul_mat_q(
                                 ne11 * ne10_padded * sizeof(block_q8_1) / (QK8_1 * sizeof(int));
         const int64_t s13 = ne12*s12;
 
-        const mmq_args args = {
+        mmq_args args = {
             src0_d, src0->type, (const int *) src1_q8_1.ptr, nullptr, nullptr, dst_d,
             src0->type == GGML_TYPE_NVFP4 && use_native_fp4 ? src1_scale.ptr : nullptr,
             ne00, ne01, ne1, s01, ne11, s1,
             ne02, ne12, s02, s12, s2,
             ne03, ne13, s03, s13, s3,
             ne1, ne1};
+        args.x_gate = gate ? (const char *) gate->data : nullptr;
         ggml_cuda_mul_mat_q_switch_type(ctx, args, stream);
         return;
     }
@@ -262,6 +281,21 @@ void ggml_cuda_mul_mat_q(
 
     ggml_cuda_mul_mat_q_switch_type(ctx, args, stream);
 }
+
+void ggml_cuda_mul_mat_q(
+        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1,
+        const ggml_tensor * ids, ggml_tensor * dst) {
+    ggml_cuda_mul_mat_q_impl(ctx, src0, src1, ids, dst, nullptr);
+}
+
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+void ggml_cuda_mul_mat_q_gate_up_swiglu(
+        ggml_backend_cuda_context & ctx, const ggml_tensor * up, const ggml_tensor * gate,
+        const ggml_tensor * src, ggml_tensor * dst) {
+    GGML_ASSERT(gate != nullptr);
+    ggml_cuda_mul_mat_q_impl(ctx, up, src, nullptr, dst, gate);
+}
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
 bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t n_experts) {
 #ifdef GGML_CUDA_FORCE_CUBLAS

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -524,7 +524,6 @@ static __device__ __forceinline__ void ggml_cuda_mmq_write_back_mma(
 }
 
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
-// Fused dense Q4_K gate + up MMQ with the SwiGLU applied in the epilogue (F32 output), needs int8 MMA and cp.async.
 static constexpr int GGML_CUDA_MMQ_GATE_UP_SWIGLU_J_MAX = 64;
 static constexpr int GGML_CUDA_MMQ_GATE_UP_SWIGLU_I     = 64;
 
@@ -562,7 +561,6 @@ static constexpr __device__ int ggml_cuda_mmq_gate_up_swiglu_get_I(ggml_type typ
     return ggml_cuda_mmq_gate_up_swiglu_get_config(type, J, fallback).I;
 }
 
-// dst = up * silu(gate) for the accumulator tiles of this warp.
 template<ggml_type type, int J, bool fallback>
 static __device__ __forceinline__ void ggml_cuda_mmq_write_back_swiglu_mma(
         const float * __restrict__ up, const float * __restrict__ gate,
@@ -1019,8 +1017,6 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
 
 #if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 #ifdef GGML_CUDA_MMQ_GATE_UP_SWIGLU_AVAILABLE
-// Loads one Q4_K tile into the layout of ggml_cuda_mmq_load_tiles_q4_K using 8 and 16 byte vector loads.
-// The lane to row order +0, +2, +1, +3 makes the 8 byte shared memory stores of each half-warp bank-conflict-free.
 template <ggml_type type, int J, bool fallback>
 static __device__ __forceinline__ void mmq_gate_up_swiglu_load_x(
         const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
@@ -1041,7 +1037,9 @@ static __device__ __forceinline__ void mmq_gate_up_swiglu_load_x(
     const int row_off   = (threadIdx.x / 16) + 2*((threadIdx.x / 8) % 2);
     const int q         = threadIdx.x % 8;
 
-    // Same placement as ggml_cuda_mmq_load_tiles_q4_K: int txi -> x_qs[16*(txi/8) + txi%8], high nibbles at +8.
+    // Same placement as ggml_cuda_mmq_load_tiles_q4_K:
+    // low nibbles:  x_qs[16*(txi/8) + txi%8]
+    // high nibbles: x_qs[16*(txi/8) + txi%8 + 8]
 #pragma unroll
     for (int g = 0; g < ngroups; ++g) {
         const int i  = warp_row0 + 4*g + row_off;
@@ -1062,7 +1060,6 @@ static __device__ __forceinline__ void mmq_gate_up_swiglu_load_x(
     const block_q4_K * bxi = (const block_q4_K *) x + kbx0 + il*stride;
     const int4 hdr = *(const int4 *) bxi;
 
-    // Register form of unpack_scales_q45_K for ksc (scales) and ksc + 2 (mins).
     const int ksc = threadIdx.x % 2;
     const int s0  = hdr.y;
     const int s1  = hdr.z;
@@ -1081,7 +1078,6 @@ static __device__ __forceinline__ void mmq_gate_up_swiglu_load_x(
     }
 }
 
-// cp.async copy of the two Q8_1 half tiles of one K slab.
 template <int J, int nwarps, int warp_size>
 static __device__ __forceinline__ void mmq_gate_up_swiglu_copy_y(
         const int * __restrict__ by0, const int ncols_y, int * __restrict__ tile_y0) {

--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "common.cuh"
+#include "cp-async.cuh"
+#include "unary.cuh"
 
 #include <climits>
 #include <cstdint>
@@ -521,6 +523,80 @@ static __device__ __forceinline__ void ggml_cuda_mmq_write_back_mma(
     }
 }
 
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+// Fused dense Q4_K gate + up MMQ with the SwiGLU applied in the epilogue (F32 output), needs int8 MMA and cp.async.
+static constexpr int GGML_CUDA_MMQ_GATE_UP_SWIGLU_J_MAX = 64;
+static constexpr int GGML_CUDA_MMQ_GATE_UP_SWIGLU_I     = 64;
+
+#if defined(TURING_MMA_AVAILABLE) && defined(CP_ASYNC_AVAILABLE)
+#define GGML_CUDA_MMQ_GATE_UP_SWIGLU_AVAILABLE
+#endif // defined(TURING_MMA_AVAILABLE) && defined(CP_ASYNC_AVAILABLE)
+
+// Half the rows and threads of the stock Q4_K configuration so that two blocks per SM overlap their loads and MMAs.
+static constexpr __host__ __device__ ggml_cuda_mmq_config ggml_cuda_mmq_gate_up_swiglu_get_config(const ggml_cuda_mmq_config & config) {
+    if (config.type == GGML_TYPE_COUNT) {
+        return config;
+    }
+    return ggml_cuda_mmq_config(config.type, 128, 2, GGML_CUDA_MMQ_GATE_UP_SWIGLU_I, config.J, config.sram_layout, config.K_vram, false, config.fallback);
+}
+
+static __host__ ggml_cuda_mmq_config ggml_cuda_mmq_gate_up_swiglu_get_config(
+        const ggml_type type, const int J, const bool fallback, const int cc) {
+    GGML_ASSERT(turing_mma_available(cc) && cp_async_available(cc));
+    return ggml_cuda_mmq_gate_up_swiglu_get_config(ggml_cuda_mmq_get_config(type, J, fallback, cc));
+}
+
+static constexpr __device__ ggml_cuda_mmq_config ggml_cuda_mmq_gate_up_swiglu_get_config(ggml_type type, int J, bool fallback) {
+    return ggml_cuda_mmq_gate_up_swiglu_get_config(ggml_cuda_mmq_get_config(type, J, fallback));
+}
+
+static constexpr __device__ int ggml_cuda_mmq_gate_up_swiglu_get_nthreads(ggml_type type, int J, bool fallback) {
+    return ggml_cuda_mmq_gate_up_swiglu_get_config(type, J, fallback).nthreads;
+}
+
+static constexpr __device__ int ggml_cuda_mmq_gate_up_swiglu_get_occupancy(ggml_type type, int J, bool fallback) {
+    return ggml_cuda_mmq_gate_up_swiglu_get_config(type, J, fallback).occupancy;
+}
+
+static constexpr __device__ int ggml_cuda_mmq_gate_up_swiglu_get_I(ggml_type type, int J, bool fallback) {
+    return ggml_cuda_mmq_gate_up_swiglu_get_config(type, J, fallback).I;
+}
+
+// dst = up * silu(gate) for the accumulator tiles of this warp.
+template<ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void ggml_cuda_mmq_write_back_swiglu_mma(
+        const float * __restrict__ up, const float * __restrict__ gate,
+        float * __restrict__ dst, const int stride, const int i_max, const int j_max) {
+    typedef tile<16,  8, int> tile_C;
+
+    constexpr int rows_per_warp = ggml_cuda_mmq_get_rows_per_warp(type, J, fallback);
+    constexpr int ntx           = rows_per_warp/tile_C::I;
+    const int i0 = (threadIdx.y / ntx) * (ntx*tile_C::I);
+
+#pragma unroll
+    for (int j0 = 0; j0 < J; j0 += ntx*tile_C::J) {
+#pragma unroll
+        for (int n = 0; n < ntx; ++n) {
+#pragma unroll
+            for (int l = 0; l < tile_C::ne; ++l) {
+                const int j = j0 + (threadIdx.y % ntx) * tile_C::J + tile_C::get_j(l);
+                if (j > j_max) {
+                    continue;
+                }
+
+                const int i = i0 + n*tile_C::I + tile_C::get_i(l);
+                if (fallback && i > i_max) {
+                    continue;
+                }
+
+                const int sum_index = (j0/tile_C::J + n)*tile_C::ne + l;
+                dst[j*stride + i] = up[sum_index] * ggml_cuda_op_silu_single(gate[sum_index]);
+            }
+        }
+    }
+}
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+
 // -------------------------------------------------------------------------------------------------------------------------------------
 
 // TODO remove this struct and use ggml_cuda_mmq_sram_layout instead.
@@ -941,6 +1017,199 @@ static __device__ __forceinline__ void mul_mat_q_process_tile(
     }
 }
 
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+#ifdef GGML_CUDA_MMQ_GATE_UP_SWIGLU_AVAILABLE
+// Loads one Q4_K tile into the layout of ggml_cuda_mmq_load_tiles_q4_K using 8 and 16 byte vector loads.
+// The lane to row order +0, +2, +1, +3 makes the 8 byte shared memory stores of each half-warp bank-conflict-free.
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void mmq_gate_up_swiglu_load_x(
+        const char * __restrict__ x, int * __restrict__ x_tile, const int kbx0, const int i_max, const int stride) {
+    constexpr int warp_size     = ggml_cuda_get_physical_warp_size();
+    constexpr int nwarps        = ggml_cuda_mmq_gate_up_swiglu_get_nthreads(type, J, fallback) / warp_size;
+    constexpr int I             = ggml_cuda_mmq_gate_up_swiglu_get_I(type, J, fallback);
+    constexpr int rows_per_warp = I / nwarps;
+    constexpr int ngroups       = rows_per_warp / 4;
+    constexpr int sram_stride   = ggml_cuda_mmq_get_sram_stride(type, J, fallback);
+
+    static_assert(type == GGML_TYPE_Q4_K, "Gate/up MMQ fusion currently supports Q4_K only");
+    static_assert(warp_size == 32 && rows_per_warp == warp_size/2, "bad fused Q4_K tile mapping");
+
+    int   * x_qs = x_tile;
+    half2 * x_dm = (half2 *) (x_qs + 2*MMQ_TILE_NE_K);
+
+    const int warp_row0 = threadIdx.y * rows_per_warp;
+    const int row_off   = (threadIdx.x / 16) + 2*((threadIdx.x / 8) % 2);
+    const int q         = threadIdx.x % 8;
+
+    // Same placement as ggml_cuda_mmq_load_tiles_q4_K: int txi -> x_qs[16*(txi/8) + txi%8], high nibbles at +8.
+#pragma unroll
+    for (int g = 0; g < ngroups; ++g) {
+        const int i  = warp_row0 + 4*g + row_off;
+        const int il = fallback ? min(i, i_max) : i;
+        const block_q4_K * bxi = (const block_q4_K *) x + kbx0 + il*stride;
+        const int2 * qs = (const int2 *) bxi->qs;
+        const int2 v0 = qs[q];
+        const int2 v1 = qs[q + 8];
+        int * row = x_qs + i*sram_stride + 16*(q/4) + 2*(q%4);
+        *(int2 *) (row +  0) = make_int2((v0.x >> 0) & 0x0F0F0F0F, (v0.y >> 0) & 0x0F0F0F0F);
+        *(int2 *) (row +  8) = make_int2((v0.x >> 4) & 0x0F0F0F0F, (v0.y >> 4) & 0x0F0F0F0F);
+        *(int2 *) (row + 32) = make_int2((v1.x >> 0) & 0x0F0F0F0F, (v1.y >> 0) & 0x0F0F0F0F);
+        *(int2 *) (row + 40) = make_int2((v1.x >> 4) & 0x0F0F0F0F, (v1.y >> 4) & 0x0F0F0F0F);
+    }
+
+    const int i  = warp_row0 + threadIdx.x/2;
+    const int il = fallback ? min(i, i_max) : i;
+    const block_q4_K * bxi = (const block_q4_K *) x + kbx0 + il*stride;
+    const int4 hdr = *(const int4 *) bxi;
+
+    // Register form of unpack_scales_q45_K for ksc (scales) and ksc + 2 (mins).
+    const int ksc = threadIdx.x % 2;
+    const int s0  = hdr.y;
+    const int s1  = hdr.z;
+    const int s2  = hdr.w;
+    const int sc32 = ( (ksc ? s2 : s0)              & 0x0F0F0F0F) | ((s0 >> (2*ksc)) & 0x30303030);
+    const int  m32 = (((ksc ? s2 : s1) >> (4*ksc)) & 0x0F0F0F0F) | ((s1 >> (2*ksc)) & 0x30303030);
+
+    const uint8_t * sc8 = (const uint8_t *) &sc32;
+    const uint8_t *  m8 = (const uint8_t *)  &m32;
+
+    const half2 dm = reinterpret_cast<const half2 &>(hdr.x) * make_half2(1.0f, -1.0f);
+
+#pragma unroll
+    for (int l = 0; l < 4; ++l) {
+        x_dm[i*sram_stride + 4*ksc + l] = dm*make_half2(sc8[l], m8[l]);
+    }
+}
+
+// cp.async copy of the two Q8_1 half tiles of one K slab.
+template <int J, int nwarps, int warp_size>
+static __device__ __forceinline__ void mmq_gate_up_swiglu_copy_y(
+        const int * __restrict__ by0, const int ncols_y, int * __restrict__ tile_y0) {
+    constexpr int sz            = sizeof(block_q8_1_mmq) / sizeof(int);
+    constexpr int tile_y_stride = GGML_PAD(J * MMQ_TILE_Y_K, nwarps * warp_size);
+    constexpr int copy_stride   = nwarps * warp_size * 4;
+    constexpr int copy_rounds   = (J * MMQ_TILE_Y_K + copy_stride - 1) / copy_stride;
+
+    int l = (threadIdx.y * warp_size + threadIdx.x) * 4;
+    unsigned int dst_y0 = ggml_cuda_cvta_generic_to_shared(tile_y0 + l);
+    unsigned int dst_y1 = ggml_cuda_cvta_generic_to_shared(tile_y0 + tile_y_stride + l);
+    const int * src_y0 = by0 + l;
+    const int * src_y1 = by0 + ncols_y * sz + l;
+#pragma unroll
+    for (int round = 0; round < copy_rounds; ++round) {
+        if (l < J * MMQ_TILE_Y_K) {
+            cp_async_cg_16<0>(dst_y0, src_y0);
+            cp_async_cg_16<0>(dst_y1, src_y1);
+        }
+        l += copy_stride;
+        dst_y0 += copy_stride * sizeof(int);
+        dst_y1 += copy_stride * sizeof(int);
+        src_y0 += copy_stride;
+        src_y1 += copy_stride;
+    }
+}
+
+template <ggml_type type, int J, bool fallback>
+static __device__ __forceinline__ void mul_mat_q_gate_up_swiglu_process_tile(
+        const char * __restrict__ x_up, const char * __restrict__ x_gate, const int offset_x,
+        const int * __restrict__ y, float * __restrict__ dst,
+        const int stride_row_x, const int ncols_y, const int stride_col_dst,
+        const int tile_x_max_i, const int tile_y_max_j, const int kb0_stop) {
+    static_assert(type == GGML_TYPE_Q4_K, "Gate/up MMQ fusion currently supports Q4_K only");
+
+    constexpr int warp_size = ggml_cuda_get_physical_warp_size();
+    constexpr int nwarps    = ggml_cuda_mmq_gate_up_swiglu_get_nthreads(type, J, fallback) / warp_size;
+    constexpr int qk        = ggml_cuda_type_traits<type>::qk;
+    constexpr int I         = ggml_cuda_mmq_gate_up_swiglu_get_I(type, J, fallback);
+
+    extern __shared__ int data_mul_mat_q[];
+    constexpr int tile_y_stride = GGML_PAD(J * MMQ_TILE_Y_K, nwarps * warp_size);
+    int * tile_y0 = data_mul_mat_q + J;
+    int * tile_y1 = tile_y0 + tile_y_stride;
+    int * tile_x  = tile_y1 + tile_y_stride;
+
+    constexpr int ITER_K          = ggml_cuda_mmq_get_K_vram(type, J, fallback);
+    constexpr int blocks_per_iter = ITER_K / qk;
+    constexpr int sum_size        = J * I / (nwarps * warp_size);
+    constexpr int sz              = sizeof(block_q8_1_mmq) / sizeof(int);
+
+    float sum_up[sum_size]   = {0.0f};
+    float sum_gate[sum_size] = {0.0f};
+
+    for (int kb0 = 0; kb0 < kb0_stop; kb0 += blocks_per_iter) {
+        mmq_gate_up_swiglu_copy_y<J, nwarps, warp_size>(y + ncols_y * (kb0 * qk / QK8_1_MMQ) * sz, ncols_y, tile_y0);
+
+        mmq_gate_up_swiglu_load_x<type, J, fallback>(x_up, tile_x, offset_x + kb0, tile_x_max_i, stride_row_x);
+        cp_async_wait_all();
+        __syncthreads();
+
+        ggml_cuda_mmq_vec_dot_q8_1_q8_1_mma<type, J, fallback>(tile_x, tile_y0, sum_up, 0);
+        ggml_cuda_mmq_vec_dot_q8_1_q8_1_mma<type, J, fallback>(tile_x, tile_y1, sum_up, MMQ_TILE_NE_K);
+        __syncthreads();
+
+        mmq_gate_up_swiglu_load_x<type, J, fallback>(x_gate, tile_x, offset_x + kb0, tile_x_max_i, stride_row_x);
+        __syncthreads();
+
+        ggml_cuda_mmq_vec_dot_q8_1_q8_1_mma<type, J, fallback>(tile_x, tile_y0, sum_gate, 0);
+        ggml_cuda_mmq_vec_dot_q8_1_q8_1_mma<type, J, fallback>(tile_x, tile_y1, sum_gate, MMQ_TILE_NE_K);
+        __syncthreads();
+    }
+
+    ggml_cuda_mmq_write_back_swiglu_mma<type, J, fallback>(
+        sum_up, sum_gate, dst, stride_col_dst, tile_x_max_i, tile_y_max_j);
+}
+#endif // GGML_CUDA_MMQ_GATE_UP_SWIGLU_AVAILABLE
+
+template <ggml_type type, int J, bool fallback>
+__launch_bounds__(ggml_cuda_mmq_gate_up_swiglu_get_nthreads(type, J, fallback), ggml_cuda_mmq_gate_up_swiglu_get_occupancy(type, J, fallback))
+static __global__ void mul_mat_q_gate_up_swiglu(
+        const char * __restrict__ x_up, const char * __restrict__ x_gate, const int * __restrict__ y,
+        float * __restrict__ dst, const int blocks_per_ne00, const int nrows_x, const int ncols_dst,
+        const int stride_row_x, const int ncols_y, const int stride_col_dst,
+        const uint3 channel_ratio, const uint3 nchannels_y, const int stride_channel_x,
+        const int stride_channel_y, const int stride_channel_dst, const uint3 sample_ratio,
+        const uint3 nsamples_y, const int stride_sample_x, const int stride_sample_y,
+        const int stride_sample_dst, const uint3 ntx) {
+#ifdef GGML_CUDA_MMQ_GATE_UP_SWIGLU_AVAILABLE
+    if (ggml_cuda_mmq_gate_up_swiglu_get_config(type, J, fallback).type == GGML_TYPE_COUNT) {
+        NO_DEVICE_CODE;
+        return;
+    }
+
+    constexpr int I = ggml_cuda_mmq_gate_up_swiglu_get_I(type, J, fallback);
+
+    // Each block does one complete K reduction: the SwiGLU epilogue is nonlinear so K cannot be split.
+    int tmp = blockIdx.x;
+    uint2 tmp2 = fast_div_modulo(tmp, ntx);
+    const int jt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nchannels_y);
+    const int zt = tmp2.y;
+    tmp = tmp2.x;
+    tmp2 = fast_div_modulo(tmp, nsamples_y);
+    const int wt = tmp2.y;
+    const int it = tmp2.x;
+
+    const int offset_y = wt * stride_sample_y + zt * stride_channel_y +
+        jt * J * (sizeof(block_q8_1_mmq) / sizeof(int));
+    const int offset_x = fastdiv(wt, sample_ratio) * stride_sample_x +
+        fastdiv(zt, channel_ratio) * stride_channel_x + it * I * stride_row_x;
+    const int offset_dst = wt * stride_sample_dst + zt * stride_channel_dst + jt * J * stride_col_dst + it * I;
+
+    const int tile_x_max_i = nrows_x - it * I - 1;
+    const int tile_y_max_j = ncols_dst - jt * J - 1;
+
+    mul_mat_q_gate_up_swiglu_process_tile<type, J, fallback>(
+        x_up, x_gate, offset_x, y + offset_y, dst + offset_dst,
+        stride_row_x, ncols_y, stride_col_dst, tile_x_max_i, tile_y_max_j, blocks_per_ne00);
+#else
+    GGML_UNUSED_VARS(x_up, x_gate, y, dst, blocks_per_ne00, nrows_x, ncols_dst, stride_row_x, ncols_y, stride_col_dst,
+        channel_ratio, nchannels_y, stride_channel_x, stride_channel_y, stride_channel_dst, sample_ratio,
+        nsamples_y, stride_sample_x, stride_sample_y, stride_sample_dst, ntx);
+    NO_DEVICE_CODE;
+#endif // GGML_CUDA_MMQ_GATE_UP_SWIGLU_AVAILABLE
+}
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
 // The mul_mat_q kernel implements "stream-k" work partitioning as described in https://arxiv.org/abs/2301.03598
 
@@ -1377,6 +1646,7 @@ struct mmq_args {
     int64_t nsamples_x; int64_t nsamples_y; int64_t stride_sample_x; int64_t stride_sample_y; int64_t stride_sample_dst;
     int64_t ncols_max;
     int64_t ncols_opt; // value to optimize the tile size against, launch grid still uses ncols_max
+    const char * x_gate = nullptr;
 };
 
 static size_t mmq_get_nbytes_shared(const ggml_cuda_mmq_config & config, const int cc) {
@@ -1385,6 +1655,112 @@ static size_t mmq_get_nbytes_shared(const ggml_cuda_mmq_config & config, const i
     const size_t nbs_y = config.J * (sizeof(block_q8_1_mmq));
     return nbs_ids + nbs_x + GGML_PAD(nbs_y, config.nthreads*sizeof(int));
 }
+
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+// The stock layout plus a second Y half tile.
+static size_t mmq_gate_up_swiglu_get_nbytes_shared(const ggml_cuda_mmq_config & config, const int cc) {
+    const size_t nbs_y = config.J * sizeof(block_q8_1_mmq);
+    return mmq_get_nbytes_shared(config, cc) + GGML_PAD(nbs_y, config.nthreads * sizeof(int));
+}
+
+template <ggml_type type, int J, bool fallback>
+static void launch_mul_mat_q_gate_up_swiglu(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
+    static_assert(type == GGML_TYPE_Q4_K, "Gate/up MMQ fusion currently supports Q4_K only");
+    static_assert(J <= GGML_CUDA_MMQ_GATE_UP_SWIGLU_J_MAX, "J exceeds the reserved Q8_1 tail, bump GGML_CUDA_MMQ_GATE_UP_SWIGLU_J_MAX");
+    GGML_ASSERT(args.x_gate != nullptr);
+    GGML_ASSERT(args.ids_dst == nullptr && args.expert_bounds == nullptr);
+
+    const int id        = ggml_cuda_get_device();
+    const int cc        = ggml_cuda_info().devices[id].cc;
+    const int warp_size = ggml_cuda_info().devices[id].warp_size;
+
+    const ggml_cuda_mmq_config config = ggml_cuda_mmq_gate_up_swiglu_get_config(type, J, fallback, cc);
+    GGML_ASSERT(config.use_mma_data_layout(cc));
+    GGML_ASSERT(config.nthreads % warp_size == 0);
+    const int nwarps = config.nthreads / warp_size;
+    const size_t nbytes_shared = mmq_gate_up_swiglu_get_nbytes_shared(config, cc);
+    GGML_ASSERT(nbytes_shared <= ggml_cuda_info().devices[id].smpbo);
+
+    const dim3 block_dims(warp_size, nwarps, 1);
+    const int nty  = (args.nrows_x   + config.I - 1) / config.I;
+    const int ntx  = (args.ncols_max + config.J - 1) / config.J;
+    const int ntzw = args.nchannels_y * args.nsamples_y;
+    const int ntiles_dst = nty * ntx * ntzw;
+    const dim3 block_nums(ntiles_dst, 1, 1);
+
+    GGML_ASSERT(args.nchannels_y % args.nchannels_x == 0);
+    GGML_ASSERT(args.nsamples_y  % args.nsamples_x  == 0);
+    const int channel_ratio = args.nchannels_y / args.nchannels_x;
+    const int sample_ratio  = args.nsamples_y  / args.nsamples_x;
+
+    const int   blocks_per_ne00    = args.ncols_x / ggml_cuda_type_traits<type>::qk;
+    const uint3 ntx_fd             = init_fastdiv_values(ntx);
+    const uint3 nchannels_y_fd     = init_fastdiv_values(args.nchannels_y);
+    const uint3 nsamples_y_fd      = init_fastdiv_values(args.nsamples_y);
+    const uint3 channel_ratio_fd   = init_fastdiv_values(channel_ratio);
+    const uint3 sample_ratio_fd    = init_fastdiv_values(sample_ratio);
+
+    CUDA_SET_SHARED_MEMORY_LIMIT((mul_mat_q_gate_up_swiglu<type, J, fallback>), nbytes_shared);
+    mul_mat_q_gate_up_swiglu<type, J, fallback><<<block_nums, block_dims, nbytes_shared, stream>>>(
+        args.x, args.x_gate, args.y, args.dst, blocks_per_ne00, args.nrows_x, args.ncols_dst,
+        args.stride_row_x, args.ncols_y, args.nrows_dst, channel_ratio_fd, nchannels_y_fd,
+        args.stride_channel_x, args.stride_channel_y, args.stride_channel_dst, sample_ratio_fd,
+        nsamples_y_fd, args.stride_sample_x, args.stride_sample_y, args.stride_sample_dst, ntx_fd);
+}
+
+template <ggml_type type, bool fallback>
+static void mul_mat_q_gate_up_swiglu_switch_J(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
+    const int id       = ggml_cuda_get_device();
+    const int cc       = ggml_cuda_info().devices[id].cc;
+    const size_t smpbo = ggml_cuda_info().devices[id].smpbo;
+
+    // Sparse set of J values to limit the number of template instances.
+    int J_best        = 0;
+    int ntiles_J_best = INT_MAX;
+    for (const int J : {8, 16, 32, GGML_CUDA_MMQ_GATE_UP_SWIGLU_J_MAX}) {
+        const ggml_cuda_mmq_config config = ggml_cuda_mmq_gate_up_swiglu_get_config(type, J, fallback, cc);
+        if (config.type == GGML_TYPE_COUNT || mmq_gate_up_swiglu_get_nbytes_shared(config, cc) > smpbo) {
+            continue;
+        }
+
+        const int ntiles_x = (args.ncols_max + J - 1) / J;
+        if (ntiles_x < ntiles_J_best) {
+            J_best = J;
+            ntiles_J_best = ntiles_x;
+        }
+        if (ntiles_J_best == 1) {
+            break;
+        }
+    }
+
+    switch (J_best) {
+        case 8:
+            launch_mul_mat_q_gate_up_swiglu<type, 8, fallback>(ctx, args, stream);
+            break;
+        case 16:
+            launch_mul_mat_q_gate_up_swiglu<type, 16, fallback>(ctx, args, stream);
+            break;
+        case 32:
+            launch_mul_mat_q_gate_up_swiglu<type, 32, fallback>(ctx, args, stream);
+            break;
+        case 64:
+            launch_mul_mat_q_gate_up_swiglu<type, 64, fallback>(ctx, args, stream);
+            break;
+        default:
+            GGML_ABORT("No valid Q4_K gate/up MMQ configuration");
+    }
+}
+
+template <ggml_type type>
+void mul_mat_q_gate_up_swiglu_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
+    static_assert(type == GGML_TYPE_Q4_K, "Gate/up MMQ fusion currently supports Q4_K only");
+    if (args.nrows_x % GGML_CUDA_MMQ_GATE_UP_SWIGLU_I == 0) {
+        mul_mat_q_gate_up_swiglu_switch_J<type, false>(ctx, args, stream);
+    } else {
+        mul_mat_q_gate_up_swiglu_switch_J<type, true>(ctx, args, stream);
+    }
+}
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
 template <ggml_type type, int J, bool fallback>
 static void launch_mul_mat_q(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) {
@@ -1565,6 +1941,12 @@ void mul_mat_q_case(ggml_backend_cuda_context & ctx, const mmq_args & args, cuda
 #define DECL_MMQ_CASE(type)                                                        \
     template void mul_mat_q_case<type>(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) \
 
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+#define DECL_MMQ_GATE_UP_SWIGLU_CASE(type)                                         \
+    template void mul_mat_q_gate_up_swiglu_case<type>(ggml_backend_cuda_context & ctx, const mmq_args & args, cudaStream_t stream) \
+
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+
 extern DECL_MMQ_CASE(GGML_TYPE_Q1_0);
 extern DECL_MMQ_CASE(GGML_TYPE_Q2_0);
 extern DECL_MMQ_CASE(GGML_TYPE_Q4_0);
@@ -1591,9 +1973,20 @@ extern DECL_MMQ_CASE(GGML_TYPE_IQ4_XS);
 extern DECL_MMQ_CASE(GGML_TYPE_MXFP4);
 extern DECL_MMQ_CASE(GGML_TYPE_NVFP4);
 
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+extern DECL_MMQ_GATE_UP_SWIGLU_CASE(GGML_TYPE_Q4_K);
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+
 // -------------------------------------------------------------------------------------------------------------------------
 
 void ggml_cuda_mul_mat_q(
-        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst);
+        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1,
+        const ggml_tensor * ids, ggml_tensor * dst);
+
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+void ggml_cuda_mul_mat_q_gate_up_swiglu(
+        ggml_backend_cuda_context & ctx, const ggml_tensor * up, const ggml_tensor * gate,
+        const ggml_tensor * src, ggml_tensor * dst);
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
 
 bool ggml_cuda_should_use_mmq(enum ggml_type type, int cc, int64_t ne11, int64_t n_experts);

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1470,16 +1470,7 @@ void ggml_cuda_mul_mat_vec_q(
         fusion_local.glu_limit = fusion->glu_limit;
     }
 
-    // If src0 is a temporary compute buffer, clear any potential padding.
-    if (ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE) {
-        const size_t size_data  = ggml_nbytes(src0);
-        const size_t size_alloc = ggml_backend_buffer_get_alloc_size(src0->buffer, src0);
-        if (size_alloc > size_data) {
-            GGML_ASSERT(ggml_is_contiguously_allocated(src0));
-            GGML_ASSERT(!src0->view_src);
-            CUDA_CHECK(cudaMemsetAsync((char *) src0->data + size_data, 0, size_alloc - size_data, stream));
-        }
-    }
+    ggml_cuda_clear_padding(src0, stream);
 
     const int64_t ne10_padded = GGML_PAD(ne10, MATRIX_ROW_PADDING);
     ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(), ne13*ne12 * ne11*ne10_padded * sizeof(block_q8_1)/QK8_1);

--- a/ggml/src/ggml-cuda/template-instances/generate_cu_files.py
+++ b/ggml/src/ggml-cuda/template-instances/generate_cu_files.py
@@ -105,6 +105,10 @@ for ncols in [8, 16, 32, 64]:
 for type in TYPES_MMQ:
     with open(f"mmq-instance-{get_short_name(type)}.cu", "w") as f:
         f.write(SOURCE_MMQ.format(type=type))
+        if type == "GGML_TYPE_Q4_K":
+            f.write("#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)\n")
+            f.write("DECL_MMQ_GATE_UP_SWIGLU_CASE(GGML_TYPE_Q4_K);\n")
+            f.write("#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)\n")
 
 for type in range(1, 17):
     with open(f"mmf-instance-ncols_{type}.cu", "w") as f:

--- a/ggml/src/ggml-cuda/template-instances/mmq-instance-q4_k.cu
+++ b/ggml/src/ggml-cuda/template-instances/mmq-instance-q4_k.cu
@@ -3,3 +3,6 @@
 #include "../mmq.cuh"
 
 DECL_MMQ_CASE(GGML_TYPE_Q4_K);
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)
+DECL_MMQ_GATE_UP_SWIGLU_CASE(GGML_TYPE_Q4_K);
+#endif // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA)

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -10728,7 +10728,6 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
             false, 16, 8, false, false, true, false, { 1, 1 }));
     }
 
-    // Dense Q4_K MMQ gate+up+SwiGLU fusion: J shapes, partial tiles, weight broadcast.
     test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 8, 128, 256,
         false, 1, 1, false, false, true, false, { 1, 1 }));
     test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 9, 127, 256,

--- a/tests/test-backend-ops.cpp
+++ b/tests/test-backend-ops.cpp
@@ -6724,19 +6724,22 @@ struct test_mul_mat_vec_fusion : public test_case {
     const bool with_gate;
     const bool with_lane_scale;
     std::array<int64_t, 2> batch_dims;
+    const bool broadcast_weights;
 
     test_mul_mat_vec_fusion(ggml_type type, ggml_glu_op op, int64_t m, int64_t n, int64_t k,
                         bool use_id = false, int n_mats = 1, int n_used = 1, bool b = false, bool with_bias = false, bool with_gate = true,
-                        bool with_lane_scale = false, std::array<int64_t, 2> batch_dims = {4, 2})
+                        bool with_lane_scale = false, std::array<int64_t, 2> batch_dims = {4, 2}, bool broadcast_weights = false)
     : type(type), glu_op(op), m(m), n(n), k(k), use_id(use_id), n_mats(n_mats), n_used(n_used), b(b), with_bias(with_bias),
-        with_gate(with_gate), with_lane_scale(with_lane_scale), batch_dims(batch_dims) {
+        with_gate(with_gate), with_lane_scale(with_lane_scale), batch_dims(batch_dims), broadcast_weights(broadcast_weights) {
         if (use_id) {
             GGML_ASSERT(n_used <= n_mats);
         }
+        GGML_ASSERT(!broadcast_weights || !use_id);
     }
 
     std::string vars() override {
-        return VARS_TO_STR13(type, glu_op, m, n, k, use_id, n_mats, n_used, b, with_bias, with_gate, with_lane_scale, batch_dims);
+        return VARS_TO_STR14(type, glu_op, m, n, k, use_id, n_mats, n_used, b, with_bias, with_gate, with_lane_scale,
+            batch_dims, broadcast_weights);
     }
 
     std::string op_desc(ggml_tensor * t) override {
@@ -6788,7 +6791,7 @@ struct test_mul_mat_vec_fusion : public test_case {
             const int              channels = batch_dims[0];
             const int              samples  = batch_dims[1];
             std::array<int64_t, 4> ne       = { k, m, channels, samples };
-            std::array<int64_t, 4> ne0      = { k, n, channels, samples };
+            std::array<int64_t, 4> ne0      = { k, n, broadcast_weights ? 1 : channels, broadcast_weights ? 1 : samples };
 
             ggml_tensor * cur  = ggml_new_tensor(ctx, GGML_TYPE_F32, 4, ne.data());
             ggml_tensor * gate = with_gate ? ggml_new_tensor(ctx, type, 4, ne0.data()) : nullptr;
@@ -6888,6 +6891,88 @@ struct test_mul_mat_vec_fusion : public test_case {
             }
         } else {
             init_mul_mat_id_tensors(ctx, n_mats);
+        }
+    }
+
+    double max_nmse_err() override {
+        return 5e-3;
+    }
+};
+
+struct test_mul_mat_vec_fusion_down : public test_case {
+    const ggml_type type_down;
+    const int64_t n_tokens;
+    const int64_t n_embd;
+    const int64_t n_ff;
+    const int64_t n_out;
+    const int64_t channels;
+    const int64_t samples;
+    const std::array<int64_t, 2> gate_up_batch_dims;
+    const std::array<int64_t, 2> down_batch_dims;
+    const bool zero_activation;
+    const bool wide_activation;
+
+    test_mul_mat_vec_fusion_down(ggml_type type_down, int64_t n_tokens, int64_t n_embd, int64_t n_ff, int64_t n_out,
+            int64_t channels = 1, int64_t samples = 1,
+            std::array<int64_t, 2> gate_up_batch_dims = { 1, 1 },
+            std::array<int64_t, 2> down_batch_dims = { 1, 1 },
+            bool zero_activation = false, bool wide_activation = false)
+        : type_down(type_down), n_tokens(n_tokens), n_embd(n_embd), n_ff(n_ff), n_out(n_out),
+          channels(channels), samples(samples), gate_up_batch_dims(gate_up_batch_dims), down_batch_dims(down_batch_dims),
+          zero_activation(zero_activation), wide_activation(wide_activation) {
+        GGML_ASSERT(channels % gate_up_batch_dims[0] == 0 && samples % gate_up_batch_dims[1] == 0);
+        GGML_ASSERT(channels % down_batch_dims[0] == 0 && samples % down_batch_dims[1] == 0);
+        GGML_ASSERT(!zero_activation || !wide_activation);
+    }
+
+    std::string vars() override {
+        return VARS_TO_STR11(type_down, n_tokens, n_embd, n_ff, n_out, channels, samples,
+            gate_up_batch_dims, down_batch_dims, zero_activation, wide_activation);
+    }
+
+    std::string op_desc(ggml_tensor * t) override {
+        GGML_UNUSED(t);
+        return "MUL_MAT_Q_GATE_UP_SWIGLU_DOWN";
+    }
+
+    bool run_whole_graph() override { return true; }
+
+    ggml_tensor * build_graph(ggml_context * ctx) override {
+        ggml_tensor * cur  = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, n_embd, n_tokens, channels, samples);
+        ggml_tensor * gate = ggml_new_tensor_4d(
+            ctx, GGML_TYPE_Q4_K, n_embd, n_ff, gate_up_batch_dims[0], gate_up_batch_dims[1]);
+        ggml_tensor * up = ggml_new_tensor_4d(
+            ctx, GGML_TYPE_Q4_K, n_embd, n_ff, gate_up_batch_dims[0], gate_up_batch_dims[1]);
+        ggml_tensor * down = ggml_new_tensor_4d(
+            ctx, type_down, n_ff, n_out, down_batch_dims[0], down_batch_dims[1]);
+        ggml_set_name(cur, "cur");
+
+        ggml_tensor * ffn_gate = ggml_mul_mat(ctx, gate, cur);
+        ggml_tensor * ffn_up   = ggml_mul_mat(ctx, up, cur);
+        ggml_tensor * out      = ggml_glu_split(ctx, ffn_gate, ffn_up, GGML_GLU_OP_SWIGLU);
+        out = ggml_mul_mat(ctx, down, out);
+
+        ggml_set_name(out, "out");
+        return out;
+    }
+
+    void initialize_tensors(ggml_context * ctx) override {
+        for (ggml_tensor * t = ggml_get_first_tensor(ctx); t != nullptr; t = ggml_get_next_tensor(ctx, t)) {
+            if (strcmp(t->name, "cur") != 0 || (!zero_activation && !wide_activation)) {
+                init_tensor_uniform(t);
+                continue;
+            }
+
+            std::vector<float> data(ggml_nelements(t), 0.0f);
+            if (wide_activation) {
+                static constexpr float pattern[] = {
+                    -2.0f, -0.5f, -0.0078125f, 0.0f, 0.0078125f, 0.5f, 2.0f,
+                };
+                for (size_t i = 0; i < data.size(); ++i) {
+                    data[i] = pattern[i % (sizeof(pattern) / sizeof(pattern[0]))];
+                }
+            }
+            ggml_backend_tensor_set(t, data.data(), 0, data.size() * sizeof(float));
         }
     }
 
@@ -10641,6 +10726,52 @@ static std::vector<std::unique_ptr<test_case>> make_test_cases_eval() {
     for (int64_t rows : {6271, 6272, 6273}) {
         test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 2, rows, 256,
             false, 16, 8, false, false, true, false, { 1, 1 }));
+    }
+
+    // Dense Q4_K MMQ gate+up+SwiGLU fusion: J shapes, partial tiles, weight broadcast.
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 8, 128, 256,
+        false, 1, 1, false, false, true, false, { 1, 1 }));
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 9, 127, 256,
+        false, 1, 1, false, false, true, false, { 1, 1 }));
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 17, 129, 512,
+        false, 1, 1, false, false, true, false, { 1, 1 }));
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 33, 257, 512,
+        false, 1, 1, false, false, true, false, { 2, 3 }));
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 65, 129, 512,
+        false, 1, 1, false, false, true, false, { 1, 1 }));
+    // Column counts between the fused J candidates exercise the Q8_1 tail allocation.
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 17, 128, 512,
+        false, 1, 1, false, false, true, false, { 1, 1 }));
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 33, 128, 512,
+        false, 1, 1, false, false, true, false, { 1, 1 }));
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 65, 128, 512,
+        false, 1, 1, false, false, true, false, { 1, 1 }));
+    test_cases.emplace_back(new test_mul_mat_vec_fusion(GGML_TYPE_Q4_K, GGML_GLU_OP_SWIGLU, 33, 129, 512,
+        false, 1, 1, false, false, true, false, { 2, 3 }, true));
+
+    // Whole dense FFN graph: fused Q4_K gate/up + SwiGLU feeding a quantized down MMQ.
+    for (ggml_type type_down : { GGML_TYPE_Q4_K, GGML_TYPE_Q6_K }) {
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 2, 256, 256, 257));
+        if (type_down == GGML_TYPE_Q4_K) {
+            // Smallest batch size that uses MMQ for Q4_K.
+            test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 6, 256, 256, 257));
+        }
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 8, 256, 256, 256));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 9, 256, 256, 257));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 17, 512, 256, 257));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 17, 512, 512, 257));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 32, 256, 256, 256));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 33, 512, 256, 257));
+        // n_ff < MATRIX_ROW_PADDING exercises the padded Q8_1 scratch stride between channels.
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(type_down, 33, 512, 256, 257, 2, 3));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(
+            type_down, 33, 512, 256, 257, 2, 3, { 2, 3 }, { 2, 3 }));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(
+            type_down, 17, 512, 256, 257, 2, 3, { 2, 1 }, { 1, 3 }));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(
+            type_down, 17, 512, 512, 257, 1, 1, { 1, 1 }, { 1, 1 }, true, false));
+        test_cases.emplace_back(new test_mul_mat_vec_fusion_down(
+            type_down, 17, 512, 512, 257, 1, 1, { 1, 1 }, { 1, 1 }, false, true));
     }
 
     for (auto gate : {GATING_FUNC_SOFTMAX, GATING_FUNC_SIGMOID, GATING_FUNC_SOFTMAX_WEIGHT, GATING_FUNC_SQRT_SOFTPLUS}) {


### PR DESCRIPTION
## Overview

Quantize the shared input to Q8_1 once, compute Gate and Up in one CUDA kernel, and apply SwiGLU after the full K reduction. This removes duplicate activation quantization, FP32 projection-output round trips and the separate SwiGLU launch.
- Vectorized loads/stores: reduce memory-instruction overhead and use a bank-conflict-free shared-memory store mapping.
- Fusion-specific configuration: 64 rows and 128 threads per CTA, targeting two resident blocks per SM to balance resource usage and latency hiding. Actual residency depends on hardware and compiled resource usage.
- Existing code reused: Q8_1 quantization, scratch allocation, MMQ shared-memory layout, stock INT8 MMA with scale/min handling, async-copy helpers and existing graph-fusion safety checks.

Scope
Supports separate dense Q4_K Gate/Up weight tensors, F32 activations and split SwiGLU on supported NVIDIA Ampere-or-newer configurations. 
FP32 output and the subsequent quantization/Down projection are unchanged. HIP/MUSA retain their existing paths. GGML_CUDA_DISABLE_FUSION=1 disables the fusion

## Validation and performance
Result collected on the DGX Spark
| Model (Q4_K_M) | Layers fused | pp16K gain (DGX Spark) | Perplexity |
| --- | ---: | ---: | --- |
| Qwen3.8-27B (ggml-org) | 64/64 | +11.1% | Identical |
| Qwen3.6-27B | 64/64 | +10.5% | Identical |
| Llama-3.1-8B-Instruct | 32/32 | +14.7% | Identical |
| Qwen3-8B (official) | 36/36 | +13.5% | Identical |

RTX 5090 results 
| Model (Q4_K_M) | Layers fused | pp16K gain (RTX 5090) | Perplexity |
| --- | ---: | ---: | --- |
| Qwen3.6-27B | 64/64 | +4.1% | Identical |

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - paired with codex on this
