### PR TITLE
jinja : support dot property integer literals

### DIFF
--- a/common/jinja/runtime.cpp
+++ b/common/jinja/runtime.cpp
@@ -842,6 +842,12 @@ value member_expression::execute_impl(context & ctx) {
         } else {
             property = this->property->execute(ctx);
         }
+    } else if (is_stmt<integer_literal>(this->property)) {
+        // syntax: obj.index
+        property = mk_val<value_int>(cast_stmt<integer_literal>(this->property)->val);
+        if (property->as_int() < 0) {
+            throw std::runtime_error("Static member property cannot be negative");
+        }
     } else {
         // syntax: obj.prop
         if (!is_stmt<identifier>(this->property)) {

--- a/tests/test-jinja.cpp
+++ b/tests/test-jinja.cpp
@@ -398,6 +398,18 @@ static void test_expressions(testing & t) {
         "Bob"
     );
 
+    test_template(t, "dot notation (integer property)",
+        "{{ {10: 'Bob'}.10 }}",
+        json::object(),
+        "Bob"
+    );
+
+    test_template(t, "dot notation (array index)",
+        "{{ user.10 }}",
+        {{"user", json::array({"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"})}},
+        "k"
+    );
+
     test_template(t, "negative float (not dot notation)",
         "{{ -1.0 }}",
         json::object(),


### PR DESCRIPTION
## Overview

Fixes #28786

## Additional information

Jinja allows you to address both array index and object property as dot-notation integer literals, f.ex:
```jinja
{% set foo = {1: 'Bob'}.1 %}
{% set bar = [1, 2, 3].0 %}
{{ foo, bar }}
```
```python
('Bob', 1)
```

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Nkatu
- Language disclosure: Kikongo