### PR TITLE
gguf-split: validate --split-max-tensors and --split-max-size

### DIFF
--- a/tools/gguf-split/gguf-split.cpp
+++ b/tools/gguf-split/gguf-split.cpp
@@ -73,12 +73,16 @@ static void split_print_usage(const char * executable) {
 // return convert string, for example "128M" or "4G" to number of bytes
 static size_t split_str_to_n_bytes(std::string str) {
     size_t n_bytes = 0;
-    int n;
+    int n = 0;
     if (str.back() == 'M') {
-        sscanf(str.c_str(), "%d", &n);
+        if (sscanf(str.c_str(), "%d", &n) != 1) {
+            throw std::invalid_argument("error: invalid size, expected a number followed by M or G, but got: " + str);
+        }
         n_bytes = (size_t)n * 1000 * 1000; // megabytes
     } else if (str.back() == 'G') {
-        sscanf(str.c_str(), "%d", &n);
+        if (sscanf(str.c_str(), "%d", &n) != 1) {
+            throw std::invalid_argument("error: invalid size, expected a number followed by M or G, but got: " + str);
+        }
         n_bytes = (size_t)n * 1000 * 1000 * 1000; // gigabytes
     } else {
         throw std::invalid_argument("error: supported units are M (megabytes) or G (gigabytes), but got: " + std::string(1, str.back()));
@@ -138,6 +142,9 @@ static void split_params_parse_ex(int argc, const char ** argv, split_params & p
             }
             params.mode = MODE_TENSOR;
             params.n_split_tensors = atoi(argv[arg_idx]);
+            if (params.n_split_tensors <= 0) {
+                throw std::invalid_argument("error: --split-max-tensors must be a positive value");
+            }
         } else if (arg == "--split-max-size") {
             if (++arg_idx >= argc) {
                 invalid_param = true;

--- a/tools/gguf-split/tests.sh
+++ b/tools/gguf-split/tests.sh
@@ -28,6 +28,19 @@ mkdir -p "$WORK_PATH"
 # Clean up in case of previously failed test
 rm -f $WORK_PATH/ggml-model-split*.gguf $WORK_PATH/ggml-model-merge*.gguf
 
+# 0. Reject invalid split limits instead of crashing or silently accepting garbage (#28720)
+# No model needed: argument validation happens before the input file is opened.
+if $SPLIT --split-max-tensors 0 nonexistent.gguf $WORK_PATH/out; then
+    echo "FAIL: --split-max-tensors 0 should be rejected"
+    exit 1
+fi
+if $SPLIT --split-max-size G nonexistent.gguf $WORK_PATH/out; then
+    echo "FAIL: --split-max-size G should be rejected"
+    exit 1
+fi
+echo PASS
+echo
+
 # 1. Get a model
 (
 cd $WORK_PATH


### PR DESCRIPTION
Neither argument was validated before use:

- `--split-max-tensors 0` reached `i_tensor % params.n_split_tensors` with a zero divisor, crashing with an integer divide-by-zero (SIGFPE / STATUS_INTEGER_DIVIDE_BY_ZERO on Windows). A negative value was silently accepted and used as-is.
- `--split-max-size` parsed the numeric part with `sscanf`, but dropped its return value. A string that doesn't start with a valid integer (e.g. "G" or "xyzM") leaves `n` uninitialized, so the parsed size limit was garbage and the program proceeded anyway instead of reporting an error.

Validate both: reject a non-positive `--split-max-tensors`, and check `sscanf`'s return value before using the parsed size. Both now fail cleanly with a clear message and non-zero exit instead of crashing or silently continuing with corrupted state.

Added regression coverage to tools/gguf-split/tests.sh: both bad invocations are rejected before any input file is opened, so the check doesn't need a downloaded model.

Closes #28720

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
