### PR TITLE
CUDA: fix crash for MTP decoding on pre-Pascal GPUs

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5173,6 +5173,11 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
             return op->type == GGML_TYPE_F32 && op->src[0]->type == GGML_TYPE_F32 && op->src[1]->type == GGML_TYPE_F32;
         case GGML_OP_GET_ROWS:
             {
+                if (ggml_cuda_info().devices[dev_ctx->device].cc < GGML_CUDA_CC_PASCAL &&
+                        op->src[0]->type == GGML_TYPE_F32 && op->src[0]->ne[0] == 1) {
+                    return false;
+                }
+
                 switch (op->src[0]->type) {
                     case GGML_TYPE_F16:
                     case GGML_TYPE_F32:


### PR DESCRIPTION
The CUDA float get_rows kernel hits an illegal memory access when src0 is F32 with ne[0] == 1 on devices older than Pascal (cc < 600). Reproducible during speculative-decoding/MTP drafting. Fall back to CPU for this degenerate case instead, matching the existing pattern used for other unsupported op/shape combinations.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->
When running the following command 
```
./bin/llama-server -hf unsloth/Qwen3.6-35B-A3B-MTP-GGUF:UD-Q4_K_M --no-mmproj --n-gpu-layers 99 --n-cpu-moe 999 --ctx-size 16000 --batch-size 2048 --ubatch-size 512 --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn auto --spec-type draft-mtp --spec-draft-n-max 2 --temp 0.6 --top-p 0.95 --top-k 20
```
Any decoding just crashes on my Ubuntu 26.04.1 LTS with GPU Quadro M1200 (4G VRAM). 100% reproducible.
Without MTP decoding, it works fine.

## Additional information
* nvidia driver version: 580.178.04 
* nvcc version
```
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2024 NVIDIA Corporation
Built on Thu_Mar_28_02:18:24_PDT_2024
Cuda compilation tools, release 12.4, V12.4.131
Build cuda_12.4.r12.4/compiler.34097967_0
```

* code based used is the latest master with b78a39a2f93b13a79a3e01aff3f14274efb43afc. Compiled with CUDA and VULKAN enabled, compiler is c++ (Ubuntu 15.2.0-16ubuntu1) 15.2.0


* Crash stacktrace

```
sing host libthread_db library "/usr/lib/x86_64-linux-gnu/libthread_db.so.1".
__syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
⚠️ warning: 56	../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S: No such file or directory
#0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
56	in ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S
#1  0x0000769f600a039c in __internal_syscall_cancel (a1=37446, a2=0, a3=0, a4=0, a5=0, a6=0, nr=61) at ./nptl/cancellation.c:49
⚠️ warning: 49	./nptl/cancellation.c: No such file or directory
#2  __syscall_cancel (a1=a1@entry=37446, a2=a2@entry=0, a3=a3@entry=0, a4=a4@entry=0, a5=a5@entry=0, a6=a6@entry=0, nr=61) at ./nptl/cancellation.c:75
75	in ./nptl/cancellation.c
#3  0x0000769f6011cacf in __GI___wait4 (pid=pid@entry=37446, stat_loc=stat_loc@entry=0x0, options=options@entry=0, usage=usage@entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
⚠️ warning: 30	../sysdeps/unix/sysv/linux/wait4.c: No such file or directory
#4  0x0000769f6011cb1b in __GI___waitpid (pid=pid@entry=37446, stat_loc=stat_loc@entry=0x0, options=options@entry=0) at ./posix/waitpid.c:38
⚠️ warning: 38	./posix/waitpid.c: No such file or directory
#5  0x0000769f60e73ef3 in ggml_print_backtrace () at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml.c:235
235	        waitpid(child_pid, NULL, 0);
#6  0x0000769f60e740a6 in ggml_abort (file=0x769f5942d1d8 "/media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu", line=108, fmt=0x769f594b5962 "CUDA error") at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml.c:269
269	        ggml_print_backtrace();
#7  0x0000769f58a0c087 in ggml_cuda_error (stmt=stmt@entry=0x769f594b4b23 "cudaGetLastError()", func=func@entry=0x769f594b4f01 "ggml_cuda_kernel_launch", file=file@entry=0x769f59419000 "/media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/common.cuh", line=line@entry=1710, msg=0x769f55a8db00 "an illegal memory access was encountered") at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu:108
108	    GGML_ABORT(GGML_CUDA_NAME " error");
#8  0x0000769f589f8916 in ggml_cuda_kernel_launch<void (*)(float const*, int const*, float*, long, long, uint3, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long, unsigned long), float const*&, int const*&, float*&, long const&, long const&, uint3 const&, unsigned long const&, unsigned long const&, unsigned long const&, unsigned long const&, unsigned long const&, unsigned long const&, unsigned long const&, unsigned long const&, unsigned long const&> (kernel=<optimized out>, launch_params=...) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/common.cuh:1710
1710	    CUDA_CHECK(cudaGetLastError());
#9  get_rows_cuda_float<float, float> (src0_d=0xbcc5f8900, src0_d@entry=0x0, src1_d=0xbcc4e0000, src1_d@entry=0x769f594b4b23, dst_d=0xbcc4e0200, dst_d@entry=0x62bd82168, ne00=1, nb01=4, nb01@entry=144, nb02=993280, nb02@entry=1639941158822021754, nb03=993280, ne10=10, ne11=1, ne12=1, nb10=4, nb11=40, nb12=40, nb1=4, nb2=40, nb3=40, stream=0x62bd8060f2a0) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/getrows.cu:286
286	    ggml_cuda_kernel_launch(k_get_rows_float<src0_t, dst_t>, launch_params,
#10 0x0000769f589fb718 in ggml_cuda_get_rows_switch_src0_type<float> (src0_d=0x0, src0_d@entry=0x7ffd728269a8, src0_type=<optimized out>, src1_d=0x769f594b4b23, dst_d=0x62bd82168, ne00=<optimized out>, nb01=144, nb02=<optimized out>, nb03=<optimized out>, ne10=<optimized out>, ne11=<optimized out>, ne12=<optimized out>, nb10=<optimized out>, nb11=<optimized out>, nb12=<optimized out>, nb1=<optimized out>, nb2=<optimized out>, nb3=<optimized out>, stream=0x62bd8060f2a0) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/getrows.cu:308
308	            get_rows_cuda_float((const float *) src0_d, src1_d, dst_d,
#11 0x0000769f58a08202 in get_rows_cuda (src0_d=0x7ffd728269a8, src0_type=<optimized out>, src1_d=<optimized out>, dst_d=<optimized out>, dst_type=<optimized out>, ne00=ne00@entry=1, nb01=<optimized out>, nb02=<optimized out>, nb03=<optimized out>, ne10=<optimized out>, ne11=<optimized out>, ne12=<optimized out>, nb10=<optimized out>, nb11=<optimized out>, nb12=<optimized out>, nb1=<optimized out>, nb2=<optimized out>, nb3=<optimized out>, stream=0x62bd8060f2a0) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/getrows.cu:421
421	            ggml_cuda_get_rows_switch_src0_type(src0_d, src0_type, src1_d, (float *) dst_d,
#12 0x0000769f58a084ba in ggml_cuda_op_get_rows (ctx=..., dst=dst@entry=0x76999a91c7f0) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/getrows.cu:457
457	    get_rows_cuda(src0->data, src0->type, (const int32_t *) src1->data, dst->data, dst->type,
#13 0x0000769f58a1eaa3 in ggml_cuda_compute_forward (dst=0x76999a91c7f0, ctx=...) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu:2074
2074	            ggml_cuda_op_get_rows(ctx, dst);
#14 ggml_cuda_graph_evaluate_and_capture (graph_key=0x76999a918180, cuda_graph_update_required=false, use_cuda_graph=false, cgraph=0x62bd8072b480, cuda_ctx=<optimized out>) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu:4346
4346	                bool ok = ggml_cuda_compute_forward(*cuda_ctx, node);
#15 ggml_backend_cuda_graph_compute (backend=<optimized out>, cgraph=0x62bd8072b480) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu:4466
4466	    ggml_cuda_graph_evaluate_and_capture(cuda_ctx, cgraph, use_cuda_graph, cuda_graph_update_required, graph_key);
#16 0x0000769f60e8db10 in ggml_backend_sched_compute_splits (sched=0x62bd805f8600) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-backend.cpp:1796
1796	            enum ggml_status ec = ggml_backend_graph_compute_async(split_backend, &split->graph);
#17 ggml_backend_sched_graph_compute_async (sched=0x62bd805f8600, graph=<optimized out>) at /media/l2ming/Disk1/AI/llama.cpp/ggml/src/ggml-backend.cpp:2026
2026	    return ggml_backend_sched_compute_splits(sched);
#18 0x0000769f5f7da8e0 in llama_context::graph_compute (this=this@entry=0x62bd73340830, gf=0x76999a7f2030, batched=<optimized out>) at /usr/include/c++/15/bits/unique_ptr.h:192
192	      pointer    _M_ptr() const noexcept { return std::get<0>(_M_t); }
#19 0x0000769f5f7dcfc9 in llama_context::process_ubatch (this=this@entry=0x62bd73340830, ubatch=..., gtype=<optimized out>, mctx=mctx@entry=0x62bd7f313990, ret=@0x7ffd728304e0: 1673) at /media/l2ming/Disk1/AI/llama.cpp/src/llama-context.cpp:1396
1396	    const auto status = graph_compute(res->get_gf(), ubatch.n_tokens > 1);
#20 0x0000769f5f7e1dc7 in llama_context::decode (this=0x62bd73340830, batch_inp=...) at /media/l2ming/Disk1/AI/llama.cpp/src/llama-context.cpp:1829
1829	        const auto * res = process_ubatch(ubatch, ctx_type_to_graph_type(cparams.ctx_type), mctx.get(), status);
#21 0x0000769f5f7e3362 in llama_decode (ctx=<optimized out>, batch=...) at /media/l2ming/Disk1/AI/llama.cpp/src/llama-context.cpp:4252
4252	    const int ret = ctx->decode(batch);
#22 0x0000769f5fd1991a in common_speculative_impl_draft_mtp::draft (this=0x62bd805f3850, dparams=std::vector of length 4, capacity 4 = {...}) at /media/l2ming/Disk1/AI/llama.cpp/common/speculative.cpp:1653
1653	            int ret = llama_decode(ctx_dft, batch);
#23 0x0000769f5fd0e972 in common_speculative_draft (spec=0x62bd785cc4a0) at /media/l2ming/Disk1/AI/llama.cpp/common/speculative.cpp:2833
2833	            impl->draft(dparams);
#24 0x0000769f609250d9 in std::function<void()>::operator() (this=0x7ffd72830cd0) at /usr/include/c++/15/bits/std_function.h:593
593		return _M_invoker(_M_functor, std::forward<_ArgTypes>(__args)...);
#25 server_queue::yield_to_queue (this=this@entry=0x62bd733523c0, work=...) at /media/l2ming/Disk1/AI/llama.cpp/tools/server/server-queue.cpp:238
238	        work();
#26 0x0000769f60979f09 in server_context_impl::pre_decode (this=this@entry=0x62bd73352390) at /media/l2ming/Disk1/AI/llama.cpp/tools/server/server-context.cpp:3045
3045	            queue_tasks.yield_to_queue([&]() {
#27 0x0000769f6098fc05 in server_context_impl::update_slots (this=0x62bd73352390) at /media/l2ming/Disk1/AI/llama.cpp/tools/server/server-context.cpp:2836
2836	            pre_decode();
#28 0x0000769f60925b38 in std::function<void()>::operator() (this=0x62bd73352580) at /usr/include/c++/15/bits/std_function.h:593
593		return _M_invoker(_M_functor, std::forward<_ArgTypes>(__args)...);
#29 server_queue::start_loop (this=0x62bd733523c0, idle_sleep_ms=-1000) at /media/l2ming/Disk1/AI/llama.cpp/tools/server/server-queue.cpp:310
310	        callback_update_slots();
#30 0x0000769f6094b9cd in server_context::start_loop (this=<optimized out>) at /media/l2ming/Disk1/AI/llama.cpp/tools/server/server-context.cpp:4166
4166	    impl->queue_tasks.start_loop(params.sleep_idle_seconds * 1000);
#31 0x0000769f608daf83 in llama_server (params=..., argc=argc@entry=30, argv=argv@entry=0x7ffd72839888) at /media/l2ming/Disk1/AI/llama.cpp/tools/server/server.cpp:545
545	        ctx_server.start_loop();
#32 0x0000769f608dcdff in llama_server (argc=30, argv=0x7ffd72839888) at /media/l2ming/Disk1/AI/llama.cpp/tools/server/server.cpp:112
112	    return llama_server(params, argc, argv);
#33 0x0000769f6002a601 in __libc_start_call_main (main=main@entry=0x62bd56a842f0 <main(int, char**)>, argc=argc@entry=30, argv=argv@entry=0x7ffd72839888) at ../sysdeps/nptl/libc_start_call_main.h:59
⚠️ warning: 59	../sysdeps/nptl/libc_start_call_main.h: No such file or directory
#34 0x0000769f6002a718 in __libc_start_main_impl (main=0x62bd56a842f0 <main(int, char**)>, argc=30, argv=0x7ffd72839888, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffd72839878) at ../csu/libc-start.c:360
⚠️ warning: 360	../csu/libc-start.c: No such file or directory
#35 0x000062bd56a84325 in _start ()
[Inferior 1 (process 36854) detached]
Aborted                    (core dumped) CUDA_LAUNCH_BLOCKING=1 ./bin/llama-server -hf unsloth/Qwen3.6-35B-A3B-MTP-GGUF:UD-Q4_K_M --no-mmproj --n-gpu-layers 99 --n-cpu-moe 999 --ctx-size 16000 --batch-size 2048 --ubatch-size 512 --cache-type-k q8_0 --cache-type-v q8_0 --flash-attn auto --spec-type draft-mtp --spec-draft-n-max 2 --temp 0.6 --top-p 0.95 --top-k 20
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)

- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->
<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
YES.
I passed the crash stack to codex(GPT 5.6 luna xhigh), AI suggested me to add the environment variable CUDA_LAUNCH_BLOCKING=1 to run. It produces a more informative stack trace and AI has identified the root cause and suggested the fix. 