### PR TITLE
fix(mamba) : make time-step projection input contiguous

### DIFF
--- a/src/models/mamba-base.cpp
+++ b/src/models/mamba-base.cpp
@@ -103,7 +103,7 @@ ggml_tensor * llm_build_mamba_base::build_mamba_layer(llm_graph_input_rs * inp,
         }
 
         // {dt_rank, d_inner} @ {dt_rank, n_seq_tokens, n_seqs} => {d_inner, n_seq_tokens, n_seqs}
-        dt = build_lora_mm(layer.ssm_dt, dt);
+        dt = build_lora_mm(layer.ssm_dt, ggml_cont(ctx0, dt));
         dt = ggml_add(ctx0, dt, layer.ssm_dt_b);
 
         cur = x;


### PR DESCRIPTION
Assisted-by: GPT-6 Astra in Codex CLI

## Overview

Makes time-step projection input contiguous for mamba models, fixes a  crash on Intel x86-64 CPUs with AMX enabled.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, found the bug from the failing CI

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
