### PR TITLE
ggml-cuda: use per-thread stream for buffer-init padding memset

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -777,12 +777,6 @@ function gg_run_test_backend_ops {
 
     local args_extra="-j $(nproc)"
 
-    # TODO: fix multi-threaded for ROCm
-    #       https://github.com/ggml-org/llama.cpp/actions/runs/34576278519/job/103297889044?pr=28740#step:3:4865
-    if [ ! -z ${GG_BUILD_ROCM} ]; then
-        args_extra=""
-    fi
-
     # TODO: MoltenVK bug?
     #       https://github.com/ggml-org/llama.cpp/actions/runs/34611260059/job/103302413736?pr=28740#step:3:5897
     if [ ! -z "${GG_BUILD_VULKAN}" ] && [ "$(uname -s)" = "Darwin" ]; then

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -767,7 +767,8 @@ static enum ggml_status ggml_backend_cuda_buffer_init_tensor(ggml_backend_buffer
 
         if (padded_size > original_size) {
             ggml_cuda_set_device(ctx->device);
-            CUDA_CHECK(cudaMemset((char *)tensor->data + original_size, 0, padded_size - original_size));
+            CUDA_CHECK(cudaMemsetAsync((char *)tensor->data + original_size, 0, padded_size - original_size, cudaStreamPerThread));
+            CUDA_CHECK(cudaStreamSynchronize(cudaStreamPerThread));
         }
     }
     return GGML_STATUS_SUCCESS;


### PR DESCRIPTION
## Overview

`ggml_backend_cuda_buffer_init_tensor` utilizes cudaMemset for zero tensor padding. This runs on the legacy stream which can collide with parallel HIP graph captures on separate streams causing failures.

This switches it to cudaMemsetAsync + sync (matches existing precedent in the file), keeping it off the legacy stream.
## Additional information

Resolves the `test-backend-ops -j` failures below on ROCm.

ROCm 10.2 + gfx1151 running `test-backend-ops -j $(nproc)`,

- Before

```
2026-09-11T14:23:16.3067027Z ROCm error: operation failed due to a previous error during capture
2026-09-11T14:23:16.3067555Z   current device: 0, in function ggml_cuda_graph_evaluate_and_capture at /scratch/actions-runner/_work/llama.cpp/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu:4366
2026-09-11T14:23:16.3068105Z ROCm error: operation would make the legacy stream depend on a capturing blocking stream
2026-09-11T14:23:16.3068441Z   hipStreamEndCapture(cuda_ctx->stream(), &graph->graph)
2026-09-11T14:23:16.3068935Z   current device: 0, in function ggml_backend_cuda_buffer_init_tensor at /scratch/actions-runner/_work/llama.cpp/llama.cpp/ggml/src/ggml-cuda/ggml-cuda.cu:770
```

- After

```
  ...
  Backend 1/2: ROCm0
    ... (all ops OK) ...
  2/2 backends passed
  [exit 0]
```
Serial case is not affected, passes before and after fix.
## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md): Yes
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used --> Yes, for debug and testing.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
