### PR TITLE
sycl : fix oneDNN scratchpad breaking the pool free order

### DIFF
--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -401,29 +401,10 @@ struct ggml_backend_sycl_context {
     dnnl::stream stream_dnnl() {
         return stream_dnnl(device, 0);
     }
-    dnnl::memory get_scratchpad_mem(const dnnl::memory::desc & scratchpad_md,
-                                    const dnnl::engine & eng, const queue_ptr q) {
-        ggml_sycl_pool_alloc<uint8_t> * pool;
-        auto it = scratchpad_map.find(q);
-        if (it == scratchpad_map.end()) {
-            scratchpad_map[q] = std::make_unique<ggml_sycl_pool_alloc<uint8_t>>(this->pool());
-            pool = scratchpad_map[q].get();
-        } else {
-            pool = it->second.get();
-        }
-
-        size_t scratchpad_size = scratchpad_md.get_size();
-        if (scratchpad_size > pool->actual_size) {
-            pool->realloc(scratchpad_size);
-        }
-        void * mem_ptr = pool->get();
-        return dnnl::memory(scratchpad_md, eng, mem_ptr);
-    }
 #endif
 
     // pool
     std::unique_ptr<ggml_sycl_pool> pools[GGML_SYCL_MAX_DEVICES];
-    std::unordered_map<sycl::queue *, std::unique_ptr<ggml_sycl_pool_alloc<uint8_t>>> scratchpad_map;
 
     std::unique_ptr<ggml_sycl_fattn_kv_buffers> fattn_bufs[GGML_SYCL_MAX_DEVICES];
 

--- a/ggml/src/ggml-sycl/gemm.hpp
+++ b/ggml/src/ggml-sycl/gemm.hpp
@@ -66,8 +66,10 @@ public:
         auto matmul_pd = dnnl::matmul::primitive_desc(eng, a_in_md, b_in_md, c_md, primitive_attr);
         auto c_mem = dnnl::memory(matmul_pd.dst_desc(), eng, c);
 
-        auto scratchpad_md = matmul_pd.scratchpad_desc();
-        auto scratchpad_mem = ctx.get_scratchpad_mem(scratchpad_md, eng, q);
+        const auto scratchpad_md = matmul_pd.scratchpad_desc();
+        ggml_sycl_pool_alloc<uint8_t> scratchpad(ctx.pool());
+        void * scratchpad_ptr = scratchpad_md.get_size() > 0 ? scratchpad.alloc(scratchpad_md.get_size()) : nullptr;
+        auto scratchpad_mem = dnnl::memory(scratchpad_md, eng, scratchpad_ptr);
 
         auto matmul_prim = dnnl::matmul(matmul_pd);
 


### PR DESCRIPTION
## Overview

oneDNN scratchpad is now allocated from SYCL pool each time `gemm` is called instead of being allocated once per queue

This is a fix for https://github.com/ggml-org/llama.cpp/issues/28660. The SYCL backend crashes during prompt processing on all 6 models tested when using oneDNN (see issue for all details) and VMM (device with `sycl::aspect::ext_oneapi_virtual_mem` aspect). The crash is:
```
GGML_ASSERT(ptr == reinterpret_cast<void *>(pool_addr + pool_used)) failed
```

This PR changes allocation strategy, which https://github.com/ggml-org/llama.cpp/pull/12097 introduced. The old strategy was valid at the time of being introduced, but became invalid once VMM allocator with LIFO requirement was added in https://github.com/ggml-org/llama.cpp/pull/22862 and code has not worked since then.

## Additional information

There are two implementations of the pool

1. VMM=0 that is the old allocator, which has a cache with 256 slots to be searched
2. VMM=1 (default) that is a new allocator, that can be used with devices having `sycl::aspect::ext_oneapi_virtual_mem`. Its allocations are ultra fast. Pool on alloc/free does not allocate/return memory, just moves pool tail like `pool_used += size` (but still may extend whole pool if needed). Calling allocate/free more often (once per `gemm` instead of once per queue) should have negligible impact on performance in this case.

Performance was measured using VMM=0 because otherwise there was no way to get baseline - no dense model prompt processing works without crash on SYCL using VMM=1

### Performance on non VMM (non-default) allocator

Observed up to 0.45% regression in the prefill phase on smaller models (1.2-1.5 B) due to smaller `gemm` operations and thus bigger proportion of allocation overhead (searching 256 cache slots) each time scratch allocation takes place.

Only three numbers represent a measurable effect (bold ones). Impact on models >=3B is unobservable.

| Model | Parameters | pp512 | pp2048 | tg128 |
| --- | --- | --- | --- | --- |
| Llama-3.2-1B | 1.2 B | **-0.36%** | -0.26% | -0.02% |
| Qwen2.5-1.5B | 1.5 B | **-0.44%** | **-0.45%** | +0.16% |
| Llama-3.2-3B | 3.2 B | +0.01% | +0.11% | -0.03% |
| Qwen2.5-7B | 7.6 B |+0.18% | +0.49% | +0.10% |
| Qwen2.5-14B | 14.8 B | +0.15% | +0.09% | -0.07% |
| Qwen2.5-32B | 32.8 B | +0.01% | -0.05% | +0.00% |

Baseline: 9cf3bf256, Intel Arc Pro B70, clang++ with intel/llvm, 100 samples per cell, run alternately, difference between medians, "-" means fix regression, "+" means performance improvement of fix

### Performance on default VMM allocator

Not measured, because baseline does not work. Negligible because of faster allocate/free (see above explanation).

### No memory regression

`gemm` is a leaf without recursion, at one time only one scratchpad is allocated
Fix improves memory utilization, as previously queue kept the biggest allocation all the time. Now exact size, currently needed, is kept.

### Related work

https://github.com/ggml-org/llama.cpp/pull/27689 touches the same function, but aims to fix a different case and I confirmed that applying that change does not resolve https://github.com/ggml-org/llama.cpp/issues/28660 issue. This PR removes function which https://github.com/ggml-org/llama.cpp/pull/27689 changes, so a textual conflict is expected.

### Code simplified

lines 4 added, 21 removed

### Correctness verification

Commands (unit test, llama-bench) from issue https://github.com/ggml-org/llama.cpp/issues/28660 pass.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: cursor IDE was used to find the issue root cause, bug history, initial fix and for measuring fix performance impact under my guidance. All descriptions of issue and PR and final fix shape are written by hand by me and are fully understood and maintainable by me.
