### PR TITLE
llama-server: reject invalid named tool choices

### DIFF
--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1158,7 +1158,50 @@ json oaicompat_chat_params_parse(
     auto tools = json_value(body, "tools", json());
     auto has_tools = tools.is_array() && !tools.empty();
     auto stream = json_value(body, "stream", false);
-    auto tool_choice = json_value(body, "tool_choice", std::string("auto"));
+    // `tool_choice` is either a string ("auto" / "none" / "required") or, to force a
+    // specific function, an object: {"type":"function","function":{"name":"..."}}.
+    // json_value() only handles the string form: given the object it logs a type
+    // warning and returns the default "auto", so the request is served as if no
+    // choice had been made and nothing surfaces to the caller.
+    //
+    // A named choice means "call exactly this function", so narrow `tools` to that
+    // entry and treat the choice as "required". Every template path already derives
+    // forced-call grammar from tools + required, so no per-template work is needed.
+    std::string tool_choice = "auto";
+    if (body.contains("tool_choice") && !body.at("tool_choice").is_null()) {
+        const auto & choice = body.at("tool_choice");
+        if (choice.is_string()) {
+            tool_choice = choice.get<std::string>();
+        } else if (choice.is_object()) {
+            if (json_value(choice, "type", std::string()) != "function") {
+                throw std::invalid_argument("Invalid tool_choice: object form requires type \"function\"");
+            }
+            if (!choice.contains("function") || !choice.at("function").is_object()) {
+                throw std::invalid_argument("Invalid tool_choice: missing \"function\" object");
+            }
+            const std::string name = json_value(choice.at("function"), "name", std::string());
+            if (name.empty()) {
+                throw std::invalid_argument("Invalid tool_choice: missing function name");
+            }
+            if (!has_tools) {
+                throw std::invalid_argument("Invalid tool_choice: names a function but no tools were provided");
+            }
+
+            json named = json::array();
+            for (const auto & tool : tools) {
+                if (tool.contains("function") && json_value(tool.at("function"), "name", std::string()) == name) {
+                    named.push_back(tool);
+                }
+            }
+            if (named.empty()) {
+                throw std::invalid_argument("Invalid tool_choice: function \"" + name + "\" is not in tools");
+            }
+            tools       = named;
+            tool_choice = "required";
+        } else {
+            throw std::invalid_argument("Invalid tool_choice: expected a string or an object");
+        }
+    }
 
     if (!opt.use_jinja) {
         if (has_tools) {

--- a/tools/server/tests/unit/test_tool_call.py
+++ b/tools/server/tests/unit/test_tool_call.py
@@ -318,6 +318,24 @@ def test_completion_without_tool_call_fast(template_name: str, n_predict: int, t
     do_test_completion_without_tool_call(server, n_predict, tools, tool_choice, stream=stream == CompletionMode.STREAMED)
 
 
+@pytest.mark.parametrize("tool_choice,tools", [
+    ({"type": "function", "function": {"name": "unknown_tool"}}, [TEST_TOOL]),
+    ({"type": "function", "function": {"name": "test"}},         []),
+    ({"type": "function"},                                       [TEST_TOOL]),
+])
+def test_named_tool_choice_is_validated(tool_choice: dict, tools: list[dict]):
+    global server
+    server.jinja = True
+    server.start()
+    res = server.make_request("POST", "/v1/chat/completions", data={
+        "max_tokens": 8,
+        "messages": [{"role": "user", "content": "Write an example"}],
+        "tools": tools,
+        "tool_choice": tool_choice,
+    })
+    assert res.status_code == 400, f'Expected 400, got {res.status_code}: {res.body}'
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize("stream", [CompletionMode.NORMAL, CompletionMode.STREAMED])
 @pytest.mark.parametrize("template_name,n_predict,tools,tool_choice", [


### PR DESCRIPTION
## Overview

Fix `llama-server` handling of object-form `tool_choice` requests for `/v1/chat/completions`.

Previously, when a request specified a named tool using the object form of `tool_choice`, the server could silently fall back to `auto` instead of honoring the requested tool. This could result in a different tool being selected when multiple similar tools were available.

This change makes invalid or unsupported named tool choices fail explicitly instead of silently falling back to `auto`.

## Additional information

The issue was reproduced with two time-related tools whose descriptions could be confused by the model. The named `tool_choice` request returned HTTP 200, while the server warning indicated that the requested choice was not being enforced.

Evidence and reproduction details:

* https://github.com/graphometer/droplet/tree/main/upstream/llamacpp-issue
* https://github.com/graphometer/droplet/tree/main/public/evidence

The behavior was rechecked against master at commit `56381e407c0ccfb3a6f71e668a27a901001d22ce`.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES - AI assistant used only for code changes
