### PR TITLE
gguf-split: validate --split-max-tensors and --split-max-size

### DIFF
--- a/tools/gguf-split/gguf-split.cpp
+++ b/tools/gguf-split/gguf-split.cpp
@@ -73,12 +73,16 @@ static void split_print_usage(const char * executable) {
 // return convert string, for example "128M" or "4G" to number of bytes
 static size_t split_str_to_n_bytes(std::string str) {
     size_t n_bytes = 0;
-    int n;
+    int n = 0;
     if (str.back() == 'M') {
-        sscanf(str.c_str(), "%d", &n);
+        if (sscanf(str.c_str(), "%dM", &n) != 1) {
+            throw std::invalid_argument("error: invalid size value: " + str);
+        }
         n_bytes = (size_t)n * 1000 * 1000; // megabytes
     } else if (str.back() == 'G') {
-        sscanf(str.c_str(), "%d", &n);
+        if (sscanf(str.c_str(), "%dG", &n) != 1) {
+            throw std::invalid_argument("error: invalid size value: " + str);
+        }
         n_bytes = (size_t)n * 1000 * 1000 * 1000; // gigabytes
     } else {
         throw std::invalid_argument("error: supported units are M (megabytes) or G (gigabytes), but got: " + std::string(1, str.back()));
@@ -137,7 +141,12 @@ static void split_params_parse_ex(int argc, const char ** argv, split_params & p
                 throw std::invalid_argument("error: either --split-max-tensors or --split-max-size can be specified, but not both");
             }
             params.mode = MODE_TENSOR;
-            params.n_split_tensors = atoi(argv[arg_idx]);
+            char * str_end = nullptr;
+            const long n_split_tensors = strtol(argv[arg_idx], &str_end, 10);
+            if (str_end == argv[arg_idx] || *str_end != '\0' || n_split_tensors <= 0 || n_split_tensors > INT_MAX) {
+                throw std::invalid_argument("error: --split-max-tensors must be a positive integer, but got: " + std::string(argv[arg_idx]));
+            }
+            params.n_split_tensors = (int) n_split_tensors;
         } else if (arg == "--split-max-size") {
             if (++arg_idx >= argc) {
                 invalid_param = true;


### PR DESCRIPTION
## Overview

Two invalid `--split` limits were accepted instead of producing an error:

- `--split-max-tensors 0` was parsed with `atoi` and later reached `i_tensor % n_split_tensors`, crashing with a division by zero (`0xC0000094` on Windows, see #28720).
- `--split-max-size G` (a unit without a number) hit `split_str_to_n_bytes`, where `sscanf` failed but left the uninitialized `int n` in place — the size limit became garbage × 1e9 and the split silently "succeeded" with a nonsense limit.

`--split-max-tensors` is now parsed with `strtol` and rejected unless it is a positive integer, and `split_str_to_n_bytes` initializes `n`, checks the `sscanf` return value, and rejects unit-only strings. Both cases now fail with a clear error and exit code 1.

Fixes #28720

## Additional information

Tested locally with a 10-tensor GGUF written by `llama-gguf`:

- `--split-max-tensors 0` → `error: --split-max-tensors must be a positive integer, but got: 0`
- `--split-max-tensors 5x` → same error (no silent truncation)
- `--split-max-size G` → `error: invalid size value: G`
- `--split-max-size 0M` → `error: size must be a positive value` (this check already existed but could never fire when `sscanf` failed)
- valid runs (`--split-max-tensors 4`, `--split-max-size 10M`) behave exactly as before

## Requirements

- [x] I have read and agree with the contributing guidelines
- AI usage disclosure: YES — the code change was implemented with AI assistance and manually reviewed and tested by me.
