### PR TITLE
nemotron-h : guard the expert FFN size fallback against a zero divisor

### DIFF
--- a/src/models/nemotron-h.cpp
+++ b/src/models/nemotron-h.cpp
@@ -145,8 +145,14 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader & ml) {
         const int64_t n_head_i       = hparams.n_head(i);
         const int64_t n_embd_k_gqa_i = hparams.n_embd_k_gqa(i);
         const int64_t n_embd_v_gqa_i = hparams.n_embd_v_gqa(i);
-        const int64_t n_ff_exp       = hparams.n_ff_exp(i) ? (int64_t)hparams.n_ff_exp(i) : n_ff / (int64_t)hparams.n_expert_used(i);
-        const int64_t n_ff_shexp     = hparams.n_ff_shexp;
+        const int64_t n_expert_used_i = hparams.n_expert_used(i);
+        const int64_t n_ff_exp_i      = hparams.n_ff_exp(i);
+        if (n_ff_exp_i == 0 && n_expert_used_i == 0) {
+            throw std::runtime_error(format("%s: layer %d declares neither expert_feed_forward_length nor expert_used_count, "
+                                            "cannot determine the expert FFN size", __func__, i));
+        }
+        const int64_t n_ff_exp   = n_ff_exp_i ? n_ff_exp_i : n_ff / n_expert_used_i;
+        const int64_t n_ff_shexp = hparams.n_ff_shexp;
 
         // NextN input-fusion tensors
         layer.nextn.enorm            = create_tensor(tn(LLM_TENSOR_NEXTN_ENORM,            "weight", i), {n_embd}, mtp_flags);


### PR DESCRIPTION
## Overview

Loading a `nemotron_h_moe` GGUF whose NextN/MTP layer has 0 in both `expert_feed_forward_length` and `expert_used_count` crashes with SIGFPE. In the MTP loop of `load_arch_tensors`, `n_ff_exp` falls back to `n_ff / n_expert_used(i)`, and since #25444 both are per-layer values that can be 0.

The GGUFs converted from the #25444 review branch hit this: `nextn_predict_layers = 2`, and index 88 is 0 in both arrays. Reported in https://github.com/ggml-org/llama.cpp/pull/25444#issuecomment-5593871393.

This throws an error instead of crashing. It does not make those files load: they use an MTP layout master doesn't read and need reconverting with the current converter.

## Additional information

- #28764 touches the same loop at a different line; no conflict.

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES — AI-assisted. I reviewed the diff and verified the fix and the test on my hardware. I take full responsibility for the change.
