### PR TITLE
server: sanitize invalid UTF-8 in generated text at the token boundary

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -883,6 +883,80 @@ llama_tokens tokenize_mixed(const llama_vocab * vocab, const json & json_prompt,
     return prompt_tokens;
 }
 
+// Replace invalid UTF-8 sequences in text[from..] with U+FFFD. Models can emit
+// corrupted multi-byte tokens (e.g. one flipped byte inside an emoji); without
+// this, the accumulated generation text stays invalid forever and every
+// downstream consumer (chat parsing, JSON serialization) fails on the whole
+// response. A trailing incomplete multi-byte sequence is preserved because it
+// may complete with the next token; when finalize is set (end of generation)
+// it is dropped, as it was never sent to the client.
+// This mirrors how vLLM's incremental detokenizer recovers from invalid UTF-8
+// output (vllm-project/vllm#17448).
+void sanitize_invalid_utf8(std::string & text, size_t from, bool finalize) {
+    const size_t start = std::min(from, text.size());
+    bool        modified = false;
+    bool        keep_tail = true;
+    std::string out;
+
+    size_t i = start;
+    while (i < text.size()) {
+        const unsigned char c = (unsigned char) text[i];
+        size_t len = 0;
+        if ((c & 0x80) == 0x00) {
+            len = 1;
+        } else if ((c & 0xE0) == 0xC0) {
+            len = 2;
+        } else if ((c & 0xF0) == 0xE0) {
+            len = 3;
+        } else if ((c & 0xF8) == 0xF0) {
+            len = 4;
+        }
+
+        bool valid = len > 0 && i + len <= text.size();
+        if (valid) {
+            for (size_t k = 1; k < len; k++) {
+                if (((unsigned char) text[i + k] & 0xC0) != 0x80) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+
+        if (valid) {
+            if (modified) {
+                out += text.substr(i, len);
+            }
+            i += len;
+            continue;
+        }
+
+        // trailing incomplete sequence: never sent; keep it (it may complete
+        // with the next token), or drop it at end of generation
+        if (len > 0 && i + len > text.size()) {
+            if (finalize) {
+                keep_tail = false;
+            }
+            break;
+        }
+
+        if (!modified) {
+            out   = text.substr(0, i);
+            modified = true;
+        }
+        out += "\xEF\xBF\xBD";
+        i += 1;
+    }
+
+    if (modified) {
+        if (keep_tail && i < text.size()) {
+            out += text.substr(i);  // trailing incomplete sequence
+        }
+        text = std::move(out);
+    } else if (!keep_tail) {
+        text.resize(i);  // drop a dangling incomplete sequence, nothing else changed
+    }
+}
+
 size_t validate_utf8(const std::string& text) {
     size_t len = text.size();
     if (len == 0) return 0;

--- a/tools/server/server-common.h
+++ b/tools/server/server-common.h
@@ -265,6 +265,10 @@ llama_tokens tokenize_mixed(const llama_vocab * vocab, const json & json_prompt,
 
 // return the last index of character that can form a valid string
 // if the last character is potentially cut in half, return the index before the cut
+// Replace invalid UTF-8 sequences in text[from..] with U+FFFD; a trailing
+// incomplete multi-byte sequence is preserved unless finalize is set.
+void sanitize_invalid_utf8(std::string & text, size_t from, bool finalize);
+
 // if validate_utf8(text) == text.size(), then the whole text is valid utf8
 size_t validate_utf8(const std::string& text);
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -1836,6 +1836,9 @@ private:
         slot.sampled = result.tok;
 
         slot.generated_text += token_str;
+        // a corrupted multi-byte token must not poison the accumulated text:
+        // every downstream parse and JSON encoding would fail on it
+        sanitize_invalid_utf8(slot.generated_text, slot.n_sent_text, /* finalize */ false);
         if (slot.task->params.return_tokens) {
             slot.generated_tokens.push_back(result.tok);
         }
@@ -2087,6 +2090,10 @@ private:
     }
 
     void send_final_response(server_slot & slot) {
+        // end of generation: drop any dangling incomplete multi-byte sequence
+        // (it was never sent to the client)
+        sanitize_invalid_utf8(slot.generated_text, slot.n_sent_text, /* finalize */ true);
+
         auto res = std::make_unique<server_task_result_cmpl_final>();
 
         res->id      = slot.task->id;


### PR DESCRIPTION
## Overview

Byte-level BPE vocabularies contain pieces that decode to invalid UTF-8 (e.g. lone continuation bytes), and models occasionally sample them mid-generation. On llama-server the final parse then fails with "The model produced output that does not match the expected peg-native format" (or the Content-only equivalent on /completions), and an HTTP 500 occurs, and no text after the bad byte is ever streamed.

Reproduced on unpatched master with Ling 3.0 tiny at Q8_K_XL and at BF16 (the release dtype): emoji-heavy checklist generations produced invalid emissions at roughly 1 per 11k and 1 per 39k tokens respectively, byte signature e2 9c 85 followed by a lone 0x85 piece after a valid U+2705. 

This sanitizes generated text at the accumulation and finalization boundaries in server-common: invalid sequences are replaced with U+FFFD; trailing incomplete sequences are held back while streaming and dropped at finalization. Strict parsing is unchanged. The replacement diverges from the token stream by the replaced bytes; the current behavior loses the entire turn to a 500.

## Additional information

vLLM handles the same class at the detokenizer boundary (vllm-project/vllm#17448).  SGLang's incremental detokenizer handles the same class at the boundary as well: text ending in U+FFFD is held back and retried with subsequent tokens (`detokenizer_manager.py`).  

The invalid pieces were discovered on Ling 3.0 Flash, but are not Ling-specific. The Qwen3 and DeepSeek-V4 vocabularies also contain them (944 and 1,470 invalid-UTF-8 pieces respectively, including a lone 0x85).

Verified no output change on a non-Ling model (Qwen3.5-9B): greedy completions under this patch are byte-identical to unpatched master.

Ling 3.0 Flash requires this, together with #28682.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md).
- AI usage disclosure: Yes, I used AI to help write and check the code.  I personally, thoroughly reviewed the CONTRIBUTING.md file.