### PR TITLE
metal: fix metal tensor kernel_mul_mm error for large tensor

### DIFF
--- a/ggml/src/ggml-metal/kernels/mul_mm.metal
+++ b/ggml/src/ggml-metal/kernels/mul_mm.metal
@@ -132,12 +132,13 @@ kernel void kernel_mul_mm(
         threadgroup_barrier(mem_flags::mem_threadgroup);
     }
 
-    // Store result tile to output matrix (with batch offset)
-    // cT.store handles bounds checking via tD's extents (M, N)
-    device float * dstBatch = (device float *)dst + im * N * M;
+    const int tileM = min(NRA, M - ra);
+    const int tileN = min(NRB, N - rb);
 
-    auto tD = tensor(dstBatch, dextents<int32_t, 2>(M, N), array<int, 2>({1, M}));
-    cT.store(tD.slice(ra, rb));
+    device float * dstTile = (device float *)dst + (uint64_t) im * N * M + (uint64_t) rb * M + ra;
+
+    auto tD = tensor(dstTile, dextents<int32_t, 2>(tileM, tileN), array<int, 2>({1, M}));
+    cT.store(tD);
 }
 
 #else


### PR DESCRIPTION
Assisted-by: Codex

## Overview

In an experiment, I consistently observed that when the offset between the slice address and the tensor base address is greater than or equal to 2 GB, the actual address produced by the Metal Tensor API's `slice` method differs from the expected address by -4 GB.

This change modifies the `kernel_mul_mm` implementation in `ggml/src/ggml-metal/kernels/mul_mm.metal` for the `GGML_METAL_HAS_TENSOR == true` path. Instead of using the `slice` method, it explicitly computes the address of each slice and constructs the tensor directly from the computed address.

Related issue: #27784

After this change, the issue is no longer reproducible.

```bash
sending long embedding request...
long: output_size=1024 invalid_values=0
 *  Terminal will be reused by tasks, press any key to close it. 

 *  Executing task: python3 scripts/issue27784_probe.py 

sending short embedding request...
short: output_size=1024 invalid_values=0
 *  Terminal will be reused by tasks, press any key to close it.
 ```

## Additional information



### Environment
Hardware:       Apple MacBook Air 13 inch M5 16G
macOS:          26.6.2 (25G83)
Metal compiler: Apple metal version 32023.883 (metalfe-32023.883), Target: air64-apple-darwin25.6.0, Thread model: posix

### Experiment Design

Each case runs the same matrix multiplication with a K dimension of `16`, producing a cooperative tensor `cT`. The only difference between the two dispatches is the storage destination:

```mermaid
flowchart TB
    A["A: K x tile_rows"] --> MM["Tensor API matmul"]
    B["B: K x tile_columns"] --> MM
    MM --> CT["cT: tile_rows x tile_columns"]
    CT --> P1["Path 1: calculate the dstTile pointer first<br/>then tensor(dstTile, tile shape)"]
    CT --> P2["Path 2: tensor(whole tensor)<br/>then whole.slice(row, column)"]
    P1 --> R1["direct_values"]
    P2 --> R2["slice_expected_values<br/>slice_wrapped_values"]
```

Path 1 uses explicit 64-bit address calculation in the host language:

```metal
device float * tile = c + (uint64_t) column * m + row;
```

Path 2 wraps the complete output as a two-dimensional tensor:

```metal
auto whole = tensor(c, dextents<int32_t, 2>(m, n), array<int, 2>({1, m}));
cT.store(whole.slice(row, column));
```
### Results

| Case | Slice start | Does the tile cross 2 GiB? | Direct path | Correct slice address | Slice -4 GiB address | Conclusion |
|---|---:|---:|---:|---:|---:|---|
| Start 1024 B below | `0x7ffffc00` | No | 256/256 | 256/256 | 0/256 | Correct |
| Start 64 B below | `0x7fffffc0` | Yes | 256/256 | 256/256 | 0/256 | Correct |
| Half of tile crosses | `0x7ffffe00` | Yes | 256/256 | 256/256 | 0/256 | Correct |
| Exactly at boundary | `0x80000000` | No | 256/256 | 0/256 | 256/256 | 4 GiB early |
| 64 B above | `0x80000040` | No | 256/256 | 0/256 | 256/256 | 4 GiB early |
| 1024 B above | `0x80000400` | No | 256/256 | 0/256 | 256/256 | 4 GiB early |

```mermaid
xychart-beta
    title "16 x 16 tile: slice start versus actual write displacement"
    x-axis ["-1024 B", "-64 B", "crossing tile", "0 B", "+64 B", "+1024 B"]
    y-axis "actual address - correct address (GiB)" -4 --> 0
    line [0, 0, 0, -4, -4, -4]
```

These results show a step with no transition interval. From `0x7fffffff` to `0x80000000`, the displacement changes directly from 0 to -4 GiB.



## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, I use codex to help me write experiment script.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
