### PR TITLE
convert : add BPE pre-tokenizer hash for Surya-OCR-2

### DIFF
--- a/conversion/base.py
+++ b/conversion/base.py
@@ -1621,6 +1621,9 @@ class TextModel(ModelBase):
         if chkhsh == "1444df51289cfa8063b96f0e62b1125440111bc79a52003ea14b6eac7016fd5f":
             # ref: https://huggingface.co/openbmb/MiniCPM-V-4_6
             res = "qwen35"
+        if chkhsh == "11865354be60ff9206694aed04242190f1807029bbd750bfbced09b4d26f1ad2":
+            # ref: https://huggingface.co/datalab-to/surya-ocr-2
+            res = "qwen35"
         if chkhsh == "66b8d4e19ab16c3bfd89bce5d785fb7e0155e8648708a1f42077cb9fe002c273":
             # ref: https://huggingface.co/alvarobartt/grok-2-tokenizer
             res = "grok-2"


### PR DESCRIPTION
This adds the tokenizer hash for the Qwen3.5-based models datalab-to/surya-ocr-2. Previously, converting these models to GGUF would fail with NotImplementedError: BPE pre-tokenizer was not recognized.

## Overview

Adds the missing chkhsh (checksum hash) for the tokenizer.json used by Surya-OCR-2 (which is based on the Qwen3.5 architecture) to conversion/base.py. This maps the tokenizer to the qwen35 pre-tokenizer type, allowing successful conversion to GGUF.

## Additional information

- Models affected: 
  - [datalab-to/surya-ocr-2](https://huggingface.co/datalab-to/surya-ocr-2)

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI was used to help identify the missing tokenizer hash, debug the conversion error, and draft the code fix.

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
