### PR TITLE
server : forward --api-key to router-spawned child instances

### DIFF
--- a/tools/server/server-models.cpp
+++ b/tools/server/server-models.cpp
@@ -468,7 +468,10 @@ static std::filesystem::path get_server_exec_path() {
 static void unset_reserved_args(common_preset & preset, bool unset_model_args) {
     preset.unset_option("LLAMA_ARG_SSL_KEY_FILE");
     preset.unset_option("LLAMA_ARG_SSL_CERT_FILE");
-    preset.unset_option("LLAMA_API_KEY");
+    // note: LLAMA_API_KEY is deliberately kept here so that child instances
+    // spawned by the router re-validate against the same key union the router
+    // accepts (--api-key and --api-key-file); the /api/models preset rendering
+    // masks it separately.
     preset.unset_option("LLAMA_ARG_MODELS_DIR");
     preset.unset_option("LLAMA_ARG_MODELS_MAX");
     preset.unset_option("LLAMA_ARG_MODELS_PRESET");
@@ -2028,6 +2031,8 @@ void server_models_routes::init_routes() {
             if (!meta.preset.name.empty()) {
                 common_preset preset_copy = meta.preset;
                 unset_reserved_args(preset_copy, false);
+                // don't render the API key into the preset shown to clients
+                preset_copy.unset_option("LLAMA_API_KEY");
                 preset_copy.unset_option("LLAMA_ARG_HOST");
                 preset_copy.unset_option("LLAMA_ARG_PORT");
                 preset_copy.unset_option("LLAMA_ARG_ALIAS");


### PR DESCRIPTION
## Overview

In router mode (`--models-preset`), `--api-key` and `--api-key-file` are supposed to be equivalent key sources — both just add keys to the accepted list. But `unset_reserved_args()` dropped `LLAMA_API_KEY` from the base preset before it was merged into the per-model presets, while `LLAMA_ARG_API_KEY_FILE` was not in the reserved list. The result: children spawned by the router only re-validated against the file keys, so a client authenticating with the router's `--api-key` key could list models but got `401 Invalid API Key` from every chat completion (repros #28820).

This keeps `LLAMA_API_KEY` in the preset so children accept the same key union the router accepts. Children bind to router-assigned loopback ports, so re-validating the union is harmless. The `/api/models` preset rendering masks the key separately, so it doesn't leak there.

## Additional information

Reproduced and verified end to end locally with a small model in router mode:

| key | before | after |
|---|---|---|
| `--api-key` value (routed chat completion) | 401 | 200 |
| `--api-key-file` key (routed chat completion) | 200 | 200 |
| invalid key | 401 | 401 |

Fixes #28820

## Requirements

- [x] I have read and agree with the contributing guidelines
- AI usage disclosure: YES — the code change was implemented with AI assistance and manually reviewed and tested by me.
