### PR TITLE
CUDA: fix IQ1_S/IQ2_S/IQ3_S garbage output on Blackwell (sm_120)

### DIFF
--- a/ggml/src/ggml-cuda/mmq-load-tiles.cuh
+++ b/ggml/src/ggml-cuda/mmq-load-tiles.cuh
@@ -1055,14 +1055,14 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
         const block_iq1_s * bxi = (const block_iq1_s *) x + kbx0 + i*stride;
 
-        const int       qs_packed = get_int_b2(bxi->qs, kqsx);
-        const uint8_t * qs        = (const uint8_t *) &qs_packed;
+        const int qs_packed = get_int_b2(bxi->qs, kqsx);
 
         const int qh = bxi->qh[kqsx];
 
     #pragma unroll
         for (int l = 0; l < QR1_S/2; ++l) {
-            const int grid = iq1s_grid_gpu[qs[l] | (((qh >> (3*l)) & 0x07) << 8)];
+            // extract the byte via __byte_perm: nvcc 13.2 drops a plain byte mask here and the grid index runs out of range
+            const int grid = iq1s_grid_gpu[__byte_perm(qs_packed, 0, 0x4440 | l) | (((qh >> (3*l)) & 0x07) << 8)];
 
             const int grid0 = (grid >> 0) & 0x0F0F0F0F;
             const int grid1 = (grid >> 4) & 0x0F0F0F0F;
@@ -1245,8 +1245,7 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
         const block_iq2_s * bxi = (const block_iq2_s *) x + kbx0 + i*stride;
 
-        const int       qs_packed = get_int_b2(bxi->qs, kqsx);
-        const uint8_t * qs        = (const uint8_t *) &qs_packed;
+        const int qs_packed = get_int_b2(bxi->qs, kqsx);
 
         const int qh = bxi->qh[kqsx];
 
@@ -1255,7 +1254,8 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
 #pragma unroll
         for (int l = 0; l < QR2_S; ++l) {
-            const int * grid_pos = (const int *)(iq2s_grid + (qs[l] | ((qh << (8-2*l)) & 0x300)));
+            // extract the byte via __byte_perm: nvcc 13.2 drops a plain byte mask here and the grid index runs out of range
+            const int * grid_pos = (const int *)(iq2s_grid + (__byte_perm(qs_packed, 0, 0x4440 | l) | ((qh << (8-2*l)) & 0x300)));
 
             const int signs0 = __vcmpne4(((signs_packed_8[l] & 0x03) << 7) | ((signs_packed_8[l] & 0x0C) << 21), 0x00000000);
             const int signs1 = __vcmpne4(((signs_packed_8[l] & 0x30) << 3) | ((signs_packed_8[l] & 0xC0) << 17), 0x00000000);
@@ -1378,8 +1378,7 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
         const block_iq3_s * bxi = (const block_iq3_s *) x + kbx0 + i*stride;
 
-        const int2      qs_packed = make_int2(get_int_b2(bxi->qs, 2*kqsx+0), get_int_b2(bxi->qs, 2*kqsx+1));
-        const uint8_t * qs        = (const uint8_t *) &qs_packed;
+        const int2 qs_packed = make_int2(get_int_b2(bxi->qs, 2*kqsx+0), get_int_b2(bxi->qs, 2*kqsx+1));
 
         const int qh = bxi->qh[kqsx];
 
@@ -1388,9 +1387,11 @@ template <ggml_type type, int J, bool fallback> static __device__ __forceinline_
 
 #pragma unroll
         for (int l = 0; l < QR3_S; ++l) {
+            // extract the byte via __byte_perm: nvcc 13.2 drops a plain byte mask here and the grid index runs out of range
+            const int qsw = l < QR3_S/2 ? qs_packed.x : qs_packed.y;
             const int2 grid_pos = make_int2(
-                iq3s_grid[qs[2*l+0] | ((qh << (8 - 2*l)) & 0x100)],
-                iq3s_grid[qs[2*l+1] | ((qh << (7 - 2*l)) & 0x100)]);
+                iq3s_grid[__byte_perm(qsw, 0, 0x4440 | (2*l & 3)) | ((qh << (8 - 2*l)) & 0x100)],
+                iq3s_grid[__byte_perm(qsw, 0, 0x4441 | (2*l & 3)) | ((qh << (7 - 2*l)) & 0x100)]);
 
             const int signs0 = __vcmpne4(((signs_packed_8[l] & 0x03) << 7) | ((signs_packed_8[l] & 0x0C) << 21), 0x00000000);
             const int signs1 = __vcmpne4(((signs_packed_8[l] & 0x30) << 3) | ((signs_packed_8[l] & 0xC0) << 17), 0x00000000);

--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -1109,8 +1109,7 @@ static __device__ __forceinline__ float vec_dot_iq2_s_q8_1(
 
     const block_iq2_s * bq2 = (const block_iq2_s *) vbq + kbx;
 
-    const int       qs_packed = get_int_b2(bq2->qs, iqs/2);
-    const uint8_t * qs        = (const uint8_t *) &qs_packed;
+    const int qs_packed = get_int_b2(bq2->qs, iqs/2);
 
     const int qh = bq2->qh[iqs/2];
 
@@ -1124,7 +1123,8 @@ static __device__ __forceinline__ float vec_dot_iq2_s_q8_1(
     int sumi1 = 0;
 #pragma unroll
     for (int l0 = 0; l0 < 8; l0 += 2) {
-        const int * grid_pos = (const int *)(iq2s_grid + (qs[l0/2] | ((qh << (8-l0)) & 0x300)));
+        // extract the byte via __byte_perm: nvcc 13.2 drops a plain byte mask here and the grid index runs out of range
+        const int * grid_pos = (const int *)(iq2s_grid + (__byte_perm(qs_packed, 0, 0x4440 | (l0/2)) | ((qh << (8-l0)) & 0x300)));
 
         const int signs0 = __vcmpne4(((signs_packed_8[l0/2] & 0x03) << 7) | ((signs_packed_8[l0/2] & 0x0C) << 21), 0x00000000);
         const int signs1 = __vcmpne4(((signs_packed_8[l0/2] & 0x30) << 3) | ((signs_packed_8[l0/2] & 0xC0) << 17), 0x00000000);
@@ -1196,8 +1196,7 @@ static __device__ __forceinline__ float vec_dot_iq3_s_q8_1(
 
     const block_iq3_s * bq3 = (const block_iq3_s *) vbq + kbx;
 
-    const int2      qs_packed = make_int2(get_int_b2(bq3->qs, iqs + 0), get_int_b2(bq3->qs, iqs + 1));
-    const uint8_t * qs        = (const uint8_t *) &qs_packed;
+    const int2 qs_packed = make_int2(get_int_b2(bq3->qs, iqs + 0), get_int_b2(bq3->qs, iqs + 1));
 
     const int qh = bq3->qh[iqs/2];
 
@@ -1207,9 +1206,11 @@ static __device__ __forceinline__ float vec_dot_iq3_s_q8_1(
     int sumi = 0;
 #pragma unroll
     for (int l0 = 0; l0 < 8; l0 += 2) {
+        // extract the byte via __byte_perm: nvcc 13.2 drops a plain byte mask here and the grid index runs out of range
+        const int qsw = l0 < 4 ? qs_packed.x : qs_packed.y;
         const int2 grid_pos = make_int2(
-            iq3s_grid[qs[l0 + 0] | ((qh << (8 - l0)) & 0x100)],
-            iq3s_grid[qs[l0 + 1] | ((qh << (7 - l0)) & 0x100)]);
+            iq3s_grid[__byte_perm(qsw, 0, 0x4440 | ((l0 & 3) + 0)) | ((qh << (8 - l0)) & 0x100)],
+            iq3s_grid[__byte_perm(qsw, 0, 0x4440 | ((l0 & 3) + 1)) | ((qh << (7 - l0)) & 0x100)]);
 
         const int signs0 = __vcmpne4(((signs_packed_8[l0/2] & 0x03) << 7) | ((signs_packed_8[l0/2] & 0x0C) << 21), 0x00000000);
         const int signs1 = __vcmpne4(((signs_packed_8[l0/2] & 0x30) << 3) | ((signs_packed_8[l0/2] & 0xC0) << 17), 0x00000000);
@@ -1237,15 +1238,15 @@ static __device__ __forceinline__ float vec_dot_iq1_s_q8_1(
     const void * __restrict__ vbq, const block_q8_1 * __restrict__ bq8_1, const int & kbx, const int & iqs) {
     const block_iq1_s * bq1 = (const block_iq1_s *) vbq + kbx;
 
-    const int       qs_packed = get_int_b2(bq1->qs, iqs);
-    const uint8_t * qs        = (const uint8_t *) &qs_packed;
+    const int qs_packed = get_int_b2(bq1->qs, iqs);
 
     const int qh = bq1->qh[iqs];
 
     int sumi = 0;
 #pragma unroll
     for (int l0 = 0; l0 < 8; l0 += 2) {
-        const int grid = iq1s_grid_gpu[qs[l0/2] | (((qh >> 3*(l0/2)) & 0x07) << 8)];
+        // extract the byte via __byte_perm: nvcc 13.2 drops a plain byte mask here and the grid index runs out of range
+        const int grid = iq1s_grid_gpu[__byte_perm(qs_packed, 0, 0x4440 | (l0/2)) | (((qh >> 3*(l0/2)) & 0x07) << 8)];
 
         const int grid0 = (grid >> 0) & 0x0F0F0F0F;
         const int grid1 = (grid >> 4) & 0x0F0F0F0F;


### PR DESCRIPTION
## Overview

The IQ1_S, IQ2_S, and IQ3_S MMQ tile-load and vec_dot kernels extract individual bytes from a packed 32-bit quant word by casting it to a uint8_t* and indexing (e.g. `qs[l]`). On nvcc 13.2 targeting sm_120 this byte read is miscompiled: the plain byte mask is dropped and the grid table index runs out of range, producing essentially random dequantized values. The result is coherent-looking output on very short prompts and garbage on anything longer. Both the MMQ path and the cuBLAS/dp4a vec_dot path are affected, so GGML_CUDA_FORCE_CUBLAS=1 does not help.

Replace the uint8_t* byte indexing with an explicit __byte_perm() byte selection, which forces correct codegen. Sibling types (IQ3_XXS, IQ4_XS, IQ2_XS, IQ2_XXS, K-quants) were already correct and are unchanged.

Fixes the 6 affected sites:
mmq-load-tiles.cuh: load_tiles_iq1_s / iq2_s / iq3_s vecdotq.cuh: vec_dot_iq1_s_q8_1 / iq2_s_q8_1 / iq3_s_q8_1


## Additional information

Verified on RTX 5060 Ti (sm_120, CUDA 13.2, driver 580.173.02): test-backend-ops -o MUL_MAT and -o MUL_MAT_ID now report OK for iq1_s/iq2_s/iq3_s (previously FAIL with NMSE ~0.2-1.1).

Fixes #28581

## Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, debug issue and propose fix.