### PR TITLE
ggml: skip 0-sized ids tensor when offloading selected experts

### DIFF
--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -1716,6 +1716,10 @@ static enum ggml_status ggml_backend_sched_compute_splits(ggml_backend_sched_t s
                     ggml_tensor * ids_tensor = node->src[2];
                     ggml_backend_t ids_backend = split_backend;
 
+                    if (ggml_nelements(ids_tensor) == 0) {
+                        continue;
+                    }
+
                     // if the ids tensor is also an input of the split, it may not have been copied yet to the split backend
                     // in that case, we use the original ids tensor
                     for (int i = input_id + 1; i < split->n_inputs; i++) {


### PR DESCRIPTION
## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

Fix issue when always offloading. Reproduce via:

```GGML_OP_OFFLOAD_MIN_BATCH=0 ./build/bin/llama-bench -m ~/workspace/Qwen3.8-Flash-Next-GGUF/UD-IQ1_S/Qwen3.8-Flash-Next-UD-IQ1_S-00001-of-00003.gguf -lm dio -ncmoe 999 -p 256 -ub 64```

Zero-sized tensors appear in the last layer of graph for e.g. in `qwen4exp`:

https://github.com/ggml-org/llama.cpp/blob/3c6409920f1a2d998178db4f94065d354473e92d/src/models/qwen4exp.cpp#L400-L402

when always offloading this loop does an out-of-bounds access:

https://github.com/ggml-org/llama.cpp/blob/3c6409920f1a2d998178db4f94065d354473e92d/ggml/src/ggml-backend.cpp#L1767-L1770

This PR exits early when the ids tensors is empty.

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, for reproducing

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
