### PR TITLE
vulkan: use 32-row coopmat2 flash attention tiles on Intel

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4055,6 +4055,11 @@ static vk_fa_tuning_params get_fa_tuning_params_coopmat2(const vk_device& device
     result.subgroup_size = device->subgroup_size;
     result.workgroup_size = (small_rows && (D % 32) == 0) ? 256 : 128;
 
+    if (device->vendor_id == VK_VENDOR_ID_INTEL) {
+        // 32 rows use fewer registers per thread than 64 and run faster at every head size measured on Xe.
+        result.block_rows = 32;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
## Overview

Constrain Flash attention's Br (block_rows) to 32 on Intel to avoid register spilling.

## Additional information

get_fa_tuning_params_coopmat2 picks Br=64 rows for every head size below 512. On Intel that tile is too large for a thread's register file. At HSK=HSV=128, the shader already needs about 200 GRFs, so Mesa allocates it the full 256 and the EU runs 4 threads. For HSK>=192 it results in hundreds of spills, and long compile times.

| hsk=hsv | GRF 64 -> 32 | kv=1024 nb=512 | kv=2048 nb=512 | compile | spills/fills |
|---|---|---|---|---|---|
| 64 | 204 -> 146 | -28 % | -25 % | -76 % | 0/0 -> 0/0 |
| 96 | 238 -> 172 | -29 % | -22 % | -81 % | 0/0 -> 0/0 |
| 128 | 200 -> 162 | -34 % | -26 % | -84 % | 0/0 -> 0/0 |
| 192 | 254 -> 255 | -44 % | -29 % | -87 % | 157/685 -> 28/28* |
| 256 | 252 -> 249 | -63 % | -47 % | -87 % | 222/2419 -> 113/1154* |

\* these remaining spills/fills will be addressed on the driver side.

## Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes. Used to generate perf and validation test runs.
