### PR TITLE
server: fix router DELETE hang from a lost child exit command

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1052,7 +1052,7 @@ void server_models::load(const std::string & name, const load_options & opts) {
                     std::string str(buffer);
                     if (string_starts_with(buffer, CMD_CHILD_TO_ROUTER_STATE)) {
                         LOG_DBG("[%5d] %s", port, buffer); // prevent spamming the log
-                        this->handle_child_state(name, str);
+                        this->handle_child_state(name, str, *child_proc);
                     } else {
                         // forward log
                         LOG("[%5d] %s", port, buffer);
@@ -1517,7 +1517,7 @@ server_http_res_ptr server_models::proxy_request(const server_http_req & req, co
     return proxy;
 }
 
-void server_models::handle_child_state(const std::string & name, const std::string & raw_input) {
+void server_models::handle_child_state(const std::string & name, const std::string & raw_input, server_subproc & subproc) {
     server_state state;
     json payload;
 
@@ -1535,19 +1535,12 @@ void server_models::handle_child_state(const std::string & name, const std::stri
             {
                 std::string result = json_value(payload, "result", std::string());
                 std::string url    = json_value(payload, "url",    std::string());
-                auto request_exit = [&]() {
-                    std::lock_guard<std::mutex> lk(mutex);
-                    auto it = mapping.find(name);
-                    if (it != mapping.end()) {
-                        return it->second.subproc->request_exit();
-                    }
-                };
                 if (result == "download_finished") {
                     update_download_progress(name, {}, true, true);
-                    request_exit();
+                    subproc.request_exit();
                 } else if (result == "download_failed") {
                     update_download_progress(name, {}, true, false);
-                    request_exit();
+                    subproc.request_exit();
                 } else if (!url.empty()) {
                     common_download_progress p;
                     p.url        = url;

--- a/tools/server/server-models.h
+++ b/tools/server/server-models.h
@@ -302,7 +302,7 @@ public:
     //     state = loading     -> payload = {} (TODO: add progress info)
     //     state = ready       -> payload = model_info (json), or {} if wakeup from sleeping
     //     state = sleeping    -> payload = {}
-    void handle_child_state(const std::string & name, const std::string & raw_input);
+    void handle_child_state(const std::string & name, const std::string & raw_input, server_subproc & subproc);
 };
 
 struct server_child {


### PR DESCRIPTION
## Overview

Superseded by #28762

The exit command for a download child is routed through a lookup in the model mapping, guarded by the models mutex, so a DELETE that erases the entry first leaves the lookup empty and the child never learns it should quit. It waits on stdin, its stdout never reaches EOF, and the DELETE blocks on th.join() until the 600s client timeout. The log thread already owns the subprocess, so the exit goes straight to it.

## Additional information

Reproduced by widening the window with a 2s sleep between publishing the completion and sending the exit, identical in both binaries: the baseline hangs with no exit command ever sent and the router log goes silent right after the download_finished chunk, exactly as in CI, while the patched one returns in 2.11s and the child exits with status 0. pytest unit/test_router.py passes 17/17. Over the last week of Server runs this accounts for half of the test_router_delete_model timeouts; the other half is a download child that acknowledges the exit, finishes cleanly, and still never reaches EOF, which this does not address.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
