### PR TITLE
model : nemotron-h, create the MTP latent FFN projection for the NextN layer

### DIFF
--- a/src/models/nemotron-h-moe.cpp
+++ b/src/models/nemotron-h-moe.cpp
@@ -97,11 +97,17 @@ llama_model_nemotron_h_moe::graph_mtp::graph_mtp(const llama_model & model, cons
     cb(cur, "mtp_attn_post_norm", il);
 
     {
+        ggml_tensor * inp_latent = cur;
+
+        if (layer.ffn_latent_down) {
+            inp_latent = ggml_mul_mat(ctx0, layer.ffn_latent_down, cur);
+        }
+
         ggml_tensor * router_logits = build_lora_mm(layer.ffn_gate_inp, cur);
         cb(router_logits, "mtp_ffn_moe_logits", il);
 
         ggml_tensor * moe_out =
-            build_moe_ffn(cur,
+            build_moe_ffn(inp_latent,
                 layer.ffn_gate_inp,
                 layer.ffn_up_exps,
                 nullptr, // no gate
@@ -117,6 +123,10 @@ llama_model_nemotron_h_moe::graph_mtp::graph_mtp(const llama_model & model, cons
                 nullptr, // no gate
                 layer.ffn_down_exps_s);
         cb(moe_out, "mtp_ffn_moe_out", il);
+
+        if (layer.ffn_latent_up) {
+            moe_out = ggml_mul_mat(ctx0, layer.ffn_latent_up, moe_out);
+        }
 
         ggml_tensor * ffn_shexp = build_ffn(cur,
                 layer.ffn_up_shexp,   NULL, layer.ffn_up_shexp_s,

--- a/src/models/nemotron-h.cpp
+++ b/src/models/nemotron-h.cpp
@@ -166,6 +166,8 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader & ml) {
         layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias",   i), {n_expert}, mtp_flags);
         layer.ffn_down_exps   = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS,   "weight", i), {n_ff_exp,   moe_n_embd, n_expert}, mtp_flags);
         layer.ffn_up_exps     = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,     "weight", i), {moe_n_embd, n_ff_exp,   n_expert}, mtp_flags);
+        layer.ffn_latent_down = create_tensor(tn(LLM_TENSOR_FFN_LATENT_DOWN, "weight", i), {n_embd, moe_n_embd}, mtp_flags | TENSOR_NOT_REQUIRED);
+        layer.ffn_latent_up   = create_tensor(tn(LLM_TENSOR_FFN_LATENT_UP,   "weight", i), {moe_n_embd, n_embd}, mtp_flags | TENSOR_NOT_REQUIRED);
         layer.ffn_down_shexp  = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP,  "weight", i), {n_ff_shexp, n_embd}, mtp_flags);
         layer.ffn_up_shexp    = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,    "weight", i), {n_embd, n_ff_shexp}, mtp_flags);
     }


### PR DESCRIPTION
## Problem

Nemotron-3-Super-120B MTPv2 composites carry two extra tensors in their NextN block:

```
blk.88.ffn_latent_down.weight
blk.88.ffn_latent_up.weight
```

`llama_model_nemotron_h::load_arch_tensors` creates that latent projection pair for the trunk MoE branch, but not for the NextN layer. Such a model is therefore rejected before any allocation:

```
done_getting_tensors: wrong number of tensors; expected 781, got 779
```

`done_getting_tensors` compares tensor counts, so the failure is independent of the flags, of `-ngl` and of the context size — verified at `-ngl 0`, ctx 512 and without `--spec-type`.

## Fix

* Create the pair in the NextN loop with the same shapes the trunk MoE branch uses (`{n_embd, moe_n_embd}` and `{moe_n_embd, n_embd}`), under `TENSOR_NOT_REQUIRED` so MTPv1 composites without those tensors keep loading unchanged.
* In `graph_mtp`, wrap `build_moe_ffn` with the same down/up projection the trunk already applies, guarded on the tensors being present.

14 lines, 2 files. No new tensor names or architecture flags — `LLM_TENSOR_FFN_LATENT_DOWN` / `_UP` already exist and are already produced by the converter.

## Testing

Built on gfx1151 / ROCm 7.2.2, master `43f3dda`.

* Mesh-LLM MTPv2 composite of NVIDIA-Nemotron-3-Super-120B-A12B (UD-Q4_K_XL, 88 layers + NextN, 781 tensors): loads, and the MTP draft context reaches **0.66 acceptance over 1884 drafted tokens** at prompt depths 256 / 4096 / 15232, mean draft length 2.3 with `--spec-draft-n-max 2`. Throughput goes from 16.1 t/s without the head to 22.4 t/s with it, measured on the same binary.
* A Nemotron-3.5-Lightning-30B MTPv1 composite (no latent pair) still loads and speculates unchanged, confirming the `TENSOR_NOT_REQUIRED` path.