### PR TITLE
server: fix Windows CI flake from the log color reset

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1713,7 +1713,10 @@ void server_child::notify_to_router(const std::string & state, const json & payl
     std::lock_guard<std::mutex> lk(mtx_stdout);
     common_log_pause(common_log_main());
     fflush(stdout);
-    fprintf(stdout, "%s%s\n", CMD_CHILD_TO_ROUTER_STATE, safe_json_to_str(data).c_str());
+    // the router matches the command on a line prefix, so the leading newline
+    // closes whatever the logger left open on the shared pipe, down to the
+    // trailing color reset that carries no newline of its own
+    fprintf(stdout, "\n%s%s\n", CMD_CHILD_TO_ROUTER_STATE, safe_json_to_str(data).c_str());
     fflush(stdout);
     common_log_resume(common_log_main());
 }


### PR DESCRIPTION
## Overview

On Windows the child logs in color, and the logger emits its reset after the newline. That stray escape lands in front of cmd_child_to_router:state: on the shared pipe, the prefix check fails, and download_finished is logged instead of handled, leaving the model stuck downloading. Hence the intermittent test_router_delete_model failures.

## Additional information

A leading newline on the command fixes it. Reproduced on Linux with LLAMA_ARG_LOG_COLORS=on, keeping the cached blob while the registry no longer knows the model. pytest unit/test_router.py passes 17/17.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
