### PR TITLE
server: report non-truncating limits as finish_reason "stop" instead of "length"

### DIFF
--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -422,6 +422,11 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat() {
     }
     if (stop == STOP_TYPE_WORD || stop == STOP_TYPE_EOS) {
         finish_reason = msg.tool_calls.empty() ? "stop" : "tool_calls";
+    } else if (stop == STOP_TYPE_LIMIT && !truncated) {
+        // a non-truncating limit (n_indent, t_max_predict_ms) is not length-truncation:
+        // report it as "stop". output-budget and context-capacity limits keep truncated=true
+        // and remain "length" (see the separate context-exhaustion discussion).
+        finish_reason = "stop";
     }
 
     json choice {
@@ -464,6 +469,11 @@ json server_task_result_cmpl_final::to_json_oaicompat_chat_stream() {
     std::string finish_reason = "length";
     if (stop == STOP_TYPE_WORD || stop == STOP_TYPE_EOS) {
         finish_reason = oaicompat_msg.tool_calls.empty() ? "stop" : "tool_calls";
+    } else if (stop == STOP_TYPE_LIMIT && !truncated) {
+        // a non-truncating limit (n_indent, t_max_predict_ms) is not length-truncation:
+        // report it as "stop". output-budget and context-capacity limits keep truncated=true
+        // and remain "length" (see the separate context-exhaustion discussion).
+        finish_reason = "stop";
     }
 
     json deltas = json::array();


### PR DESCRIPTION
   ## Overview                                                                                                                                                                                
                                                                                                                                                                                              
   The OpenAI-compatible chat endpoint reports `finish_reason: "length"` for every `STOP_TYPE_LIMIT` stop. That stop-type is reached for four different reasons:                              
                                                                                                                                                                                              
   1. output budget (`max_tokens`) exhausted - `truncated` is false                                                                                                                           
   2. context capacity full - `truncated` is true                                                                                                                                             
   3. indentation cut (`n_indent`) - `truncated` is false                                                                                                                                     
   4. `t_max_predict_ms` timeout - `truncated` is false                                                                                                                                       
                                                                                                                                                                                              
   Cases 3 and 4 do not truncate the output, so reporting them as `length` is wrong for any client that branches on `finish_reason == "length"`.                                              
                                                                                                                                                                                              
   This change returns `stop` when `stop == STOP_TYPE_LIMIT` and `truncated` is false. Cases 1 and 2 keep `truncated` set and still report `length`, so the common output-truncation path is  
 unchanged.                                                                                                                                                                                   
                                                                                                                                                                                              
   ## Additional information                                                                                                                                                                  
                                                                                                                                                                                              
   Case 2 (context capacity) reporting `length` is a separate question: the OpenAI finish_reason enum has no value for "ran out of context", so separating it from output-truncation is an    
 API-level decision, not a mapping fix. This PR does not touch it.                                                                                                                            
                                                                                                                                                                                              
   Verified: builds clean (llama-server-impl, CUDA 13.0 / aarch64). The diff is additive (two `else if` branches), no existing branch modified.                                               
                                                                                                                                                                                              
   ## Requirements                                                                                                                                                                            
                                                                                                                                                                                              
   - I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)                                                              
   - AI usage disclosure: AI was used to draft the code and run the build check. The change is small and I reviewed it line by line.  