### PR TITLE
server : accept Responses input items without explicit type

### DIFF
--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1974,6 +1974,65 @@ static void test_convert_responses_to_chatcmpl() {
 
         assert_equals(false, result.contains("tools"));
     }
+
+    // Assistant message items may omit type (defaults to "message")
+    {
+        json input = json::parse(R"({
+            "input": [
+                {
+                    "role": "assistant",
+                    "content": "hello"
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "hello"
+                        }
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": "hi"
+                }
+            ]
+        })");
+
+        json result = server_chat_convert_responses_to_chatcmpl(input);
+
+        assert_equals((size_t)2, result.at("messages").size());
+        const auto & msg0 = result.at("messages")[0];
+        assert_equals(std::string("assistant"), msg0.at("role").get<std::string>());
+        assert_equals((size_t)2, msg0.at("content").size());
+        assert_equals(std::string("hello"), msg0.at("content")[0].at("text").get<std::string>());
+        assert_equals(std::string("hello"), msg0.at("content")[1].at("text").get<std::string>());
+        const auto & msg1 = result.at("messages")[1];
+        assert_equals(std::string("user"), msg1.at("role").get<std::string>());
+    }
+
+    // Reasoning items with only summary (or empty content) are skipped
+    {
+        json input = json::parse(R"({
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [],
+                    "encrypted_content": "abc"
+                },
+                {
+                    "role": "user",
+                    "content": "hi"
+                }
+            ]
+        })");
+
+        json result = server_chat_convert_responses_to_chatcmpl(input);
+
+        assert_equals((size_t)1, result.at("messages").size());
+        assert_equals(std::string("user"), result.at("messages")[0].at("role").get<std::string>());
+    }
 }
 
 // Shared LFM2 parser cases - all variants use one output format and parser

--- a/tools/server/server-chat.cpp
+++ b/tools/server/server-chat.cpp
@@ -107,8 +107,8 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
                 chatcmpl_messages.push_back(item);
             } else if (exists_and_is_string(item, "role") &&
                 item.at("role") == "assistant" &&
-                exists_and_is_string(item, "type") &&
-                item.at("type") == "message"
+                (!item.contains("type") ||
+                    (exists_and_is_string(item, "type") && item.at("type") == "message"))
             ) {
                 // #responses_create-input-input_item_list-item-output_message
                 auto chatcmpl_content = json::array();
@@ -214,29 +214,35 @@ json server_chat_convert_responses_to_chatcmpl(const json & response_body) {
                         {"tool_call_id", item.at("call_id")},
                     });
                 }
-            } else if (exists_and_is_array(item, "summary") &&
-                exists_and_is_string(item, "type") &&
+            } else if (exists_and_is_string(item, "type") &&
                 item.at("type") == "reasoning") {
                 // #responses_create-input-input_item_list-item-reasoning
+                // skip when there is no content/summary text (encrypted_content only)
 
-                if (!exists_and_is_array(item, "content")) {
-                    throw std::invalid_argument("item['content'] is not an array");
+                std::string reasoning_text;
+                if (exists_and_is_array(item, "content") &&
+                    !item.at("content").empty() &&
+                    exists_and_is_string(item.at("content")[0], "text")) {
+                    reasoning_text = item.at("content")[0].at("text").get<std::string>();
+                } else if (exists_and_is_array(item, "summary")) {
+                    for (const json & part : item.at("summary")) {
+                        if (exists_and_is_string(part, "text")) {
+                            reasoning_text += part.at("text").get<std::string>();
+                        }
+                    }
                 }
-                if (item.at("content").empty()) {
-                    throw std::invalid_argument("item['content'] is empty");
-                }
-                if (!exists_and_is_string(item.at("content")[0], "text")) {
-                    throw std::invalid_argument("item['content']['text'] is not a string");
+                if (reasoning_text.empty()) {
+                    continue;
                 }
 
                 if (merge_prev) {
                     auto & prev_msg = chatcmpl_messages.back();
-                    prev_msg["reasoning_content"] = item.at("content")[0].at("text");
+                    prev_msg["reasoning_content"] = reasoning_text;
                 } else {
                     chatcmpl_messages.push_back(json {
                         {"role", "assistant"},
                         {"content", json::array()},
-                        {"reasoning_content", item.at("content")[0].at("text")},
+                        {"reasoning_content", reasoning_text},
                     });
                 }
             } else {


### PR DESCRIPTION
## Overview

Fixes #26394

Sending an assistant item without `type` to `/v1/responses` fails with `Cannot determine type of 'item'`. The user/system/developer branch in `server_chat_convert_responses_to_chatcmpl` already works without `type`, but the assistant branch required `type == "message"`. `type` is optional in the Responses API, so I made the assistant branch accept a missing one too.

While testing this I hit a second 400: reasoning items that only carry `summary` / `encrypted_content` (which is what OpenAI returns and clients echo back) fail with `item['content'] is not an array`. The converter now takes the text from `content[0].text`, falls back to `summary[].text`, and skips the item if there is nothing to use.

Added two cases to `tests/test-chat.cpp`.

## Additional information

Reproduced on b10809, converter is the same on b10902.

#27751 touches the reasoning `summary` part but not the missing `type`, which is the actual report in #26394.

Object-valued `function_call.arguments` is still rejected. Spec says string, so left as is.

Built with `-DGGML_CUDA=OFF -DLLAMA_CURL=OFF`, `test-chat` passes. Did not run the server pytest suite.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)