### PR TITLE
gguf: guard GGML_PAD inputs against integer overflow

### DIFF
--- a/ggml/src/gguf.cpp
+++ b/ggml/src/gguf.cpp
@@ -761,6 +761,7 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
     // compute the total size of the data section, taking into account the alignment
     {
         ctx->size = 0;
+        GGML_ASSERT(ctx->alignment > 0 && (ctx->alignment & (ctx->alignment - 1)) == 0 && "alignment must be a power of 2");
         for (size_t i = 0; i < ctx->info.size(); ++i) {
             const gguf_tensor_info & ti = ctx->info[i];
             if (ti.offset != ctx->size) {
@@ -770,7 +771,14 @@ static struct gguf_context * gguf_init_from_reader(const struct gguf_reader & gr
                 gguf_free(ctx);
                 return nullptr;
             }
-            size_t padded_size = GGML_PAD(ggml_nbytes(&ti.t), ctx->alignment);
+            const size_t nbytes = ggml_nbytes(&ti.t);
+            if (nbytes > SIZE_MAX - (ctx->alignment - 1)) {
+                GGML_LOG_ERROR("%s: tensor '%s' size %zu too large for alignment padding (alignment %zu)\n",
+                    __func__, ti.t.name, nbytes, ctx->alignment);
+                gguf_free(ctx);
+                return nullptr;
+            }
+            size_t padded_size = GGML_PAD(nbytes, ctx->alignment);
             if (SIZE_MAX - ctx->size < padded_size) {
                 GGML_LOG_ERROR("%s: tensor '%s' size overflow, cannot accumulate size %zu + %zu\n",
                     __func__, ti.t.name, ctx->size, padded_size);


### PR DESCRIPTION
GGML_PAD(x, n) adds n - 1 before masking. If x is close to SIZE_MAX, that addition can wrap and produce a small padded size, including 0.

The existing post-GGML_PAD accumulation guard only checks ctx->size + padded_size. It cannot detect overflow that already happened inside GGML_PAD, so a crafted GGUF can keep ctx->size smaller than the tensor's logical byte size and later expose out-of-bounds tensor data reads.

Guard nbytes before calling GGML_PAD so nbytes + (alignment - 1) cannot overflow. Also assert at the call site that ctx->alignment is non-zero and a power of two, documenting the invariant required by GGML_PAD and ensuring the invariant is checked before using ctx->alignment - 1 here.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
