### PR TITLE
HIP: add MMQ N-tiles heuristic for cdna

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cu
+++ b/ggml/src/ggml-cuda/mmq.cu
@@ -245,10 +245,12 @@ void ggml_cuda_mul_mat_q(
     const int64_t s13 = ne12*s12;
 
     // Each expert only sees ne12*n_expert_used/ne02 tokens on average.
-    // On RDNA3 and RDNA4 it is faster to pick the tile size against this value instead of ne12.
+    // On RDNA3, RDNA4 and CDNA it is faster to pick the tile size against the values below instead of ne12.
     int64_t ncols_opt = ne12;
     if (GGML_CUDA_CC_IS_RDNA3_0(cc) || GGML_CUDA_CC_IS_RDNA4(cc)) {
         ncols_opt = (ne12*n_expert_used + ne02 - 1) / ne02;
+    } else if (GGML_CUDA_CC_IS_CDNA(cc)) {
+        ncols_opt = std::min((4*ne12*n_expert_used + 3*ne02 - 1) / (3*ne02), (int64_t)64);
     }
 
     // Note that ne02 is used instead of ne12 because the number of y channels determines the z dimension of the CUDA grid.


### PR DESCRIPTION
## Overview

In https://github.com/ggml-org/llama.cpp/pull/24546 i noted that for several shapes the performance was better but that the heuristic that works on RDNA has mixed results on CDNA.

So i vibe-coded up a script to scan the parameter space and from that came up with the empirical heuristic in this pr.

## Additional information

[sweep.log](https://github.com/user-attachments/files/32067632/sweep.log)

<details>
<summary>End to end benchmarks</summary>

| GPU   | Model                 |   Microbatch size | Test   |   t/s master |   t/s typical_cdna |   Speedup |
|:------|:----------------------|------------------:|:-------|-------------:|-------------------:|----------:|
| MI100 | gemma4 26B.A4B Q6_K   |                 1 | pp2048 |        88.82 |              89.06 |      1.00 |
| MI100 | gemma4 26B.A4B Q6_K   |                64 | pp2048 |       573.75 |             816.48 |      1.42 |
| MI100 | gemma4 26B.A4B Q6_K   |               512 | pp2048 |      1679.03 |            1684.00 |      1.00 |
| MI100 | gemma4 26B.A4B Q6_K   |              1024 | pp2048 |      1951.90 |            1955.33 |      1.00 |
| MI100 | gpt-oss 20B MXFP4 MoE |                 1 | pp2048 |       155.76 |             159.00 |      1.02 |
| MI100 | gpt-oss 20B MXFP4 MoE |                64 | pp2048 |       951.56 |            1056.88 |      1.11 |
| MI100 | gpt-oss 20B MXFP4 MoE |               512 | pp2048 |      2266.48 |            2266.59 |      1.00 |
| MI100 | gpt-oss 20B MXFP4 MoE |              1024 | pp2048 |      2471.18 |            2470.32 |      1.00 |
| MI100 | lfm2moe 8B.A1B F16    |                 1 | pp2048 |       163.15 |             166.76 |      1.02 |
| MI100 | lfm2moe 8B.A1B F16    |                64 | pp2048 |      1960.30 |            1974.85 |      1.01 |
| MI100 | lfm2moe 8B.A1B F16    |               512 | pp2048 |      6389.96 |            6392.73 |      1.00 |
| MI100 | lfm2moe 8B.A1B F16    |              1024 | pp2048 |      8803.78 |            8818.93 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q4_0   |                 1 | pp2048 |       287.81 |             294.58 |      1.02 |
| MI100 | lfm2moe 8B.A1B Q4_0   |                64 | pp2048 |      1868.15 |            2142.56 |      1.15 |
| MI100 | lfm2moe 8B.A1B Q4_0   |               512 | pp2048 |      4903.93 |            4903.54 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q4_0   |              1024 | pp2048 |      5401.32 |            5395.00 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q4_K_M |                 1 | pp2048 |       258.54 |             260.37 |      1.01 |
| MI100 | lfm2moe 8B.A1B Q4_K_M |                64 | pp2048 |      1682.01 |            2173.60 |      1.29 |
| MI100 | lfm2moe 8B.A1B Q4_K_M |               512 | pp2048 |      4389.76 |            4389.23 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q4_K_M |              1024 | pp2048 |      4854.53 |            4855.91 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q5_K_M |                 1 | pp2048 |       241.99 |             242.05 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q5_K_M |                64 | pp2048 |      1596.87 |            2055.69 |      1.29 |
| MI100 | lfm2moe 8B.A1B Q5_K_M |               512 | pp2048 |      4157.92 |            4163.18 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q5_K_M |              1024 | pp2048 |      4614.40 |            4617.82 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q6_K   |                 1 | pp2048 |       225.63 |             223.43 |      0.99 |
| MI100 | lfm2moe 8B.A1B Q6_K   |                64 | pp2048 |      1239.93 |            1598.98 |      1.29 |
| MI100 | lfm2moe 8B.A1B Q6_K   |               512 | pp2048 |      3165.20 |            3163.92 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q6_K   |              1024 | pp2048 |      3491.35 |            3490.04 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q8_0   |                 1 | pp2048 |       249.80 |             254.30 |      1.02 |
| MI100 | lfm2moe 8B.A1B Q8_0   |                64 | pp2048 |      1880.09 |            1960.38 |      1.04 |
| MI100 | lfm2moe 8B.A1B Q8_0   |               512 | pp2048 |      5200.46 |            5180.45 |      1.00 |
| MI100 | lfm2moe 8B.A1B Q8_0   |              1024 | pp2048 |      5764.20 |            5749.35 |      1.00 |
| MI100 | qwen35 27B Q5_K_M     |                 1 | pp2048 |        23.56 |              23.59 |      1.00 |
| MI100 | qwen35 27B Q5_K_M     |                64 | pp2048 |       373.34 |             372.85 |      1.00 |
| MI100 | qwen35 27B Q5_K_M     |               512 | pp2048 |       427.71 |             427.49 |      1.00 |
| MI100 | qwen35 27B Q5_K_M     |              1024 | pp2048 |       428.24 |             428.00 |      1.00 |

</details>

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - the script that created the sweep was vibe coded