### PR TITLE
server: fix router DELETE hang on a finished download

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1535,19 +1535,13 @@ void server_models::handle_child_state(const std::string & name, const std::stri
             {
                 std::string result = json_value(payload, "result", std::string());
                 std::string url    = json_value(payload, "url",    std::string());
-                auto request_exit = [&]() {
+                if (result == "download_finished" || result == "download_failed") {
+                    update_download_progress(name, {}, true, result == "download_finished");
+                    // the monitoring thread owns the child's stdin and the stop
+                    // timeout, so the exit request travels through it and a child
+                    // that outlives the command is killed after stop_timeout
                     std::lock_guard<std::mutex> lk(mutex);
-                    auto it = mapping.find(name);
-                    if (it != mapping.end()) {
-                        return it->second.subproc->request_exit();
-                    }
-                };
-                if (result == "download_finished") {
-                    update_download_progress(name, {}, true, true);
-                    request_exit();
-                } else if (result == "download_failed") {
-                    update_download_progress(name, {}, true, false);
-                    request_exit();
+                    request_stop(name);
                 } else if (!url.empty()) {
                     common_download_progress p;
                     p.url        = url;

--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -1320,14 +1320,17 @@ bool server_models::remove(const std::string & name) {
         return true;
     }
 
-    // join before erasing - thread no longer acquires this mutex
-    if (it->second.th.joinable()) {
-        it->second.th.join();
+    // the monitoring thread takes this mutex on its way out, so join outside it
+    std::thread th = std::move(it->second.th);
+    mapping.erase(name);
+    lk.unlock();
+
+    if (th.joinable()) {
+        th.join();
     }
 
     // remove from disk (best-effort: cancelled downloads may have no cached files)
     bool ok = common_download_remove(name);
-    mapping.erase(name);
     if (!ok) {
         SRV_WRN("removing model name=%s from disk returned false (no cached files?)\n", name.c_str());
     }
@@ -2076,8 +2079,9 @@ void server_models_routes::init_routes() {
             server_models::load_options load_opts;
             load_opts.mode = SERVER_CHILD_MODE_DOWNLOAD;
             load_opts.custom_meta = server_model_meta{};
-            load_opts.custom_meta->source = SERVER_MODEL_SOURCE_CACHE;
-            load_opts.custom_meta->name   = name;
+            load_opts.custom_meta->source       = SERVER_MODEL_SOURCE_CACHE;
+            load_opts.custom_meta->name         = name;
+            load_opts.custom_meta->stop_timeout = DEFAULT_STOP_TIMEOUT;
             models.load(name, load_opts);
         }
 


### PR DESCRIPTION
## Overview

Supersedes #28755

A finished download child was asked to quit through its own private path: a lookup in the model mapping, plus a flag saying the process had already stopped. So a DELETE erasing the entry first meant nobody ever sent the exit command, and the flag disarmed the stop timeout that watches every other child. The child waited on stdin forever, its stdout never reached EOF, and the DELETE blocked on th.join() until the 600s client timeout. It now goes through request_stop() like any other instance, so the exit command travels on the stdin the monitoring thread already owns, and a child that outlives it is killed after stop_timeout.

## Additional information

This covers both halves of the hang seen in CI, the one where the exit command never leaves the router and the one where the child acknowledges it, finishes cleanly, and still never reaches EOF. Together they account for 10 failing Windows jobs over the past week, and none of them ever logged instance name=... exited with status. Only the branch reporting the final download result takes the new path, so the timeout clock starts after the child has announced it is done; a download in flight never enters stopping_models and an explicit cancel keeps its own path.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
