### PR TITLE
batched-bench: apply CPU affinity options through common threadpools

### DIFF
--- a/tools/batched-bench/batched-bench.cpp
+++ b/tools/batched-bench/batched-bench.cpp
@@ -65,6 +65,9 @@ int llama_batched_bench(int argc, char ** argv) {
         return 1;
     }
 
+    common_threadpools threadpools;
+    threadpools.init(ctx, params);
+
     const llama_vocab * vocab   = llama_model_get_vocab(model);
     const int32_t       n_vocab = llama_vocab_n_tokens(vocab);
 


### PR DESCRIPTION
## Overview

Fixes #28650.

`llama-batched-bench` parses CPU affinity options but creates its context directly without attaching configured threadpools. Initialize `common_threadpools` before warmup, using the same helper reached by the server. The wrapper releases the pools after context cleanup.

## Additional information

Tested on Linux with GCC and clang compilers. Confirmed affinity set using `taskset -pc <PID>` and `Cpus_allowed_list` in `/proc/<pid>/task/<tid>/status`.

## Requirements

- [x] I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES. Codex inspected the source, generated the three-line change and local regression fixtures, ran the checks, and prepared this submission under user direction. Human review and responsibility for the submitted change remain with the contributor.
