### PR TITLE
CUDA: radix top-k for large row counts

### DIFF
--- a/ggml/src/ggml-cuda/top-k.cu
+++ b/ggml/src/ggml-cuda/top-k.cu
@@ -48,7 +48,9 @@ static int next_power_of_2(int x) {
 
 #endif                            // CUB_TOP_K_AVAILABLE
 
-#if !defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP)
+#define GGML_CUDA_TOP_K_RADIX
+
+#ifdef GGML_CUDA_TOP_K_RADIX
 
 static __device__ __forceinline__ uint32_t top_k_float_to_ordered(float value) {
     const uint32_t bits = __float_as_uint(value);
@@ -208,7 +210,17 @@ static void top_k_radix_cuda(
             src, dst, states, ncols, k, blocks_per_row);
 }
 
-#endif // !defined(GGML_CUDA_USE_CUB) && defined(GGML_USE_HIP)
+// nrows above which grid-over-rows radix select beats a per-row loop; env-tunable for sweeps
+static int top_k_radix_min_rows() {
+    static int v = -1;
+    if (v < 0) {
+        const char * e = getenv("GGML_CUDA_TOPK_RADIX_MIN_ROWS");
+        v = e ? atoi(e) : 8;
+    }
+    return v;
+}
+
+#endif // GGML_CUDA_TOP_K_RADIX
 
 void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     const ggml_tensor * src0   = dst->src[0];
@@ -229,10 +241,18 @@ void ggml_cuda_op_top_k(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {
     // TODO: Switch to `DeviceSegmentedTopK` for multi-row TopK once implemented
     // https://github.com/NVIDIA/cccl/issues/6391
     // TODO: investigate if there exists a point where parallelized argsort is faster than sequential top-k
-    for (int i = 0; i < nrows; i++) {
-        top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+    if (nrows >= top_k_radix_min_rows() && ncols > 1024) {
+        top_k_radix_cuda(pool, src0_d, dst_d, ncols, nrows, k, stream);
+    } else {
+        for (int i = 0; i < nrows; i++) {
+            top_k_cub(pool, src0_d + i * ncols, dst_d + i * k, ncols, k, stream);
+        }
     }
 #elif defined(GGML_CUDA_USE_CUB)  // CUB_TOP_K_AVAILABLE
+    if (nrows >= top_k_radix_min_rows() && ncols > 1024) {
+        top_k_radix_cuda(pool, src0_d, dst_d, ncols, nrows, k, stream);
+        return;
+    }
     // Fall back to argsort + copy
     const int    ncols_pad      = next_power_of_2(ncols);
     const size_t shared_mem     = ncols_pad * sizeof(int);


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Replaces CUB's per-row DeviceTopKKernel with a grid-over-rows radix select, gated on GGML_CUDA_TOPK_RADIX_MIN_ROWS. 
Current implementation of top_k finding is sequential over rows (internal to a row, it is parallel). There is a for loop that goes over all the rows. The upstream top-k uses CPU processing over rows to loop over, but GPU processing internal to the row. This PR introduces radix select that is a single call at the op level that processes on the GPU completely and has a positive impact on the prefill perf.

Also, the optimization applies to any model that calls ggml_top_k, with some conditionals on row and column count. Some examples that call ggml_top_k include deepseek32, deepseek4, minimax-m3.
top_k calls are used after MOE router, with backend sampling, DFlash and Sparse-attention indexers.

<details><summary>Performance with various -lzm options on Qwen 3.8 Flash Next over DGX Spark</summary>
<p>

Six runs per arm over two rounds. Cold cache before every arm. Prompts from a 2.09M-word prose corpus so no two requests share n-grams — filler from a small vocabulary saturates the reachable n-gram set after one request and inflates the demand-paged arm. On/off order flipped between rounds.

The on arm is I/O-bound, demand-paging a 26.8 GiB embedding table one fault at a time, so removing launches buys nothing there — hence its runs interleaving. An independent 2×2 at pp8192 agrees: 675.2 → 800.8 resident, 182.4 → 193.6 faulting.

Decode is unchanged in every arm (~17.9–22.3 tok/s): ggml_top_k is not on this model's decode path at batch 1.

**`--lazy-mode auto`** (resolves to OFF on this device, so the table is read resident)

| run | prompt tok | radix on | radix off |
|---|---|---|---|
| 1 | 34,865 | 798.60 | 639.90 |
| 2 | 34,661 | 804.00 | 644.60 |
| 3 | 34,798 | 800.90 | 643.60 |
| 4 | 34,812 | 805.40 | 658.80 |
| 5 | 34,742 | 803.40 | 662.60 |
| 6 | 34,733 | 804.00 | 662.40 |
| | **mean** | **802.72 ± 2.50** | **651.98 ± 10.38** |
| | **median** | 803.70 | 651.70 |

**`--lazy-mode on-direct`** (from #28136 )

| run | prompt tok | radix on | radix off |
|---|---|---|---|
| 1 | 34,865 | 728.90 | 619.30 |
| 2 | 34,661 | 737.00 | 622.10 |
| 3 | 34,798 | 741.80 | 624.10 |
| 4 | 34,812 | 733.90 | 616.40 |
| 5 | 34,742 | 742.70 | 621.60 |
| 6 | 34,733 | 748.10 | 625.70 |
| | **mean** | **738.73 ± 6.87** | **621.53 ± 3.34** |
| | **median** | 739.40 | 621.85 |

**`--lazy-mode on`** (demand-paged mmap)

| run | prompt tok | radix on | radix off |
|---|---|---|---|
| 1 | 34,865 | 214.40 | 196.80 |
| 2 | 34,661 | 216.30 | 216.70 |
| 3 | 34,798 | 247.40 | 233.50 |
| 4 | 34,812 | 199.60 | 196.30 |
| 5 | 34,742 | 227.60 | 218.00 |
| 6 | 34,733 | 225.60 | 217.90 |
| | **mean** | **221.82 ± 16.01** | **213.20 ± 14.31** |
| | **median** | 220.95 | 217.30 |

Summary:

| `--lazy-mode` | radix on | radix off | effect of radix |
|---|---|---|---|
| `auto` (resident) | 802.72 ± 2.50 | 651.98 ± 10.38 | **+23.1%** |
| `on-direct` | 738.73 ± 6.87 | 621.53 ± 3.34 | **+18.9%** |
| `on` (demand-paged) | 221.82 ± 16.01 | 213.20 ± 14.31 | +4.0%, inside noise |

</p>
</details> 

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> AI was used to partially assist while making the code edits and to understand the contexts of the code base.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
